### PR TITLE
 [p4_constraints] Added StableStatusToString method suitable for golden testing.

### DIFF
--- a/p4rt_app/p4runtime/p4runtime_impl.cc
+++ b/p4rt_app/p4runtime/p4runtime_impl.cc
@@ -1138,6 +1138,7 @@ absl::Status P4RuntimeImpl::ConfigureAppDbTables(
       }
     }
   }
+}
   return absl::OkStatus();
 }
 

--- a/p4rt_app/p4runtime/p4runtime_impl.cc
+++ b/p4rt_app/p4runtime/p4runtime_impl.cc
@@ -1117,19 +1117,19 @@ absl::Status P4RuntimeImpl::ConfigureAppDbTables(
       if (status.code() != google::rpc::OK) {
         return gutil::InvalidArgumentErrorBuilder() << status.message();
       }
-    }
-    if (!ext_tables_json.dump().empty()) {
-       // Publish all tables at once and get one success/failure response for them
-      ASSIGN_OR_RETURN(
-            std::string acl_key,
-            sonic::PublishExtTablesDefinitionToAppDb(ext_tables_json, (uint64_t)0,
-                       p4rt_table_),
-            _ << "Could not publish Table Definition Set to APPDB");
+  }
+  if (!ext_tables_json.dump().empty()) {
+     // Publish all tables at once and get one success/failure response for them
+    ASSIGN_OR_RETURN(
+          std::string acl_key,
+          sonic::PublishExtTablesDefinitionToAppDb(ext_tables_json, (uint64_t)0,
+                     p4rt_table_),
+          _ << "Could not publish Table Definition Set to APPDB");
 
-      ASSIGN_OR_RETURN(
-            pdpi::IrUpdateStatus status,
-            sonic::GetAndProcessResponseNotificationWithoutRevertingState(
-                 *p4rt_table_.notification_consumer, acl_key));
+    ASSIGN_OR_RETURN(
+          pdpi::IrUpdateStatus status,
+          sonic::GetAndProcessResponseNotificationWithoutRevertingState(
+               *p4rt_table_.notification_consumer, acl_key));
 
       // Any issue with the forwarding config should be sent back to the
       // controller as an INVALID_ARGUMENT.

--- a/p4rt_app/p4runtime/p4runtime_impl.cc
+++ b/p4rt_app/p4runtime/p4runtime_impl.cc
@@ -1138,7 +1138,6 @@ absl::Status P4RuntimeImpl::ConfigureAppDbTables(
       }
     }
   }
-}
   return absl::OkStatus();
 }
 

--- a/p4rt_app/sonic/response_handler.h
+++ b/p4rt_app/sonic/response_handler.h
@@ -62,6 +62,20 @@ absl::StatusOr<pdpi::IrUpdateStatus>
 GetAndProcessResponseNotificationWithoutRevertingState(
     ConsumerNotifierAdapter& notification_interface, const std::string& key);
 
+// Given a mapping of keys to IR statuses this function will wait for an
+// OrchAgent respsponse for every key and update it's status. On a failed
+// OrchAgent response it will not try to revert any state.
+absl::Status GetAndProcessResponseNotificationWithoutRevertingState(
+    ConsumerNotifierAdapter& notification_interface,
+    absl::btree_map<std::string, pdpi::IrUpdateStatus*>& key_to_status_map);
+
+// Given a single key this function will wait for an OrchAgent respsponse, and
+// return it. On a failed OrchAgent response it will not try to revert any
+// state.
+absl::StatusOr<pdpi::IrUpdateStatus>
+GetAndProcessResponseNotificationWithoutRevertingState(
+    ConsumerNotifierAdapter& notification_interface, const std::string& key);
+
 }  // namespace sonic
 }  // namespace p4rt_app
 

--- a/p4rt_app/utils/BUILD.bazel
+++ b/p4rt_app/utils/BUILD.bazel
@@ -79,3 +79,18 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "event_data_tracker",
+    hdrs = ["event_data_tracker.h"],
+)
+
+cc_test(
+    name = "event_data_tracker_test",
+    srcs = ["event_data_tracker_test.cc"],
+    deps = [
+        ":event_data_tracker",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/p4rt_app/utils/BUILD.bazel
+++ b/p4rt_app/utils/BUILD.bazel
@@ -79,18 +79,3 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
-
-cc_library(
-    name = "event_data_tracker",
-    hdrs = ["event_data_tracker.h"],
-)
-
-cc_test(
-    name = "event_data_tracker_test",
-    srcs = ["event_data_tracker_test.cc"],
-    deps = [
-        ":event_data_tracker",
-        "@com_google_absl//absl/time",
-        "@com_google_googletest//:gtest_main",
-    ],
-)


### PR DESCRIPTION
### Build Results:

divya@d2a5b56330ca:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 219 targets (0 packages loaded, 0 targets configured).
INFO: Found 219 targets...
INFO: Elapsed time: 0.316s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
divya@d2a5b56330ca:/sonic/src/sonic-p4rt/sonic-pins$

### Test Results:

divya@d2a5b56330ca:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Analyzed 219 targets (1 packages loaded, 48 targets configured).
INFO: Found 143 targets and 76 test targets...
INFO: Elapsed time: 23.062s, Critical Path: 4.96s
INFO: 77 processes: 83 linux-sandbox, 13 local.
INFO: Build completed successfully, 77 total actions
//gutil:collections_test                                                 PASSED in 0.2s
//gutil:io_test                                                          PASSED in 0.2s
//gutil:proto_matchers_test                                              PASSED in 0.3s
//gutil:proto_test                                                       PASSED in 0.2s
//gutil:status_matchers_test                                             PASSED in 0.2s
//gutil:table_entry_key_test                                             PASSED in 0.1s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.2s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.3s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.3s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.0s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.3s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.2s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.3s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.4s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.4s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.3s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.4s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.3s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.5s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 0.7s
//p4rt_app/tests:action_set_test                                         PASSED in 0.5s
//p4rt_app/tests:api_access_test                                         PASSED in 0.5s
//p4rt_app/tests:arbitration_test                                        PASSED in 0.6s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 1.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 2.0s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.0s
//p4rt_app/tests:p4_programs_test                                        PASSED in 0.8s
//p4rt_app/tests:packetio_test                                           PASSED in 2.9s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 0.7s
//p4rt_app/tests:response_path_test                                      PASSED in 1.2s
//p4rt_app/tests:role_test                                               PASSED in 0.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 0.7s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.2s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.4s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.2s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.3s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.5s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.2s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.3s

Executed 76 out of 76 tests: 76 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeoutINFO: Build completed successfully, 77 total actions