### PR TITLE
Install libyang to azure pipeline

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -42,4 +42,4 @@
 # TODO: Avoid system dependencies like libnl, currently these are
 # coming because Sonic swss common depends on them.
 sudo apt-get update
-sudo apt-get install bison flex libfl-dev libgmp-dev libhiredis-dev libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libnl-nf-3-dev libboost-dev
+sudo apt-get install bison flex libfl-dev libgmp-dev libhiredis-dev libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libnl-nf-3-dev libboost-dev libyang-dev libyang0.16


### PR DESCRIPTION
#### Why I did it
sonic-swss-common lib will add dependency to libyang soon, so need install libyang lib to prevent build and UT break.

#### How I did it
Modify azure pipeline to install libyang in azure pipeline steps.

#### How to verify it
Pass all UT.

#### Which release branch to backport (provide reason below if selected)

#### Description for the changelog
Modify azure pipeline to install libyang in azure pipeline steps.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

