### PR TITLE
Set gRPC channel argument about keepalive ping's timeout and ping without rpc and adding method that both reads all remaining messages & finishes session.

### DIFF
--- a/p4_pdpi/BUILD.bazel
+++ b/p4_pdpi/BUILD.bazel
@@ -218,6 +218,7 @@ cc_library(
         "//gutil:status",
         "//p4_pdpi/utils:ir",
         "//sai_p4/fixed:p4_roles",
+        "@com_github_google_glog//:glog",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",

--- a/p4_pdpi/BUILD.bazel
+++ b/p4_pdpi/BUILD.bazel
@@ -227,6 +227,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",

--- a/p4_pdpi/p4_runtime_session.cc
+++ b/p4_pdpi/p4_runtime_session.cc
@@ -142,6 +142,51 @@ std::unique_ptr<P4RuntimeSession> P4RuntimeSession::Default(
       new P4RuntimeSession(device_id, std::move(stub), device_id, role));
 }
 
+absl::Status P4RuntimeSession::Write(const p4::v1::WriteRequest& request) {
+  return WriteRpcGrpcStatusToAbslStatus(WriteAndReturnGrpcStatus(request),
+                                        request.updates_size());
+}
+
+grpc::Status P4RuntimeSession::WriteAndReturnGrpcStatus(
+    const p4::v1::WriteRequest& request) {
+  grpc::ClientContext context;
+  p4::v1::WriteResponse response;
+  return stub_->Write(&context, request, &response);
+}
+
+absl::StatusOr<p4::v1::ReadResponse> P4RuntimeSession::Read(
+    const p4::v1::ReadRequest& request) {
+  grpc::ClientContext context;
+  auto reader = stub_->Read(&context, request);
+
+  p4::v1::ReadResponse result;
+  p4::v1::ReadResponse response;
+  while (reader->Read(&response)) {
+    result.MergeFrom(response);
+  }
+
+  RETURN_IF_ERROR(gutil::GrpcStatusToAbslStatus(reader->Finish()));
+  return result;
+}
+
+absl::Status P4RuntimeSession::SetForwardingPipelineConfig(
+    const p4::v1::SetForwardingPipelineConfigRequest& request) {
+  grpc::ClientContext context;
+  p4::v1::SetForwardingPipelineConfigResponse response;
+  return gutil::GrpcStatusToAbslStatus(
+      stub_->SetForwardingPipelineConfig(&context, request, &response));
+}
+
+absl::StatusOr<p4::v1::GetForwardingPipelineConfigResponse>
+P4RuntimeSession::GetForwardingPipelineConfig(
+    const p4::v1::GetForwardingPipelineConfigRequest& request) {
+  grpc::ClientContext context;
+  p4::v1::GetForwardingPipelineConfigResponse response;
+  RETURN_IF_ERROR(gutil::GrpcStatusToAbslStatus(
+      stub_->GetForwardingPipelineConfig(&context, request, &response)));
+  return response;
+}
+
 absl::Status P4RuntimeSession::Finish() {
   stream_channel_->WritesDone();
 
@@ -171,31 +216,7 @@ absl::StatusOr<ReadResponse> SetMetadataAndSendPiReadRequest(
     P4RuntimeSession* session, ReadRequest& read_request) {
   read_request.set_device_id(session->DeviceId());
   read_request.set_role(session->Role());
-  grpc::ClientContext context;
-  auto reader = session->Stub().Read(&context, read_request);
-
-  ReadResponse response;
-  ReadResponse partial_response;
-  while (reader->Read(&partial_response)) {
-    response.MergeFrom(partial_response);
-  }
-
-  grpc::Status reader_status = reader->Finish();
-  if (!reader_status.ok()) {
-    return gutil::GrpcStatusToAbslStatus(reader_status);
-  }
-  return response;
-}
-
-absl::Status SendPiWriteRequest(P4Runtime::StubInterface* stub,
-                                const p4::v1::WriteRequest& request) {
-  grpc::ClientContext context;
-  // Empty message; intentionally discarded.
-  WriteResponse pi_response;
-  RETURN_IF_ERROR(WriteRpcGrpcStatusToAbslStatus(
-      stub->Write(&context, request, &pi_response), request.updates_size()))
-      << "Failed write request: " << request.DebugString();
-  return absl::OkStatus();
+  return session->Read(read_request);
 }
 
 absl::Status SetMetadataAndSendPiWriteRequest(P4RuntimeSession* session,
@@ -204,7 +225,7 @@ absl::Status SetMetadataAndSendPiWriteRequest(P4RuntimeSession* session,
   write_request.set_role(session->Role());
   *write_request.mutable_election_id() = session->ElectionId();
 
-  return SendPiWriteRequest(&session->Stub(), write_request);
+  return session->Write(write_request);
 }
 
 absl::Status SetMetadataAndSendPiWriteRequests(
@@ -375,12 +396,7 @@ absl::Status SetForwardingPipelineConfig(
   request.set_action(action);
   *request.mutable_config() = config;
 
-  // Empty message; intentionally discarded.
-  SetForwardingPipelineConfigResponse response;
-  grpc::ClientContext context;
-  return gutil::GrpcStatusToAbslStatus(
-      session->Stub().SetForwardingPipelineConfig(&context, request,
-                                                  &response));
+  return session->SetForwardingPipelineConfig(request);
 }
 
 absl::Status SetForwardingPipelineConfig(
@@ -404,14 +420,7 @@ GetForwardingPipelineConfig(
   request.set_device_id(session->DeviceId());
   request.set_response_type(type);
 
-  grpc::ClientContext context;
-  p4::v1::GetForwardingPipelineConfigResponse response;
-  grpc::Status response_status =
-      session->Stub().GetForwardingPipelineConfig(&context, request, &response);
-  if (!response_status.ok()) {
-    return gutil::GrpcStatusToAbslStatus(response_status);
-  }
-  return response;
+  return session->GetForwardingPipelineConfig(request);
 }
 
 }  // namespace pdpi

--- a/p4_pdpi/p4_runtime_session.cc
+++ b/p4_pdpi/p4_runtime_session.cc
@@ -20,6 +20,7 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/substitute.h"
+#include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "glog/logging.h"
 #include "google/protobuf/descriptor.h"
@@ -75,7 +76,7 @@ absl::StatusOr<std::unique_ptr<P4RuntimeSession>> P4RuntimeSession::Create(
   arbitration->set_device_id(device_id);
   arbitration->mutable_role()->set_name(metadata.role);
   *arbitration->mutable_election_id() = session->election_id_;
-  if (!session->stream_channel_->Write(request)) {
+  if (!session->StreamChannelWrite(request)) {
     return gutil::UnavailableErrorBuilder()
            << "Unable to initiate P4RT connection to device ID " << device_id
            << "; gRPC stream channel closed.";
@@ -83,7 +84,7 @@ absl::StatusOr<std::unique_ptr<P4RuntimeSession>> P4RuntimeSession::Create(
 
   // Wait for arbitration response.
   p4::v1::StreamMessageResponse response;
-  if (!session->stream_channel_->Read(&response)) {
+  if (!session->StreamChannelRead(response)) {
     return gutil::InternalErrorBuilder()
            << "P4RT stream closed while awaiting arbitration response: "
            << gutil::GrpcStatusToAbslStatus(session->stream_channel_->Finish());
@@ -188,7 +189,20 @@ P4RuntimeSession::GetForwardingPipelineConfig(
   return response;
 }
 
+bool P4RuntimeSession::StreamChannelRead(
+    p4::v1::StreamMessageResponse& response) {
+  absl::MutexLock lock(&stream_read_lock_);
+  return stream_channel_->Read(&response);
+}
+
+bool P4RuntimeSession::StreamChannelWrite(
+    const p4::v1::StreamMessageRequest& request) {
+  absl::MutexLock lock(&stream_write_lock_);
+  return stream_channel_->Write(request);
+}
+
 absl::Status P4RuntimeSession::Finish() {
+  absl::MutexLock write_lock(&stream_write_lock_);
   stream_channel_->WritesDone();
 
   // Finish will block if there are unread messages in the channel. Therefore,
@@ -196,15 +210,18 @@ absl::Status P4RuntimeSession::Finish() {
   // Multiple threads reading at once should be ok as it only causes an
   // undefined ordering of responses.
   p4::v1::StreamMessageResponse response;
+  absl::MutexLock read_lock(&stream_read_lock_);
   while (stream_channel_->Read(&response)) {
     LOG(WARNING) << "dropping unread message from switch on stream channel "
                     "when trying to Finish P4RuntimeSession: "
                  << response.DebugString();
   }
 
+  grpc::Status finish = stream_channel_->Finish();
   // WritesDone() or TryCancel() can close the stream with a CANCELLED status.
   // Because this case is expected we treat CANCELED as OKAY.
-  grpc::Status finish = stream_channel_->Finish();
+  // TODO: Stop treating CANCELLED as an acceptable error after
+  // migrating tests away from using it as such.
   if (finish.error_code() == grpc::StatusCode::CANCELLED) {
     return absl::OkStatus();
   }

--- a/p4_pdpi/p4_runtime_session.h
+++ b/p4_pdpi/p4_runtime_session.h
@@ -177,8 +177,9 @@ class P4RuntimeSession {
   }
   // Cancels the RPC. It is done in a best-effort fashion.
   void TryCancel() { stream_channel_context_->TryCancel(); }
-  // Closes the RPC connection by telling the server it is done writing. Once
-  // the server finishes handling all outstanding writes it will close.
+  // Closes the RPC connection by telling the server it is done writing, then
+  // reads and logs any outstanding messages from the server. Once the server
+  // finishes handling all outstanding writes it will close.
   absl::Status Finish();
 
  private:

--- a/p4_pdpi/p4_runtime_session.h
+++ b/p4_pdpi/p4_runtime_session.h
@@ -184,10 +184,16 @@ class P4RuntimeSession {
   // WARNING: This is not thread-safe.
   // TODO: Remove once clients have migrated to using Finish.
   void TryCancel() { stream_channel_context_->TryCancel(); }
+
   // Closes the RPC connection by telling the server it is done writing, then
   // reads and logs any outstanding messages from the server. Once the server
   // finishes handling all outstanding writes it will close.
   absl::Status Finish()
+      ABSL_LOCKS_EXCLUDED(stream_write_lock_, stream_read_lock_);
+
+  // Like `Finish`, but returns any outstanding message from the server.
+  absl::StatusOr<std::vector<p4::v1::StreamMessageResponse>>
+  ReadStreamChannelResponsesAndFinish()
       ABSL_LOCKS_EXCLUDED(stream_write_lock_, stream_read_lock_);
 
  private:

--- a/p4_pdpi/p4_runtime_session.h
+++ b/p4_pdpi/p4_runtime_session.h
@@ -72,12 +72,15 @@ inline grpc::ChannelArguments GrpcChannelArgumentsForP4rt() {
   return args;
 }
 
-// Returns the gRPC ChannelArguments for P4Runtime by setting
-// `GRPC_ARG_KEEPALIVE_TIME_MS` to 1s to avoid connection problems and serve as
-// reverse path signalling.
-// `GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA` to 0 to allow KeepAlive ping without
-// traffic in the transport.
-// `GRPC_ARG_MAX_METADATA_SIZE` to P4GRPCMaxMetadataSize because P4RT returns
+// Returns the gRPC ChannelArguments for P4Runtime by setting the following:
+// - `GRPC_ARG_KEEPALIVE_TIME_MS` to 1s to avoid connection problems and serve
+// as reverse path signalling.
+// - `GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA` to 0 to allow KeepAlive ping
+// without traffic in the transport,
+// - `GRPC_ARG_KEEPALIVE_TIMEOUT_MS` to 10s,
+// - `GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS` to 1 to allow keepalive on
+// grpc::Channel without ongoing RPCs,
+// - `GRPC_ARG_MAX_METADATA_SIZE` to P4GRPCMaxMetadataSize because P4RT returns
 // batch element status in the grpc::Status, which can require a large metadata
 // size.
 inline grpc::ChannelArguments
@@ -86,7 +89,9 @@ GrpcChannelArgumentsForP4rtWithAggressiveKeepAlive() {
   args.SetInt(GRPC_ARG_MAX_METADATA_SIZE, P4GRPCMaxMetadataSize());
   // Allows grpc::channel to send keepalive ping without on-going traffic.
   args.SetInt(GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA, 0);
-  args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 1000 /*1 second*/);
+  args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+  args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 10'000 /*10 seconds*/);
+  args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 1'000 /*1 second*/);
   return args;
 }
 

--- a/p4_pdpi/p4_runtime_session.h
+++ b/p4_pdpi/p4_runtime_session.h
@@ -26,6 +26,7 @@
 #include "absl/numeric/int128.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/synchronization/mutex.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "absl/types/optional.h"
@@ -165,22 +166,24 @@ class P4RuntimeSession {
   p4::v1::Uint128 ElectionId() const { return election_id_; }
   // Returns the role of this session.
   std::string Role() const { return role_; }
-  // Reads back stream message response.
+  // Thread-safe wrapper around the stream channel's `Read` method.
   ABSL_MUST_USE_RESULT bool StreamChannelRead(
-      p4::v1::StreamMessageResponse& response) {
-    return stream_channel_->Read(&response);
-  }
-  // Writes stream message request.
+      p4::v1::StreamMessageResponse& response)
+      ABSL_LOCKS_EXCLUDED(stream_read_lock_);
+  // Thread-safe wrapper around the stream channel's `Write` method.
   ABSL_MUST_USE_RESULT bool StreamChannelWrite(
-      const p4::v1::StreamMessageRequest& request) {
-    return stream_channel_->Write(request);
-  }
+      const p4::v1::StreamMessageRequest& request)
+      ABSL_LOCKS_EXCLUDED(stream_write_lock_);
+
   // Cancels the RPC. It is done in a best-effort fashion.
+  // WARNING: This is not thread-safe.
+  // TODO: Remove once clients have migrated to using Finish.
   void TryCancel() { stream_channel_context_->TryCancel(); }
   // Closes the RPC connection by telling the server it is done writing, then
   // reads and logs any outstanding messages from the server. Once the server
   // finishes handling all outstanding writes it will close.
-  absl::Status Finish();
+  absl::Status Finish()
+      ABSL_LOCKS_EXCLUDED(stream_write_lock_, stream_read_lock_);
 
  private:
   P4RuntimeSession(uint32_t device_id,
@@ -210,6 +213,11 @@ class P4RuntimeSession {
   std::unique_ptr<grpc::ClientReaderWriterInterface<
       p4::v1::StreamMessageRequest, p4::v1::StreamMessageResponse>>
       stream_channel_;
+
+  // Used to ensure atomic reads and writes on the stream channel. Write lock
+  // must be acquired before read lock in cases where both locks are acquired.
+  absl::Mutex stream_read_lock_;
+  absl::Mutex stream_write_lock_ ABSL_ACQUIRED_BEFORE(stream_read_lock_);
 };
 
 // Create P4Runtime stub.

--- a/p4_pdpi/p4_runtime_session.h
+++ b/p4_pdpi/p4_runtime_session.h
@@ -135,14 +135,36 @@ class P4RuntimeSession {
   P4RuntimeSession(P4RuntimeSession&&) = default;
   P4RuntimeSession& operator=(P4RuntimeSession&&) = default;
 
+  // Sends the write request, and returns OK if all requests in the batch were
+  // handled successfully. If you need to evaluate the result of each request
+  // individually consider using WriteAndReturnGrpcStatus.
+  absl::Status Write(const p4::v1::WriteRequest& request);
+
+  // Sends the write request, and returns the raw gRPC response from the switch.
+  // Notice that the status only means the request was sent and handled
+  // correctly, but NOT that the flow was successfully programmed.
+  //
+  // https://p4.org/p4-spec/p4runtime/main/P4Runtime-Spec.html#sec-error-reporting
+  grpc::Status WriteAndReturnGrpcStatus(const p4::v1::WriteRequest& request);
+
+  // Sends the read request, and aggregates all the read responses into a
+  // single response. Will return an error if an issue is detected with the
+  // stream.
+  absl::StatusOr<p4::v1::ReadResponse> Read(const p4::v1::ReadRequest& request);
+
+  // Set/Get methods for the forwarding pipeline.
+  absl::Status SetForwardingPipelineConfig(
+      const p4::v1::SetForwardingPipelineConfigRequest& request);
+  absl::StatusOr<p4::v1::GetForwardingPipelineConfigResponse>
+  GetForwardingPipelineConfig(
+      const p4::v1::GetForwardingPipelineConfigRequest& request);
+
   // Returns the id of the node that this session belongs to.
   uint32_t DeviceId() const { return device_id_; }
   // Returns the election id that has been used to perform arbitration.
   p4::v1::Uint128 ElectionId() const { return election_id_; }
   // Returns the role of this session.
   std::string Role() const { return role_; }
-  // Returns the P4Runtime stub.
-  p4::v1::P4Runtime::StubInterface& Stub() { return *stub_; }
   // Reads back stream message response.
   ABSL_MUST_USE_RESULT bool StreamChannelRead(
       p4::v1::StreamMessageResponse& response) {
@@ -210,10 +232,6 @@ absl::StatusOr<p4::v1::ReadResponse> SetMetadataAndSendPiReadRequest(
 // And sends a PI (program independent) write request.
 absl::Status SetMetadataAndSendPiWriteRequest(
     P4RuntimeSession* session, p4::v1::WriteRequest& write_request);
-
-// Sends a PI (program independent) write request with given stub.
-absl::Status SendPiWriteRequest(p4::v1::P4Runtime::StubInterface* stub,
-                                const p4::v1::WriteRequest& request);
 
 // Sets the requests' metadata (i.e. device id, role and election id). And sends
 // PI (program independent) write requests.

--- a/p4rt_app/scripts/BUILD.bazel
+++ b/p4rt_app/scripts/BUILD.bazel
@@ -39,6 +39,7 @@ cc_binary(
         "//gutil:io",
         "//gutil:proto",
         "//gutil:proto_matchers",
+        "//gutil:status",
         "//gutil:status_matchers",
         "//p4_pdpi:ir",
         "//p4_pdpi:p4_runtime_session",

--- a/p4rt_app/scripts/p4rt_route_measurement_test.cc
+++ b/p4rt_app/scripts/p4rt_route_measurement_test.cc
@@ -30,6 +30,7 @@
 #include "gutil/io.h"
 #include "gutil/proto.h"
 #include "gutil/proto_matchers.h"
+#include "gutil/status.h"
 #include "gutil/status_matchers.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
@@ -292,19 +293,13 @@ class P4rtRouteTest : public Test {
 
     absl::Duration total_execution_time;
     for (const auto& request : requests) {
-      grpc::ClientContext context;
-      p4::v1::WriteResponse response;
-
       // Send a batch of requests to the server and measure the response time.
       absl::Time start = absl::Now();
-      grpc::Status grpc_status =
-          p4rt_session_->Stub().Write(&context, request, &response);
-      total_execution_time += absl::Now() - start;
 
       // We don't expect any errors in the test. So if we see one we invalidate
       // the run.
-      RETURN_IF_ERROR(pdpi::WriteRpcGrpcStatusToAbslStatus(
-          grpc_status, request.updates_size()));
+      RETURN_IF_ERROR(p4rt_session_->Write(request));
+      total_execution_time += absl::Now() - start;
     }
 
     return total_execution_time;

--- a/p4rt_app/scripts/p4rt_write.cc
+++ b/p4rt_app/scripts/p4rt_write.cc
@@ -66,10 +66,7 @@ absl::Status SendWriteRequest(pdpi::P4RuntimeSession& session,
   *pi_write_request.mutable_election_id() = session.ElectionId();
   pi_write_request.set_role(session.Role());
 
-  grpc::ClientContext context;
-  p4::v1::WriteResponse pi_write_response;
-  return gutil::GrpcStatusToAbslStatus(
-      session.Stub().Write(&context, pi_write_request, &pi_write_response));
+  return session.Write(pi_write_request);
 }
 
 absl::Status Main() {

--- a/p4rt_app/tests/forwarding_pipeline_config_test.cc
+++ b/p4rt_app/tests/forwarding_pipeline_config_test.cc
@@ -52,13 +52,8 @@ using ::gutil::StatusIs;
 using ::p4::v1::GetForwardingPipelineConfigRequest;
 using ::p4::v1::GetForwardingPipelineConfigResponse;
 using ::p4::v1::SetForwardingPipelineConfigRequest;
-using ::p4::v1::SetForwardingPipelineConfigResponse;
 using ::testing::IsEmpty;
 using ::testing::Not;
-
-MATCHER_P(GrpcStatusIs, status_code, "") {
-  return arg.error_code() == status_code;
-}
 
 // Get a writeable directory where bazel tests can save output files to.
 // https://docs.bazel.build/versions/main/test-encyclopedia.html#initial-conditions
@@ -170,14 +165,10 @@ TEST_F(VerifyTest, DoesNotUpdateAppDbState) {
       sai::GetP4Info(sai::Instantiation::kMiddleblock);
 
   // However, since we're only verifying the config we should not see anything
-  // being written to the AppDb tables.
-  SetForwardingPipelineConfigResponse response;
-  grpc::ClientContext context;
-  // This is the first test that runs verify against the P4info so it's the most
-  // visible failure. Therefore, annotate this failure with suggestions for
-  // fixing verification issues.
-  EXPECT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(&context, request,
-                                                              &response))
+  // being written to the AppDb tables. This is the first test that runs verify
+  // against the P4info so it's the most visible failure. Therefore, annotate
+  // this failure with suggestions for fixing verification issues.
+  EXPECT_OK(p4rt_session_->SetForwardingPipelineConfig(request))
       << "Is the p4info_verification_schema updated? If not, run: "
       << "p4rt_app/scripts/"
       << "update_p4info_verification_schema.sh";
@@ -188,11 +179,8 @@ TEST_F(VerifyTest, FailsWhenNoConfigIsSet) {
   auto request = GetBasicForwardingRequest();
   request.set_action(SetForwardingPipelineConfigRequest::VERIFY);
 
-  SetForwardingPipelineConfigResponse response;
-  grpc::ClientContext context;
-  EXPECT_THAT(p4rt_session_->Stub().SetForwardingPipelineConfig(
-                  &context, request, &response),
-              GrpcStatusIs(grpc::StatusCode::INVALID_ARGUMENT));
+  EXPECT_THAT(p4rt_session_->SetForwardingPipelineConfig(request),
+              StatusIs(absl::StatusCode::kInvalidArgument));
 }
 
 TEST_F(VerifyTest, FailsWhenVerifyFails) {
@@ -202,11 +190,8 @@ TEST_F(VerifyTest, FailsWhenVerifyFails) {
       sai::GetP4Info(sai::Instantiation::kMiddleblock);
   request.mutable_config()->mutable_p4info()->clear_actions();
 
-  SetForwardingPipelineConfigResponse response;
-  grpc::ClientContext context;
-  EXPECT_THAT(p4rt_session_->Stub().SetForwardingPipelineConfig(
-                  &context, request, &response),
-              GrpcStatusIs(grpc::StatusCode::INVALID_ARGUMENT));
+  EXPECT_THAT(p4rt_session_->SetForwardingPipelineConfig(request),
+              StatusIs(absl::StatusCode::kInvalidArgument));
 }
 
 using VerifyAndCommitTest = ForwardingPipelineConfigTest;
@@ -221,10 +206,7 @@ TEST_F(VerifyAndCommitTest, UpdatesAppDbState) {
 
   // Since we're both verifying and committing the config we expect to see
   // changes to the AppDb tables.
-  SetForwardingPipelineConfigResponse response;
-  grpc::ClientContext context;
-  EXPECT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(&context, request,
-                                                              &response));
+  EXPECT_OK(p4rt_session_->SetForwardingPipelineConfig(request));
   EXPECT_THAT(p4rt_service_->GetP4rtAppDbTable().GetAllKeys(), Not(IsEmpty()));
 }
 
@@ -232,11 +214,8 @@ TEST_F(VerifyAndCommitTest, FailsWhenNoConfigIsSet) {
   auto request = GetBasicForwardingRequest();
   request.set_action(SetForwardingPipelineConfigRequest::VERIFY_AND_COMMIT);
 
-  SetForwardingPipelineConfigResponse response;
-  grpc::ClientContext context;
-  EXPECT_THAT(p4rt_session_->Stub().SetForwardingPipelineConfig(
-                  &context, request, &response),
-              GrpcStatusIs(grpc::StatusCode::INVALID_ARGUMENT));
+  EXPECT_THAT(p4rt_session_->SetForwardingPipelineConfig(request),
+              StatusIs(absl::StatusCode::kInvalidArgument));
 }
 
 // This is not expected P4Runtime behavior. We simply haven't implemented it
@@ -249,22 +228,12 @@ TEST_F(VerifyAndCommitTest, CannotClearForwardingState) {
 
   // For the first config push we expect everything to pass since the switch is
   // in a clean state.
-  {
-    SetForwardingPipelineConfigResponse response;
-    grpc::ClientContext context;
-    ASSERT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(
-        &context, request, &response));
-  }
+  ASSERT_OK(p4rt_session_->SetForwardingPipelineConfig(request));
 
   // Because we don't support it today we fail when trying to push the same
   // config a second time.
-  {
-    SetForwardingPipelineConfigResponse response;
-    grpc::ClientContext context;
-    EXPECT_THAT(p4rt_session_->Stub().SetForwardingPipelineConfig(
-                    &context, request, &response),
-                GrpcStatusIs(grpc::StatusCode::UNIMPLEMENTED));
-  }
+  EXPECT_THAT(p4rt_session_->SetForwardingPipelineConfig(request),
+              StatusIs(absl::StatusCode::kUnimplemented));
 }
 
 using CommitTest = ForwardingPipelineConfigTest;
@@ -284,15 +253,10 @@ TEST_F(CommitTest, LoadsLastSavedConfig) {
   GetForwardingPipelineConfigRequest get_request;
   get_request.set_device_id(p4rt_session_->DeviceId());
 
-  SetForwardingPipelineConfigResponse load_response;
-  grpc::ClientContext load_context;
-  ASSERT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(
-      &load_context, load_request, &load_response));
+  ASSERT_OK(p4rt_session_->SetForwardingPipelineConfig(load_request));
 
-  GetForwardingPipelineConfigResponse get_response;
-  grpc::ClientContext get_context;
-  EXPECT_OK(p4rt_session_->Stub().GetForwardingPipelineConfig(
-      &get_context, get_request, &get_response));
+  ASSERT_OK_AND_ASSIGN(GetForwardingPipelineConfigResponse get_response,
+                       p4rt_session_->GetForwardingPipelineConfig(get_request));
   EXPECT_THAT(get_response.config(), EqualsProto(expected_config));
 }
 
@@ -306,11 +270,8 @@ TEST_F(CommitTest, FailsIfNoConfigHasBeenSaved) {
   auto request = GetBasicForwardingRequest();
   request.set_action(SetForwardingPipelineConfigRequest::COMMIT);
 
-  SetForwardingPipelineConfigResponse response;
-  grpc::ClientContext context;
-  EXPECT_THAT(p4rt_session_->Stub().SetForwardingPipelineConfig(
-                  &context, request, &response),
-              GrpcStatusIs(grpc::StatusCode::INVALID_ARGUMENT));
+  EXPECT_THAT(p4rt_session_->SetForwardingPipelineConfig(request),
+              StatusIs(absl::StatusCode::kInvalidArgument));
 }
 
 TEST_F(CommitTest, FailsIfAConfigIsSet) {
@@ -319,11 +280,8 @@ TEST_F(CommitTest, FailsIfAConfigIsSet) {
   *request.mutable_config()->mutable_p4info() =
       sai::GetP4Info(sai::Instantiation::kMiddleblock);
 
-  SetForwardingPipelineConfigResponse response;
-  grpc::ClientContext context;
-  EXPECT_THAT(p4rt_session_->Stub().SetForwardingPipelineConfig(
-                  &context, request, &response),
-              GrpcStatusIs(grpc::StatusCode::INVALID_ARGUMENT));
+  EXPECT_THAT(p4rt_session_->SetForwardingPipelineConfig(request),
+              StatusIs(absl::StatusCode::kInvalidArgument));
 }
 
 using ReconcileAndCommitTest = ForwardingPipelineConfigTest;
@@ -339,15 +297,10 @@ TEST_F(ReconcileAndCommitTest, SetForwardingPipelineConfig) {
   GetForwardingPipelineConfigRequest get_request;
   get_request.set_device_id(p4rt_session_->DeviceId());
 
-  SetForwardingPipelineConfigResponse commit_response;
-  grpc::ClientContext commit_context;
-  EXPECT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(
-      &commit_context, commit_request, &commit_response));
+  EXPECT_OK(p4rt_session_->SetForwardingPipelineConfig(commit_request));
 
-  GetForwardingPipelineConfigResponse get_response;
-  grpc::ClientContext get_context;
-  EXPECT_OK(p4rt_session_->Stub().GetForwardingPipelineConfig(
-      &get_context, get_request, &get_response));
+  ASSERT_OK_AND_ASSIGN(GetForwardingPipelineConfigResponse get_response,
+                       p4rt_session_->GetForwardingPipelineConfig(get_request));
   EXPECT_THAT(get_response.config(), EqualsProto(commit_request.config()));
 }
 
@@ -357,10 +310,7 @@ TEST_F(ReconcileAndCommitTest, WritesConfigToAFile) {
   *request.mutable_config()->mutable_p4info() =
       sai::GetP4Info(sai::Instantiation::kMiddleblock);
 
-  SetForwardingPipelineConfigResponse response;
-  grpc::ClientContext context;
-  ASSERT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(&context, request,
-                                                              &response));
+  ASSERT_OK(p4rt_session_->SetForwardingPipelineConfig(request));
 
   EXPECT_THAT(GetSavedConfig(), IsOkAndHolds(EqualsProto(request.config())));
 }
@@ -369,11 +319,8 @@ TEST_F(ReconcileAndCommitTest, FailsWhenNoConfigIsSet) {
   auto request = GetBasicForwardingRequest();
   request.set_action(SetForwardingPipelineConfigRequest::RECONCILE_AND_COMMIT);
 
-  SetForwardingPipelineConfigResponse response;
-  grpc::ClientContext context;
-  EXPECT_THAT(p4rt_session_->Stub().SetForwardingPipelineConfig(
-                  &context, request, &response),
-              GrpcStatusIs(grpc::StatusCode::INVALID_ARGUMENT));
+  EXPECT_THAT(p4rt_session_->SetForwardingPipelineConfig(request),
+              StatusIs(absl::StatusCode::kInvalidArgument));
 }
 
 TEST_F(ReconcileAndCommitTest, SetDuplicateForwardingPipelineConfig) {
@@ -382,14 +329,8 @@ TEST_F(ReconcileAndCommitTest, SetDuplicateForwardingPipelineConfig) {
   *request.mutable_config()->mutable_p4info() =
       sai::GetP4Info(sai::Instantiation::kMiddleblock);
 
-  SetForwardingPipelineConfigResponse response;
-  grpc::ClientContext context;
-  ASSERT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(&context, request,
-                                                              &response));
-
-  grpc::ClientContext duplicate_context;
-  EXPECT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(
-      &duplicate_context, request, &response));
+  ASSERT_OK(p4rt_session_->SetForwardingPipelineConfig(request));
+  EXPECT_OK(p4rt_session_->SetForwardingPipelineConfig(request));
 }
 
 TEST_F(ReconcileAndCommitTest, FailsIfAModifiedConfigIsPushed) {
@@ -398,17 +339,12 @@ TEST_F(ReconcileAndCommitTest, FailsIfAModifiedConfigIsPushed) {
   *request.mutable_config()->mutable_p4info() =
       sai::GetP4Info(sai::Instantiation::kMiddleblock);
 
-  SetForwardingPipelineConfigResponse response;
-  grpc::ClientContext context;
-  ASSERT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(&context, request,
-                                                              &response));
+  ASSERT_OK(p4rt_session_->SetForwardingPipelineConfig(request));
 
   // Remove the last table from the P4Info, and try pushing again.
   request.mutable_config()->mutable_p4info()->mutable_tables()->RemoveLast();
-  grpc::ClientContext modify_context;
-  EXPECT_THAT(p4rt_session_->Stub().SetForwardingPipelineConfig(
-                  &modify_context, request, &response),
-              GrpcStatusIs(grpc::StatusCode::UNIMPLEMENTED));
+  EXPECT_THAT(p4rt_session_->SetForwardingPipelineConfig(request),
+              StatusIs(absl::StatusCode::kUnimplemented));
 }
 
 using GetForwardingConfigTest = ForwardingPipelineConfigTest;
@@ -418,10 +354,8 @@ TEST_F(GetForwardingConfigTest, ReturnsNothingIfConfigHasNotBeenSet) {
   get_request.set_device_id(p4rt_session_->DeviceId());
   get_request.set_response_type(GetForwardingPipelineConfigRequest::ALL);
 
-  GetForwardingPipelineConfigResponse get_response;
-  grpc::ClientContext get_context;
-  EXPECT_OK(p4rt_session_->Stub().GetForwardingPipelineConfig(
-      &get_context, get_request, &get_response));
+  ASSERT_OK_AND_ASSIGN(GetForwardingPipelineConfigResponse get_response,
+                       p4rt_session_->GetForwardingPipelineConfig(get_request));
   EXPECT_THAT(get_response.config(),
               EqualsProto(p4::v1::ForwardingPipelineConfig{}));
 }
@@ -440,15 +374,10 @@ TEST_F(GetForwardingConfigTest, CanReadBackAllTheConfig) {
   get_request.set_device_id(p4rt_session_->DeviceId());
   get_request.set_response_type(GetForwardingPipelineConfigRequest::ALL);
 
-  SetForwardingPipelineConfigResponse set_response;
-  grpc::ClientContext set_context;
-  ASSERT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(
-      &set_context, set_request, &set_response));
+  ASSERT_OK(p4rt_session_->SetForwardingPipelineConfig(set_request));
 
-  GetForwardingPipelineConfigResponse get_response;
-  grpc::ClientContext get_context;
-  EXPECT_OK(p4rt_session_->Stub().GetForwardingPipelineConfig(
-      &get_context, get_request, &get_response));
+  ASSERT_OK_AND_ASSIGN(GetForwardingPipelineConfigResponse get_response,
+                       p4rt_session_->GetForwardingPipelineConfig(get_request));
   EXPECT_THAT(get_response.config(), EqualsProto(set_request.config()));
 }
 
@@ -471,15 +400,10 @@ TEST_F(GetForwardingConfigTest, CanReadBackCookieOnly) {
   p4::v1::ForwardingPipelineConfig expected_config;
   expected_config.mutable_cookie()->set_cookie(123);
 
-  SetForwardingPipelineConfigResponse set_response;
-  grpc::ClientContext set_context;
-  ASSERT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(
-      &set_context, set_request, &set_response));
+  ASSERT_OK(p4rt_session_->SetForwardingPipelineConfig(set_request));
 
-  GetForwardingPipelineConfigResponse get_response;
-  grpc::ClientContext get_context;
-  EXPECT_OK(p4rt_session_->Stub().GetForwardingPipelineConfig(
-      &get_context, get_request, &get_response));
+  ASSERT_OK_AND_ASSIGN(GetForwardingPipelineConfigResponse get_response,
+                       p4rt_session_->GetForwardingPipelineConfig(get_request));
   EXPECT_THAT(get_response.config(), EqualsProto(expected_config));
 }
 
@@ -503,15 +427,10 @@ TEST_F(GetForwardingConfigTest, CanReadBackP4InfoAndCookie) {
   *expected_config.mutable_cookie() = set_request.config().cookie();
   *expected_config.mutable_p4info() = set_request.config().p4info();
 
-  SetForwardingPipelineConfigResponse set_response;
-  grpc::ClientContext set_context;
-  ASSERT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(
-      &set_context, set_request, &set_response));
+  ASSERT_OK(p4rt_session_->SetForwardingPipelineConfig(set_request));
 
-  GetForwardingPipelineConfigResponse get_response;
-  grpc::ClientContext get_context;
-  EXPECT_OK(p4rt_session_->Stub().GetForwardingPipelineConfig(
-      &get_context, get_request, &get_response));
+  ASSERT_OK_AND_ASSIGN(GetForwardingPipelineConfigResponse get_response,
+                       p4rt_session_->GetForwardingPipelineConfig(get_request));
   EXPECT_THAT(get_response.config(), EqualsProto(expected_config));
 }
 
@@ -536,15 +455,10 @@ TEST_F(GetForwardingConfigTest, CanReadBackDeviceConfigAndCookie) {
   *expected_config.mutable_p4_device_config() =
       set_request.config().p4_device_config();
 
-  SetForwardingPipelineConfigResponse set_response;
-  grpc::ClientContext set_context;
-  ASSERT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(
-      &set_context, set_request, &set_response));
+  ASSERT_OK(p4rt_session_->SetForwardingPipelineConfig(set_request));
 
-  GetForwardingPipelineConfigResponse get_response;
-  grpc::ClientContext get_context;
-  EXPECT_OK(p4rt_session_->Stub().GetForwardingPipelineConfig(
-      &get_context, get_request, &get_response));
+  ASSERT_OK_AND_ASSIGN(GetForwardingPipelineConfigResponse get_response,
+                       p4rt_session_->GetForwardingPipelineConfig(get_request));
   EXPECT_THAT(get_response.config(), EqualsProto(expected_config));
 }
 
@@ -557,41 +471,29 @@ TEST_F(GetForwardingConfigTest, CanUpdateTheConfigAndReadItBack) {
       sai::GetP4Info(sai::Instantiation::kMiddleblock);
 
   // Set the forwarding pipeline.
-  {
-    SetForwardingPipelineConfigResponse set_response;
-    grpc::ClientContext set_context;
-    ASSERT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(
-        &set_context, set_request, &set_response));
-  }
+  ASSERT_OK(p4rt_session_->SetForwardingPipelineConfig(set_request));
 
   // Verify we can read the same forwarding config back.
   {
     GetForwardingPipelineConfigRequest get_request;
     get_request.set_device_id(p4rt_session_->DeviceId());
-    GetForwardingPipelineConfigResponse get_response;
-    grpc::ClientContext get_context;
-    EXPECT_OK(p4rt_session_->Stub().GetForwardingPipelineConfig(
-        &get_context, get_request, &get_response));
+    ASSERT_OK_AND_ASSIGN(
+        GetForwardingPipelineConfigResponse get_response,
+        p4rt_session_->GetForwardingPipelineConfig(get_request));
     EXPECT_THAT(get_response.config(), EqualsProto(set_request.config()));
   }
 
   // Update the forwarding config's cookie, and reset it.
   set_request.mutable_config()->mutable_cookie()->set_cookie(456);
-  {
-    SetForwardingPipelineConfigResponse set_response;
-    grpc::ClientContext set_context;
-    ASSERT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(
-        &set_context, set_request, &set_response));
-  }
+  ASSERT_OK(p4rt_session_->SetForwardingPipelineConfig(set_request));
 
   // Verify we can read back the new forwarding config.
   {
     GetForwardingPipelineConfigRequest get_request;
     get_request.set_device_id(p4rt_session_->DeviceId());
-    GetForwardingPipelineConfigResponse get_response;
-    grpc::ClientContext get_context;
-    EXPECT_OK(p4rt_session_->Stub().GetForwardingPipelineConfig(
-        &get_context, get_request, &get_response));
+    ASSERT_OK_AND_ASSIGN(
+        GetForwardingPipelineConfigResponse get_response,
+        p4rt_session_->GetForwardingPipelineConfig(get_request));
     EXPECT_THAT(get_response.config(), EqualsProto(set_request.config()));
   }
 }
@@ -630,10 +532,7 @@ TEST_P(PerConfigTest, VerifySucceeds) {
   *request.mutable_config()->mutable_p4info() =
       sai::FetchP4Info(std::get<0>(GetParam()), std::get<1>(GetParam()));
 
-  SetForwardingPipelineConfigResponse response;
-  grpc::ClientContext context;
-  EXPECT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(&context, request,
-                                                              &response));
+  EXPECT_OK(p4rt_session_->SetForwardingPipelineConfig(request));
 }
 
 TEST_P(PerConfigTest, VerifyAndCommitSucceeds) {
@@ -642,10 +541,7 @@ TEST_P(PerConfigTest, VerifyAndCommitSucceeds) {
   *request.mutable_config()->mutable_p4info() =
       sai::FetchP4Info(std::get<0>(GetParam()), std::get<1>(GetParam()));
 
-  SetForwardingPipelineConfigResponse response;
-  grpc::ClientContext context;
-  EXPECT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(&context, request,
-                                                              &response));
+  EXPECT_OK(p4rt_session_->SetForwardingPipelineConfig(request));
   EXPECT_THAT(p4rt_service_->GetP4rtAppDbTable().GetAllKeys(), Not(IsEmpty()));
 }
 
@@ -655,19 +551,10 @@ TEST_P(PerConfigTest, ReconcileAndCommitSucceeds) {
   *request.mutable_config()->mutable_p4info() =
       sai::FetchP4Info(std::get<0>(GetParam()), std::get<1>(GetParam()));
 
-  SetForwardingPipelineConfigResponse response;
-  {
-    grpc::ClientContext context;
-    EXPECT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(
-        &context, request, &response));
-  }
+  EXPECT_OK(p4rt_session_->SetForwardingPipelineConfig(request));
   EXPECT_THAT(p4rt_service_->GetP4rtAppDbTable().GetAllKeys(), Not(IsEmpty()));
-  {
-    grpc::ClientContext context;
-    EXPECT_OK(p4rt_session_->Stub().SetForwardingPipelineConfig(
-        &context, request, &response))
-        << "Failed second commit (expected no-op)";
-  }
+  EXPECT_OK(p4rt_session_->SetForwardingPipelineConfig(request))
+      << "Failed second commit (expected no-op)";
   EXPECT_THAT(p4rt_service_->GetP4rtAppDbTable().GetAllKeys(), Not(IsEmpty()));
 }
 


### PR DESCRIPTION
### PR Description : 
Set gRPC channel argument about keepalive ping's timeout and ping without rpc.
[[p4_runtime_session] Add method that both reads all remaining messages & finishes session.

### Build Results :
bibhuprasad@b621e980bfc1:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS p4_pdpi/...
INFO: Analyzed 70 targets (1 packages loaded, 90 targets configured).
INFO: Found 70 targets...
INFO: Elapsed time: 9.693s, Critical Path: 7.68s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions

bibhuprasad@b621e980bfc1:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS p4rt_app/...
INFO: Analyzed 92 targets (0 packages loaded, 0 targets configured).
INFO: Found 92 targets...
INFO: Elapsed time: 0.581s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### UT Results :
bibhuprasad@b621e980bfc1:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4_pdpi/...
INFO: Analyzed 70 targets (0 packages loaded, 0 targets configured).
INFO: Found 44 targets and 26 test targets...
INFO: Elapsed time: 0.581s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//p4_pdpi:ir_tools_test                                         (cached) PASSED in 0.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test         (cached) PASSED in 0.3s
//p4_pdpi/netaddr:ipv6_address_test                             (cached) PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                              (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:bit_string_test                      (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                     (cached) PASSED in 0.3s
//p4_pdpi/string_encodings:decimal_string_test                  (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner           (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                      (cached) PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner               (cached) PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test            (cached) PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                          (cached) PASSED in 0.3s
//p4_pdpi/testing:info_test                                     (cached) PASSED in 0.0s
//p4_pdpi/testing:info_test_runner                              (cached) PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                  (cached) PASSED in 0.0s
//p4_pdpi/testing:packet_io_test                                (cached) PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                         (cached) PASSED in 0.0s
//p4_pdpi/testing:rpc_test                                      (cached) PASSED in 0.0s
//p4_pdpi/testing:rpc_test_runner                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                               (cached) PASSED in 0.0s
//p4_pdpi/testing:sequencing_test_runner                        (cached) PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                        (cached) PASSED in 0.3s
//p4_pdpi/testing:table_entry_test                              (cached) PASSED in 0.0s
//p4_pdpi/testing:table_entry_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                          (cached) PASSED in 0.2s
//p4_pdpi/utils:ir_test                                         (cached) PASSED in 0.3s

Executed 0 out of 26 tests: 26 tests pass.
INFO: Build completed successfully, 1 total action
