### PR TITLE
Set gRPC channel argument about keepalive ping's timeout and ping without rpc. [p4_runtime_session] Add method that both reads all remaining messages & finishes session. and [p4_runtime_session] Fix off-by-one bug in ReadStreamChannelResponsesAndFinish.

### DIFF
--- a/p4_pdpi/p4_runtime_session.cc
+++ b/p4_pdpi/p4_runtime_session.cc
@@ -15,6 +15,7 @@
 #include "p4_pdpi/p4_runtime_session.h"
 
 #include <string>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -200,30 +201,42 @@ bool P4RuntimeSession::StreamChannelWrite(
 }
 
 absl::Status P4RuntimeSession::Finish() {
+  ASSIGN_OR_RETURN(std::vector<p4::v1::StreamMessageResponse> responses,
+                   ReadStreamChannelResponsesAndFinish());
+  for (auto& response : responses) {
+    LOG(WARNING) << "dropping unread message from switch on stream channel "
+                    "when trying to Finish P4RuntimeSession: "
+                 << response.DebugString();
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::vector<p4::v1::StreamMessageResponse>>
+P4RuntimeSession::ReadStreamChannelResponsesAndFinish() {
+  std::vector<p4::v1::StreamMessageResponse> responses;
+
+  // Signal server to close down the connection.
   absl::MutexLock write_lock(&stream_write_lock_);
   stream_channel_->WritesDone();
 
   // Finish will block if there are unread messages in the channel. Therefore,
   // we read any outstanding messages and log their existence before calling it.
-  // Multiple threads reading at once should be ok as it only causes an
-  // undefined ordering of responses.
-  p4::v1::StreamMessageResponse response;
   absl::MutexLock read_lock(&stream_read_lock_);
+  p4::v1::StreamMessageResponse response;
   while (stream_channel_->Read(&response)) {
-    LOG(WARNING) << "dropping unread message from switch on stream channel "
-                    "when trying to Finish P4RuntimeSession: "
-                 << response.DebugString();
+    responses.push_back(std::move(response));
   }
 
-  grpc::Status finish = stream_channel_->Finish();
-  // WritesDone() or TryCancel() can close the stream with a CANCELLED status.
-  // Because this case is expected we treat CANCELED as OKAY.
-  // TODO: Stop treating CANCELLED as an acceptable error after
-  // migrating tests away from using it as such.
-  if (finish.error_code() == grpc::StatusCode::CANCELLED) {
-    return absl::OkStatus();
+  absl::Status finish =
+      gutil::GrpcStatusToAbslStatus(stream_channel_->Finish());
+  if (!finish.ok()) {
+    // TryCancel() can close the stream with a CANCELLED status.
+    // Because this case is expected we treat CANCELLED as OKAY.
+    // TODO: Stop treating CANCELLED as an acceptable error after
+    // migrating tests away from using it as such.
+    if (!absl::IsCancelled(finish)) return finish;
   }
-  return gutil::GrpcStatusToAbslStatus(finish);
+  return responses;
 }
 
 std::vector<Update> CreatePiUpdates(absl::Span<const TableEntry> pi_entries,


### PR DESCRIPTION
### PR Description :
Set gRPC channel argument about keepalive ping's timeout and ping without rpc.
[p4_runtime_session] Add method that both reads all remaining messages & finishes session.
[p4_runtime_session] Fix off-by-one bug in ReadStreamChannelResponsesAndFinish.

### Build Results :
bibhuprasad@a2e4c78134d7:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS p4_pdpi/...
DEBUG: Rule 'com_github_nelhage_rules_boost' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1619053724 -0700"
DEBUG: Repository com_github_nelhage_rules_boost instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:73:9: in <toplevel>
  /var/bibhuprasad/.cache/bazel/_bazel_bibhuprasad/5fd88bad78ef03829a4685c83637a020/external/com_github_p4lang_p4c/bazel/p4c_deps.bzl:25:23: in p4c_deps
Repository rule git_repository defined at:
  /var/bibhuprasad/.cache/bazel/_bazel_bibhuprasad/5fd88bad78ef03829a4685c83637a020/external/bazel_tools/tools/build_defs/repo/git.bzl:199:33: in <toplevel>
INFO: Analyzed 71 targets (1 packages loaded, 93 targets configured).
INFO: Found 71 targets...
INFO: Elapsed time: 4.188s, Critical Path: 3.49s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions
bibhuprasad@a2e4c78134d7:/sonic/src/sonic-p4rt/sonic-pins$ 
bibhuprasad@a2e4c78134d7:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS p4rt_app/...
DEBUG: Rule 'com_github_nelhage_rules_boost' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1619053724 -0700"
DEBUG: Repository com_github_nelhage_rules_boost instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:73:9: in <toplevel>
  /var/bibhuprasad/.cache/bazel/_bazel_bibhuprasad/5fd88bad78ef03829a4685c83637a020/external/com_github_p4lang_p4c/bazel/p4c_deps.bzl:25:23: in p4c_deps
Repository rule git_repository defined at:
  /var/bibhuprasad/.cache/bazel/_bazel_bibhuprasad/5fd88bad78ef03829a4685c83637a020/external/bazel_tools/tools/build_defs/repo/git.bzl:199:33: in <toplevel>
INFO: Analyzed 94 targets (1 packages loaded, 102 targets configured).
INFO: Found 94 targets...
INFO: Elapsed time: 1.358s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bibhuprasad@a2e4c78134d7:/sonic/src/sonic-p4rt/sonic-pins$ 

### UT Results :
bibhuprasad@a2e4c78134d7:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4_pdpi/...
DEBUG: Rule 'com_github_nelhage_rules_boost' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1619053724 -0700"
DEBUG: Repository com_github_nelhage_rules_boost instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:73:9: in <toplevel>
  /var/bibhuprasad/.cache/bazel/_bazel_bibhuprasad/5fd88bad78ef03829a4685c83637a020/external/com_github_p4lang_p4c/bazel/p4c_deps.bzl:25:23: in p4c_deps
Repository rule git_repository defined at:
  /var/bibhuprasad/.cache/bazel/_bazel_bibhuprasad/5fd88bad78ef03829a4685c83637a020/external/bazel_tools/tools/build_defs/repo/git.bzl:199:33: in <toplevel>
INFO: Analyzed 71 targets (0 packages loaded, 0 targets configured).
INFO: Found 45 targets and 26 test targets...
INFO: Elapsed time: 0.415s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//p4_pdpi:ir_tools_test                                         (cached) PASSED in 0.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test         (cached) PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                             (cached) PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                              (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:bit_string_test                      (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                     (cached) PASSED in 0.3s
//p4_pdpi/string_encodings:decimal_string_test                  (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner           (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                      (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner               (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test            (cached) PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                          (cached) PASSED in 0.3s
//p4_pdpi/testing:info_test                                     (cached) PASSED in 0.0s
//p4_pdpi/testing:info_test_runner                              (cached) PASSED in 0.0s
//p4_pdpi/testing:main_pd_test                                  (cached) PASSED in 0.2s
//p4_pdpi/testing:packet_io_test                                (cached) PASSED in 0.0s
//p4_pdpi/testing:packet_io_test_runner                         (cached) PASSED in 0.0s
//p4_pdpi/testing:rpc_test                                      (cached) PASSED in 0.0s
//p4_pdpi/testing:rpc_test_runner                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                               (cached) PASSED in 0.0s
//p4_pdpi/testing:sequencing_test_runner                        (cached) PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                        (cached) PASSED in 0.3s
//p4_pdpi/testing:table_entry_test                              (cached) PASSED in 0.0s
//p4_pdpi/testing:table_entry_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                          (cached) PASSED in 0.2s
//p4_pdpi/utils:ir_test                                         (cached) PASSED in 0.3s

Executed 0 out of 26 tests: 26 tests pass.
INFO: Build completed successfully, 1 total action
bibhuprasad@a2e4c78134d7:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4rt_app/...
DEBUG: Rule 'com_github_nelhage_rules_boost' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1619053724 -0700"
DEBUG: Repository com_github_nelhage_rules_boost instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:73:9: in <toplevel>
  /var/bibhuprasad/.cache/bazel/_bazel_bibhuprasad/5fd88bad78ef03829a4685c83637a020/external/com_github_p4lang_p4c/bazel/p4c_deps.bzl:25:23: in p4c_deps
Repository rule git_repository defined at:
  /var/bibhuprasad/.cache/bazel/_bazel_bibhuprasad/5fd88bad78ef03829a4685c83637a020/external/bazel_tools/tools/build_defs/repo/git.bzl:199:33: in <toplevel>
INFO: Analyzed 94 targets (0 packages loaded, 0 targets configured).
INFO: Found 63 targets and 31 test targets...
INFO: Elapsed time: 0.435s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//p4rt_app/event_monitoring:app_state_db_port_table_event_test  (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test     (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test      (cached) PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                        (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test            (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                   (cached) PASSED in 0.4s
//p4rt_app/p4runtime:packetio_helpers_test                      (cached) PASSED in 0.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test              (cached) PASSED in 0.5s
//p4rt_app/sonic:app_db_manager_test                            (cached) PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test              (cached) PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                             (cached) PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                             (cached) PASSED in 0.3s
//p4rt_app/sonic:response_handler_test                          (cached) PASSED in 0.4s
//p4rt_app/sonic:state_verification_test                        (cached) PASSED in 0.2s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test              (cached) PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                 (cached) PASSED in 0.9s
//p4rt_app/tests:action_set_test                                (cached) PASSED in 0.7s
//p4rt_app/tests:api_access_test                                (cached) PASSED in 0.6s
//p4rt_app/tests:arbitration_test                               (cached) PASSED in 0.7s
//p4rt_app/tests:fixed_l3_tables_test                           (cached) PASSED in 2.6s
//p4rt_app/tests:forwarding_pipeline_config_test                (cached) PASSED in 3.6s
//p4rt_app/tests:grpc_behavior_test                             (cached) PASSED in 5.0s
//p4rt_app/tests:p4_programs_test                               (cached) PASSED in 1.2s
//p4rt_app/tests:packetio_test                                  (cached) PASSED in 3.3s
//p4rt_app/tests:port_name_and_id_test                          (cached) PASSED in 0.9s
//p4rt_app/tests:response_path_test                             (cached) PASSED in 1.8s
//p4rt_app/tests:role_test                                      (cached) PASSED in 0.7s
//p4rt_app/tests/lib:app_db_entry_builder_test                  (cached) PASSED in 0.0s
//p4rt_app/utils:event_execution_time_monitor_test              (cached) PASSED in 0.2s
//p4rt_app/utils:table_utility_test                             (cached) PASSED in 0.5s

Executed 0 out of 31 tests: 31 tests pass.
INFO: Build completed successfully, 1 total action

