### PR TITLE
Use json.hpp from nlohmann-json-dev instead of from swss-common

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -42,4 +42,4 @@
 # TODO: Avoid system dependencies like libnl, currently these are
 # coming because Sonic swss common depends on them.
 sudo apt-get update
-sudo apt-get install bison flex libfl-dev libgmp-dev libhiredis-dev libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libnl-nf-3-dev libboost-dev libyang-dev libyang0.16 libboost-serialization-dev uuid-dev libzmq5 libzmq3-dev
+sudo apt-get install bison flex libfl-dev libgmp-dev libhiredis-dev libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libnl-nf-3-dev libboost-dev libyang-dev libyang0.16 libboost-serialization-dev uuid-dev libzmq5 libzmq3-dev nlohmann-json3-dev

--- a/p4rt_app/p4runtime/p4runtime_impl.cc
+++ b/p4rt_app/p4runtime/p4runtime_impl.cc
@@ -54,7 +54,7 @@
 #include "p4rt_app/utils/status_utility.h"
 #include "p4rt_app/utils/table_utility.h"
 #include "swss/json.h"
-#include "swss/json.hpp"
+#include <nlohmann/json.hpp>
 
 namespace p4rt_app {
 namespace {

--- a/p4rt_app/sonic/app_db_acl_def_table_manager.cc
+++ b/p4rt_app/sonic/app_db_acl_def_table_manager.cc
@@ -32,7 +32,7 @@
 #include "p4_pdpi/utils/annotation_parser.h"
 #include "p4rt_app/utils/table_utility.h"
 #include "swss/json.h"
-#include "swss/json.hpp"
+#include <nlohmann/json.hpp>
 #include "swss/saiaclschema.h"
 
 namespace p4rt_app {

--- a/p4rt_app/sonic/app_db_acl_def_table_manager_test.cc
+++ b/p4rt_app/sonic/app_db_acl_def_table_manager_test.cc
@@ -26,7 +26,7 @@
 #include "p4rt_app/sonic/redis_connections.h"
 #include "p4rt_app/utils/ir_builder.h"
 #include "swss/json.h"
-#include "swss/json.hpp"
+#include <nlohmann/json.hpp>
 
 namespace p4rt_app {
 namespace sonic {

--- a/p4rt_app/sonic/app_db_manager.cc
+++ b/p4rt_app/sonic/app_db_manager.cc
@@ -37,7 +37,7 @@
 #include "p4rt_app/utils/status_utility.h"
 #include "p4rt_app/utils/table_utility.h"
 #include "swss/json.h"
-#include "swss/json.hpp"
+#include <nlohmann/json.hpp>
 #include "swss/schema.h"
 
 namespace p4rt_app {

--- a/p4rt_app/sonic/app_db_manager.h
+++ b/p4rt_app/sonic/app_db_manager.h
@@ -27,7 +27,7 @@
 #include "p4_pdpi/ir.pb.h"
 #include "p4rt_app/sonic/redis_connections.h"
 #include "swss/json.h"
-#include "swss/json.hpp"
+#include <nlohmann/json.hpp>
 
 namespace p4rt_app {
 namespace sonic {

--- a/p4rt_app/sonic/app_db_to_pdpi_ir_translator.cc
+++ b/p4rt_app/sonic/app_db_to_pdpi_ir_translator.cc
@@ -31,7 +31,7 @@
 #include "p4_pdpi/utils/ir.h"
 #include "p4rt_app/utils/table_utility.h"
 #include "swss/json.h"
-#include "swss/json.hpp"
+#include <nlohmann/json.hpp>
 
 namespace p4rt_app {
 namespace sonic {

--- a/p4rt_app/sonic/hashing.cc
+++ b/p4rt_app/sonic/hashing.cc
@@ -27,7 +27,7 @@
 #include "p4rt_app/sonic/redis_connections.h"
 #include "p4rt_app/sonic/response_handler.h"
 #include "swss/json.h"
-#include "swss/json.hpp"
+#include <nlohmann/json.hpp>
 #include "swss/rediscommand.h"
 
 namespace p4rt_app {

--- a/p4rt_app/tests/p4_programs_test.cc
+++ b/p4rt_app/tests/p4_programs_test.cc
@@ -29,7 +29,7 @@
 #include "p4rt_app/tests/lib/p4runtime_grpc_service.h"
 #include "sai_p4/instantiations/google/instantiations.h"
 #include "sai_p4/instantiations/google/sai_p4info.h"
-#include "swss/json.hpp"
+#include <nlohmann/json.hpp>
 
 namespace p4rt_app {
 namespace {


### PR DESCRIPTION
This header file comes from an external package, and a very old version of the header file has been checked into swss-common. This will cause problems for the upcoming Bookworm upgrade.

Change references to the header file to use the Debian package nlohmann-json-dev (added in sonic-net/sonic-buildimage#16308), instead of from swss-common.