### PR TITLE
[packetlib] Add SAI P4 BMv2 packet_in header support in packetlib.

### DIFF
--- a/p4_pdpi/packetlib/BUILD.bazel
+++ b/p4_pdpi/packetlib/BUILD.bazel
@@ -1,0 +1,109 @@
+load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+proto_library(
+    name = "packetlib_proto",
+    srcs = ["packetlib.proto"],
+)
+
+cc_proto_library(
+    name = "packetlib_cc_proto",
+    deps = [
+        ":packetlib_proto",
+    ],
+)
+
+cc_library(
+    name = "bit_widths",
+    hdrs = ["bit_widths.h"],
+)
+
+cc_library(
+    name = "packetlib",
+    srcs = ["packetlib.cc"],
+    hdrs = ["packetlib.h"],
+    deps = [
+        ":bit_widths",
+        ":packetlib_cc_proto",
+        "//gutil:overload",
+        "//gutil:status",
+        "//p4_pdpi/netaddr:ipv4_address",
+        "//p4_pdpi/netaddr:ipv6_address",
+        "//p4_pdpi/netaddr:mac_address",
+        "//p4_pdpi/netaddr:network_address",
+        "//p4_pdpi/string_encodings:bit_string",
+        "//p4_pdpi/string_encodings:hex_string",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/numeric:bits",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:optional",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_test(
+    name = "packetlib_fuzzer_test",
+    srcs = ["packetlib_fuzzer_test.cc"],
+    deps = [
+        ":packetlib",
+        ":packetlib_cc_proto",
+        "//gutil:proto",
+        "//gutil:status_matchers",
+        "//p4_pdpi/string_encodings:hex_string",
+        "//p4_pdpi/string_encodings:readable_byte_string",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/random",
+        "@com_google_absl//absl/random:distributions",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "packetlib_unit_test",
+    srcs = ["packetlib_unit_test.cc"],
+    deps = [
+        ":bit_widths",
+        ":packetlib",
+        ":packetlib_cc_proto",
+        "//gutil:status_matchers",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+# go/golden-test-with-coverage
+cc_test(
+    name = "packetlib_test_runner",
+    srcs = ["packetlib_test_runner.cc"],
+    linkstatic = True,
+    deps = [
+        ":packetlib",
+        ":packetlib_cc_proto",
+        "//gutil:proto",
+        "//gutil:testing",
+        "//p4_pdpi/string_encodings:readable_byte_string",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cmd_diff_test(
+    name = "packetlib_test",
+    actual_cmd = "$(execpath :packetlib_test_runner)",
+    expected = "//p4_pdpi/packetlib:packetlib_test_runner.expected",
+    tools = [
+        ":packetlib_test_runner",
+    ],
+)

--- a/p4_pdpi/packetlib/bit_widths.h
+++ b/p4_pdpi/packetlib/bit_widths.h
@@ -1,0 +1,101 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef GOOGLE_P4_PDPI_PACKETLIB_BIT_WIDTHS_H_
+#define GOOGLE_P4_PDPI_PACKETLIB_BIT_WIDTHS_H_
+
+// Bit widths of packet fields. Naming convention is:
+//   "k" <header-name> <field-name> "Bitwidth"
+// Some headers may be combined, e.g. Ip for IPv4 and IPv6.
+namespace packetlib {
+
+// Standard header sizes (for headers without extensions, etc).
+constexpr int kEthernetHeaderBitwidth = 48 * 2 + 16;
+constexpr int kStandardIpv4HeaderBitwidth = 160;
+constexpr int kIpv6HeaderBitwidth = 320;
+constexpr int kUdpHeaderBitwidth = 64;
+constexpr int kStandardTcpHeaderBitwidth = 5 * 32;
+constexpr int kArpHeaderBitwidth = 28 * 8;
+constexpr int kIcmpHeaderBitwidth = 8 * 8;
+constexpr int kVlanHeaderBitwidth = 32;
+constexpr int kRfc2784GreHeaderWithoutOptionalsBitwidth = 32;
+
+// Ethernet constants.
+constexpr int kEthernetEthertypeBitwidth = 16;
+
+// VLAN constants.
+constexpr int kVlanPriorityCodePointBitwidth = 3;
+constexpr int kVlanDropEligibilityIndicatorBitwidth = 1;
+constexpr int kVlanVlanIdentifierBitwidth = 12;
+constexpr int kVlanEthertypeBitwidth = 16;
+
+// IP constants.
+constexpr int kIpVersionBitwidth = 4;          // IPv4 & IPv6
+constexpr int kIpIhlBitwidth = 4;              // IPv4
+constexpr int kIpDscpBitwidth = 6;             // IPv4 & IPv6
+constexpr int kIpEcnBitwidth = 2;              // IPv4 & IPv6
+constexpr int kIpTotalLengthBitwidth = 16;     // IPv4
+constexpr int kIpIdentificationBitwidth = 16;  // IPv4
+constexpr int kIpFlagsBitwidth = 3;            // IPv4
+constexpr int kIpFragmentOffsetBitwidth = 13;  // IPv4
+constexpr int kIpTtlBitwidth = 8;              // IPv4
+constexpr int kIpProtocolBitwidth = 8;         // IPv4
+constexpr int kIpChecksumBitwidth = 16;        // IPv4
+constexpr int kIpFlowLabelBitwidth = 20;       // IPv6
+constexpr int kIpPayloadLengthBitwidth = 16;   // IPv6
+constexpr int kIpNextHeaderBitwidth = 8;       // IPv6
+constexpr int kIpHopLimitBitwidth = 8;         // IPv6
+
+// UDP constants.
+constexpr int kUdpPortBitwidth = 16;
+constexpr int kUdpLengthBitwidth = 16;
+constexpr int kUdpChecksumBitwidth = 16;
+
+// TCP constants.
+constexpr int kTcpPortBitwidth = 16;
+constexpr int kTcpSequenceNumberBitwidth = 32;
+constexpr int kTcpAcknowledgementNumberBitwidth = 32;
+constexpr int kTcpDataOffsetBitwidth = 4;
+constexpr int kTcpRestOfHeaderBitwidth = 60;
+
+// ARP constants.
+constexpr int kArpTypeBitwidth = 16;
+constexpr int kArpLengthBitwidth = 8;
+constexpr int kArpOperationBitwidth = 16;
+
+// ICMP constants.
+constexpr int kIcmpTypeBitwidth = 8;
+constexpr int kIcmpCodeBitwidth = 8;
+constexpr int kIcmpChecksumBitwidth = 16;
+constexpr int kIcmpRestOfHeaderBitwidth = 32;
+
+// GRE constants.
+constexpr int kGreChecksumPresentBitwidth = 1;
+constexpr int kGreReserved0Bitwidth = 12;
+constexpr int kGreVersionBitwidth = 3;
+constexpr int kGreProtocolTypeBitwidth = 16;
+constexpr int kGreChecksumBitwidth = 16;
+constexpr int kGreReserved1Bitwidth = 16;
+
+// Minimum packet sizes, in bytes.
+constexpr int kMinNumBytesInEthernetPayload = 46;
+
+// SAI P4 packet_in header on BMv2 targets constants.
+constexpr int kSaiP4BMv2PacketInHeaderBitwidth = 24;
+constexpr int kSaiP4BMv2PacketInIngressPortBitwidth = 9;
+constexpr int kSaiP4BMv2PacketInTargetEgressPortBitwidth = 9;
+constexpr int kSaiP4BMv2PacketInUnusedPadBitwidth = 6;
+
+}  // namespace packetlib
+
+#endif  // GOOGLE_P4_PDPI_PACKETLIB_BIT_WIDTHS_H_

--- a/p4_pdpi/packetlib/packetlib.cc
+++ b/p4_pdpi/packetlib/packetlib.cc
@@ -1,0 +1,2279 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "p4_pdpi/packetlib/packetlib.h"
+
+#include <cstddef>
+#include <ostream>
+#include <string>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "absl/strings/strip.h"
+#include "absl/types/optional.h"
+#include "absl/types/span.h"
+#include "glog/logging.h"
+#include "gutil/overload.h"
+#include "gutil/status.h"
+#include "p4_pdpi/netaddr/ipv4_address.h"
+#include "p4_pdpi/netaddr/ipv6_address.h"
+#include "p4_pdpi/netaddr/mac_address.h"
+#include "p4_pdpi/netaddr/network_address.h"
+#include "p4_pdpi/packetlib/bit_widths.h"
+#include "p4_pdpi/packetlib/packetlib.pb.h"
+#include "p4_pdpi/string_encodings/bit_string.h"
+#include "p4_pdpi/string_encodings/hex_string.h"
+
+namespace packetlib {
+
+using ::netaddr::Ipv4Address;
+using ::netaddr::Ipv6Address;
+using ::netaddr::MacAddress;
+
+namespace {
+
+// -- Determining the header following a given header  -------------------------
+
+// Indicates that a header should follow the current header, but that that
+// header is unsupported by packetlib.
+struct UnsupportedNextHeader {
+  std::string reason;
+};
+
+// Encodes header, if any, that should follow the current header.
+using NextHeader = absl::variant<
+    // A supported next header, or no next header (encoded as HEADER_NOT_SET) if
+    // the previous header was the final one before the payload.
+    Header::HeaderCase,
+    // An unsupported next header.
+    UnsupportedNextHeader>;
+
+absl::StatusOr<NextHeader> GetNextHeaderForEtherType(
+    absl::string_view header_name, absl::string_view ethertype_hexstring) {
+  ASSIGN_OR_RETURN(int ethertype, pdpi::HexStringToInt(ethertype_hexstring),
+                   _.SetCode(absl::StatusCode::kInternal).SetPrepend()
+                       << "unable to parse ethertype: ");
+  // See https://en.wikipedia.org/wiki/EtherType.
+  if (ethertype <= 1535) return Header::HEADER_NOT_SET;
+  if (ethertype == 0x0800) return Header::kIpv4Header;
+  if (ethertype == 0x86dd) return Header::kIpv6Header;
+  if (ethertype == 0x0806) return Header::kArpHeader;
+  if (ethertype == 0x8100) return Header::kVlanHeader;
+  return UnsupportedNextHeader{
+      .reason = absl::StrFormat("%s.ethertype %s: unsupported", header_name,
+                                ethertype_hexstring)};
+}
+
+absl::StatusOr<NextHeader> GetNextHeader(const EthernetHeader& header) {
+  return GetNextHeaderForEtherType("ethernet_header", header.ethertype());
+}
+absl::StatusOr<NextHeader> GetNextHeader(const VlanHeader& header) {
+  return GetNextHeaderForEtherType("vlan_header", header.ethertype());
+}
+absl::StatusOr<NextHeader> GetNextHeader(const GreHeader& header) {
+  return GetNextHeaderForEtherType("gre_header", header.protocol_type());
+}
+absl::StatusOr<NextHeader> GetNextHeader(
+    const SaiP4BMv2PacketInHeader& header) {
+  return Header::kEthernetHeader;
+}
+absl::StatusOr<NextHeader> GetNextHeader(const Ipv4Header& header) {
+  if (header.protocol() == "0x06") return Header::kTcpHeader;
+  if (header.protocol() == "0x11") return Header::kUdpHeader;
+  if (header.protocol() == "0x01") return Header::kIcmpHeader;
+  if (header.protocol() == "0x2f") return Header::kGreHeader;
+  // The following IP protcol numbers are "reserved for experimentation",
+  // meaning the bits after the L3 header are arbitrary.
+  if (header.protocol() == "0xfd") return Header::HEADER_NOT_SET;
+  if (header.protocol() == "0xfe") return Header::HEADER_NOT_SET;
+  return UnsupportedNextHeader{
+      .reason = absl::StrFormat("ipv4_header.protocol %s: unsupported",
+                                header.protocol())};
+}
+absl::StatusOr<NextHeader> GetNextHeader(const Ipv6Header& header) {
+  if (header.next_header() == "0x06") return Header::kTcpHeader;
+  if (header.next_header() == "0x11") return Header::kUdpHeader;
+  if (header.next_header() == "0x3a") return Header::kIcmpHeader;
+  if (header.next_header() == "0x2f") return Header::kGreHeader;
+  // The following IP protcol numbers are "reserved for experimentation",
+  // meaning the bits after the L3 header are arbitrary.
+  if (header.next_header() == "0xfd") return Header::HEADER_NOT_SET;
+  if (header.next_header() == "0xfe") return Header::HEADER_NOT_SET;
+  return UnsupportedNextHeader{
+      .reason = absl::StrFormat("ipv6_header.next_header %s: unsupported",
+                                header.next_header())};
+}
+absl::StatusOr<NextHeader> GetNextHeader(const UdpHeader& header) {
+  return Header::HEADER_NOT_SET;
+}
+absl::StatusOr<NextHeader> GetNextHeader(const TcpHeader& header) {
+  return Header::HEADER_NOT_SET;
+}
+absl::StatusOr<NextHeader> GetNextHeader(const ArpHeader& header) {
+  return Header::HEADER_NOT_SET;
+}
+absl::StatusOr<NextHeader> GetNextHeader(const IcmpHeader& header) {
+  return Header::HEADER_NOT_SET;
+}
+absl::StatusOr<NextHeader> GetNextHeader(const Header& header) {
+  switch (header.header_case()) {
+    case Header::kEthernetHeader:
+      return GetNextHeader(header.ethernet_header());
+    case Header::kIpv4Header:
+      return GetNextHeader(header.ipv4_header());
+    case Header::kIpv6Header:
+      return GetNextHeader(header.ipv6_header());
+    case Header::kUdpHeader:
+      return GetNextHeader(header.udp_header());
+    case Header::kTcpHeader:
+      return GetNextHeader(header.tcp_header());
+    case Header::kArpHeader:
+      return GetNextHeader(header.arp_header());
+    case Header::kIcmpHeader:
+      return GetNextHeader(header.icmp_header());
+    case Header::kVlanHeader:
+      return GetNextHeader(header.vlan_header());
+    case Header::kGreHeader:
+      return GetNextHeader(header.gre_header());
+    case Header::kSaiP4Bmv2PacketInHeader:
+      return GetNextHeader(header.sai_p4_bmv2_packet_in_header());
+    case Header::HEADER_NOT_SET:
+      return Header::HEADER_NOT_SET;
+  }
+  return Header::HEADER_NOT_SET;
+}
+
+// ---- Parsing ----------------------------------------------------------------
+
+// Parser helper functions.  Assumes that there are enough bits left in data.
+std::string ParseMacAddress(pdpi::BitString& data) {
+  if (auto mac = data.ConsumeMacAddress(); mac.ok()) {
+    return mac->ToString();
+  } else {
+    LOG(DFATAL) << "Size was already checked, should never fail; "
+                << mac.status();
+    return "INTERNAL ERROR";
+  }
+}
+std::string ParseIpv4Address(pdpi::BitString& data) {
+  if (auto ip = data.ConsumeIpv4Address(); ip.ok()) {
+    return ip->ToString();
+  } else {
+    LOG(DFATAL) << "Size was already checked, should never fail; "
+                << ip.status();
+    return "INTERNAL ERROR";
+  }
+}
+std::string ParseIpv6Address(pdpi::BitString& data) {
+  if (auto ip = data.ConsumeIpv6Address(); ip.ok()) {
+    return ip->ToString();
+  } else {
+    LOG(DFATAL) << "Size was already checked, should never fail; "
+                << ip.status();
+    return "INTERNAL ERROR";
+  }
+}
+std::string ParseBits(pdpi::BitString& data, int num_bits) {
+  if (auto bits = data.ConsumeHexString(num_bits); bits.ok()) {
+    return *bits;
+  } else {
+    LOG(DFATAL) << "Size was already checked, should never fail; "
+                << bits.status();
+    return "INTERNAL ERROR";
+  }
+}
+
+// Parse and return an Ethernet header, or return error if the packet is too
+// small.
+absl::StatusOr<EthernetHeader> ParseEthernetHeader(pdpi::BitString& data) {
+  if (data.size() < kEthernetHeaderBitwidth) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Packet is too short to parse an Ethernet header next. Only "
+           << data.size() << " bits left, need at least "
+           << kEthernetHeaderBitwidth << ".";
+  }
+
+  EthernetHeader header;
+  header.set_ethernet_destination(ParseMacAddress(data));
+  header.set_ethernet_source(ParseMacAddress(data));
+  header.set_ethertype(ParseBits(data, kEthernetEthertypeBitwidth));
+  return header;
+}
+
+// Parse and return an IPv4 header, or return error if the packet is too small.
+absl::StatusOr<Ipv4Header> ParseIpv4Header(pdpi::BitString& data) {
+  if (data.size() < kStandardIpv4HeaderBitwidth) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Packet is too short to parse an IPv4 header next. Only "
+           << data.size() << " bits left, need at least "
+           << kStandardIpv4HeaderBitwidth << ".";
+  }
+
+  Ipv4Header header;
+  header.set_version(ParseBits(data, kIpVersionBitwidth));
+  header.set_ihl(ParseBits(data, kIpIhlBitwidth));
+  header.set_dscp(ParseBits(data, kIpDscpBitwidth));
+  header.set_ecn(ParseBits(data, kIpEcnBitwidth));
+  header.set_total_length(ParseBits(data, kIpTotalLengthBitwidth));
+  header.set_identification(ParseBits(data, kIpIdentificationBitwidth));
+  header.set_flags(ParseBits(data, kIpFlagsBitwidth));
+  header.set_fragment_offset(ParseBits(data, kIpFragmentOffsetBitwidth));
+  header.set_ttl(ParseBits(data, kIpTtlBitwidth));
+  header.set_protocol(ParseBits(data, kIpProtocolBitwidth));
+  header.set_checksum(ParseBits(data, kIpChecksumBitwidth));
+  header.set_ipv4_source(ParseIpv4Address(data));
+  header.set_ipv4_destination(ParseIpv4Address(data));
+
+  // Parse suffix/options.
+  absl::StatusOr<int> ihl = pdpi::HexStringToInt(header.ihl());
+  if (!ihl.ok()) {
+    LOG(DFATAL) << "SHOULD NEVER HAPPEN: IHL badly formatted: " << ihl.status();
+    // Don't return error status so parsing is lossless despite error.
+    // The packet will be invalid, but this will be caught by validity checking.
+  } else if (*ihl > 5) {
+    int options_bit_width = 32 * (*ihl - 5);
+    // If the packet ends prematurely, we still parse what's there to maintain
+    // the property that parsing is lossless. The result is an invalid packet,
+    // since the IHL and the options length will be inconsistent, but this will
+    // be caught by the validity check.
+    if (data.size() < options_bit_width) {
+      options_bit_width = data.size();
+    }
+    header.set_uninterpreted_options(ParseBits(data, options_bit_width));
+  }
+  return header;
+}
+
+// Parse and return an IPv6 header, or return error if the packet is too small.
+absl::StatusOr<Ipv6Header> ParseIpv6Header(pdpi::BitString& data) {
+  if (data.size() < kIpv6HeaderBitwidth) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Packet is too short to parse an IPv6 header next. Only "
+           << data.size() << " bits left, need at least " << kIpv6HeaderBitwidth
+           << ".";
+  }
+
+  Ipv6Header header;
+  header.set_version(ParseBits(data, kIpVersionBitwidth));
+  header.set_dscp(ParseBits(data, kIpDscpBitwidth));
+  header.set_ecn(ParseBits(data, kIpEcnBitwidth));
+  header.set_flow_label(ParseBits(data, kIpFlowLabelBitwidth));
+  header.set_payload_length(ParseBits(data, kIpPayloadLengthBitwidth));
+  header.set_next_header(ParseBits(data, kIpNextHeaderBitwidth));
+  header.set_hop_limit(ParseBits(data, kIpHopLimitBitwidth));
+  header.set_ipv6_source(ParseIpv6Address(data));
+  header.set_ipv6_destination(ParseIpv6Address(data));
+  return header;
+}
+
+// Parse a UDP header, or return error if the packet is too small.
+absl::StatusOr<UdpHeader> ParseUdpHeader(pdpi::BitString& data) {
+  if (data.size() < kUdpHeaderBitwidth) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Packet is too short to parse an UDP header next. Only "
+           << data.size() << " bits left, need at least " << kUdpHeaderBitwidth
+           << ".";
+  }
+
+  UdpHeader header;
+  header.set_source_port(ParseBits(data, kUdpPortBitwidth));
+  header.set_destination_port(ParseBits(data, kUdpPortBitwidth));
+  header.set_length(ParseBits(data, kUdpLengthBitwidth));
+  header.set_checksum(ParseBits(data, kUdpChecksumBitwidth));
+  return header;
+}
+
+// Parse a TCP header prefix, or return error if the packet is too small.
+absl::StatusOr<TcpHeader> ParseTcpHeader(pdpi::BitString& data) {
+  if (data.size() < kStandardTcpHeaderBitwidth) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Packet is too short to parse a TCP header next. Only "
+           << data.size() << " bits left, need at least "
+           << kStandardTcpHeaderBitwidth << ".";
+  }
+
+  TcpHeader header;
+  header.set_source_port(ParseBits(data, kTcpPortBitwidth));
+  header.set_destination_port(ParseBits(data, kTcpPortBitwidth));
+  header.set_sequence_number(ParseBits(data, kTcpSequenceNumberBitwidth));
+  header.set_acknowledgement_number(
+      ParseBits(data, kTcpAcknowledgementNumberBitwidth));
+  header.set_data_offset(ParseBits(data, kTcpDataOffsetBitwidth));
+  header.set_rest_of_header(ParseBits(data, kTcpRestOfHeaderBitwidth));
+
+  // Parse suffix/options.
+  absl::StatusOr<int> offset = pdpi::HexStringToInt(header.data_offset());
+  if (!offset.ok()) {
+    LOG(DFATAL) << "SHOULD NEVER HAPPEN: data_offset badly formatted: "
+                << offset.status();
+    // Don't return error status so parsing is lossless despite error.
+    // The packet will be invalid, but this will be caught by validity checking.
+  } else if (*offset > 5) {
+    int options_bit_width = 32 * (*offset - 5);
+    // If the packet ends prematurely, we still parse what's there to maintain
+    // the property that parsing is lossless. The result is an invalid packet,
+    // since the IHL and the options length will be inconsistent, but this will
+    // be caught by the validity check.
+    if (data.size() < options_bit_width) {
+      options_bit_width = data.size();
+    }
+    header.set_uninterpreted_options(ParseBits(data, options_bit_width));
+  }
+  return header;
+}
+
+// Parse an ARP header, or return error if the packet is too small.
+absl::StatusOr<ArpHeader> ParseArpHeader(pdpi::BitString& data) {
+  if (data.size() < kArpHeaderBitwidth) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Packet is too short to parse an ARP header next. Only "
+           << data.size() << " bits left, need at least " << kArpHeaderBitwidth
+           << ".";
+  }
+
+  ArpHeader header;
+  header.set_hardware_type(ParseBits(data, kArpTypeBitwidth));
+  header.set_protocol_type(ParseBits(data, kArpTypeBitwidth));
+  header.set_hardware_length(ParseBits(data, kArpLengthBitwidth));
+  header.set_protocol_length(ParseBits(data, kArpLengthBitwidth));
+  header.set_operation(ParseBits(data, kArpOperationBitwidth));
+  header.set_sender_hardware_address(ParseMacAddress(data));
+  header.set_sender_protocol_address(ParseIpv4Address(data));
+  header.set_target_hardware_address(ParseMacAddress(data));
+  header.set_target_protocol_address(ParseIpv4Address(data));
+  return header;
+}
+
+// Parse an ICMP header, or return error if the packet is too small.
+absl::StatusOr<IcmpHeader> ParseIcmpHeader(pdpi::BitString& data) {
+  if (data.size() < kIcmpHeaderBitwidth) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Packet is too short to parse an ICMP header next. Only "
+           << data.size() << " bits left, need at least " << kIcmpHeaderBitwidth
+           << ".";
+  }
+
+  IcmpHeader header;
+  header.set_type(ParseBits(data, kIcmpTypeBitwidth));
+  header.set_code(ParseBits(data, kIcmpCodeBitwidth));
+  header.set_checksum(ParseBits(data, kIcmpChecksumBitwidth));
+  header.set_rest_of_header(ParseBits(data, kIcmpRestOfHeaderBitwidth));
+  return header;
+}
+
+// Parse a VLAN header, or return error if the packet is too small.
+absl::StatusOr<VlanHeader> ParseVlanHeader(pdpi::BitString& data) {
+  if (data.size() < kVlanHeaderBitwidth) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Packet is too short to parse a VLAN header next. Only "
+           << data.size() << " bits left, need at least " << kVlanHeaderBitwidth
+           << ".";
+  }
+
+  VlanHeader header;
+  header.set_priority_code_point(
+      ParseBits(data, kVlanPriorityCodePointBitwidth));
+  header.set_drop_eligible_indicator(
+      ParseBits(data, kVlanDropEligibilityIndicatorBitwidth));
+  header.set_vlan_identifier(ParseBits(data, kVlanVlanIdentifierBitwidth));
+  header.set_ethertype(ParseBits(data, kVlanEthertypeBitwidth));
+  return header;
+}
+
+// Parse a GRE header, or return error if the packet is too small.
+absl::StatusOr<GreHeader> ParseGreHeader(pdpi::BitString& data) {
+  int size = kRfc2784GreHeaderWithoutOptionalsBitwidth;
+
+  if (data.size() < size) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Packet is too short to parse a GRE header next. Only "
+           << data.size() << " bits left, need at least " << size << ".";
+  }
+
+  ASSIGN_OR_RETURN(std::string checksum_present,
+                   data.PeekHexString(kGreChecksumPresentBitwidth));
+
+  if (checksum_present == "0x1") {
+    size += kGreChecksumBitwidth + kGreReserved1Bitwidth;
+
+    if (data.size() < size) {
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Packet is too short to parse a GRE header with optional "
+                "fields. "
+                "Only "
+             << data.size() << " bits left, need at least " << size << ".";
+    }
+  }
+
+  GreHeader header;
+  header.set_checksum_present(ParseBits(data, kGreChecksumPresentBitwidth));
+  header.set_reserved0(ParseBits(data, kGreReserved0Bitwidth));
+  header.set_version(ParseBits(data, kGreVersionBitwidth));
+  header.set_protocol_type(ParseBits(data, kGreProtocolTypeBitwidth));
+
+  // Parse optional checksum and reserved1 fields.
+  if (checksum_present == "0x1") {
+    header.set_checksum(
+        ParseBits(data, std::min(data.size(), kGreChecksumBitwidth)));
+    header.set_reserved1(
+        ParseBits(data, std::min(data.size(), kGreReserved1Bitwidth)));
+  }
+
+  return header;
+}
+
+// Parse a SAI P4 BMv2 packet_in header, or return error if the packet is too
+// small.
+absl::StatusOr<SaiP4BMv2PacketInHeader> ParseSaiP4BMv2PacketInHeader(
+    pdpi::BitString& data) {
+  if (data.size() < kSaiP4BMv2PacketInHeaderBitwidth) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Packet is too short to parse a SAI P4 BMv2 packet_in header "
+              "next. Only "
+           << data.size() << " bits left, need at least "
+           << kSaiP4BMv2PacketInHeaderBitwidth << ".";
+  }
+
+  SaiP4BMv2PacketInHeader header;
+  header.set_ingress_port(
+      ParseBits(data, kSaiP4BMv2PacketInIngressPortBitwidth));
+  header.set_target_egress_port(
+      ParseBits(data, kSaiP4BMv2PacketInTargetEgressPortBitwidth));
+  header.set_unused_pad(ParseBits(data, kSaiP4BMv2PacketInUnusedPadBitwidth));
+  return header;
+}
+
+absl::StatusOr<Header> ParseHeader(Header::HeaderCase header_case,
+                                   pdpi::BitString& data) {
+  Header result;
+  switch (header_case) {
+    case Header::kEthernetHeader: {
+      ASSIGN_OR_RETURN(*result.mutable_ethernet_header(),
+                       ParseEthernetHeader(data));
+      return result;
+    }
+    case Header::kIpv4Header: {
+      ASSIGN_OR_RETURN(*result.mutable_ipv4_header(), ParseIpv4Header(data));
+      return result;
+    }
+    case Header::kIpv6Header: {
+      ASSIGN_OR_RETURN(*result.mutable_ipv6_header(), ParseIpv6Header(data));
+      return result;
+    }
+    case Header::kUdpHeader: {
+      ASSIGN_OR_RETURN(*result.mutable_udp_header(), ParseUdpHeader(data));
+      return result;
+    }
+    case Header::kTcpHeader: {
+      ASSIGN_OR_RETURN(*result.mutable_tcp_header(), ParseTcpHeader(data));
+      return result;
+    }
+    case Header::kArpHeader: {
+      ASSIGN_OR_RETURN(*result.mutable_arp_header(), ParseArpHeader(data));
+      return result;
+    }
+    case Header::kIcmpHeader: {
+      ASSIGN_OR_RETURN(*result.mutable_icmp_header(), ParseIcmpHeader(data));
+      return result;
+    }
+    case Header::kVlanHeader: {
+      ASSIGN_OR_RETURN(*result.mutable_vlan_header(), ParseVlanHeader(data));
+      return result;
+    }
+    case Header::kGreHeader: {
+      ASSIGN_OR_RETURN(*result.mutable_gre_header(), ParseGreHeader(data));
+      return result;
+    }
+    case Header::kSaiP4Bmv2PacketInHeader: {
+      ASSIGN_OR_RETURN(*result.mutable_sai_p4_bmv2_packet_in_header(),
+                       ParseSaiP4BMv2PacketInHeader(data));
+      return result;
+    }
+    case Header::HEADER_NOT_SET:
+      break;
+  }
+  return gutil::InvalidArgumentErrorBuilder()
+         << "unexpected HeaderCase: " << HeaderCaseName(header_case);
+}
+
+}  // namespace
+
+Packet ParsePacket(absl::string_view input, Header::HeaderCase first_header) {
+  pdpi::BitString data = pdpi::BitString::OfByteString(input);
+  Packet packet;
+
+  // Parse headers.
+  Header::HeaderCase next_header = first_header;
+  while (next_header != Header::HEADER_NOT_SET) {
+    absl::StatusOr<Header> header = ParseHeader(next_header, data);
+    if (!header.ok()) {
+      packet.add_reasons_invalid(std::string(header.status().message()));
+      break;
+    }
+    *packet.add_headers() = *header;
+    if (absl::StatusOr<NextHeader> next = GetNextHeader(*header); next.ok()) {
+      absl::visit(gutil::Overload{
+                      [&](Header::HeaderCase next) { next_header = next; },
+                      [&](UnsupportedNextHeader unsupported) {
+                        next_header = Header::HEADER_NOT_SET;
+                        packet.set_reason_not_fully_parsed(unsupported.reason);
+                      }},
+                  *next);
+    } else {
+      LOG(DFATAL) << "SHOULD NEVER HAPPEN: " << next.status();
+      next_header = Header::HEADER_NOT_SET;
+    }
+  }
+
+  // Set payload.
+  if (auto payload = data.ToByteString(); payload.ok()) {
+    packet.set_payload(*payload);
+  } else {
+    LOG(DFATAL) << payload.status();
+    packet.add_reasons_invalid(absl::StrCat(
+        "INTERNAL ERROR WHILE PARSING PAYLOAD: ", payload.status().ToString()));
+  }
+
+  // Check packet validity.
+  for (const auto& invalid_reason : PacketInvalidReasons(packet)) {
+    packet.add_reasons_invalid(invalid_reason);
+  }
+
+  return packet;
+}
+
+// ---- Validation -------------------------------------------------------------
+
+absl::Status ValidatePacket(const Packet& packet) {
+  std::vector<std::string> invalid = PacketInvalidReasons(packet);
+  if (invalid.empty()) return absl::OkStatus();
+  return gutil::InvalidArgumentErrorBuilder()
+         << "Packet invalid for the following reasons:\n- "
+         << absl::StrJoin(invalid, "\n- ");
+}
+
+namespace {
+
+void MacAddressInvalidReasons(absl::string_view address,
+                              const std::string& field,
+                              std::vector<std::string>& output) {
+  if (address.empty()) {
+    output.push_back(absl::StrCat(field, ": missing"));
+    return;
+  }
+  if (auto parsed_address = MacAddress::OfString(address);
+      !parsed_address.ok()) {
+    output.push_back(absl::StrCat(
+        field, ": invalid format: ", parsed_address.status().message()));
+  }
+}
+void Ipv4AddressInvalidReasons(absl::string_view address,
+                               const std::string& field,
+                               std::vector<std::string>& output) {
+  if (address.empty()) {
+    output.push_back(absl::StrCat(field, ": missing"));
+    return;
+  }
+  if (auto parsed_address = Ipv4Address::OfString(address);
+      !parsed_address.ok()) {
+    output.push_back(absl::StrCat(
+        field, ": invalid format: ", parsed_address.status().message()));
+  }
+}
+void Ipv6AddressInvalidReasons(absl::string_view address,
+                               const std::string& field,
+                               std::vector<std::string>& output) {
+  if (address.empty()) {
+    output.push_back(absl::StrCat(field, ": missing"));
+    return;
+  }
+  if (auto parsed_address = Ipv6Address::OfString(address);
+      !parsed_address.ok()) {
+    output.push_back(absl::StrCat(
+        field, ": invalid format: ", parsed_address.status().message()));
+  }
+}
+// Returns `true` if invalid, `false` otherwise.
+template <size_t num_bits>
+bool HexStringInvalidReasons(absl::string_view hex_string,
+                             const std::string& field,
+                             std::vector<std::string>& output) {
+  if (hex_string.empty()) {
+    output.push_back(absl::StrCat(field, ": missing"));
+    return true;
+  }
+  if (auto parsed = pdpi::HexStringToBitset<num_bits>(hex_string);
+      !parsed.ok()) {
+    output.push_back(
+        absl::StrCat(field, ": invalid format: ", parsed.status().message()));
+    return true;
+  }
+  return false;
+}
+
+bool Ipv4UninterpretedOptionsInvalidReasons(
+    absl::string_view uninterpreted_options, const std::string& error_prefix,
+    std::vector<std::string>& output) {
+  if (uninterpreted_options.empty()) return false;
+  if (auto bytes = pdpi::HexStringToByteString(uninterpreted_options);
+      !bytes.ok()) {
+    output.push_back(absl::StrCat(
+        error_prefix, "invalid format: ", bytes.status().message()));
+    return true;
+  } else if (int num_bits = bytes->size() * 8; num_bits % 32 != 0) {
+    output.push_back(absl::StrCat(error_prefix, "found ", num_bits,
+                                  " bits, but expected multiple of 32 bits"));
+    return true;
+  }
+  return false;
+}
+
+bool TcpUninterpretedOptionsInvalidReasons(
+    absl::string_view uninterpreted_options, const std::string& error_prefix,
+    std::vector<std::string>& output) {
+  if (uninterpreted_options.empty()) return false;
+  if (auto bytes = pdpi::HexStringToByteString(uninterpreted_options);
+      !bytes.ok()) {
+    output.push_back(absl::StrCat(
+        error_prefix, "invalid format: ", bytes.status().message()));
+    return true;
+  } else if (int num_bits = bytes->size() * 8; num_bits % 32 != 0) {
+    output.push_back(absl::StrCat(error_prefix, "found ", num_bits,
+                                  " bits, but expected multiple of 32 bits"));
+    return true;
+  } else if (int num_words = num_bits / 32; num_words > 10) {
+    output.push_back(absl::StrCat(error_prefix, "found ", num_words,
+                                  " 32-bit words, but at most 10 are allowed"));
+  }
+  return false;
+}
+
+bool GreOptionalFieldsInvalidReasons(const std::string& checksum,
+                                     const std::string& reserved1,
+                                     const std::string& error_prefix,
+                                     std::vector<std::string>& output) {
+  if (checksum.empty() && reserved1.empty()) return false;
+
+  bool invalid = false;
+  if (auto bytes = pdpi::HexStringToByteString(checksum); !bytes.ok()) {
+    output.push_back(absl::StrCat(
+        error_prefix, "invalid format: ", bytes.status().message()));
+    invalid = true;
+  } else if (int num_bits = bytes->size() * 8; num_bits != 16) {
+    output.push_back(absl::StrCat(error_prefix, "found ", num_bits,
+                                  " bits, but expected 16 bits"));
+    invalid = true;
+  }
+
+  if (auto bytes = pdpi::HexStringToByteString(reserved1); !bytes.ok()) {
+    output.push_back(absl::StrCat(
+        error_prefix, "invalid format: ", bytes.status().message()));
+    invalid = true;
+  } else if (int num_bits = bytes->size() * 8; num_bits != 16) {
+    output.push_back(absl::StrCat(error_prefix, "found ", num_bits,
+                                  " bits, but expected 16 bits"));
+    invalid = true;
+  }
+
+  return invalid;
+}
+
+void EthernetHeaderInvalidReasons(const EthernetHeader& header,
+                                  const std::string& field_prefix,
+                                  const Packet& packet, int header_index,
+                                  std::vector<std::string>& output) {
+  MacAddressInvalidReasons(header.ethernet_destination(),
+                           absl::StrCat(field_prefix, "ethernet_destination"),
+                           output);
+  MacAddressInvalidReasons(header.ethernet_source(),
+                           absl::StrCat(field_prefix, "ethernet_source"),
+                           output);
+  bool ethertype_invalid = HexStringInvalidReasons<kEthernetEthertypeBitwidth>(
+      header.ethertype(), absl::StrCat(field_prefix, "ethertype"), output);
+
+  // Check EtherType and minimum payload size, see
+  // https://en.wikipedia.org/wiki/EtherType.
+  if (auto size = PacketSizeInBytes(packet, header_index + 1); !size.ok()) {
+    output.push_back(absl::StrCat(
+        field_prefix,
+        "couldn't compute payload size: ", size.status().ToString()));
+  } else if (auto ethertype = pdpi::HexStringToInt(header.ethertype());
+             !ethertype_invalid && !ethertype.ok()) {
+    LOG(DFATAL) << field_prefix << "ethertype invalid despite previous check: "
+                << ethertype.status();
+    output.push_back(absl::StrCat(field_prefix, "ethertype: INTERNAL ERROR: ",
+                                  ethertype.status().ToString()));
+  } else if (*ethertype <= 1500 && *size != *ethertype) {
+    output.push_back(
+        absl::StrFormat("%sethertype: value %s is <= 1500 and should thus "
+                        "match payload size, but payload size is %d bytes",
+                        field_prefix, header.ethertype(), *size));
+
+  } else if (*ethertype > 1500 && *size < kMinNumBytesInEthernetPayload) {
+    output.push_back(absl::StrCat(
+        field_prefix, "expected at least ", kMinNumBytesInEthernetPayload,
+        " bytes of Ethernet payload, but got only ", *size));
+  }
+}
+
+void Ipv4HeaderInvalidReasons(const Ipv4Header& header,
+                              const std::string& field_prefix,
+                              const Packet& packet, int header_index,
+                              std::vector<std::string>& output) {
+  bool version_invalid = HexStringInvalidReasons<kIpVersionBitwidth>(
+      header.version(), absl::StrCat(field_prefix, "version"), output);
+  bool ihl_invalid = HexStringInvalidReasons<kIpIhlBitwidth>(
+      header.ihl(), absl::StrCat(field_prefix, "ihl"), output);
+  HexStringInvalidReasons<kIpDscpBitwidth>(
+      header.dscp(), absl::StrCat(field_prefix, "dscp"), output);
+  HexStringInvalidReasons<kIpEcnBitwidth>(
+      header.ecn(), absl::StrCat(field_prefix, "ecn"), output);
+  bool length_invalid = HexStringInvalidReasons<kIpTotalLengthBitwidth>(
+      header.total_length(), absl::StrCat(field_prefix, "total_length"),
+      output);
+  HexStringInvalidReasons<kIpIdentificationBitwidth>(
+      header.identification(), absl::StrCat(field_prefix, "identification"),
+      output);
+  HexStringInvalidReasons<kIpFlagsBitwidth>(
+      header.flags(), absl::StrCat(field_prefix, "flags"), output);
+  HexStringInvalidReasons<kIpFragmentOffsetBitwidth>(
+      header.fragment_offset(), absl::StrCat(field_prefix, "fragment_offset"),
+      output);
+  HexStringInvalidReasons<kIpTtlBitwidth>(
+      header.ttl(), absl::StrCat(field_prefix, "ttl"), output);
+  HexStringInvalidReasons<kIpProtocolBitwidth>(
+      header.protocol(), absl::StrCat(field_prefix, "protocol"), output);
+  bool checksum_invalid = HexStringInvalidReasons<kIpChecksumBitwidth>(
+      header.checksum(), absl::StrCat(field_prefix, "checksum"), output);
+  Ipv4AddressInvalidReasons(header.ipv4_source(),
+                            absl::StrCat(field_prefix, "ipv4_source"), output);
+  Ipv4AddressInvalidReasons(header.ipv4_destination(),
+                            absl::StrCat(field_prefix, "ipv4_destination"),
+                            output);
+  bool options_invalid = Ipv4UninterpretedOptionsInvalidReasons(
+      header.uninterpreted_options(),
+      absl::StrCat(field_prefix, "uninterpreted_options: "), output);
+
+  // Check computed fields.
+  if (!ihl_invalid) {
+    if (options_invalid) {
+      output.push_back(absl::StrCat(field_prefix,
+                                    "ihl: Correct value undefined since "
+                                    "uninterpreted_options is invalid."));
+    } else {
+      absl::string_view options = header.uninterpreted_options();
+      // 4 bits for every hex char after "0x"-prefix.
+      int options_bitwidth = options.empty() ? 0 : 4 * (options.size() - 2);
+      int num_32bit_words = 5 + options_bitwidth / 32;
+      std::string expected =
+          pdpi::BitsetToHexString<kIpIhlBitwidth>(num_32bit_words);
+      if (header.ihl() != expected) {
+        output.push_back(absl::StrCat(field_prefix, "ihl: Must be ", expected,
+                                      ", but was ", header.ihl(), " instead."));
+      }
+    }
+  }
+  if (!version_invalid && header.version() != "0x4") {
+    output.push_back(absl::StrCat(field_prefix,
+                                  "version: Must be 0x4, but was ",
+                                  header.version(), " instead."));
+  }
+  if (!length_invalid) {
+    if (auto size = PacketSizeInBytes(packet, header_index); !size.ok()) {
+      output.push_back(absl::StrCat(
+          field_prefix, "total_length: Couldn't compute expected size: ",
+          size.status().ToString()));
+    } else {
+      std::string expected =
+          pdpi::BitsetToHexString(std::bitset<kIpTotalLengthBitwidth>(*size));
+      if (header.total_length() != expected) {
+        output.push_back(absl::StrCat(field_prefix, "total_length: Must be ",
+                                      expected, ", but was ",
+                                      header.total_length(), " instead."));
+      }
+    }
+  }
+  if (!checksum_invalid) {
+    if (auto checksum = Ipv4HeaderChecksum(header); !checksum.ok()) {
+      output.push_back(absl::StrCat(
+          field_prefix, "checksum: Couldn't compute expected checksum: ",
+          checksum.status().ToString()));
+    } else {
+      std::string expected =
+          pdpi::BitsetToHexString(std::bitset<kIpChecksumBitwidth>(*checksum));
+      if (header.checksum() != expected) {
+        output.push_back(absl::StrCat(field_prefix, "checksum: Must be ",
+                                      expected, ", but was ", header.checksum(),
+                                      " instead."));
+      }
+    }
+  }
+}
+
+void Ipv6HeaderInvalidReasons(const Ipv6Header& header,
+                              const std::string& field_prefix,
+                              const Packet& packet, int header_index,
+                              std::vector<std::string>& output) {
+  bool version_invalid = HexStringInvalidReasons<kIpVersionBitwidth>(
+      header.version(), absl::StrCat(field_prefix, "version"), output);
+  HexStringInvalidReasons<kIpDscpBitwidth>(
+      header.dscp(), absl::StrCat(field_prefix, "dscp"), output);
+  HexStringInvalidReasons<kIpEcnBitwidth>(
+      header.ecn(), absl::StrCat(field_prefix, "ecn"), output);
+  HexStringInvalidReasons<kIpFlowLabelBitwidth>(
+      header.flow_label(), absl::StrCat(field_prefix, "flow_label"), output);
+  bool length_invalid = HexStringInvalidReasons<kIpPayloadLengthBitwidth>(
+      header.payload_length(), absl::StrCat(field_prefix, "payload_length"),
+      output);
+  HexStringInvalidReasons<kIpNextHeaderBitwidth>(
+      header.next_header(), absl::StrCat(field_prefix, "next_header"), output);
+  HexStringInvalidReasons<kIpHopLimitBitwidth>(
+      header.hop_limit(), absl::StrCat(field_prefix, "hop_limit"), output);
+  Ipv6AddressInvalidReasons(header.ipv6_source(),
+                            absl::StrCat(field_prefix, "ipv6_source"), output);
+  Ipv6AddressInvalidReasons(header.ipv6_destination(),
+                            absl::StrCat(field_prefix, "ipv6_destination"),
+                            output);
+
+  // Check computed fields.
+  if (!version_invalid && header.version() != "0x6") {
+    output.push_back(absl::StrCat(field_prefix,
+                                  "version: Must be 0x6, but was ",
+                                  header.version(), " instead."));
+  }
+  if (!length_invalid) {
+    // `+1` to skip the IPv6 header and previous headers in the calculation.
+    if (auto size = PacketSizeInBytes(packet, header_index + 1); !size.ok()) {
+      output.push_back(absl::StrCat(
+          field_prefix, "total_length: Couldn't compute expected size: ",
+          size.status().ToString()));
+    } else {
+      std::string expected =
+          pdpi::BitsetToHexString(std::bitset<kIpPayloadLengthBitwidth>(*size));
+      if (header.payload_length() != expected) {
+        output.push_back(absl::StrCat(field_prefix, "payload_length: Must be ",
+                                      expected, ", but was ",
+                                      header.payload_length(), " instead."));
+      }
+    }
+  }
+}
+
+void UdpHeaderInvalidReasons(const UdpHeader& header,
+                             const std::string& field_prefix,
+                             const Packet& packet, int header_index,
+                             std::vector<std::string>& output) {
+  HexStringInvalidReasons<kUdpPortBitwidth>(
+      header.source_port(), absl::StrCat(field_prefix, "source_port"), output);
+  HexStringInvalidReasons<kUdpPortBitwidth>(
+      header.destination_port(), absl::StrCat(field_prefix, "destination_port"),
+      output);
+  bool length_invalid = HexStringInvalidReasons<kUdpLengthBitwidth>(
+      header.length(), absl::StrCat(field_prefix, "length"), output);
+  bool checksum_invalid = HexStringInvalidReasons<kUdpChecksumBitwidth>(
+      header.checksum(), absl::StrCat(field_prefix, "checksum"), output);
+
+  // Check computed field: length.
+  if (!length_invalid) {
+    if (auto size = PacketSizeInBytes(packet, header_index); !size.ok()) {
+      output.push_back(absl::StrCat(field_prefix,
+                                    "length: Couldn't compute expected size: ",
+                                    size.status().ToString()));
+    } else {
+      std::string expected =
+          pdpi::BitsetToHexString(std::bitset<kUdpLengthBitwidth>(*size));
+      if (header.length() != expected) {
+        output.push_back(absl::StrCat(field_prefix, "length: Must be ",
+                                      expected, ", but was ", header.length(),
+                                      " instead."));
+      }
+    }
+  }
+  // Check computed field: checksum.
+  if (header_index <= 0) {
+    output.push_back(absl::StrCat(
+        field_prefix,
+        "checksum: UDP header must be preceded by IP header for checksum to be "
+        "defined; found no header instead"));
+  } else if (auto previous = packet.headers(header_index - 1).header_case();
+             previous != Header::kIpv4Header &&
+             previous != Header::kIpv6Header) {
+    output.push_back(absl::StrCat(
+        field_prefix,
+        "checksum: UDP header must be preceded by IP header for checksum to be "
+        "defined; found ",
+        HeaderCaseName(previous), " at headers[", (header_index - 1),
+        "] instead"));
+  } else if (!checksum_invalid) {
+    if (auto checksum = UdpHeaderChecksum(packet, header_index);
+        !checksum.ok()) {
+      output.push_back(absl::StrCat(
+          field_prefix, "checksum: Couldn't compute expected checksum: ",
+          checksum.status().ToString()));
+    } else {
+      std::string expected =
+          pdpi::BitsetToHexString(std::bitset<kUdpChecksumBitwidth>(*checksum));
+      if (header.checksum() != expected) {
+        output.push_back(absl::StrCat(field_prefix, "checksum: Must be ",
+                                      expected, ", but was ", header.checksum(),
+                                      " instead."));
+      }
+    }
+  }
+}
+
+void TcpHeaderInvalidReasons(const TcpHeader& header,
+                             const std::string& field_prefix,
+                             const Packet& packet, int header_index,
+                             std::vector<std::string>& output) {
+  HexStringInvalidReasons<kUdpPortBitwidth>(
+      header.source_port(), absl::StrCat(field_prefix, "source_port"), output);
+  HexStringInvalidReasons<kUdpPortBitwidth>(
+      header.destination_port(), absl::StrCat(field_prefix, "destination_port"),
+      output);
+  HexStringInvalidReasons<kTcpSequenceNumberBitwidth>(
+      header.sequence_number(), absl::StrCat(field_prefix, "sequence_number"),
+      output);
+  HexStringInvalidReasons<kTcpAcknowledgementNumberBitwidth>(
+      header.acknowledgement_number(),
+      absl::StrCat(field_prefix, "acknowledgement_number"), output);
+  bool data_offset_invalid = HexStringInvalidReasons<kTcpDataOffsetBitwidth>(
+      header.data_offset(), absl::StrCat(field_prefix, "data_offset"), output);
+  HexStringInvalidReasons<kTcpRestOfHeaderBitwidth>(
+      header.rest_of_header(), absl::StrCat(field_prefix, "rest_of_header"),
+      output);
+  bool options_invalid = TcpUninterpretedOptionsInvalidReasons(
+      header.uninterpreted_options(),
+      absl::StrCat(field_prefix, "uninterpreted_options: "), output);
+
+  // Check computed fields.
+  if (!data_offset_invalid) {
+    if (options_invalid) {
+      output.push_back(absl::StrCat(field_prefix,
+                                    "data_offset: Correct value undefined "
+                                    "since uninterpreted_options is invalid."));
+    } else {
+      absl::string_view options = header.uninterpreted_options();
+      // 4 bits for every hex char after "0x"-prefix.
+      int options_bitwidth = options.empty() ? 0 : 4 * (options.size() - 2);
+      int num_32bit_words = 5 + options_bitwidth / 32;
+      std::string expected =
+          pdpi::BitsetToHexString<kIpIhlBitwidth>(num_32bit_words);
+      if (header.data_offset() != expected) {
+        output.push_back(absl::StrCat(field_prefix, "data_offset: Must be ",
+                                      expected, ", but was ",
+                                      header.data_offset(), " instead."));
+      }
+    }
+  }
+}
+
+void ArpHeaderInvalidReasons(const ArpHeader& header,
+                             const std::string& field_prefix,
+                             const Packet& packet, int header_index,
+                             std::vector<std::string>& output) {
+  bool hardware_type_invalid = HexStringInvalidReasons<kArpTypeBitwidth>(
+      header.hardware_type(), absl::StrCat(field_prefix, "hardware_type"),
+      output);
+  bool protocol_type_invalid = HexStringInvalidReasons<kArpTypeBitwidth>(
+      header.protocol_type(), absl::StrCat(field_prefix, "protocol_type"),
+      output);
+  bool hardware_length_invalid = HexStringInvalidReasons<kArpLengthBitwidth>(
+      header.hardware_length(), absl::StrCat(field_prefix, "hardware_length"),
+      output);
+  bool protocol_length_invalid = HexStringInvalidReasons<kArpLengthBitwidth>(
+      header.protocol_length(), absl::StrCat(field_prefix, "protocol_length"),
+      output);
+  HexStringInvalidReasons<kArpOperationBitwidth>(
+      header.operation(), absl::StrCat(field_prefix, "operation"), output);
+  MacAddressInvalidReasons(
+      header.sender_hardware_address(),
+      absl::StrCat(field_prefix, "sender_hardware_address"), output);
+  Ipv4AddressInvalidReasons(
+      header.sender_protocol_address(),
+      absl::StrCat(field_prefix, "sender_protocol_address"), output);
+  MacAddressInvalidReasons(
+      header.target_hardware_address(),
+      absl::StrCat(field_prefix, "target_hardware_address"), output);
+  Ipv4AddressInvalidReasons(
+      header.target_protocol_address(),
+      absl::StrCat(field_prefix, "target_protocol_address"), output);
+
+  if (!hardware_type_invalid && header.hardware_type() != "0x0001") {
+    output.push_back(absl::StrCat(field_prefix,
+                                  "hardware_type: Must be 0x0001, but was ",
+                                  header.hardware_type(), " instead."));
+  }
+  if (!protocol_type_invalid && header.protocol_type() != "0x0800") {
+    output.push_back(absl::StrCat(field_prefix,
+                                  "protocol_type: Must be 0x0800, but was ",
+                                  header.protocol_type(), " instead."));
+  }
+  if (!hardware_length_invalid && header.hardware_length() != "0x06") {
+    output.push_back(absl::StrCat(field_prefix,
+                                  "hardware_length: Must be 0x06, but was ",
+                                  header.hardware_length(), " instead."));
+  }
+  if (!protocol_length_invalid && header.protocol_length() != "0x04") {
+    output.push_back(absl::StrCat(field_prefix,
+                                  "hardware_type: Must be 0x04, but was ",
+                                  header.protocol_length(), " instead."));
+  }
+}
+
+void IcmpHeaderInvalidReasons(const IcmpHeader& header,
+                              const std::string& field_prefix,
+                              const Packet& packet, int header_index,
+                              std::vector<std::string>& output) {
+  HexStringInvalidReasons<kIcmpTypeBitwidth>(
+      header.type(), absl::StrCat(field_prefix, "type"), output);
+  HexStringInvalidReasons<kIcmpCodeBitwidth>(
+      header.code(), absl::StrCat(field_prefix, "code"), output);
+  bool checksum_invalid = HexStringInvalidReasons<kIcmpChecksumBitwidth>(
+      header.checksum(), absl::StrCat(field_prefix, "checksum"), output);
+  HexStringInvalidReasons<kIcmpRestOfHeaderBitwidth>(
+      header.rest_of_header(), absl::StrCat(field_prefix, "rest_of_header"),
+      output);
+
+  // ICMP should be preceded by either an IPv4 or IPv6 header.
+  if (header_index <= 0) {
+    output.push_back(absl::StrCat(field_prefix,
+                                  "checksum: ICMP header must be preceded by "
+                                  "IP header for checksum to be "
+                                  "defined; found no header instead"));
+    return;
+  }
+  Header::HeaderCase previous = packet.headers(header_index - 1).header_case();
+  if (previous != Header::kIpv4Header && previous != Header::kIpv6Header) {
+    output.push_back(absl::StrCat(field_prefix,
+                                  "checksum: ICMP header must be preceded by "
+                                  "IP header for checksum to be "
+                                  "defined; found ",
+                                  HeaderCaseName(previous), " at headers[",
+                                  (header_index - 1), "] instead"));
+    return;
+  }
+
+  // Validate checksum if it isn't invalid.
+  if (checksum_invalid) {
+    return;
+  }
+  if (auto checksum = IcmpHeaderChecksum(packet, header_index);
+      !checksum.ok()) {
+    output.push_back(absl::StrCat(
+        field_prefix, "checksum: Couldn't compute expected checksum: ",
+        checksum.status().ToString()));
+  } else {
+    std::string expected =
+        pdpi::BitsetToHexString(std::bitset<kIcmpChecksumBitwidth>(*checksum));
+    if (header.checksum() != expected) {
+      output.push_back(absl::StrCat(field_prefix, "checksum: Must be ",
+                                    expected, ", but was ", header.checksum(),
+                                    " instead."));
+    }
+  }
+}
+
+void VlanHeaderInvalidReasons(const VlanHeader& header,
+                              const std::string& field_prefix,
+                              const Packet& packet, int header_index,
+                              std::vector<std::string>& output) {
+  HexStringInvalidReasons<kVlanPriorityCodePointBitwidth>(
+      header.priority_code_point(),
+      absl::StrCat(field_prefix, "priority_code_point"), output);
+  HexStringInvalidReasons<kVlanDropEligibilityIndicatorBitwidth>(
+      header.drop_eligible_indicator(),
+      absl::StrCat(field_prefix, "drop_eligible_indicator"), output);
+  HexStringInvalidReasons<kVlanVlanIdentifierBitwidth>(
+      header.vlan_identifier(), absl::StrCat(field_prefix, "vlan_identifier"),
+      output);
+  HexStringInvalidReasons<kVlanEthertypeBitwidth>(
+      header.ethertype(), absl::StrCat(field_prefix, "ethertype"), output);
+}
+
+void GreHeaderInvalidReasons(const GreHeader& header,
+                             const std::string& field_prefix,
+                             const Packet& packet, int header_index,
+                             std::vector<std::string>& output) {
+  bool checksum_present_invalid =
+      HexStringInvalidReasons<kGreChecksumPresentBitwidth>(
+          header.checksum_present(),
+          absl::StrCat(field_prefix, "checksum_present"), output);
+  bool reserved0_invalid = HexStringInvalidReasons<kGreReserved0Bitwidth>(
+      header.reserved0(), absl::StrCat(field_prefix, "reserved0"), output);
+  bool version_invalid = HexStringInvalidReasons<kGreVersionBitwidth>(
+      header.version(), absl::StrCat(field_prefix, "version"), output);
+
+  if (!reserved0_invalid && header.reserved0() != "0x000") {
+    output.push_back(absl::StrCat(field_prefix,
+                                  "reserved0: Must be 0x000, but was ",
+                                  header.reserved0(), " instead."));
+  }
+
+  if (!version_invalid && header.version() != "0x0") {
+    output.push_back(absl::StrCat(field_prefix,
+                                  "version: Must be 0x0, but was ",
+                                  header.version(), " instead."));
+  }
+
+  if (checksum_present_invalid || header.checksum_present() != "0x1") {
+    if (!header.checksum().empty())
+      output.push_back(
+          absl::StrCat(field_prefix,
+                       "Checksum_present: checksum present bit is not set and "
+                       "checksum must be empty, but was '",
+                       header.checksum(), "' instead."));
+    if (!header.reserved1().empty())
+      output.push_back(
+          absl::StrCat(field_prefix,
+                       "Checksum_present: checksum present bit is not set and "
+                       "reserved1 must be empty, but was ",
+                       header.reserved1(), " instead."));
+    return;
+  }
+
+  bool optional_fields_invalid = GreOptionalFieldsInvalidReasons(
+      header.checksum(), header.reserved1(),
+      absl::StrCat(field_prefix, "optional fields: "), output);
+
+  if (optional_fields_invalid) {
+    output.push_back(absl::StrCat(field_prefix,
+                                  "checksum_present: checksum present bit is "
+                                  "set, but optional fields are invalid."));
+  } else {
+    // Check computed field: checksum.
+    if (auto checksum = GreHeaderChecksum(packet, header_index);
+        !checksum.ok()) {
+      output.push_back(absl::StrCat(
+          field_prefix, "checksum: Couldn't compute expected checksum: ",
+          checksum.status().ToString()));
+    } else {
+      std::string expected =
+          pdpi::BitsetToHexString(std::bitset<kGreChecksumBitwidth>(*checksum));
+      if (header.checksum() != expected) {
+        output.push_back(absl::StrCat(field_prefix, "checksum: Must be ",
+                                      expected, ", but was ", header.checksum(),
+                                      " instead."));
+      }
+    }
+
+    if (header.reserved1() != "0x0000") {
+      output.push_back(absl::StrCat(field_prefix,
+                                    "reserved1: Must be 0x0000, but was ",
+                                    header.reserved1(), " instead."));
+    }
+  }
+}
+
+void SaiP4BMv2PacketInHeaderInvalidReasons(
+    const SaiP4BMv2PacketInHeader& header, const std::string& field_prefix,
+    const Packet& packet, int header_index, std::vector<std::string>& output) {
+  HexStringInvalidReasons<kSaiP4BMv2PacketInIngressPortBitwidth>(
+      header.ingress_port(), absl::StrCat(field_prefix, "ingress_port"),
+      output);
+  HexStringInvalidReasons<kSaiP4BMv2PacketInTargetEgressPortBitwidth>(
+      header.target_egress_port(),
+      absl::StrCat(field_prefix, "target_egress_port"), output);
+  bool unused_pad_invalid =
+      HexStringInvalidReasons<kSaiP4BMv2PacketInUnusedPadBitwidth>(
+          header.unused_pad(), absl::StrCat(field_prefix, "unused_pad"),
+          output);
+
+  if (!unused_pad_invalid) {
+    absl::StatusOr<int> unused_pad = pdpi::HexStringToInt(header.unused_pad());
+    if (!unused_pad.ok()) {
+      LOG(DFATAL) << "SHOULD NEVER HAPPEN: unused_pad badly formatted: "
+                  << unused_pad.status();
+    }
+    if (*unused_pad != 0) {
+      output.push_back(absl::StrCat(field_prefix,
+                                    "unused_pad: Must be 0, but was ",
+                                    header.unused_pad(), " instead."));
+    }
+  }
+}
+}  // namespace
+
+std::string HeaderCaseName(Header::HeaderCase header_case) {
+  switch (header_case) {
+    case Header::kEthernetHeader:
+      return "EthernetHeader";
+    case Header::kIpv4Header:
+      return "Ipv4Header";
+    case Header::kIpv6Header:
+      return "Ipv6Header";
+    case Header::kUdpHeader:
+      return "UdpHeader";
+    case Header::kTcpHeader:
+      return "TcpHeader";
+    case Header::kArpHeader:
+      return "ArpHeader";
+    case Header::kIcmpHeader:
+      return "IcmpHeader";
+    case Header::kVlanHeader:
+      return "VlanHeader";
+    case Header::kGreHeader:
+      return "GreHeader";
+    case Header::kSaiP4Bmv2PacketInHeader:
+      return "SaiP4BMv2PacketInHeader";
+    case Header::HEADER_NOT_SET:
+      return "HEADER_NOT_SET";
+  }
+  LOG(DFATAL) << "unexpected HeaderCase: " << header_case;
+  return "";
+}
+
+std::vector<std::string> PacketInvalidReasons(const Packet& packet) {
+  std::vector<std::string> result;
+
+  if (packet.ByteSize() == 0) {
+    result.push_back("Packet is empty.");
+    return result;
+  }
+
+  if (auto bitsize = PacketSizeInBits(packet); !bitsize.ok()) {
+    result.push_back(absl::StrCat("Unable to determine total packet size: ",
+                                  bitsize.status().ToString()));
+  } else if (*bitsize % 8 != 0) {
+    result.push_back(absl::StrCat(
+        "Packet size must be multiple of 8 bits; found ", *bitsize, " bits"));
+  }
+
+  Header::HeaderCase expected_header_case =
+      packet.headers().empty() ? Header::HEADER_NOT_SET
+                               : packet.headers(0).header_case();
+  int index = -1;
+  for (const Header& header : packet.headers()) {
+    index += 1;
+    const std::string error_prefix = absl::StrFormat(
+        "in %s headers[%d]: ", HeaderCaseName(header.header_case()), index);
+
+    switch (header.header_case()) {
+      case Header::kEthernetHeader:
+        EthernetHeaderInvalidReasons(header.ethernet_header(), error_prefix,
+                                     packet, index, result);
+        break;
+      case Header::kIpv4Header:
+        Ipv4HeaderInvalidReasons(header.ipv4_header(), error_prefix, packet,
+                                 index, result);
+        break;
+      case Header::kIpv6Header:
+        Ipv6HeaderInvalidReasons(header.ipv6_header(), error_prefix, packet,
+                                 index, result);
+        break;
+      case Header::kUdpHeader: {
+        UdpHeaderInvalidReasons(header.udp_header(), error_prefix, packet,
+                                index, result);
+        break;
+      }
+      case Header::kTcpHeader: {
+        TcpHeaderInvalidReasons(header.tcp_header(), error_prefix, packet,
+                                index, result);
+        break;
+      }
+      case Header::kArpHeader: {
+        ArpHeaderInvalidReasons(header.arp_header(), error_prefix, packet,
+                                index, result);
+        break;
+      }
+      case Header::kIcmpHeader: {
+        IcmpHeaderInvalidReasons(header.icmp_header(), error_prefix, packet,
+                                 index, result);
+        break;
+      }
+      case Header::kVlanHeader: {
+        VlanHeaderInvalidReasons(header.vlan_header(), error_prefix, packet,
+                                 index, result);
+        break;
+      }
+      case Header::kGreHeader: {
+        GreHeaderInvalidReasons(header.gre_header(), error_prefix, packet,
+                                index, result);
+        break;
+      }
+      case Header::kSaiP4Bmv2PacketInHeader: {
+        SaiP4BMv2PacketInHeaderInvalidReasons(
+            header.sai_p4_bmv2_packet_in_header(), error_prefix, packet, index,
+            result);
+        break;
+      }
+      case Header::HEADER_NOT_SET:
+        result.push_back(absl::StrCat(error_prefix, "header uninitialized"));
+        continue;  // skip expected_header_case check
+    }
+
+    // Check order of headers.
+    if (expected_header_case == Header::HEADER_NOT_SET) {
+      result.push_back(absl::StrCat(
+          error_prefix,
+          "expected no header (because the previous header demands either no "
+          "header or an unsupported header), got ",
+          HeaderCaseName(header.header_case())));
+    } else if (header.header_case() != expected_header_case) {
+      result.push_back(absl::StrCat(
+          error_prefix, "expected ", HeaderCaseName(expected_header_case),
+          " (because the previous header demands it), got ",
+          HeaderCaseName(header.header_case())));
+    }
+
+    // Update `expected_header_case`.
+    if (absl::StatusOr<NextHeader> next = GetNextHeader(header); next.ok()) {
+      expected_header_case = absl::visit(
+          gutil::Overload{
+              [](Header::HeaderCase next) { return next; },
+              [](UnsupportedNextHeader) { return Header::HEADER_NOT_SET; }},
+          *next);
+    } else {
+      expected_header_case = Header::HEADER_NOT_SET;
+    }
+  }
+
+  if (expected_header_case != Header::HEADER_NOT_SET) {
+    result.push_back(absl::StrCat("headers[", packet.headers().size(),
+                                  "]: header missing - expected ",
+                                  HeaderCaseName(expected_header_case)));
+  }
+
+  return result;
+}
+
+// ---- Serialization ----------------------------------------------------------
+
+namespace {
+
+absl::Status SerializeMacAddress(absl::string_view address,
+                                 pdpi::BitString& output) {
+  ASSIGN_OR_RETURN(MacAddress parsed_address, MacAddress::OfString(address));
+  output.AppendBits(parsed_address.ToBitset());
+  return absl::OkStatus();
+}
+absl::Status SerializeIpv4Address(absl::string_view address,
+                                  pdpi::BitString& output) {
+  ASSIGN_OR_RETURN(Ipv4Address parsed_address, Ipv4Address::OfString(address));
+  output.AppendBits(parsed_address.ToBitset());
+  return absl::OkStatus();
+}
+absl::Status SerializeIpv6Address(absl::string_view address,
+                                  pdpi::BitString& output) {
+  ASSIGN_OR_RETURN(Ipv6Address parsed_address, Ipv6Address::OfString(address));
+  output.AppendBits(parsed_address.ToBitset());
+  return absl::OkStatus();
+}
+template <size_t num_bits>
+absl::Status SerializeBits(absl::string_view hex_string,
+                           pdpi::BitString& output) {
+  ASSIGN_OR_RETURN(auto bitset, pdpi::HexStringToBitset<num_bits>(hex_string));
+  output.AppendBits(bitset);
+  return absl::OkStatus();
+}
+
+absl::Status SerializeEthernetHeader(const EthernetHeader& header,
+                                     pdpi::BitString& output) {
+  RETURN_IF_ERROR(SerializeMacAddress(header.ethernet_destination(), output));
+  RETURN_IF_ERROR(SerializeMacAddress(header.ethernet_source(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kEthernetEthertypeBitwidth>(header.ethertype(), output));
+  return absl::OkStatus();
+}
+
+absl::Status SerializeIpv4Header(const Ipv4Header& header,
+                                 pdpi::BitString& output) {
+  RETURN_IF_ERROR(SerializeBits<kIpVersionBitwidth>(header.version(), output));
+  RETURN_IF_ERROR(SerializeBits<kIpIhlBitwidth>(header.ihl(), output));
+  RETURN_IF_ERROR(SerializeBits<kIpDscpBitwidth>(header.dscp(), output));
+  RETURN_IF_ERROR(SerializeBits<kIpEcnBitwidth>(header.ecn(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kIpTotalLengthBitwidth>(header.total_length(), output));
+  RETURN_IF_ERROR(SerializeBits<kIpIdentificationBitwidth>(
+      header.identification(), output));
+  RETURN_IF_ERROR(SerializeBits<kIpFlagsBitwidth>(header.flags(), output));
+  RETURN_IF_ERROR(SerializeBits<kIpFragmentOffsetBitwidth>(
+      header.fragment_offset(), output));
+  RETURN_IF_ERROR(SerializeBits<kIpTtlBitwidth>(header.ttl(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kIpProtocolBitwidth>(header.protocol(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kIpChecksumBitwidth>(header.checksum(), output));
+  RETURN_IF_ERROR(SerializeIpv4Address(header.ipv4_source(), output));
+  RETURN_IF_ERROR(SerializeIpv4Address(header.ipv4_destination(), output));
+  if (!header.uninterpreted_options().empty()) {
+    RETURN_IF_ERROR(output.AppendHexString(header.uninterpreted_options()));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status SerializeIpv6Header(const Ipv6Header& header,
+                                 pdpi::BitString& output) {
+  RETURN_IF_ERROR(SerializeBits<kIpVersionBitwidth>(header.version(), output));
+  RETURN_IF_ERROR(SerializeBits<kIpDscpBitwidth>(header.dscp(), output));
+  RETURN_IF_ERROR(SerializeBits<kIpEcnBitwidth>(header.ecn(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kIpFlowLabelBitwidth>(header.flow_label(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kIpPayloadLengthBitwidth>(header.payload_length(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kIpNextHeaderBitwidth>(header.next_header(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kIpHopLimitBitwidth>(header.hop_limit(), output));
+  RETURN_IF_ERROR(SerializeIpv6Address(header.ipv6_source(), output));
+  RETURN_IF_ERROR(SerializeIpv6Address(header.ipv6_destination(), output));
+  return absl::OkStatus();
+}
+
+absl::Status SerializeUdpHeader(const UdpHeader& header,
+                                pdpi::BitString& output) {
+  RETURN_IF_ERROR(
+      SerializeBits<kUdpPortBitwidth>(header.source_port(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kUdpPortBitwidth>(header.destination_port(), output));
+  RETURN_IF_ERROR(SerializeBits<kUdpLengthBitwidth>(header.length(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kUdpChecksumBitwidth>(header.checksum(), output));
+  return absl::OkStatus();
+}
+
+absl::Status SerializeTcpHeader(const TcpHeader& header,
+                                pdpi::BitString& output) {
+  RETURN_IF_ERROR(
+      SerializeBits<kTcpPortBitwidth>(header.source_port(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kTcpPortBitwidth>(header.destination_port(), output));
+  RETURN_IF_ERROR(SerializeBits<kTcpSequenceNumberBitwidth>(
+      header.sequence_number(), output));
+  RETURN_IF_ERROR(SerializeBits<kTcpAcknowledgementNumberBitwidth>(
+      header.acknowledgement_number(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kTcpDataOffsetBitwidth>(header.data_offset(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kTcpRestOfHeaderBitwidth>(header.rest_of_header(), output));
+  if (!header.uninterpreted_options().empty()) {
+    RETURN_IF_ERROR(output.AppendHexString(header.uninterpreted_options()));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status SerializeArpHeader(const ArpHeader& header,
+                                pdpi::BitString& output) {
+  RETURN_IF_ERROR(
+      SerializeBits<kArpTypeBitwidth>(header.hardware_type(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kArpTypeBitwidth>(header.protocol_type(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kArpLengthBitwidth>(header.hardware_length(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kArpLengthBitwidth>(header.protocol_length(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kArpOperationBitwidth>(header.operation(), output));
+  RETURN_IF_ERROR(
+      SerializeMacAddress(header.sender_hardware_address(), output));
+  RETURN_IF_ERROR(
+      SerializeIpv4Address(header.sender_protocol_address(), output));
+  RETURN_IF_ERROR(
+      SerializeMacAddress(header.target_hardware_address(), output));
+  RETURN_IF_ERROR(
+      SerializeIpv4Address(header.target_protocol_address(), output));
+  return absl::OkStatus();
+}
+
+absl::Status SerializeIcmpHeader(const IcmpHeader& header,
+                                 pdpi::BitString& output) {
+  RETURN_IF_ERROR(SerializeBits<kIcmpTypeBitwidth>(header.type(), output));
+  RETURN_IF_ERROR(SerializeBits<kIcmpCodeBitwidth>(header.code(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kIcmpChecksumBitwidth>(header.checksum(), output));
+  RETURN_IF_ERROR(SerializeBits<kIcmpRestOfHeaderBitwidth>(
+      header.rest_of_header(), output));
+  return absl::OkStatus();
+}
+
+absl::Status SerializeVlanHeader(const VlanHeader& header,
+                                 pdpi::BitString& output) {
+  RETURN_IF_ERROR(SerializeBits<kVlanPriorityCodePointBitwidth>(
+      header.priority_code_point(), output));
+  RETURN_IF_ERROR(SerializeBits<kVlanDropEligibilityIndicatorBitwidth>(
+      header.drop_eligible_indicator(), output));
+  RETURN_IF_ERROR(SerializeBits<kVlanVlanIdentifierBitwidth>(
+      header.vlan_identifier(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kVlanEthertypeBitwidth>(header.ethertype(), output));
+  return absl::OkStatus();
+}
+
+absl::Status SerializeGreHeader(const GreHeader& header,
+                                pdpi::BitString& output) {
+  RETURN_IF_ERROR(SerializeBits<kGreChecksumPresentBitwidth>(
+      header.checksum_present(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kGreReserved0Bitwidth>(header.reserved0(), output));
+  RETURN_IF_ERROR(SerializeBits<kGreVersionBitwidth>(header.version(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kGreProtocolTypeBitwidth>(header.protocol_type(), output));
+  if (header.checksum_present() == "0x1") {
+    RETURN_IF_ERROR(output.AppendHexString(header.checksum()));
+    RETURN_IF_ERROR(output.AppendHexString(header.reserved1()));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status SerializeSaiP4BMv2PacketInHeader(
+    const SaiP4BMv2PacketInHeader& header, pdpi::BitString& output) {
+  RETURN_IF_ERROR(SerializeBits<kSaiP4BMv2PacketInIngressPortBitwidth>(
+      header.ingress_port(), output));
+  RETURN_IF_ERROR(SerializeBits<kSaiP4BMv2PacketInTargetEgressPortBitwidth>(
+      header.target_egress_port(), output));
+  RETURN_IF_ERROR(SerializeBits<kSaiP4BMv2PacketInUnusedPadBitwidth>(
+      header.unused_pad(), output));
+  return absl::OkStatus();
+}
+
+absl::Status SerializeHeader(const Header& header, pdpi::BitString& output) {
+  switch (header.header_case()) {
+    case Header::kEthernetHeader:
+      return SerializeEthernetHeader(header.ethernet_header(), output);
+    case Header::kIpv4Header:
+      return SerializeIpv4Header(header.ipv4_header(), output);
+    case Header::kIpv6Header:
+      return SerializeIpv6Header(header.ipv6_header(), output);
+    case Header::kUdpHeader:
+      return SerializeUdpHeader(header.udp_header(), output);
+    case Header::kTcpHeader:
+      return SerializeTcpHeader(header.tcp_header(), output);
+    case Header::kArpHeader:
+      return SerializeArpHeader(header.arp_header(), output);
+    case Header::kIcmpHeader:
+      return SerializeIcmpHeader(header.icmp_header(), output);
+    case Header::kVlanHeader:
+      return SerializeVlanHeader(header.vlan_header(), output);
+    case Header::kGreHeader:
+      return SerializeGreHeader(header.gre_header(), output);
+    case Header::kSaiP4Bmv2PacketInHeader:
+      return SerializeSaiP4BMv2PacketInHeader(
+          header.sai_p4_bmv2_packet_in_header(), output);
+    case Header::HEADER_NOT_SET:
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Found invalid HEADER_NOT_SET in header.";
+  }
+}
+
+}  // namespace
+
+absl::Status RawSerializePacket(const Packet& packet, int start_header_index,
+                                pdpi::BitString& output) {
+  if (start_header_index > packet.headers_size() || start_header_index < 0) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Invalid header index " << start_header_index
+           << " for a packet with " << packet.headers_size() << " headers.";
+  }
+
+  for (int i = start_header_index; i < packet.headers().size(); ++i) {
+    RETURN_IF_ERROR(SerializeHeader(packet.headers(i), output)).SetPrepend()
+        << "while trying to serialize packet.headers(" << i << "): ";
+  }
+  output.AppendBytes(packet.payload());
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::string> RawSerializePacket(const Packet& packet) {
+  pdpi::BitString bits;
+  RETURN_IF_ERROR(RawSerializePacket(packet, 0, bits));
+  return bits.ToByteString();
+}
+
+absl::StatusOr<std::string> SerializePacket(Packet packet) {
+  RETURN_IF_ERROR(PadPacketToMinimumSize(packet).status());
+  RETURN_IF_ERROR(UpdateMissingComputedFields(packet).status());
+  RETURN_IF_ERROR(ValidatePacket(packet));
+  return RawSerializePacket(packet);
+}
+
+// ---- Computed field logic ---------------------------------------------------
+
+absl::StatusOr<bool> UpdateComputedFields(Packet& packet, bool overwrite) {
+  bool changes = false;
+
+  int header_index = 0;
+  for (Header& header : *packet.mutable_headers()) {
+    std::string error_prefix =
+        absl::StrFormat("%s: failed to compute packet.headers[%d].",
+                        HeaderCaseName(header.header_case()), header_index);
+    switch (header.header_case()) {
+      case Header::kEthernetHeader: {
+        EthernetHeader& ethernet_header = *header.mutable_ethernet_header();
+        // Read current ethertype.
+        int ethertype = 0;
+        if (!ethernet_header.ethertype().empty()) {
+          ASSIGN_OR_RETURN(ethertype,
+                           pdpi::HexStringToInt(ethernet_header.ethertype()));
+        }
+        // If ethertype <= 1500, it must be equal to the payload size and we
+        // thus consider it a computed field that we should update.
+        // To avoid surprises, we only perform an update if the ethernet header
+        // is the final header, indicating that a size-encoding ethertype is
+        // indeed appropriate.
+        if ((ethernet_header.ethertype().empty() || overwrite) &&
+            ethertype <= 1500 && header_index == packet.headers_size() - 1) {
+          if (auto size = PacketSizeInBytes(packet, header_index + 1);
+              !size.ok()) {
+            return gutil::InvalidArgumentErrorBuilder()
+                   << "unable to compute payload size: " << size.status();
+          } else if (*size > 1500) {
+            return gutil::InvalidArgumentErrorBuilder()
+                   << "payload size " << *size << " exceeds MTU";
+          } else {
+            ethernet_header.set_ethertype(EtherType(*size));
+            changes = true;
+          }
+        }
+        break;
+      }
+      case Header::kIpv4Header: {
+        Ipv4Header& ipv4_header = *header.mutable_ipv4_header();
+        if (ipv4_header.version().empty() || overwrite) {
+          ipv4_header.set_version("0x4");
+          changes = true;
+        }
+        if (ipv4_header.ihl().empty() || overwrite) {
+          absl::string_view options = ipv4_header.uninterpreted_options();
+          if (options.empty()) {
+            ipv4_header.set_ihl("0x5");
+            changes = true;
+          } else if (absl::ConsumePrefix(&options, "0x") &&
+                     (options.size() * 4) % 32 == 0) {
+            // 4 bits per hex char.
+            int num_32bit_words_in_options = (options.size() * 4) / 32;
+            ipv4_header.set_ihl(pdpi::BitsetToHexString<kIpIhlBitwidth>(
+                5 + num_32bit_words_in_options));
+            changes = true;
+          } else {
+            return gutil::InvalidArgumentErrorBuilder()
+                   << error_prefix
+                   << "ihl: uninterpreted_options field is invalid";
+          }
+        }
+        if (ipv4_header.total_length().empty() || overwrite) {
+          ASSIGN_OR_RETURN(int size, PacketSizeInBytes(packet, header_index),
+                           _.SetPrepend() << error_prefix << "total_length: ");
+          ipv4_header.set_total_length(pdpi::BitsetToHexString(
+              std::bitset<kIpTotalLengthBitwidth>(size)));
+          changes = true;
+        }
+        if (ipv4_header.checksum().empty() || overwrite) {
+          ASSIGN_OR_RETURN(int checksum, Ipv4HeaderChecksum(ipv4_header),
+                           _.SetPrepend() << error_prefix << "checksum: ");
+          ipv4_header.set_checksum(pdpi::BitsetToHexString(
+              std::bitset<kIpChecksumBitwidth>(checksum)));
+          changes = true;
+        }
+        break;
+      }
+      case Header::kIpv6Header: {
+        Ipv6Header& ipv6_header = *header.mutable_ipv6_header();
+        if (ipv6_header.version().empty() || overwrite) {
+          ipv6_header.set_version("0x6");
+          changes = true;
+        }
+        if (ipv6_header.payload_length().empty() || overwrite) {
+          // `+1` to skip the IPv6 header and previous headers in calculation.
+          ASSIGN_OR_RETURN(
+              int size, PacketSizeInBytes(packet, header_index + 1),
+              _.SetPrepend() << error_prefix << "payload_length: ");
+          ipv6_header.set_payload_length(pdpi::BitsetToHexString(
+              std::bitset<kIpTotalLengthBitwidth>(size)));
+          changes = true;
+        }
+        break;
+      }
+      case Header::kUdpHeader: {
+        UdpHeader& udp_header = *header.mutable_udp_header();
+        if (udp_header.length().empty() || overwrite) {
+          ASSIGN_OR_RETURN(int size, PacketSizeInBytes(packet, header_index),
+                           _.SetPrepend() << error_prefix << "length: ");
+          udp_header.set_length(
+              pdpi::BitsetToHexString(std::bitset<kUdpLengthBitwidth>(size)));
+          changes = true;
+        }
+        if (udp_header.checksum().empty() || overwrite) {
+          ASSIGN_OR_RETURN(int checksum,
+                           UdpHeaderChecksum(packet, header_index),
+                           _.SetPrepend() << error_prefix << "checksum: ");
+          udp_header.set_checksum(pdpi::BitsetToHexString(
+              std::bitset<kUdpChecksumBitwidth>(checksum)));
+          changes = true;
+        }
+        break;
+      }
+      case Header::kArpHeader: {
+        ArpHeader& arp_header = *header.mutable_arp_header();
+        if (arp_header.hardware_type().empty() || overwrite) {
+          arp_header.set_hardware_type("0x0001");
+          changes = true;
+        }
+        if (arp_header.protocol_type().empty() || overwrite) {
+          arp_header.set_protocol_type("0x0800");
+          changes = true;
+        }
+        if (arp_header.hardware_length().empty() || overwrite) {
+          arp_header.set_hardware_length("0x06");
+          changes = true;
+        }
+        if (arp_header.protocol_length().empty() || overwrite) {
+          arp_header.set_protocol_length("0x04");
+          changes = true;
+        }
+        break;
+      }
+      case Header::kIcmpHeader: {
+        IcmpHeader& icmp_header = *header.mutable_icmp_header();
+        if (icmp_header.checksum().empty() || overwrite) {
+          ASSIGN_OR_RETURN(int checksum,
+                           IcmpHeaderChecksum(packet, header_index));
+          icmp_header.set_checksum(pdpi::BitsetToHexString(
+              std::bitset<kIcmpChecksumBitwidth>(checksum)));
+          changes = true;
+        }
+        break;
+      }
+      case Header::kTcpHeader: {
+        TcpHeader& tcp_header = *header.mutable_tcp_header();
+        if (tcp_header.data_offset().empty() || overwrite) {
+          ASSIGN_OR_RETURN(int size, PacketSizeInBits(packet, header_index),
+                           _.SetPrepend() << error_prefix << "data_offset: ");
+          ASSIGN_OR_RETURN(int payload_size,
+                           PacketSizeInBits(packet, header_index + 1),
+                           _.SetPrepend() << error_prefix << "data_offset: ");
+          int data_offset_in_bits = size - payload_size;
+          if (data_offset_in_bits % 32 != 0) {
+            return gutil::InvalidArgumentErrorBuilder()
+                   << error_prefix << "data_offset: comuted offset of "
+                   << data_offset_in_bits
+                   << " bits is not a multiple of 32 bits; this indicates that "
+                   << "uninterpreted_options is of invalid length";
+          }
+          int data_offset = data_offset_in_bits / 32;
+          if (data_offset < 5 || data_offset > 15) {
+            return gutil::InvalidArgumentErrorBuilder()
+                   << "data_offset: computed offset of " << data_offset
+                   << " is outside of legal range [5, 15]; this indicates that "
+                   << "uninterpreted_options is of invalid length";
+          }
+          tcp_header.set_data_offset(
+              pdpi::BitsetToHexString<kTcpDataOffsetBitwidth>(data_offset));
+          changes = true;
+        }
+        break;
+      }
+      case Header::kVlanHeader:
+        // No computed fields.
+        break;
+      case Header::kGreHeader: {
+        GreHeader& gre_header = *header.mutable_gre_header();
+        if (gre_header.checksum_present() == "0x1") {
+          if (gre_header.checksum().empty() || overwrite) {
+            ASSIGN_OR_RETURN(int checksum,
+                             GreHeaderChecksum(packet, header_index));
+            gre_header.set_checksum(pdpi::BitsetToHexString(
+                std::bitset<kGreChecksumBitwidth>(checksum)));
+            changes = true;
+          }
+          if (gre_header.reserved1().empty() || overwrite) {
+            gre_header.set_reserved1("0x0000");
+            changes = true;
+          }
+        }
+        break;
+      }
+      case Header::kSaiP4Bmv2PacketInHeader:
+        break;
+      case Header::HEADER_NOT_SET:
+        return gutil::InvalidArgumentErrorBuilder()
+               << "Invalid packet with HEADER_NOT_SET: "
+               << packet.DebugString();
+    }
+    header_index += 1;
+  }
+
+  return changes;
+}
+
+absl::StatusOr<bool> UpdateMissingComputedFields(Packet& packet) {
+  return UpdateComputedFields(packet, /*overwrite=*/false);
+}
+
+absl::StatusOr<bool> UpdateAllComputedFields(Packet& packet) {
+  return UpdateComputedFields(packet, /*overwrite=*/true);
+}
+
+absl::StatusOr<bool> PadPacketToMinimumSizeFromHeaderIndex(Packet& packet,
+                                                           int header_index) {
+  if (packet.headers().size() <= header_index) return false;
+  switch (packet.headers(header_index).header_case()) {
+    case Header::kEthernetHeader: {
+      if (auto after_eth_size = PacketSizeInBytes(packet, header_index + 1);
+          !after_eth_size.ok()) {
+        return gutil::InvalidArgumentErrorBuilder()
+               << "couldn't compute packet size: " << after_eth_size.status();
+      } else {
+        if (*after_eth_size >= kMinNumBytesInEthernetPayload) return false;
+        int target_payload_size = kMinNumBytesInEthernetPayload -
+                                  (*after_eth_size - packet.payload().size());
+        packet.mutable_payload()->resize(target_payload_size);
+        return true;
+      }
+    }
+    case Header::kIpv4Header:
+    case Header::kIpv6Header:
+    case Header::kUdpHeader:
+    case Header::kTcpHeader:
+    case Header::kArpHeader:
+    case Header::kIcmpHeader:
+    case Header::kVlanHeader:
+    case Header::kGreHeader:
+    case Header::kSaiP4Bmv2PacketInHeader:
+      return PadPacketToMinimumSizeFromHeaderIndex(packet, header_index + 1);
+    case Header::HEADER_NOT_SET:
+      return false;
+  }
+  LOG(DFATAL) << "exhaustive switch statement failed: " << packet.DebugString();
+  return false;
+}
+
+absl::StatusOr<bool> PadPacketToMinimumSize(Packet& packet) {
+  return PadPacketToMinimumSizeFromHeaderIndex(packet, 0);
+}
+
+absl::StatusOr<bool> PadPacket(int num_bytes, Packet& packet) {
+  ASSIGN_OR_RETURN(int current_size, PacketSizeInBytes(packet));
+  if (current_size >= num_bytes) return false;
+  int header_size = current_size - packet.payload().size();
+  int target_payload_size = num_bytes - header_size;
+  packet.mutable_payload()->resize(target_payload_size);
+  return true;
+}
+
+absl::StatusOr<int> PacketSizeInBytes(const Packet& packet,
+                                      int start_header_index) {
+  ASSIGN_OR_RETURN(int bit_size, PacketSizeInBits(packet, start_header_index));
+  if (bit_size % 8 != 0) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "packet size of " << bit_size << " cannot be converted to bytes";
+  }
+  return bit_size / 8;
+}
+
+absl::StatusOr<int> PacketSizeInBits(const Packet& packet,
+                                     int start_header_index) {
+  if (start_header_index > packet.headers_size() || start_header_index < 0) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Invalid header index " << start_header_index
+           << " for a packet with " << packet.headers_size() << " headers.";
+  }
+
+  int size = 0;
+
+  for (auto* header :
+       absl::MakeSpan(packet.headers()).subspan(start_header_index)) {
+    switch (header->header_case()) {
+      case Header::kEthernetHeader:
+        size += kEthernetHeaderBitwidth;
+        break;
+      case Header::kIpv4Header: {
+        size += kStandardIpv4HeaderBitwidth;
+        if (const auto& options = header->ipv4_header().uninterpreted_options();
+            !options.empty()) {
+          ASSIGN_OR_RETURN(
+              auto bytes, pdpi::HexStringToByteString(options),
+              _.SetPrepend()
+                  << "failed to parse uninterpreted_options in Ipv4Header: ");
+          size += 8 * bytes.size();
+        }
+        break;
+      }
+      case Header::kIpv6Header:
+        size += kIpv6HeaderBitwidth;
+        break;
+      case Header::kUdpHeader:
+        size += kUdpHeaderBitwidth;
+        break;
+      case Header::kTcpHeader: {
+        size += kStandardTcpHeaderBitwidth;
+        if (const auto& options = header->tcp_header().uninterpreted_options();
+            !options.empty()) {
+          ASSIGN_OR_RETURN(
+              auto bytes, pdpi::HexStringToByteString(options),
+              _.SetPrepend()
+                  << "failed to parse uninterpreted_options in TcpHeader: ");
+          size += 8 * bytes.size();
+        }
+        break;
+      }
+      case Header::kArpHeader:
+        size += kArpHeaderBitwidth;
+        break;
+      case Header::kIcmpHeader:
+        size += kIcmpHeaderBitwidth;
+        break;
+      case Header::kVlanHeader:
+        size += kVlanHeaderBitwidth;
+        break;
+      case Header::kGreHeader:
+        size += kRfc2784GreHeaderWithoutOptionalsBitwidth;
+        if (header->gre_header().checksum_present() == "0x1") {
+          size += kGreChecksumBitwidth + kGreReserved1Bitwidth;
+        }
+        break;
+      case Header::kSaiP4Bmv2PacketInHeader:
+        size += kSaiP4BMv2PacketInHeaderBitwidth;
+        break;
+      case Header::HEADER_NOT_SET:
+        return gutil::InvalidArgumentErrorBuilder()
+               << "Found invalid HEADER_NOT_SET in header.";
+    }
+  }
+
+  size += 8 * packet.payload().size();
+  return size;
+}
+
+// Returns 16-bit ones' complement of the ones' complement sum of all 16-bit
+// words in the given BitString.
+static absl::StatusOr<int> OnesComplementChecksum(pdpi::BitString data) {
+  // Pad string to be 16-bit multiple.
+  while (data.size() % 16 != 0) data.AppendBit(0);
+
+  // Following RFC 1071 and
+  // wikipedia.org/wiki/IPv4_header_checksum#Calculating_the_IPv4_header_checksum
+  int sum = 0;
+  while (data.size() != 0) {
+    ASSIGN_OR_RETURN(std::bitset<16> word, data.ConsumeBitset<16>(),
+                     _.SetCode(absl::StatusCode::kInternal));
+    // This looks wrong because we're not taking the ones' complement, but
+    // turns out to work.
+    sum += word.to_ulong();
+  }
+  // Add carry bits until sum fits into 16 bits.
+  while (sum >> 16 != 0) {
+    sum = (sum & 0xffff) + (sum >> 16);
+  }
+  // Return 16 bit ones' complement.
+  return (~sum) & 0xffff;
+}
+
+absl::StatusOr<int> Ipv4HeaderChecksum(Ipv4Header header) {
+  // The checksum field is the 16-bit ones' complement of the ones' complement
+  // sum of all 16-bit words in the header. For purposes of computing the
+  // checksum, the value of the checksum field is zero.
+
+  // We compute the checksum by setting the checksum field to 0, serializing
+  // the header, and then going over all 16-bit words.
+  header.set_checksum("0x0000");
+  pdpi::BitString data;
+  RETURN_IF_ERROR(SerializeIpv4Header(header, data));
+  return OnesComplementChecksum(std::move(data));
+}
+
+absl::StatusOr<int> UdpHeaderChecksum(Packet packet, int udp_header_index) {
+  auto invalid_argument = gutil::InvalidArgumentErrorBuilder()
+                          << "UdpHeaderChecksum(packet, udp_header_index = "
+                          << udp_header_index << "): ";
+  if (udp_header_index < 1 || udp_header_index >= packet.headers().size()) {
+    return invalid_argument
+           << "udp_header_index must be in [1, " << packet.headers().size()
+           << ") since the given packet has " << packet.headers().size()
+           << " headers and the UDP header must be preceded by an IP header";
+  }
+  const Header& preceding_header = packet.headers(udp_header_index - 1);
+  if (auto header_case = packet.headers(udp_header_index).header_case();
+      header_case != Header::kUdpHeader) {
+    return invalid_argument << "packet.headers[" << udp_header_index
+                            << "] is a " << HeaderCaseName(header_case)
+                            << ", expected UdpHeader";
+  }
+  UdpHeader& udp_header =
+      *packet.mutable_headers(udp_header_index)->mutable_udp_header();
+  udp_header.set_checksum("0x0000");
+
+  // Serialize "pseudo header" for checksum calculation, following
+  // https://en.wikipedia.org/wiki/User_Datagram_Protocol#Checksum_computation.
+  pdpi::BitString data;
+  switch (preceding_header.header_case()) {
+    case Header::kIpv4Header: {
+      auto& header = preceding_header.ipv4_header();
+      RETURN_IF_ERROR(SerializeIpv4Address(header.ipv4_source(), data));
+      RETURN_IF_ERROR(SerializeIpv4Address(header.ipv4_destination(), data));
+      data.AppendBits<8>(0);
+      RETURN_IF_ERROR(
+          SerializeBits<kIpProtocolBitwidth>(header.protocol(), data));
+      RETURN_IF_ERROR(
+          SerializeBits<kUdpLengthBitwidth>(udp_header.length(), data));
+      break;
+    }
+    case Header::kIpv6Header: {
+      auto& header = preceding_header.ipv6_header();
+      RETURN_IF_ERROR(SerializeIpv6Address(header.ipv6_source(), data));
+      RETURN_IF_ERROR(SerializeIpv6Address(header.ipv6_destination(), data));
+      data.AppendBits<16>(0);
+      RETURN_IF_ERROR(
+          SerializeBits<kUdpLengthBitwidth>(udp_header.length(), data));
+      data.AppendBits<24>(0);
+      RETURN_IF_ERROR(
+          SerializeBits<kIpNextHeaderBitwidth>(header.next_header(), data));
+      break;
+    }
+    default:
+      return invalid_argument << "expected packet.headers[udp_header_index - "
+                                 "1] to be an IP header, got "
+                              << HeaderCaseName(preceding_header.header_case());
+  }
+  RETURN_IF_ERROR(RawSerializePacket(packet, udp_header_index, data));
+  return OnesComplementChecksum(std::move(data));
+}
+
+absl::StatusOr<int> IcmpHeaderChecksum(Packet packet, int icmp_header_index) {
+  auto invalid_argument = gutil::InvalidArgumentErrorBuilder()
+                          << "IcmpHeaderChecksum(packet, icmp_header_index = "
+                          << icmp_header_index << "): ";
+  if (icmp_header_index < 1 || icmp_header_index >= packet.headers().size()) {
+    return invalid_argument
+           << "icmp_header_index must be in [1, " << packet.headers().size()
+           << ") since the given packet has " << packet.headers().size()
+           << " headers and the ICMP header must be preceded by an IP header";
+  }
+  if (auto header_case = packet.headers(icmp_header_index).header_case();
+      header_case != Header::kIcmpHeader) {
+    return invalid_argument << "packet.headers[" << icmp_header_index
+                            << "] is a " << HeaderCaseName(header_case)
+                            << ", expected IcmpHeader";
+  }
+
+  IcmpHeader& icmp_header =
+      *packet.mutable_headers(icmp_header_index)->mutable_icmp_header();
+  icmp_header.set_checksum("0x0000");
+
+  pdpi::BitString data;
+  const Header& preceding_header = packet.headers(icmp_header_index - 1);
+  switch (preceding_header.header_case()) {
+    case Header::kIpv6Header: {
+      // Serialize "pseudo header" for checksum calculation, following
+      // https://en.wikipedia.org/wiki/Internet_Control_Message_Protocol_for_IPv6#Checksum.
+      auto& header = preceding_header.ipv6_header();
+      RETURN_IF_ERROR(SerializeIpv6Address(header.ipv6_source(), data));
+      RETURN_IF_ERROR(SerializeIpv6Address(header.ipv6_destination(), data));
+      ASSIGN_OR_RETURN(int icmpv6_size,
+                       PacketSizeInBytes(packet, icmp_header_index));
+      data.AppendBits<32>(icmpv6_size);
+      data.AppendBits<24>(0);
+      RETURN_IF_ERROR(
+          SerializeBits<kIpNextHeaderBitwidth>(header.next_header(), data));
+      break;
+    }
+    case Header::kIpv4Header: {
+      // For ICMPv4, only the ICMP header and payload is used in the checksum
+      // calculation.
+      break;
+    }
+    default:
+      return invalid_argument << "expected packet.headers[udp_header_index - "
+                                 "1] to be an IP header, got "
+                              << HeaderCaseName(preceding_header.header_case());
+  }
+  RETURN_IF_ERROR(RawSerializePacket(packet, icmp_header_index, data));
+  return OnesComplementChecksum(std::move(data));
+}
+
+absl::StatusOr<int> GreHeaderChecksum(Packet packet, int gre_header_index) {
+  auto invalid_argument = gutil::InvalidArgumentErrorBuilder()
+                          << "GreHeaderChecksum(packet, gre_header_index = "
+                          << gre_header_index << "): ";
+  if (gre_header_index >= packet.headers().size()) {
+    return invalid_argument
+           << "gre_header_index must be in [0, " << packet.headers().size()
+           << ") since the given packet has " << packet.headers().size()
+           << " headers.";
+  }
+  if (auto header_case = packet.headers(gre_header_index).header_case();
+      header_case != Header::kGreHeader) {
+    return invalid_argument << "packet.headers[" << gre_header_index
+                            << "] is a " << HeaderCaseName(header_case)
+                            << ", expected GreHeader";
+  }
+  GreHeader& gre_header =
+      *packet.mutable_headers(gre_header_index)->mutable_gre_header();
+
+  gre_header.set_checksum("0x0000");
+  pdpi::BitString data;
+
+  RETURN_IF_ERROR(RawSerializePacket(packet, gre_header_index, data));
+
+  return OnesComplementChecksum(std::move(data));
+}
+
+std::string EtherType(uint32_t ether_type) {
+  return ValidateAndConvertToHexString<kEthernetEthertypeBitwidth>(ether_type);
+}
+
+std::string IpVersion(uint32_t version) {
+  return ValidateAndConvertToHexString<kIpVersionBitwidth>(version);
+}
+
+std::string IpIhl(uint32_t ihl) {
+  return ValidateAndConvertToHexString<kIpIhlBitwidth>(ihl);
+}
+
+std::string IpDscp(uint32_t dscp) {
+  return ValidateAndConvertToHexString<kIpDscpBitwidth>(dscp);
+}
+
+std::string IpEcn(uint32_t ecn) {
+  return ValidateAndConvertToHexString<kIpEcnBitwidth>(ecn);
+}
+
+std::string IpTotalLength(uint32_t total_length) {
+  return ValidateAndConvertToHexString<kIpTotalLengthBitwidth>(total_length);
+}
+
+std::string IpIdentification(uint32_t identification) {
+  return ValidateAndConvertToHexString<kIpIdentificationBitwidth>(
+      identification);
+}
+
+std::string IpFlags(uint32_t flag) {
+  return ValidateAndConvertToHexString<kIpFlagsBitwidth>(flag);
+}
+
+std::string IpFragmentOffset(uint32_t fragment_offset) {
+  return ValidateAndConvertToHexString<kIpFragmentOffsetBitwidth>(
+      fragment_offset);
+}
+
+std::string IpTtl(uint32_t ttl) {
+  return ValidateAndConvertToHexString<kIpTtlBitwidth>(ttl);
+}
+
+std::string IpProtocol(uint32_t protocol) {
+  return ValidateAndConvertToHexString<kIpProtocolBitwidth>(protocol);
+}
+
+std::string IpChecksum(uint32_t checksum) {
+  return ValidateAndConvertToHexString<kIpChecksumBitwidth>(checksum);
+}
+
+std::string IpFlowLabel(uint32_t flow_label) {
+  return ValidateAndConvertToHexString<kIpFlowLabelBitwidth>(flow_label);
+}
+
+std::string IpPayloadLength(uint32_t payload_length) {
+  return ValidateAndConvertToHexString<kIpPayloadLengthBitwidth>(
+      payload_length);
+}
+
+std::string IpNextHeader(uint32_t next_header) {
+  return ValidateAndConvertToHexString<kIpNextHeaderBitwidth>(next_header);
+}
+
+std::string IpHopLimit(uint32_t hop_limit) {
+  return ValidateAndConvertToHexString<kIpHopLimitBitwidth>(hop_limit);
+}
+
+std::string UdpPort(uint32_t udp_port) {
+  return ValidateAndConvertToHexString<kUdpPortBitwidth>(udp_port);
+}
+
+std::string UdpChecksum(uint32_t checksum) {
+  return ValidateAndConvertToHexString<kUdpChecksumBitwidth>(checksum);
+}
+
+std::string UdpLength(uint32_t udp_length) {
+  return ValidateAndConvertToHexString<kUdpLengthBitwidth>(udp_length);
+}
+
+std::string TcpPort(uint32_t tcp_port) {
+  return ValidateAndConvertToHexString<kTcpPortBitwidth>(tcp_port);
+}
+
+std::string TcpSequenceNumber(uint32_t sequence_number) {
+  return ValidateAndConvertToHexString<kTcpSequenceNumberBitwidth>(
+      sequence_number);
+}
+
+std::string TcpAcknowledgementNumber(uint32_t ackowledgement_number) {
+  return ValidateAndConvertToHexString<kTcpAcknowledgementNumberBitwidth>(
+      ackowledgement_number);
+}
+
+std::string TcpDataOffset(uint32_t data_offset) {
+  return ValidateAndConvertToHexString<kTcpDataOffsetBitwidth>(data_offset);
+}
+
+std::string TcpRestOfHeader(uint64_t rest_of_header) {
+  return ValidateAndConvertToHexString<kTcpRestOfHeaderBitwidth>(
+      rest_of_header);
+}
+
+std::string ArpType(uint32_t type) {
+  return ValidateAndConvertToHexString<kArpTypeBitwidth>(type);
+}
+
+std::string ArpLength(uint32_t length) {
+  return ValidateAndConvertToHexString<kArpLengthBitwidth>(length);
+}
+
+std::string ArpOperation(uint32_t operation) {
+  return ValidateAndConvertToHexString<kArpOperationBitwidth>(operation);
+}
+
+std::string IcmpType(uint32_t type) {
+  return ValidateAndConvertToHexString<kIcmpTypeBitwidth>(type);
+}
+
+std::string IcmpCode(uint32_t code) {
+  return ValidateAndConvertToHexString<kIcmpCodeBitwidth>(code);
+}
+
+std::string IcmpChecksum(uint32_t checksum) {
+  return ValidateAndConvertToHexString<kIcmpChecksumBitwidth>(checksum);
+}
+
+std::string IcmpRestOfHeader(uint32_t rest_of_header) {
+  return ValidateAndConvertToHexString<kIcmpRestOfHeaderBitwidth>(
+      rest_of_header);
+}
+
+std::string GreChecksumPresent(uint32_t checksum_present) {
+  return ValidateAndConvertToHexString<kGreChecksumPresentBitwidth>(
+      checksum_present);
+}
+
+std::string GreReserved0(uint32_t reserved0) {
+  return ValidateAndConvertToHexString<kGreReserved0Bitwidth>(reserved0);
+}
+
+std::string GreVersion(uint32_t version) {
+  return ValidateAndConvertToHexString<kGreVersionBitwidth>(version);
+}
+
+std::string GreProtocolType(uint32_t protocol_type) {
+  return ValidateAndConvertToHexString<kGreProtocolTypeBitwidth>(protocol_type);
+}
+
+std::string GreChecksum(uint32_t checksum) {
+  return ValidateAndConvertToHexString<kGreChecksumBitwidth>(checksum);
+}
+
+std::string GreReserved1(uint32_t reserved1) {
+  return ValidateAndConvertToHexString<kGreReserved1Bitwidth>(reserved1);
+}
+}  // namespace packetlib

--- a/p4_pdpi/packetlib/packetlib.h
+++ b/p4_pdpi/packetlib/packetlib.h
@@ -1,0 +1,208 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef GOOGLE_P4_PDPI_PACKETLIB_PACKETLIB_H_
+#define GOOGLE_P4_PDPI_PACKETLIB_PACKETLIB_H_
+
+#include <cstdint>
+
+#include "absl/numeric/bits.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "glog/logging.h"
+#include "p4_pdpi/packetlib/packetlib.pb.h"
+#include "p4_pdpi/string_encodings/hex_string.h"
+
+namespace packetlib {
+
+// Parses the given packet. Parsing is a total function, and any aspect that
+// cannot be parsed correctly will be put into `payload` of `Packet`.
+//
+// Even invalid packets will be parsed into the header structure of `Packet`
+// when possible. For instance an invalid checksum will be parsed. However, not
+// all invalid packets can be parsed into the header structure. Specifically, if
+// trying to represent the packet would lose information, the function will
+// instead not parse that header and put the data in `payload` instead. For
+// example IPv4 packets with options is treated this way (since the library does
+// not support options and thus has no place in `Ipv4Header` for options).
+//
+// Parsing starts with the given header (defaulting to Ethernet).
+//
+// Guarantees for `packet = ParsePacket(data)`:
+// 1. Valid packets are valid:
+//    `packet.reasons_invalid.empty()` implies `ValidatePacket(packet).ok()`.
+// 2. Parsing is loss-less:
+//    Running `serialized = RawSerializePacket(packet);` guarantees
+//    `serialized.ok() && *serialized == data`.
+// 3. If a header is supported by packetlib, it will be parsed. Partially
+//    supported headers may not be parsed, but then `reason_not_fully_parsed`
+//    will indicate what unsupported feature the packet uses, and the
+//    unsupported header will appear uninterpreted in the payload.
+Packet ParsePacket(absl::string_view input,
+                   Header::HeaderCase first_header = Header::kEthernetHeader);
+
+// Validates packets by checking that:
+// 1. Headers appear in a valid order, and fields indicating the next header
+//    match the actual next header for all supported header types.
+// 2. Each field is specified, and of the correct format.
+// 3. Computed fields have the right value.
+// 4. The packet has the minimum size required by its headers.
+// 5. The packet is non-empty (not uninitialized).
+absl::Status ValidatePacket(const Packet& packet);
+
+// Same as ValidatePacket, but returns a list of reasons why the packet isn't
+// valid instead.
+std::vector<std::string> PacketInvalidReasons(const Packet& packet);
+
+// Seralizes a given packet. The packet may miss computed fields, which will be
+// filled in automatically when missing (but not changed if they are present).
+// Serialization succeeds iff `ValidatePacket(packet).ok()` after calling
+// `PadPacketToMinimumSize(packet); UpdateMisssingComputedFields(packet)`. An
+// error status is returned otherwise.
+absl::StatusOr<std::string> SerializePacket(Packet packet);
+
+// Seralizes a given packet without checking header invariants. All fields must
+// be present and use a valid value (according to ir::Format), but otherwise no
+// requirements are made on the set of headers; they will just be serialized in
+// order without checking, if computed fields are correct, header order is
+// valid, etc.
+absl::StatusOr<std::string> RawSerializePacket(const Packet& packet);
+
+// Updates all computed fields that are missing. Computed fields that are
+// already present are not modified. Returns true iff any changes where made.
+// Fails if fields that are required for determining computed fields are missing
+// or invalid.
+absl::StatusOr<bool> UpdateMissingComputedFields(Packet& packet);
+
+// Like `UpdateMissingComputedFields`, but also overwrites comuted fields
+// that are already present.
+absl::StatusOr<bool> UpdateAllComputedFields(Packet& packet);
+
+// If the given packet must have a minimum size based on its headers (e.g., an
+// Ethernet payload can be no smaller than 46 bytes), and if the packet size can
+// be computed, appends the minimum number  of additional zeros needed to the
+// payload and returns true. If the packet size cannot be computed, returns
+// error status.
+// If no padding is required, leaves the packet unmodified and returns false.
+//
+// Note: This function may invalidate computed fields (e.g., checksum and length
+// fields) and should be called prior to `Update*ComputedFields`.
+absl::StatusOr<bool> PadPacketToMinimumSize(Packet& packet);
+
+// Pads a packet to certain size by appending zeros to the payload and return
+// true. If the packet size is bigger than or equal to the target size,
+// leaves the packet unmodified and returns false. If the packet size cannot be
+// computed, returns error satus.
+absl::StatusOr<bool> PadPacket(int num_bytes, Packet& packet);
+
+// Returns the size of the given packet in bits, starting at the nth header and
+// ignoring all headers before that. Works even when computed fields are
+// missing.
+// Returns error if
+// - `start_header_index` is not in [0, packet.headers().size()], or
+// - `packet.headers(i)` is uninitialized for i in
+//   [start_header_index, packet.headers().size()]
+absl::StatusOr<int> PacketSizeInBits(const Packet& packet,
+                                     int start_header_index = 0);
+
+// Like `PacketSizeInBits`, but returns size in bytes, or an error if the bit
+// size is not divisible by 8.
+absl::StatusOr<int> PacketSizeInBytes(const Packet& packet,
+                                      int start_header_index = 0);
+
+// Computes the 16-bit checksum of an IPv4 header. All fields must be set and
+// valid except possibly the checksum, which is ignored.
+absl::StatusOr<int> Ipv4HeaderChecksum(Ipv4Header header);
+
+// Computes the 16-bit UDP checksum for the given `packet` and
+// `udp_header_index`.
+// The header at the given index must be a UDP header, and it must be preceded
+// by an IP header. All fields in all headers following that IP header must be
+// set and valid except possibly the UDP checksum field, which is ignored.
+absl::StatusOr<int> UdpHeaderChecksum(Packet packet, int udp_header_index);
+
+// Computes the 16-bit ICMP checksum for the given `packet` and
+// `icmp_header_index`.
+// The header at the given index must be an ICMP header, and it must be preceded
+// by an IP header. All fields in all headers following that IP header must be
+// set and valid except possibly the UDP checksum field, which is ignored.
+absl::StatusOr<int> IcmpHeaderChecksum(Packet packet, int icmp_header_index);
+
+// Computes the 16-bit GRE checksum for the given `packet` and
+// `gre_header_index`. The header at the given index must be an GRE header. All
+// fields in all headers following that GRE header must be set and valid except
+// possibly the GRE checksum field, which is ignored.
+absl::StatusOr<int> GreHeaderChecksum(Packet packet, int gre_header_index);
+
+std::string HeaderCaseName(Header::HeaderCase header_case);
+
+// Helper functions to translate the header fields to hex string. It abstracts
+// the bitwidth limitation away from the client and provides the validation that
+// checks if the input data is truncated because its bit width exceeds the
+// limitation.
+std::string EtherType(uint32_t ether_type);
+std::string IpVersion(uint32_t version);
+std::string IpIhl(uint32_t ihl);
+std::string IpDscp(uint32_t dscp);
+std::string IpEcn(uint32_t ecn);
+std::string IpTotalLength(uint32_t total_length);
+std::string IpIdentification(uint32_t identification);
+std::string IpFlags(uint32_t flag);
+std::string IpFragmentOffset(uint32_t fragment_offset);
+std::string IpTtl(uint32_t ttl);
+std::string IpProtocol(uint32_t protocol);
+std::string IpChecksum(uint32_t checksum);
+std::string IpFlowLabel(uint32_t flow_label);
+std::string IpPayloadLength(uint32_t payload_length);
+std::string IpNextHeader(uint32_t next_header);
+std::string IpHopLimit(uint32_t hop_limit);
+std::string UdpPort(uint32_t udp_port);
+std::string UdpChecksum(uint32_t checksum);
+std::string UdpLength(uint32_t udp_length);
+std::string TcpPort(uint32_t tcp_port);
+std::string TcpSequenceNumber(uint32_t sequence_number);
+std::string TcpAcknowledgementNumber(uint32_t ackowledgement_number);
+std::string TcpDataOffset(uint32_t data_offset);
+std::string TcpRestOfHeader(uint64_t rest_of_header);
+std::string ArpType(uint32_t type);
+std::string ArpLength(uint32_t length);
+std::string ArpOperation(uint32_t operation);
+std::string IcmpType(uint32_t type);
+std::string IcmpCode(uint32_t code);
+std::string IcmpChecksum(uint32_t checksum);
+std::string IcmpRestOfHeader(uint32_t rest_of_header);
+std::string GreChecksumPresent(uint32_t checksum_present);
+std::string GreReserved0(uint32_t reserved0);
+std::string GreVersion(uint32_t version);
+std::string GreProtocolType(uint32_t protocol_type);
+std::string GreChecksum(uint32_t checksum);
+std::string GreReserved1(uint32_t reserved1);
+
+// -- END OF PUBLIC INTERFACE --------------------------------------------------
+
+template <int bit_limit>
+std::string ValidateAndConvertToHexString(uint64_t input) {
+  int bit_width = absl::bit_width(input);
+  if (bit_width > bit_limit) {
+    LOG(DFATAL)
+        << "Input has been truncated because maximum allowable bitwidth "
+           "for this field is "
+        << bit_limit << " but input has " << bit_width << " bits: " << input;
+  }
+
+  return pdpi::BitsetToHexString(std::bitset<bit_limit>(input));
+}
+
+}  // namespace packetlib
+
+#endif  // GOOGLE_P4_PDPI_PACKETLIB_PACKETLIB_H_

--- a/p4_pdpi/packetlib/packetlib.proto
+++ b/p4_pdpi/packetlib/packetlib.proto
@@ -1,0 +1,186 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package packetlib;
+
+// Describes a network packet.
+message Packet {
+  // Headers in order, starting with outermost header. Can be empty.
+  repeated Header headers = 1;
+  // Arbitrary sequence of raw, uninterpreted bytes.
+  bytes payload = 2;
+  // Explanation why parsing has stopped early due to a feature that is not
+  // supported. Describes a problem with the first set of bytes in `payload`.
+  // Only used in the output of parsing functions, and is ignored during
+  // serialization.
+  string reason_not_fully_parsed = 3;
+  // Explanation why the parsed set of headers is not valid (e.g., invalid
+  // checksum). Only covers `headers`, not the `payload`.
+  // Only used in the output of parsing functions, and is ignored during
+  // serialization.
+  repeated string reasons_invalid = 4;
+}
+
+// Describes a network packet header. This is not an exhaustive list of headers,
+// and not every header may support all fields available for that particular
+// header (e.g. optional fields may not be supported).
+//
+// Individual header fields are named roughly according to what the
+// corresponding Wikipedia article names the fields, and fields are ordered
+// based on the order of the fields in the packet.
+//
+// The header fields use the format from PDPI's ir.proto, i.e.
+// "00:11:ab:cd:ef:22" for  MAC addresses, "10.0.0.2" or
+// "fe80::21a:11ff:fe17:5f80" for IP addresses, and hex strings such as "0x0800"
+// for most other fields. This allows us to distinguish the absence of fields
+// even though we use proto3, since the empty string is never a valid value.
+message Header {
+  oneof header {
+    EthernetHeader ethernet_header = 1;
+    Ipv4Header ipv4_header = 2;
+    Ipv6Header ipv6_header = 3;
+    UdpHeader udp_header = 4;
+    TcpHeader tcp_header = 5;
+    ArpHeader arp_header = 6;
+    IcmpHeader icmp_header = 7;
+    VlanHeader vlan_header = 8;
+    GreHeader gre_header = 9;
+    SaiP4BMv2PacketInHeader sai_p4_bmv2_packet_in_header = 10;
+  }
+}
+
+// An ethernet header.
+// Only a handful of ethertypes are supported.
+message EthernetHeader {
+  string ethernet_destination = 1;  // Format::MAC
+  string ethernet_source = 2;       // Format::MAC
+  string ethertype = 3;             // 16 bits
+}
+
+// A VLAN header.
+// Only a handful of ethertypes are supported.
+message VlanHeader {
+  string priority_code_point = 1;      // 3 bits
+  string drop_eligible_indicator = 2;  // 1 bit
+  string vlan_identifier = 3;          // 12 bits
+  string ethertype = 4;                // 16 bits
+}
+
+// An ARP header.
+// It is assumed to be used with Ethernet and IPv4.
+message ArpHeader {
+  string hardware_type = 1;  // 16 bits (computed field, constant 1 (Ethernet))
+  string protocol_type = 2;  // 16 bits (computed field, constant 0x800 (IPv4))
+  string hardware_length = 3;          // 8 bits (computed field, constant 6)
+  string protocol_length = 4;          // 8 bits (computed field, constant 4)
+  string operation = 5;                // 16 bits
+  string sender_hardware_address = 6;  // Format::MAC
+  string sender_protocol_address = 7;  // Format::IPV4
+  string target_hardware_address = 8;  // Format::MAC
+  string target_protocol_address = 9;  // Format::IPV4
+}
+
+// An IPv4 header.
+message Ipv4Header {
+  string version = 1;            //  4 bits (computed field, constant 4)
+  string ihl = 2;                //  4 bits (computed field)
+  string dscp = 3;               //  6 bits
+  string ecn = 4;                //  2 bits
+  string total_length = 5;       // 16 bits (computed field)
+  string identification = 6;     // 16 bits
+  string flags = 7;              //  3 bits
+  string fragment_offset = 8;    // 13 bits
+  string ttl = 9;                //  8 bits
+  string protocol = 10;          //  8 bits
+  string checksum = 11;          // 16 bits (computed field)
+  string ipv4_source = 12;       // Format::IPV4
+  string ipv4_destination = 13;  // Format::IPV4
+  // Empty string when IHL = 5. Sequence of (IHL - 5) uninterpreted 32-bit words
+  // in hex format when IHL > 5. Includes the options, but may contain
+  // additional trailing bits so as to match in length what is specified by IHL.
+  string uninterpreted_options = 14;
+}
+
+// An IPv6 header.
+message Ipv6Header {
+  string version = 1;           //  4 bits (computed field, constant 6)
+  string dscp = 2;              //  6 bits
+  string ecn = 3;               //  2 bits
+  string flow_label = 4;        // 20 bits
+  string payload_length = 5;    // 16 bits (computed field)
+  string next_header = 6;       // 8 bits
+  string hop_limit = 7;         // 8 bits
+  string ipv6_source = 8;       // Format::IPV6
+  string ipv6_destination = 9;  // Format::IPV6
+}
+
+// An ICMP header.
+message IcmpHeader {
+  string type = 1;            // 8 bits
+  string code = 2;            // 8 bits
+  string checksum = 3;        // 16 bits (computed field)
+  string rest_of_header = 4;  // 32 bits
+}
+
+// A UDP header.
+message UdpHeader {
+  string source_port = 1;       // 16 bits
+  string destination_port = 2;  // 16 bits
+  string length = 3;            // 16 bits (computed field)
+  string checksum = 4;          // 16 bits (computed field)
+}
+
+// A TCP header.
+message TcpHeader {
+  string source_port = 1;             // 16 bits
+  string destination_port = 2;        // 16 bits
+  string sequence_number = 3;         // 32 bits
+  string acknowledgement_number = 4;  // 32 bits
+  string data_offset = 5;             // 4 bits (computed field)
+  string rest_of_header = 6;          // 60 bits.
+  // Empty string when data_offset = 5. Sequence of (data_offset - 5)
+  // uninterpreted 32-bit words in hex format when data_offset > 5.
+  string uninterpreted_options = 7;
+}
+
+// Standard GRE packet header (RFC 2784).
+message GreHeader {
+  // If the checksum_present bit is set, then the checksum and the reserved1
+  // fields are present and the checksum field contains valid information.
+  string checksum_present = 1;  // 1 bit
+  string reserved0 = 2;         // 12 bits (computed field, constant 0)
+  // The version field must contain value zero (RFC 2784).
+  string version = 3;  // 3 bits (computed field, constant 0)
+  // Indicates the EtherType of the encapsulated payload.
+  string protocol_type = 4;  // 16 bits
+  // Empty string if checksum_bit is not set.
+  string checksum = 5;  // 16 bits (computed field, optional)
+  // Empty string if checksum_bit is not set.
+  string reserved1 = 6;  // 16 bits (optional)
+}
+
+// Packet IO header is used to encapsulate packet-ins, i.e. packets punted from
+// the switch to the controller, in SAI P4 / PINS. Never extracted during
+// parsing, but serialized during deparsing for packets punted to the
+// controller.
+message SaiP4BMv2PacketInHeader {
+  // The port the packet ingressed on.
+  string ingress_port = 1;  // 9 bits
+  // The initial intended egress port decided for the packet by the pipeline.
+  string target_egress_port = 2;  // 9 bits
+  // Padding field to align the header to 8-bit multiple, as required by BMv2.
+  string unused_pad = 3;  // 6 bits
+}

--- a/p4_pdpi/packetlib/packetlib_fuzzer_test.cc
+++ b/p4_pdpi/packetlib/packetlib_fuzzer_test.cc
@@ -1,0 +1,163 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include "absl/random/distributions.h"
+#include "absl/random/random.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/escaping.h"
+#include "absl/strings/str_cat.h"
+#include "glog/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/proto.h"
+#include "gutil/status_matchers.h"
+#include "p4_pdpi/packetlib/packetlib.h"
+#include "p4_pdpi/string_encodings/hex_string.h"
+#include "p4_pdpi/string_encodings/readable_byte_string.h"
+
+namespace packetlib {
+
+using ::gutil::IsOkAndHolds;
+
+constexpr int kFuzzerIterations = 10000;
+
+using FuzzerTemplateInput = std::pair<std::string, std::string>;
+
+// We use templates to help the fuzzer come up with parsable packets, otherwise
+// one usually can only parse the first header. Templates are readable bit
+// strings, but with ? for random hex characters.
+std::string TemplateForEthertype(std::string ethertype) {
+  return absl::StrCat(R"R(
+  # ethernet header
+  ethernet_source: 0x????????????
+  ethernet_destination: 0x????????????
+  ether_type:
+)R",
+                      ethertype);
+}
+std::vector<FuzzerTemplateInput> AllFuzzerTemplateInputs() {
+  std::vector<FuzzerTemplateInput> result;
+
+  // No template.
+  result.push_back({"random", ""});
+
+  // Known ether types.
+  result.push_back({"ipv4", TemplateForEthertype("0x0800")});
+  result.push_back({"ipv6", TemplateForEthertype("0x86dd")});
+  result.push_back({"arp", TemplateForEthertype("0x0806")});
+  result.push_back({"vlan", TemplateForEthertype("0x8100")});
+
+  return result;
+}
+
+std::string RandomPacket(absl::BitGen& gen,
+                         const std::string& packet_template = "") {
+  int num_bytes = absl::Uniform<int>(gen, /*lo=*/1, /*hi=*/200);
+  std::string result;
+
+  if (!packet_template.empty()) {
+    std::string readable_byte_string;
+    // Substitute '?' with a random hex character.
+    for (char c : packet_template) {
+      if (c == '?') {
+        readable_byte_string += pdpi::HexDigitToChar(absl::Uniform(gen, 0, 16));
+      } else {
+        readable_byte_string += c;
+      }
+    }
+    auto prefix = pdpi::ReadableByteStringToByteString(readable_byte_string);
+    CHECK(prefix.status().ok())
+        << "Invalid packet template: " << packet_template;
+    result = *prefix;
+  }
+
+  // Randomly fill the rest of the packet.
+  for (int i = result.size(); i < num_bytes; i++) {
+    char c = absl::Uniform<int>(gen, /*lo=*/0, /*hi=*/256);
+    result += c;
+  }
+  return result;
+}
+
+std::string ShortPacketDescription(const Packet& packet) {
+  std::stringstream result;
+  for (const Header& header : packet.headers()) {
+    auto header_name = gutil::GetOneOfFieldName(header, "header");
+    result << header_name.value_or("error") << "; ";
+  }
+  int size = packet.payload().size();
+  result << size << " byte" << (size > 0 ? "s" : "") << " payload";
+  if (!packet.reasons_invalid().empty()) {
+    result << "; invalid";
+  }
+  if (!packet.reason_not_fully_parsed().empty()) {
+    result << "; unsupported";
+  }
+  return result.str();
+}
+
+class PacketlibFuzzerTest
+    : public testing::TestWithParam<std::pair<std::string, std::string>> {};
+
+TEST_P(PacketlibFuzzerTest, RandomPacketStringParseAndSerializeRoundtrip) {
+  absl::BitGen gen;
+
+  std::string packet_template = GetParam().second;
+
+  for (int i = 0; i < kFuzzerIterations; i++) {
+    std::string packet = RandomPacket(gen, packet_template);
+    Packet parsed_packet = ParsePacket(packet);
+
+    LOG(INFO) << "Fuzzing packet: " << ShortPacketDescription(parsed_packet);
+
+    std::string context =
+        absl::StrCat("\npacket = ", absl::BytesToHexString(packet),
+                     "\nparsed_packet = ", parsed_packet.DebugString());
+
+    absl::StatusOr<std::string> serialized_packet =
+        RawSerializePacket(parsed_packet);
+    if (serialized_packet.ok()) {
+      EXPECT_EQ(absl::BytesToHexString(packet),
+                absl::BytesToHexString(*serialized_packet))
+          << context;
+      EXPECT_THAT(PacketSizeInBits(parsed_packet),
+                  IsOkAndHolds(packet.size() * 8))
+          << context;
+
+      if (parsed_packet.reasons_invalid().empty()) {
+        EXPECT_OK(ValidatePacket(parsed_packet))
+            << "parsed_packet =\n"
+            << parsed_packet.DebugString() << "\n"
+            << "\nValidatePacket(parsed_packet) = "
+            << ValidatePacket(parsed_packet).ToString();
+      }
+    } else {
+      ADD_FAILURE() << "Parsed random packet string and tried to serialize, "
+                       "but failed\nerror = "
+                    << serialized_packet.status() << context;
+    }
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Templates, PacketlibFuzzerTest,
+    testing::ValuesIn(AllFuzzerTemplateInputs()),
+    [](const testing::TestParamInfo<PacketlibFuzzerTest::ParamType>& info) {
+      return info.param.first;
+    });
+
+}  // namespace packetlib

--- a/p4_pdpi/packetlib/packetlib_test_runner.cc
+++ b/p4_pdpi/packetlib/packetlib_test_runner.cc
@@ -1,0 +1,1431 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/escaping.h"
+#include "absl/strings/str_cat.h"
+#include "google/protobuf/util/message_differencer.h"
+#include "gutil/proto.h"
+#include "gutil/testing.h"
+#include "p4_pdpi/packetlib/packetlib.h"
+#include "p4_pdpi/packetlib/packetlib.pb.h"
+#include "p4_pdpi/string_encodings/readable_byte_string.h"
+
+namespace packetlib {
+
+using ::gutil::PrintShortTextProto;
+using ::gutil::PrintTextProto;
+
+constexpr char kBanner[] =
+    "=========================================================================="
+    "======\n";
+constexpr char kInputHeader[] =
+    "-- INPUT -----------------------------------------------------------------"
+    "------\n";
+constexpr char kOutputHeader[] =
+    "-- OUTPUT ----------------------------------------------------------------"
+    "------\n";
+constexpr char kRoundtripHeader[] =
+    "-- ROUNDTRIP ERRORS ------------------------------------------------------"
+    "------\n";
+
+// Return "<status_code>: <status_message>. The ToString method for absl::Status
+// is not meant to be used directly in tests.
+const std::string StatusToStableString(const absl::Status& status) {
+  std::string status_message = absl::StatusCodeToString(status.code());
+  if (!status.ok()) {
+    absl::StrAppend(&status_message, ": ", status.message());
+  }
+  return status_message;
+}
+
+// Parses packet from bytes, and if it succeeds, re-serializes the parsed packet
+// to check that the resulting bytes match the original input.
+void RunPacketParseTest(
+    const std::string& name, const std::string& readable_byte_string,
+    Header::HeaderCase first_header = Header::kEthernetHeader) {
+  std::cout << kBanner << "Parsing test: " << name << "\n" << kBanner;
+  std::cout << kInputHeader << absl::StripAsciiWhitespace(readable_byte_string)
+            << "\n"
+            << kOutputHeader;
+
+  // Attempt to parse.
+  auto byte_string = pdpi::ReadableByteStringToByteString(readable_byte_string);
+  if (!byte_string.ok()) {
+    std::cout << "TEST BUG, DO NOT"
+              << " SUBMIT! ReadableByteStringToByteString failed: "
+              << byte_string.status() << "\n";
+    return;
+  }
+  Packet packet = ParsePacket(*byte_string, first_header);
+  std::cout << PrintTextProto(packet) << "\n";
+
+  // Check roundtrip if parsing succeeded, or try to fix packet otherwise.
+  if (packet.reasons_invalid().empty()) {
+    auto byte_string_after_roundtrip = SerializePacket(packet);
+    if (!byte_string_after_roundtrip.ok()) {
+      std::cout << kRoundtripHeader
+                << StatusToStableString(byte_string_after_roundtrip.status())
+                << "\n";
+    } else if (*byte_string_after_roundtrip != *byte_string) {
+      std::cout << kRoundtripHeader
+                << "Original packet does not match packet after parsing and "
+                << "reserialization.\nOriginal packet:\n"
+                << absl::BytesToHexString(*byte_string)
+                << "\nParsed and reserialized packet:\n"
+                << absl::BytesToHexString(*byte_string_after_roundtrip) << "\n";
+    }
+  } else {
+    // The packet is invalid. Try to fix it.
+    auto padded = PadPacketToMinimumSize(packet);
+    std::cout << "PadPacketToMinimumSize(packet) = ";
+    if (padded.ok()) {
+      std::cout << (*padded ? "true" : "false") << "\n";
+    } else {
+      std::cout << StatusToStableString(padded.status()) << "\n";
+    }
+    auto updated = UpdateAllComputedFields(packet);
+    std::cout << "UpdateAllComputedFields(packet) = ";
+    if (updated.ok()) {
+      std::cout << (*updated ? "true" : "false") << "\n";
+    } else {
+      std::cout << StatusToStableString(updated.status()) << "\n";
+    }
+    if ((padded.ok() && *padded) || (updated.ok() && *updated)) {
+      packet.clear_reason_not_fully_parsed();
+      packet.clear_reasons_invalid();
+      std::cout << "ValidatePacket(packet) = "
+                << StatusToStableString(ValidatePacket(packet)) << "\n";
+    }
+  }
+}
+
+// Validates the packet, and if it's not valid, attempts to
+// UpdateAllComputedFields and revalidate.
+// Then attempt to serialize the packet, and if this succeeds, parse the
+// serialized packet back and verify that it matches the original packet.
+void RunProtoPacketTest(
+    const std::string& name, Packet packet,
+    Header::HeaderCase first_header = Header::kEthernetHeader) {
+  std::cout << kBanner << "Proto packet test: " << name << "\n" << kBanner;
+  std::cout << kInputHeader << "packet =" << std::endl
+            << PrintTextProto(packet) << std::endl
+            << kOutputHeader;
+
+  auto valid = ValidatePacket(packet);
+  std::cout << "ValidatePacket(packet) = " << StatusToStableString(valid)
+            << std::endl;
+
+  if (!valid.ok()) {
+    std::cout << std::endl << "PadPacketToMinimumSize(packet) = ";
+    if (auto padded = PadPacketToMinimumSize(packet); padded.ok()) {
+      std::cout << (*padded ? "true" : "false") << std::endl;
+      if (*padded) {
+        // To print the payload in protobuf style, we put it in an otherwise
+        // empty packet.
+        Packet payload_only;
+        payload_only.set_payload(packet.payload());
+        std::cout << "new " << PrintShortTextProto(payload_only) << std::endl;
+      }
+    } else {
+      std::cout << StatusToStableString(padded.status()) << std::endl;
+    }
+
+    std::cout << std::endl << "UpdateMissingComputedFields(packet) = ";
+    if (auto updated = UpdateMissingComputedFields(packet); updated.ok()) {
+      std::cout << (*updated ? "true" : "false") << std::endl;
+      if (*updated) {
+        std::cout << "packet =" << std::endl
+                  << PrintTextProto(packet) << std::endl;
+        // Try validating once more.
+        std::cout << "ValidatePacket(packet) = "
+                  << StatusToStableString(ValidatePacket(packet)) << std::endl;
+      }
+    } else {
+      std::cout << StatusToStableString(updated.status()) << std::endl;
+    }
+  }
+
+  // Try serializing (valid or invalid) packet.
+  absl::StatusOr<std::string> bytes = SerializePacket(packet);
+  std::cout << std::endl
+            << "Serialize(Packet) = " << StatusToStableString(bytes.status())
+            << "\n\n";
+  if (!bytes.ok()) return;
+
+  // Test if the packet can be parsed back.
+  auto reparsed_packet = ParsePacket(*bytes, first_header);
+  // Check roundtrip property modulo `reason_not_fully_parsed` field.
+  reparsed_packet.clear_reason_not_fully_parsed();
+  google::protobuf::util::MessageDifferencer differ;
+  std::string diff;
+  differ.ReportDifferencesToString(&diff);
+  if (!differ.Compare(packet, reparsed_packet)) {
+    std::cout << kRoundtripHeader
+              << "Original packet does not match packet after serialization "
+                 "and reparsing:\n"
+              << diff << "\n\n";
+  }
+}
+
+void RunPacketParseTests() {
+  RunPacketParseTest("Ethernet packet (valid)", R"pb(
+    # ethernet header
+    ethernet_destination: 0xaabbccddeeff
+    ethernet_source: 0x112233445566
+    ether_type: 0x002e  # This means size(payload) = 0x2e bytes = 46 bytes.
+    # payload
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd
+  )pb");
+
+  RunPacketParseTest("Ethernet packet (invalid)", R"pb(
+    # ethernet header
+    ethernet_destination: 0xaabbccddeeff
+    ethernet_source: 0x112233445566
+    ether_type: 0x0001  # This means size(payload) = 1 byte.
+    # payload
+    payload: 0x0102  # 2 bytes, but ether_type says 1 byte & minimum size is 46.
+  )pb");
+
+  RunPacketParseTest("Ethernet packet (unsupported EtherType)", R"pb(
+    # ethernet header
+    ethernet_destination: 0xaabbccddeeff
+    ethernet_source: 0x112233445566
+    ether_type: 0x0842  # Wake-on-LAN
+  )pb");
+
+  RunPacketParseTest("IPv4 packet (invalid)", R"pb(
+    # ethernet header
+    ethernet_destination: 0xaabbccddeeff
+    ethernet_source: 0x112233445566
+    ether_type: 0x0800
+    # IPv4 header:
+    version: 0x4
+    ihl: 0x5
+    dscp: 0b011011
+    ecn: 0b01
+    total_length: 0x6fc6
+    identification: 0xa3cd
+    flags: 0b000
+    fragment_offset: 0b0000000000000
+    ttl: 0x10
+    protocol: 0x05  # some unsupported protocol
+    checksum: 0x1234
+    ipv4_source: 0x0a000001
+    ipv4_destination: 0x14000003
+    # other headers:
+    payload: 0x1234
+  )pb");
+
+  RunPacketParseTest("IPv4 packet (valid)", R"pb(
+    # ethernet header
+    ethernet_destination: 0xaabbccddeeff
+    ethernet_source: 0x112233445566
+    ether_type: 0x0800
+    # IPv4 header:
+    version: 0x4
+    ihl: 0x5
+    dscp: 0b011011
+    ecn: 0b01
+    total_length: 0x0034
+    identification: 0xa3cd
+    flags: 0b000
+    fragment_offset: 0b0000000000000
+    ttl: 0x10
+    protocol: 0x05  # some unsupported protocol
+    checksum: 0xe887
+    ipv4_source: 0x0a000001
+    ipv4_destination: 0x14000003
+    # payload:
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff
+  )pb");
+
+  RunPacketParseTest("IPv4 packet (checksum example)", R"pb(
+    # Taken from
+    # wikipedia.org/wiki/IPv4_header_checksum#Calculating_the_IPv4_header_checksum
+    #
+    # ethernet header
+    ethernet_destination: 0xaabbccddeeff
+    ethernet_source: 0x112233445566
+    ether_type: 0x0800
+    # IPv4 header and payload
+    ipv4_header: 0x 4500 0073 0000 4000 4011 b861 c0a8 0001 c0a8 00c7
+    payload: 0x 0035 e97c 005f 279f 1e4b 8180
+  )pb");
+
+  RunPacketParseTest("IPv4 packet with options (valid)", R"pb(
+    # Ethernet header
+    ethernet_destination: 0xaabbccddeeff
+    ethernet_source: 0x112233445566
+    ether_type: 0x0800
+    # IPv4 header:
+    version: 0x4
+    ihl: 0x6  # 5 + 1 x 32-bit suffix
+    dscp: 0b011011
+    ecn: 0b01
+    total_length: 0x0038
+    identification: 0xa3cd
+    flags: 0b000
+    fragment_offset: 0b0000000000000
+    ttl: 0x10
+    protocol: 0x05  # some unsupported protocol
+    checksum: 0xa31d
+    ipv4_source: 0x0a000001
+    ipv4_destination: 0x14000003
+    uninterpreted_suffix: 0x11223344
+    # Payload
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff
+  )pb");
+
+  RunPacketParseTest("IPv4 packet with options (too short)", R"pb(
+    # Ethernet header
+    ethernet_destination: 0xaabbccddeeff
+    ethernet_source: 0x112233445566
+    ether_type: 0x0800
+    # IPv4 header:
+    version: 0x4
+    ihl: 0x6  # 5 + 1 x 32-bit suffix
+    dscp: 0b011011
+    ecn: 0b01
+    total_length: 0x0018
+    identification: 0xa3cd
+    flags: 0b000
+    fragment_offset: 0b0000000000000
+    ttl: 0x10
+    protocol: 0x05  # some unsupported protocol
+    checksum: 0xd6a3
+    ipv4_source: 0x0a000001
+    ipv4_destination: 0x14000003
+    uninterpreted_suffix: 0x11  # Should be 32 bits, but is only 8 bits.
+  )pb");
+
+  RunPacketParseTest("IPv4 packet with IP protocol 0xfd", R"pb(
+    # ethernet header
+    ethernet_destination: 0xaabbccddeeff
+    ethernet_source: 0x112233445566
+    ether_type: 0x0800
+    # IPv4 header:
+    version: 0x4
+    ihl: 0x5
+    dscp: 0b011011
+    ecn: 0b01
+    total_length: 0x0034
+    identification: 0xa3cd
+    flags: 0b000
+    fragment_offset: 0b0000000000000
+    ttl: 0x10
+    protocol: 0xfd  # Reserved for experimentation -- payload is arbitrary.
+    checksum: 0xe78f
+    ipv4_source: 0x0a000001
+    ipv4_destination: 0x14000003
+    # payload:
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff
+  )pb");
+
+  RunPacketParseTest("IPv6 packet with IP protocol 0xfe", R"pb(
+    # ethernet header
+    ethernet_destination: 0xffeeddccbbaa
+    ethernet_source: 0x554433221100
+    ether_type: 0x86DD
+    # IPv6 header:
+    version: 0x6
+    dscp: 0b011011
+    ecn: 0b01
+    flow_label: 0x12345
+    payload_length: 0x0010
+    next_header: 0xfd  # Reserved for experimentation -- payload is arbitrary.
+    hop_limit: 0x03
+    ipv6_source: 0x00001111222233334444555566667777
+    ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+    # other headers:
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff
+  )pb");
+
+  RunPacketParseTest("IPv6 packet (invalid)", R"pb(
+    # ethernet header
+    ethernet_destination: 0xffeeddccbbaa
+    ethernet_source: 0x554433221100
+    ether_type: 0x86DD
+    # IPv6 header:
+    version: 0x4
+    dscp: 0b011011
+    ecn: 0b01
+    flow_label: 0x12345
+    payload_length: 0x0000
+    next_header: 0x90  # some unassigned protocol
+    hop_limit: 0xff
+    ipv6_source: 0x00001111222233334444555566667777
+    ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+    # other headers:
+    payload: 0x12
+  )pb");
+
+  RunPacketParseTest("IPv6 packet (valid)", R"pb(
+    # ethernet header
+    ethernet_destination: 0xffeeddccbbaa
+    ethernet_source: 0x554433221100
+    ether_type: 0x86DD
+    # IPv6 header:
+    version: 0x6
+    dscp: 0b011011
+    ecn: 0b01
+    flow_label: 0x12345
+    payload_length: 0x0020
+    next_header: 0x90  # some unassigned protocol
+    hop_limit: 0x03
+    ipv6_source: 0x00001111222233334444555566667777
+    ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+    # other headers:
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff
+  )pb");
+
+  RunPacketParseTest("UDP packet (valid)", R"pb(
+    # Taken from
+    # www.securitynik.com/2015/08/calculating-udp-checksum-with-taste-of.html
+    # --------------------------------------------------------------------------
+    # Ethernet header
+    ethernet_destination: 0xaabbccddeeff
+    ethernet_source: 0x112233445566
+    ether_type: 0x0800
+    # IPv4 header
+    version: 0x4
+    ihl: 0x5
+    dscp: 0b011011
+    ecn: 0b01
+    total_length: 0x002e
+    identification: 0x0000
+    flags: 0b000
+    fragment_offset: 0b0000000000000
+    ttl: 0x10
+    protocol: 0x11  # UDP
+    checksum: 0x28c5
+    ipv4_source: 0xc0a8001f       # 192.168.0.31
+    ipv4_destination: 0xc0a8001e  # 192.168.0.30
+    # UDP header
+    source_port: 0x0014       # 20
+    destination_port: 0x000a  # 10
+    length: 0x001a            # 26
+    checksum: 0x7961
+    # Payload
+    payload: 0x4869                                             # "Hi" in ASCII
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff  # Padding
+  )pb");
+
+  RunPacketParseTest("TCP packet (valid)", R"pb(
+    # Taken from
+    # www.erg.abdn.ac.uk/users/gorry/course/inet-pages/packet-decode3.html
+    # --------------------------------------------------------------------------
+    # Ethernet header
+    ethernet_destination: 0x 00 e0 f7 26 3f e9
+    ethernet_source: 0x 08 00 20 86 35 4b
+    ether_type: 0x0800
+    # IPv4 header
+    version: 0x4
+    ihl: 0x5
+    dscp: 0b000000
+    ecn: 0b00
+    total_length: 0x002e
+    identification: 0x08b8
+    flags: 0b010
+    fragment_offset: 0b0000000000000
+    ttl: 0xff
+    protocol: 0x06  # TCP
+    checksum: 0x9995
+    ipv4_source: 0x8b85d96e       # 139.133.217.110
+    ipv4_destination: 0x8b85e902  # 139.133.233.2
+    # TCP header
+    source_port: 0x9005          # 36869
+    destination_port: 0x0017     # 23 (TELNET)
+    sequence_number: 0x7214f114  # 1913975060
+    acknowledgement_number: 0x00000000
+    data_offset: 0x6  # 6 x 32 bits = 24 bytes
+    reserved: 0b000
+    flags: 0b 0 0 0 0 0 0 0 1 0  # SYN
+    window_size: 0x2238          # 8760
+    checksum: 0xa92c
+    urgent_pointer: 0x0000
+    options: 0x 0204 05b4
+    # Payload
+    payload: 0x 11 22
+  )pb");
+
+  RunPacketParseTest("ARP Packet (Valid)", R"pb(
+    # Ethernet header
+    ethernet_destination: 0x ff ff ff ff ff ff
+    ethernet_source: 0x 00 11 22 33 44 55
+    ether_type: 0x0806
+    # ARP header
+    hardware_type: 0x0001  # Ethernet
+    protocol_type: 0x0800  # IPv4
+    hardware_length: 0x06
+    protocol_length: 0x04
+    operation: 0x0001  # Request
+    sender_hardware_address: 0x 00 11 22 33 44 55
+    sender_protocol_address: 0x 0a 00 00 01
+    target_hardware_address: 0x 00 00 00 00 00 00
+    target_protocol_address: 0x 0a 00 00 02
+    # Payload
+    payload: 0x 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  )pb");
+
+  RunPacketParseTest("ICMPv4 Packet (Valid)", R"pb(
+    # Taken from
+    # www.erg.abdn.ac.uk/users/gorry/course/inet-pages/packet-dec1.html
+    # --------------------------------------------------------------------------
+    # Ethernet header
+    ethernet_destination: 0x 08 00 20 86 35 4b
+    ethernet_source: 0x 00 e0 f7 26 3f e9
+    ether_type: 0x0800
+    # IPv4 header
+    version: 0x4
+    ihl: 0x5
+    dscp: 0b000000
+    ecn: 0b00
+    total_length: 0x0054
+    identification: 0xaafb
+    flags: 0b010  # website's 0x4 is from interpreting 4 bits.
+    fragment_offset: 0b0000000000000
+    ttl: 0xfc       # 252
+    protocol: 0x01  # ICMP
+    checksum: 0xfa30
+    ipv4_source: 0x 8b 85 e9 02       # 139.133.233.2
+    ipv4_destination: 0x 8b 85 d9 6e  # 139.133.233.110
+    # ICMP header
+    type: 0x00
+    code: 0x00
+    checksum: 0x45da
+    rest_of_header: 0x 1e 60 00 00
+    # payload
+    payload: 0x 33 5e 3a b8 00 00 42 ac 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14
+    payload: 0x 15 16 17 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25 26 27 28 29
+    payload: 0x 2a 2b 2c 2d 2e 2f 30 31 32 33 34 35 36 37
+  )pb");
+  RunPacketParseTest("ICMPv6 Packet (Valid)", R"pb(
+    # Taken from
+    # www.cloudshark.org/captures/e98730aee1fb
+    # --------------------------------------------------------------------------
+    # Ethernet header
+    ethernet_destination: 0x c2 01 51 fa 00 00
+    ethernet_source: 0x c2 00 51 fa 00 00
+    ethertype: 0x86dd
+    # IPv6 header:
+    version: 0x6
+    dscp: 0b000000
+    ecn: 0b00
+    flow_label: 0x00000
+    payload_length: 0x003c
+    next_header: 0x3a  # ICMP
+    hop_limit: 0x40
+    ipv6_source: 0x20010db8000000120000000000000001
+    ipv6_destination: 0x20010db8000000120000000000000002
+    # ICMP header:
+    type: 0x80
+    code: 0x00
+    checksum: 0x863c
+    rest_of_header: 0x 11 0d 00 00
+    # payload
+    payload: 0x 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14
+    payload: 0x 15 16 17 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25 26 27 28 29
+    payload: 0x 2a 2b 2c 2d 2e 2f 30 31 32 33
+  )pb");
+
+  RunPacketParseTest("VLAN Packet with ARP (Valid)", R"pb(
+    # Taken from
+    # www.cloudshark.org/captures/e7f1b8c0b434
+    # --------------------------------------------------------------------------
+    # Ethernet header
+    ethernet_destination: 0x ff ff ff ff ff ff
+    ethernet_source: 0x 00 19 06 ea b8 c1
+    ether_type: 0x8100
+    # VLAN header
+    priority_code_point: 0b000
+    drop_eligibility_indicator: 0b0
+    vlan_identifier: 0x07b
+    ether_type: 0x0806
+    # ARP header
+    hardware_type: 0x0001  # Ethernet
+    protocol_type: 0x0800  # IPv4
+    hardware_length: 0x06
+    protocol_length: 0x04
+    operation: 0x0002  # Reply
+    sender_hardware_address: 0x 00 19 06 ea b8 c1
+    sender_protocol_address: 0x c0 a8 7b 01
+    target_hardware_address: 0x ff ff ff ff ff ff
+    target_protocol_address: 0x c0 a8 7b 01
+    # Payload
+    payload: 0x 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  )pb");
+}
+
+void RunAdditionalPacketParseTests() {
+  RunPacketParseTest("Packet too short to parse a GRE header (Invalid)", R"pb(
+    # Ethernet header
+    ethernet_destination: 0x c2 01 51 fa 00 00
+    ethernet_source: 0x c2 00 51 fa 00 00
+    ethertype: 0x86DD
+    # IPv6 header:
+    version: 0x6
+    dscp: 0b000000
+    ecn: 0b00
+    flow_label: 0x00000
+    payload_length: 0x0001
+    next_header: 0x2f  # GRE
+    hop_limit: 0x3f
+    ipv6_source: 0x2607F8B0C15000100000000000000000
+    ipv6_destination: 0x20020A05686007490000000000000000
+    # GRE header:
+    checksum_present: 0b0
+    reserved0: 0b0000000
+  )pb");
+  RunPacketParseTest(
+      "Packet too short to parse a GRE header with optional fields (Invalid)",
+      R"pb(
+        # Ethernet header
+        ethernet_destination: 0x c2 01 51 fa 00 00
+        ethernet_source: 0x c2 00 51 fa 00 00
+        ethertype: 0x86DD
+        # IPv6 header:
+        version: 0x6
+        dscp: 0b000000
+        ecn: 0b00
+        flow_label: 0x00000
+        payload_length: 0x0004
+        next_header: 0x2f  # GRE
+        hop_limit: 0x3f
+        ipv6_source: 0x2607F8B0C15000100000000000000000
+        ipv6_destination: 0x20020A05686007490000000000000000
+        # GRE header:
+        checksum_present: 0b1
+        reserved0: 0b000000000000
+        version: 0b000
+        protocol_type: 0x0800
+      )pb");
+
+  RunPacketParseTest("GRE Ipv4 Encapsulated with Ipv6 Header (Valid)", R"pb(
+    # Ethernet header
+    ethernet_destination: 0x c2 01 51 fa 00 00
+    ethernet_source: 0x c2 00 51 fa 00 00
+    ethertype: 0x86DD
+    # IPv6 header:
+    version: 0x6
+    dscp: 0b000000
+    ecn: 0b00
+    flow_label: 0x00000
+    payload_length: 0x011e
+    next_header: 0x2f  # GRE
+    hop_limit: 0x3f
+    ipv6_source: 0x2607F8B0C15000100000000000000000
+    ipv6_destination: 0x20020A05686007490000000000000000
+    # GRE header:
+    checksum_present: 0b0
+    reserved0: 0b000000000000
+    version: 0b000
+    protocol_type: 0x0800
+    # Encapsulated IPv4 header
+    version: 0x4
+    ihl: 0x5
+    dscp: 0b000000
+    ecn: 0b00
+    total_length: 0x011a
+    identification: 0x0000
+    flags: 0b000
+    fragment_offset: 0b0000000000000
+    ttl: 0x3f       # 63
+    protocol: 0x01  # ICMP
+    checksum: 0x753a
+    ipv4_source: 0x 80 00 00 00       # 128.0.0.0
+    ipv4_destination: 0x b9 a8 cc 00  # 185.168.204.0
+    # ICMP header:
+    type: 0x00
+    code: 0x00
+    checksum: 0x00e4
+    rest_of_header: 0x 00 00 00 00
+    # Payload
+    payload: 0x 74 65 73 74 20 70 61 63 6b 65 74 20 23 35 3a 20 52 4f 55 54 49
+    payload: 0x 4e 47 5f 50 49 4e 42 41 4c 4c 4c 33 54 4f 47 52 4f 55 50 5f 46
+    payload: 0x 4c 4f 57 3a 20 69 70 76 34 5F 74 61 62 6c 65 5f 65 6e 74 72 79
+    payload: 0x 20 09 20 7b 20 6d 61 74 63 68 20 7b 20 76 72 66 5f 69 64 3a 20
+    payload: 0x 22 76 72 66 2d 32 31 30 22 20 69 70 76 34 5f 64 73 74 20 7b 20
+    payload: 0x 76 61 6c 75 65 3a 20 22 31 38 35 2e 31 36 38 2e 32 30 34 2e 30
+    payload: 0x 22 20 70 72 65 66 69 78 5f 6c 65 6e 67 74 68 3a 20 32 38 20 7d
+    payload: 0x 20 7d 20 61 63 74 69 6f 6e 20 7b 20 73 65 74 5f 77 63 6d 70 5f
+    payload: 0x 67 72 6f 75 70 5f 69 64 5f 61 6e 64 5f 6d 65 74 61 64 61 74 61
+    payload: 0x 20 7b 20 77 63 6d 70 5f 67 72 6f 75 70 5f 69 64 3a 20 22 67 72
+    payload: 0x 6f 75 70 2d 34 32 39 34 39 33 34 35 37 38 22 20 72 6f 75 74 65
+    payload: 0x 5f 6d 65 74 61 64 61 74 61 3a 20 22 30 78 30 31 22 20 7d 20 7d
+    payload: 0x 20 7d
+  )pb");
+  RunPacketParseTest(
+      "GRE Ipv4 Encapsulated with Ipv6 Header with checksum present (Valid)",
+      R"pb(
+        # Ethernet header
+        ethernet_destination: 0x c2 01 51 fa 00 00
+        ethernet_source: 0x c2 00 51 fa 00 00
+        ethertype: 0x86DD
+        # IPv6 header:
+        version: 0x6
+        dscp: 0b000000
+        ecn: 0b00
+        flow_label: 0x00000
+        payload_length: 0x0122
+        next_header: 0x2f  # GRE
+        hop_limit: 0x3f
+        ipv6_source: 0x2607F8B0C15000100000000000000000
+        ipv6_destination: 0x20020A05686007490000000000000000
+        # GRE header:
+        checksum_present: 0b1
+        reserved0: 0b000000000000
+        version: 0b000
+        protocol_type: 0x0800
+        checksum: 0x77ff
+        reserved1: 0x0000
+        # Encapsulated IPv4 header
+        version: 0x4
+        ihl: 0x5
+        dscp: 0b000000
+        ecn: 0b00
+        total_length: 0x011a
+        identification: 0x0000
+        flags: 0b000
+        fragment_offset: 0b0000000000000
+        ttl: 0x3f       # 63
+        protocol: 0x01  # ICMP
+        checksum: 0x753a
+        ipv4_source: 0x 80 00 00 00       # 128.0.0.0
+        ipv4_destination: 0x b9 a8 cc 00  # 185.168.204.0
+        # ICMP header:
+        type: 0x00
+        code: 0x00
+        checksum: 0x00e4
+        rest_of_header: 0x 00 00 00 00
+        # Payload
+        payload:
+            0x 74 65 73 74 20 70 61 63 6b 65 74 20 23 35 3a 20 52 4f 55 54 49
+        payload:
+            0x 4e 47 5f 50 49 4e 42 41 4c 4c 4c 33 54 4f 47 52 4f 55 50 5f 46
+        payload:
+            0x 4c 4f 57 3a 20 69 70 76 34 5F 74 61 62 6c 65 5f 65 6e 74 72 79
+        payload:
+            0x 20 09 20 7b 20 6d 61 74 63 68 20 7b 20 76 72 66 5f 69 64 3a 20
+        payload:
+            0x 22 76 72 66 2d 32 31 30 22 20 69 70 76 34 5f 64 73 74 20 7b 20
+        payload:
+            0x 76 61 6c 75 65 3a 20 22 31 38 35 2e 31 36 38 2e 32 30 34 2e 30
+        payload:
+            0x 22 20 70 72 65 66 69 78 5f 6c 65 6e 67 74 68 3a 20 32 38 20 7d
+        payload:
+            0x 20 7d 20 61 63 74 69 6f 6e 20 7b 20 73 65 74 5f 77 63 6d 70 5f
+        payload:
+            0x 67 72 6f 75 70 5f 69 64 5f 61 6e 64 5f 6d 65 74 61 64 61 74 61
+        payload:
+            0x 20 7b 20 77 63 6d 70 5f 67 72 6f 75 70 5f 69 64 3a 20 22 67 72
+        payload:
+            0x 6f 75 70 2d 34 32 39 34 39 33 34 35 37 38 22 20 72 6f 75 74 65
+        payload:
+            0x 5f 6d 65 74 61 64 61 74 61 3a 20 22 30 78 30 31 22 20 7d 20 7d
+        payload: 0x 20 7d
+      )pb");
+  RunPacketParseTest(
+      "SAI P4 BMv2 packet_in header (Valid)", R"pb(
+        # SAI P4 BMv2 packet_in header
+        ingress_port: 0b000000001
+        target_egress_port: 0b000000010
+        unused_pad: 0b000000
+        # Ethernet header
+        ethernet_destination: 0x ff ff ff ff ff ff
+        ethernet_source: 0x 00 11 22 33 44 55
+        ether_type: 0x0806
+        # ARP header
+        hardware_type: 0x0001  # Ethernet
+        protocol_type: 0x0800  # IPv4
+        hardware_length: 0x06
+        protocol_length: 0x04
+        operation: 0x0001  # Request
+        sender_hardware_address: 0x 00 11 22 33 44 55
+        sender_protocol_address: 0x 0a 00 00 01
+        target_hardware_address: 0x 00 00 00 00 00 00
+        target_protocol_address: 0x 0a 00 00 02
+        # Payload
+        payload: 0x 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+      )pb",
+      /*first_header=*/Header::kSaiP4Bmv2PacketInHeader);
+  RunPacketParseTest(
+      "SAI P4 BMv2 packet_in header unused_pad value is not 0 (Invalid)",
+      R"pb(
+        # SAI P4 BMv2 packet_in header
+        ingress_port: 0b000000001
+        target_egress_port: 0b000000010
+        unused_pad: 0b000001
+        # Ethernet header
+        ethernet_destination: 0x ff ff ff ff ff ff
+        ethernet_source: 0x 00 11 22 33 44 55
+        ether_type: 0x0806
+        # ARP header
+        hardware_type: 0x0001  # Ethernet
+        protocol_type: 0x0800  # IPv4
+        hardware_length: 0x06
+        protocol_length: 0x04
+        operation: 0x0001  # Request
+        sender_hardware_address: 0x 00 11 22 33 44 55
+        sender_protocol_address: 0x 0a 00 00 01
+        target_hardware_address: 0x 00 00 00 00 00 00
+        target_protocol_address: 0x 0a 00 00 02
+        # Payload
+        payload: 0x 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+      )pb",
+      /*first_header=*/Header::kSaiP4Bmv2PacketInHeader);
+}
+
+void RunProtoPacketTests() {
+  RunProtoPacketTest("UDP header not preceded by other header",
+                     gutil::ParseProtoOrDie<Packet>(R"pb(
+                       headers {
+                         udp_header {
+                           source_port: "0x0014"
+                           destination_port: "0x000a"
+                           length: "0x000a"
+                           checksum: "0x35c5"
+                         }
+                       }
+                       payload: "Hi"
+                     )pb"));
+
+  RunProtoPacketTest("UDP header not preceded by IP header",
+                     gutil::ParseProtoOrDie<Packet>(R"pb(
+                       headers {
+                         ethernet_header {
+                           ethernet_destination: "aa:bb:cc:dd:ee:ff"
+                           ethernet_source: "11:22:33:44:55:66"
+                           ethertype: "0x000a"
+                         }
+                       }
+                       headers {
+                         udp_header {
+                           source_port: "0x0014"
+                           destination_port: "0x000a"
+                           length: "0x000a"
+                           checksum: "0x35c5"
+                         }
+                       }
+                       payload: "Hi"
+                     )pb"));
+
+  RunProtoPacketTest(
+      "UDP header empty length and checksum",
+      gutil::ParseProtoOrDie<Packet>(R"pb(
+        headers {
+          ethernet_header {
+            ethernet_destination: "aa:bb:cc:dd:ee:ff"
+            ethernet_source: "11:22:33:44:55:66"
+            ethertype: "0x0800"
+          }
+        }
+        headers {
+          ipv4_header {
+            version: "0x4"
+            ihl: "0x5"
+            dscp: "0x1b"
+            ecn: "0x1"
+            identification: "0x0000"
+            flags: "0x0"
+            fragment_offset: "0x0000"
+            ttl: "0x10"
+            protocol: "0x11"  # UDP
+            ipv4_source: "192.168.0.31"
+            ipv4_destination: "192.168.0.30"
+          }
+        }
+        headers {
+          udp_header { source_port: "0x0014" destination_port: "0x000a" }
+        }
+        payload: "Some random payload."
+      )pb"));
+
+  RunProtoPacketTest(
+      "UDP header illegally succeeding IPv6 header whose next_header is not "
+      "UDP",
+      gutil::ParseProtoOrDie<Packet>(R"pb(
+        headers {
+          ethernet_header {
+            ethernet_destination: "aa:bb:cc:dd:ee:ff"
+            ethernet_source: "11:22:33:44:55:66"
+            ethertype: "0x86dd"
+          }
+        }
+        headers {
+          ipv6_header {
+            version: "0x6"
+            dscp: "0x1b"
+            ecn: "0x1"
+            flow_label: "0x12345"
+            payload_length: "0x000a"
+            next_header: "0x90"  # some unassigned protocol
+            hop_limit: "0x03"
+            ipv6_source: "0000:1111:2222:3333:4444:5555:6666:7777"
+            ipv6_destination: "8888:9999:aaaa:bbbb:cccc:dddd:eeee:ffff"
+          }
+        }
+        headers {
+          udp_header { source_port: "0x0014" destination_port: "0x000a" }
+        }
+        payload: "Hi"
+      )pb"));
+
+  RunProtoPacketTest("TCP header whose options field is not word-aligned",
+                     gutil::ParseProtoOrDie<Packet>(R"pb(
+                       headers {
+                         tcp_header {
+                           source_port: "0x0001"
+                           destination_port: "0x0002"
+                           sequence_number: "0x00000001"
+                           acknowledgement_number: "0x00000000"
+                           rest_of_header: "0x000000000000000"
+                           uninterpreted_options: "0x00"
+                         }
+                       }
+                     )pb"));
+
+  RunProtoPacketTest(
+      "TCP header whose options field is too long",
+      gutil::ParseProtoOrDie<Packet>(R"pb(
+        headers {
+          tcp_header {
+            source_port: "0x0001"
+            destination_port: "0x0002"
+            sequence_number: "0x00000001"
+            acknowledgement_number: "0x00000000"
+            rest_of_header: "0x000000000000000"
+            uninterpreted_options: "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"  # 11 * 32 bits
+          }
+        }
+      )pb"));
+
+  RunProtoPacketTest("IPv4 without computed fields",
+                     gutil::ParseProtoOrDie<Packet>(R"pb(
+                       headers {
+                         ethernet_header {
+                           ethernet_destination: "aa:bb:cc:dd:ee:ff"
+                           ethernet_source: "11:22:33:44:55:66"
+                           ethertype: "0x0800"
+                         }
+                       }
+                       headers {
+                         ipv4_header {
+                           dscp: "0x1b"
+                           ecn: "0x1"
+                           identification: "0xa3cd"
+                           flags: "0x0"
+                           fragment_offset: "0x0000"
+                           ttl: "0x10"
+                           protocol: "0x05"
+                           ipv4_source: "10.0.0.1"
+                           ipv4_destination: "20.0.0.3"
+                         }
+                       }
+                       payload: "payloads everywhere"
+                     )pb"));
+
+  RunProtoPacketTest("Ipv4 empty ihl, invalid options",
+                     gutil::ParseProtoOrDie<Packet>(R"pb(
+                       headers {
+                         ethernet_header {
+                           ethernet_destination: "aa:bb:cc:dd:ee:ff"
+                           ethernet_source: "11:22:33:44:55:66"
+                           ethertype: "0x0800"
+                         }
+                       }
+                       headers {
+                         ipv4_header {
+                           version: "0x4"
+                           dscp: "0x1b"
+                           ecn: "0x1"
+                           total_length: "0x0025"
+                           identification: "0xa3cd"
+                           flags: "0x0"
+                           fragment_offset: "0x0000"
+                           ttl: "0x10"
+                           protocol: "0x05"  # some unsupported protocol
+                           checksum: "0xe887"
+                           ipv4_source: "10.0.0.1"
+                           ipv4_destination: "20.0.0.3"
+                           uninterpreted_options: "0x12"
+                         }
+                       }
+                       payload: "A somewhat longer payload."
+                     )pb"));
+
+  RunProtoPacketTest("Ipv4 empty ihl, valid options",
+                     gutil::ParseProtoOrDie<Packet>(R"pb(
+                       headers {
+                         ethernet_header {
+                           ethernet_destination: "aa:bb:cc:dd:ee:ff"
+                           ethernet_source: "11:22:33:44:55:66"
+                           ethertype: "0x0800"
+                         }
+                       }
+                       headers {
+                         ipv4_header {
+                           version: "0x4"
+                           dscp: "0x011011"
+                           ecn: "0x01"
+                           total_length: "0x0034"
+                           identification: "0xa3cd"
+                           flags: "0x000"
+                           fragment_offset: "0x0000000000000"
+                           ttl: "0x10"
+                           protocol: "0x05"  # some unsupported protocol
+                           checksum: "0xe887"
+                           ipv4_source: "0x0a000001"
+                           ipv4_destination: "0x14000003"
+                           uninterpreted_options: "0x12345678"
+                         }
+                       }
+                       payload: "A somewhat longer payload."
+                     )pb"));
+
+  RunProtoPacketTest("IPv4 with various invalid fields",
+                     gutil::ParseProtoOrDie<Packet>(R"pb(
+                       headers {
+                         ethernet_header {
+                           ethernet_destination: "aa:bb:cc:dd:ee:ff"
+                           ethertype: "0x0800"
+                         }
+                       }
+                       headers {
+                         ipv4_header {
+                           version: "0x3"
+                           ihl: "0x6k"
+                           dscp: "0x1b"
+                           ecn: "0x1"
+                           identification: "0xa3cd"
+                           flags: "0x0"
+                           fragment_offset: "0x0000"
+                           ttl: "0x10"
+                           protocol: "0x05"
+                           ipv4_source: "ffff:1::"
+                           ipv4_destination: "20.0.0.3"
+                         }
+                       }
+                       payload: "Hi"
+                     )pb"));
+
+  RunProtoPacketTest("IPv6 without computed fields",
+                     gutil::ParseProtoOrDie<Packet>(R"pb(
+                       headers {
+                         ethernet_header {
+                           ethernet_destination: "aa:bb:cc:dd:ee:ff"
+                           ethernet_source: "11:22:33:44:55:66"
+                           ethertype: "0x86dd"
+                         }
+                       }
+                       headers {
+                         ipv6_header {
+                           dscp: "0x1b"
+                           ecn: "0x1"
+                           flow_label: "0x12345"
+                           next_header: "0x05"
+                           hop_limit: "0x10"
+                           ipv6_source: "::"
+                           ipv6_destination: "f::f"
+                         }
+                       }
+                       payload: "Hello"
+                     )pb"));
+
+  RunProtoPacketTest("IPv6 with various invalid fields",
+                     gutil::ParseProtoOrDie<Packet>(R"pb(
+                       headers {
+                         ethernet_header {
+                           ethernet_destination: "aa:bb:cc:dd:ee:ff"
+                           ethernet_source: "11:22:33:44:55:66"
+                           ethertype: "0x86dd"
+                         }
+                       }
+                       headers {
+                         ipv6_header {
+                           version: "0x4"
+                           dscp: "1b"
+                           ecn: "0b01"
+                           flow_label: "0x1234"
+                           payload_length: "0x0000"
+                           next_header: "0x050"
+                           hop_limit: "0x1"
+                           ipv6_source: "20.0.0.3"
+                           ipv6_destination: ":"
+                         }
+                       }
+                       payload: "I am the payload"
+                     )pb"));
+
+  RunProtoPacketTest("IPv6 packet with IPv4 ethertype",
+                     gutil::ParseProtoOrDie<Packet>(R"pb(
+                       headers {
+                         ethernet_header {
+                           ethernet_destination: "aa:bb:cc:dd:ee:ff"
+                           ethernet_source: "11:22:33:44:55:66"
+                           ethertype: "0x0800"
+                         }
+                       }
+                       headers {
+                         ipv6_header {
+                           version: "0x6"
+                           dscp: "0x1b"
+                           ecn: "0x1"
+                           flow_label: "0x12345"
+                           payload_length: "0x0000"
+                           next_header: "0x05"
+                           hop_limit: "0x10"
+                           ipv6_source: "::"
+                           ipv6_destination: "f::f"
+                         }
+                       }
+                     )pb"));
+
+  RunProtoPacketTest("IPv6 packet without IPv6 header",
+                     gutil::ParseProtoOrDie<Packet>(R"pb(
+                       headers {
+                         ethernet_header {
+                           ethernet_destination: "aa:bb:cc:dd:ee:ff"
+                           ethernet_source: "11:22:33:44:55:66"
+                           ethertype: "0x86dd"
+                         }
+                       }
+                       payload: "hi"
+                     )pb"));
+
+  RunProtoPacketTest("ARP packet without computed fields",
+                     gutil::ParseProtoOrDie<Packet>(
+                         R"pb(
+                           headers {
+                             ethernet_header {
+                               ethernet_destination: "ff:ff:ff:ff:ff:ff"
+                               ethernet_source: "11:22:33:44:55:66"
+                               ethertype: "0x0806"
+                             }
+                           }
+                           headers {
+                             arp_header {
+                               operation: "0x0001"
+                               sender_hardware_address: "11:22:33:44:55:66"
+                               sender_protocol_address: "1.2.3.4"
+                               target_hardware_address: "00:00:00:00:00:00"
+                               target_protocol_address: "1.2.3.5"
+                             }
+                           }
+                         )pb"));
+  RunProtoPacketTest("ARP packet with unsupported computed field values",
+                     gutil::ParseProtoOrDie<Packet>(
+                         R"pb(
+                           headers {
+                             ethernet_header {
+                               ethernet_destination: "ff:ff:ff:ff:ff:ff"
+                               ethernet_source: "11:22:33:44:55:66"
+                               ethertype: "0x0806"
+                             }
+                           }
+                           headers {
+                             arp_header {
+                               hardware_type: "0x0002"
+                               protocol_type: "0x0801"
+                               hardware_length: "0x07"
+                               protocol_length: "0x05"
+                               operation: "0x0001"
+                               sender_hardware_address: "11:22:33:44:55:66"
+                               sender_protocol_address: "1.2.3.4"
+                               target_hardware_address: "00:00:00:00:00:00"
+                               target_protocol_address: "1.2.3.5"
+                             }
+                           }
+                         )pb"));
+
+  RunProtoPacketTest(
+      "ICMPv4 packet without computed fields",
+      gutil::ParseProtoOrDie<Packet>(R"pb(
+        headers {
+          ethernet_header {
+            ethernet_destination: "08:00:20:86:35:4b"
+            ethernet_source: "00:e0:f7:26:3f:e9"
+            ethertype: "0x0800"
+          }
+        }
+        headers {
+          ipv4_header {
+            dscp: "0x00"
+            ecn: "0x0"
+            identification: "0xaafb"
+            flags: "0x2"
+            fragment_offset: "0x0000"
+            ttl: "0xfc"
+            protocol: "0x01"
+            ipv4_source: "139.133.233.2"
+            ipv4_destination: "139.133.217.110"
+          }
+        }
+        headers {
+          icmp_header { type: "0x00" code: "0x00" rest_of_header: "0x1e600000" }
+        }
+        payload: "ICMPv4 packet without computed fields"
+      )pb"));
+  RunProtoPacketTest(
+      "ICMPv6 packet without computed fields",
+      gutil::ParseProtoOrDie<Packet>(R"pb(
+        headers {
+          ethernet_header {
+            ethernet_destination: "c2:01:51:fa:00:00"
+            ethernet_source: "c2:00:51:fa:00:00"
+            ethertype: "0x86dd"
+          }
+        }
+        headers {
+          ipv6_header {
+            dscp: "0x00"
+            ecn: "0x0"
+            flow_label: "0x00000"
+            next_header: "0x3a"
+            hop_limit: "0x40"
+            ipv6_source: "2001:db8:0:12::1"
+            ipv6_destination: "2001:db8:0:12::2"
+          }
+        }
+        headers {
+          icmp_header { type: "0x80" code: "0x00" rest_of_header: "0x110d0000" }
+        }
+        payload: "ICMPv6 packet without computed fields"
+      )pb"));
+  RunProtoPacketTest(
+      "ICMP packet without a preceding IP header",
+      gutil::ParseProtoOrDie<Packet>(R"pb(
+        headers {
+          ethernet_header {
+            ethernet_destination: "c2:01:51:fa:00:00"
+            ethernet_source: "c2:00:51:fa:00:00"
+            ethertype: "0x86dd"
+          }
+        }
+        headers {
+          icmp_header { type: "0x80" code: "0x00" rest_of_header: "0x110d0000" }
+        }
+        payload: "ICMP packet without a preceding IP header"
+      )pb"));
+  RunProtoPacketTest("VLAN ARP packet",
+                     gutil::ParseProtoOrDie<Packet>(
+                         R"pb(
+                           headers {
+                             ethernet_header {
+                               ethernet_destination: "ff:ff:ff:ff:ff:ff"
+                               ethernet_source: "11:22:33:44:55:66"
+                               ethertype: "0x8100"
+                             }
+                           }
+                           headers {
+                             vlan_header {
+                               priority_code_point: "0x0"
+                               drop_eligible_indicator: "0x1"
+                               vlan_identifier: "0x123"
+                               ethertype: "0x0806"
+                             }
+                           }
+                           headers {
+                             arp_header {
+                               operation: "0x0001"
+                               sender_hardware_address: "11:22:33:44:55:66"
+                               sender_protocol_address: "1.2.3.4"
+                               target_hardware_address: "00:00:00:00:00:00"
+                               target_protocol_address: "1.2.3.5"
+                             }
+                           }
+                         )pb"));
+
+  RunProtoPacketTest("Uninitialized (empty packet) - should be invalid",
+                     gutil::ParseProtoOrDie<Packet>(R"pb()pb"));
+}
+
+void RunAdditionalProtoPacketTests() {
+  RunProtoPacketTest(
+      "GRE Ipv4 Encapsulated with Ipv6 Header (Valid)",
+      gutil::ParseProtoOrDie<Packet>(R"pb(
+        headers {
+          ethernet_header {
+            ethernet_destination: "c2:01:51:fa:00:00"
+            ethernet_source: "c2:00:51:fa:00:00"
+            ethertype: "0x86dd"
+          }
+        }
+        headers {
+          ipv6_header {
+            version: "0x6"
+            dscp: "0x00"
+            ecn: "0x0"
+            flow_label: "0x00000"
+            payload_length: "0x011e"
+            next_header: "0x2f"
+            hop_limit: "0x3f"
+            ipv6_source: "2607:f8b0:c150:10::"
+            ipv6_destination: "2002:a05:6860:749::"
+          }
+        }
+        headers {
+          gre_header {
+            checksum_present: "0x0"
+            reserved0: "0x000"
+            version: "0x0"
+            protocol_type: "0x0800"
+          }
+        }
+        headers {
+          ipv4_header {
+            version: "0x4"
+            ihl: "0x5"
+            dscp: "0x00"
+            ecn: "0x0"
+            total_length: "0x011a"
+            identification: "0x0000"
+            flags: "0x0"
+            fragment_offset: "0x0000"
+            ttl: "0x3f"
+            protocol: "0x01"
+            checksum: "0x753a"
+            ipv4_source: "128.0.0.0"
+            ipv4_destination: "185.168.204.0"
+          }
+        }
+        headers {
+          icmp_header {
+            type: "0x00"
+            code: "0x00"
+            checksum: "0x00e4"
+            rest_of_header: "0x00000000"
+          }
+        }
+        payload: "test packet #5: ROUTING_PINBALLL3TOGROUP_FLOW: ipv4_table_entry \t { match { vrf_id: \"vrf-210\" ipv4_dst { value: \"185.168.204.0\" prefix_length: 28 } } action { set_wcmp_group_id_and_metadata { wcmp_group_id: \"group-4294934578\" route_metadata: \"0x01\" } } }"
+      )pb"));
+  RunProtoPacketTest("SAI P4 BMv2 packet_in Header (Valid)",
+                     gutil::ParseProtoOrDie<Packet>(
+                         R"pb(
+                           headers {
+                             sai_p4_bmv2_packet_in_header {
+                               ingress_port: "0x001"
+                               target_egress_port: "0x002"
+                               unused_pad: "0x00"
+                             }
+                           }
+                           headers {
+                             ethernet_header {
+                               ethernet_destination: "ff:ff:ff:ff:ff:ff"
+                               ethernet_source: "11:22:33:44:55:66"
+                               ethertype: "0x0806"
+                             }
+                           }
+                           headers {
+                             arp_header {
+                               operation: "0x0001"
+                               sender_hardware_address: "11:22:33:44:55:66"
+                               sender_protocol_address: "1.2.3.4"
+                               target_hardware_address: "00:00:00:00:00:00"
+                               target_protocol_address: "1.2.3.5"
+                             }
+                           }
+                         )pb"),
+                     /*first_header=*/Header::kSaiP4Bmv2PacketInHeader);
+  RunProtoPacketTest(
+      "SAI P4 BMv2 packet_in Header ingress_port number out of range (Invalid)",
+      gutil::ParseProtoOrDie<Packet>(
+          R"pb(
+            headers {
+              sai_p4_bmv2_packet_in_header {
+                ingress_port: "0xf00"
+                target_egress_port: "0x002"
+                unused_pad: "0x00"
+              }
+            }
+            headers {
+              ethernet_header {
+                ethernet_destination: "ff:ff:ff:ff:ff:ff"
+                ethernet_source: "11:22:33:44:55:66"
+                ethertype: "0x0806"
+              }
+            }
+            headers {
+              arp_header {
+                operation: "0x0001"
+                sender_hardware_address: "11:22:33:44:55:66"
+                sender_protocol_address: "1.2.3.4"
+                target_hardware_address: "00:00:00:00:00:00"
+                target_protocol_address: "1.2.3.5"
+              }
+            }
+          )pb"),
+      /*first_header=*/Header::kSaiP4Bmv2PacketInHeader);
+  RunProtoPacketTest(
+      "SAI P4 BMv2 packet_in Header target_egress_port number out of range "
+      "(Invalid)",
+      gutil::ParseProtoOrDie<Packet>(
+          R"pb(
+            headers {
+              sai_p4_bmv2_packet_in_header {
+                ingress_port: "0x001"
+                target_egress_port: "0xf00"
+                unused_pad: "0x00"
+              }
+            }
+            headers {
+              ethernet_header {
+                ethernet_destination: "ff:ff:ff:ff:ff:ff"
+                ethernet_source: "11:22:33:44:55:66"
+                ethertype: "0x0806"
+              }
+            }
+            headers {
+              arp_header {
+                operation: "0x0001"
+                sender_hardware_address: "11:22:33:44:55:66"
+                sender_protocol_address: "1.2.3.4"
+                target_hardware_address: "00:00:00:00:00:00"
+                target_protocol_address: "1.2.3.5"
+              }
+            }
+          )pb"),
+      /*first_header=*/Header::kSaiP4Bmv2PacketInHeader);
+}
+
+void main() {
+  RunPacketParseTests();
+  // If there are too many lines (error triggered by exceeding 500 lines) in a
+  // function, presubmit will fail. So split packet parse tests into two
+  // functions.
+  RunAdditionalPacketParseTests();
+  RunProtoPacketTests();
+  // If there are too many lines (error triggered by exceeding 500 lines) in a
+  // function, presubmit will fail. So split proto packets tests into two
+  // functions.
+  RunAdditionalProtoPacketTests();
+}
+
+}  // namespace packetlib
+
+int main() {
+  packetlib::main();
+  return 0;
+}

--- a/p4_pdpi/packetlib/packetlib_test_runner.expected
+++ b/p4_pdpi/packetlib/packetlib_test_runner.expected
@@ -1261,6 +1261,119 @@ headers {
 payload: "test packet #5: ROUTING_PINBALLL3TOGROUP_FLOW: ipv4_table_entry \t { match { vrf_id: \"vrf-210\" ipv4_dst { value: \"185.168.204.0\" prefix_length: 28 } } action { set_wcmp_group_id_and_metadata { wcmp_group_id: \"group-4294934578\" route_metadata: \"0x01\" } } }"
 
 ================================================================================
+Parsing test: SAI P4 BMv2 packet_in header (Valid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+# SAI P4 BMv2 packet_in header
+        ingress_port: 0b000000001
+        target_egress_port: 0b000000010
+        unused_pad: 0b000000
+        # Ethernet header
+        ethernet_destination: 0x ff ff ff ff ff ff
+        ethernet_source: 0x 00 11 22 33 44 55
+        ether_type: 0x0806
+        # ARP header
+        hardware_type: 0x0001  # Ethernet
+        protocol_type: 0x0800  # IPv4
+        hardware_length: 0x06
+        protocol_length: 0x04
+        operation: 0x0001  # Request
+        sender_hardware_address: 0x 00 11 22 33 44 55
+        sender_protocol_address: 0x 0a 00 00 01
+        target_hardware_address: 0x 00 00 00 00 00 00
+        target_protocol_address: 0x 0a 00 00 02
+        # Payload
+        payload: 0x 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+-- OUTPUT ----------------------------------------------------------------------
+headers {
+  sai_p4_bmv2_packet_in_header {
+    ingress_port: "0x001"
+    target_egress_port: "0x002"
+    unused_pad: "0x00"
+  }
+}
+headers {
+  ethernet_header {
+    ethernet_destination: "ff:ff:ff:ff:ff:ff"
+    ethernet_source: "00:11:22:33:44:55"
+    ethertype: "0x0806"
+  }
+}
+headers {
+  arp_header {
+    hardware_type: "0x0001"
+    protocol_type: "0x0800"
+    hardware_length: "0x06"
+    protocol_length: "0x04"
+    operation: "0x0001"
+    sender_hardware_address: "00:11:22:33:44:55"
+    sender_protocol_address: "10.0.0.1"
+    target_hardware_address: "00:00:00:00:00:00"
+    target_protocol_address: "10.0.0.2"
+  }
+}
+payload: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+
+================================================================================
+Parsing test: SAI P4 BMv2 packet_in header unused_pad value is not 0 (Invalid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+# SAI P4 BMv2 packet_in header
+        ingress_port: 0b000000001
+        target_egress_port: 0b000000010
+        unused_pad: 0b000001
+        # Ethernet header
+        ethernet_destination: 0x ff ff ff ff ff ff
+        ethernet_source: 0x 00 11 22 33 44 55
+        ether_type: 0x0806
+        # ARP header
+        hardware_type: 0x0001  # Ethernet
+        protocol_type: 0x0800  # IPv4
+        hardware_length: 0x06
+        protocol_length: 0x04
+        operation: 0x0001  # Request
+        sender_hardware_address: 0x 00 11 22 33 44 55
+        sender_protocol_address: 0x 0a 00 00 01
+        target_hardware_address: 0x 00 00 00 00 00 00
+        target_protocol_address: 0x 0a 00 00 02
+        # Payload
+        payload: 0x 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+-- OUTPUT ----------------------------------------------------------------------
+headers {
+  sai_p4_bmv2_packet_in_header {
+    ingress_port: "0x001"
+    target_egress_port: "0x002"
+    unused_pad: "0x01"
+  }
+}
+headers {
+  ethernet_header {
+    ethernet_destination: "ff:ff:ff:ff:ff:ff"
+    ethernet_source: "00:11:22:33:44:55"
+    ethertype: "0x0806"
+  }
+}
+headers {
+  arp_header {
+    hardware_type: "0x0001"
+    protocol_type: "0x0800"
+    hardware_length: "0x06"
+    protocol_length: "0x04"
+    operation: "0x0001"
+    sender_hardware_address: "00:11:22:33:44:55"
+    sender_protocol_address: "10.0.0.1"
+    target_hardware_address: "00:00:00:00:00:00"
+    target_protocol_address: "10.0.0.2"
+  }
+}
+payload: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+reasons_invalid: "in SaiP4BMv2PacketInHeader headers[0]: unused_pad: Must be 0, but was 0x01 instead."
+
+PadPacketToMinimumSize(packet) = false
+UpdateAllComputedFields(packet) = true
+ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in SaiP4BMv2PacketInHeader headers[0]: unused_pad: Must be 0, but was 0x01 instead.
+================================================================================
 Proto packet test: UDP header not preceded by other header
 ================================================================================
 -- INPUT -----------------------------------------------------------------------
@@ -1689,10 +1802,10 @@ payload: "A somewhat longer payload."
 -- OUTPUT ----------------------------------------------------------------------
 ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
 - in Ipv4Header headers[1]: ihl: missing
-- in Ipv4Header headers[1]: dscp: invalid format: illegal conversion from hex string '0x011011' to 6 bits; expected between 21 and 24 bits
-- in Ipv4Header headers[1]: ecn: invalid format: illegal conversion from hex string '0x01' to 2 bits; expected between 5 and 8 bits
-- in Ipv4Header headers[1]: flags: invalid format: illegal conversion from hex string '0x000' to 3 bits; expected between 9 and 12 bits
-- in Ipv4Header headers[1]: fragment_offset: invalid format: illegal conversion from hex string '0x0000000000000' to 13 bits; expected between 49 and 52 bits
+- in Ipv4Header headers[1]: dscp: invalid format: illegal conversion from hex string '0x011011' to 6 bits; expected 2 hex digits but got 6
+- in Ipv4Header headers[1]: ecn: invalid format: illegal conversion from hex string '0x01' to 2 bits; expected 1 hex digits but got 2
+- in Ipv4Header headers[1]: flags: invalid format: illegal conversion from hex string '0x000' to 3 bits; expected 1 hex digits but got 3
+- in Ipv4Header headers[1]: fragment_offset: invalid format: illegal conversion from hex string '0x0000000000000' to 13 bits; expected 4 hex digits but got 13
 - in Ipv4Header headers[1]: ipv4_source: invalid format: Invalid IPv4 address: '0x0a000001'
 - in Ipv4Header headers[1]: ipv4_destination: invalid format: Invalid IPv4 address: '0x14000003'
 - in Ipv4Header headers[1]: total_length: Must be 0x0032, but was 0x0034 instead.
@@ -1730,24 +1843,24 @@ headers {
 payload: "A somewhat longer payload."
 
 ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
-- in Ipv4Header headers[1]: dscp: invalid format: illegal conversion from hex string '0x011011' to 6 bits; expected between 21 and 24 bits
-- in Ipv4Header headers[1]: ecn: invalid format: illegal conversion from hex string '0x01' to 2 bits; expected between 5 and 8 bits
-- in Ipv4Header headers[1]: flags: invalid format: illegal conversion from hex string '0x000' to 3 bits; expected between 9 and 12 bits
-- in Ipv4Header headers[1]: fragment_offset: invalid format: illegal conversion from hex string '0x0000000000000' to 13 bits; expected between 49 and 52 bits
+- in Ipv4Header headers[1]: dscp: invalid format: illegal conversion from hex string '0x011011' to 6 bits; expected 2 hex digits but got 6
+- in Ipv4Header headers[1]: ecn: invalid format: illegal conversion from hex string '0x01' to 2 bits; expected 1 hex digits but got 2
+- in Ipv4Header headers[1]: flags: invalid format: illegal conversion from hex string '0x000' to 3 bits; expected 1 hex digits but got 3
+- in Ipv4Header headers[1]: fragment_offset: invalid format: illegal conversion from hex string '0x0000000000000' to 13 bits; expected 4 hex digits but got 13
 - in Ipv4Header headers[1]: ipv4_source: invalid format: Invalid IPv4 address: '0x0a000001'
 - in Ipv4Header headers[1]: ipv4_destination: invalid format: Invalid IPv4 address: '0x14000003'
 - in Ipv4Header headers[1]: total_length: Must be 0x0032, but was 0x0034 instead.
-- in Ipv4Header headers[1]: checksum: Couldn't compute expected checksum: INVALID_ARGUMENT: illegal conversion from hex string '0x011011' to 6 bits; expected between 21 and 24 bits
+- in Ipv4Header headers[1]: checksum: Couldn't compute expected checksum: INVALID_ARGUMENT: illegal conversion from hex string '0x011011' to 6 bits; expected 2 hex digits but got 6
 
 Serialize(Packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
-- in Ipv4Header headers[1]: dscp: invalid format: illegal conversion from hex string '0x011011' to 6 bits; expected between 21 and 24 bits
-- in Ipv4Header headers[1]: ecn: invalid format: illegal conversion from hex string '0x01' to 2 bits; expected between 5 and 8 bits
-- in Ipv4Header headers[1]: flags: invalid format: illegal conversion from hex string '0x000' to 3 bits; expected between 9 and 12 bits
-- in Ipv4Header headers[1]: fragment_offset: invalid format: illegal conversion from hex string '0x0000000000000' to 13 bits; expected between 49 and 52 bits
+- in Ipv4Header headers[1]: dscp: invalid format: illegal conversion from hex string '0x011011' to 6 bits; expected 2 hex digits but got 6
+- in Ipv4Header headers[1]: ecn: invalid format: illegal conversion from hex string '0x01' to 2 bits; expected 1 hex digits but got 2
+- in Ipv4Header headers[1]: flags: invalid format: illegal conversion from hex string '0x000' to 3 bits; expected 1 hex digits but got 3
+- in Ipv4Header headers[1]: fragment_offset: invalid format: illegal conversion from hex string '0x0000000000000' to 13 bits; expected 4 hex digits but got 13
 - in Ipv4Header headers[1]: ipv4_source: invalid format: Invalid IPv4 address: '0x0a000001'
 - in Ipv4Header headers[1]: ipv4_destination: invalid format: Invalid IPv4 address: '0x14000003'
 - in Ipv4Header headers[1]: total_length: Must be 0x0032, but was 0x0034 instead.
-- in Ipv4Header headers[1]: checksum: Couldn't compute expected checksum: INVALID_ARGUMENT: illegal conversion from hex string '0x011011' to 6 bits; expected between 21 and 24 bits
+- in Ipv4Header headers[1]: checksum: Couldn't compute expected checksum: INVALID_ARGUMENT: illegal conversion from hex string '0x011011' to 6 bits; expected 2 hex digits but got 6
 
 ================================================================================
 Proto packet test: IPv4 with various invalid fields
@@ -1781,7 +1894,7 @@ payload: "Hi"
 ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
 - in EthernetHeader headers[0]: ethernet_source: missing
 - in EthernetHeader headers[0]: expected at least 46 bytes of Ethernet payload, but got only 22
-- in Ipv4Header headers[1]: ihl: invalid format: illegal conversion from hex string '0x6k' to 4 bits; expected between 5 and 8 bits
+- in Ipv4Header headers[1]: ihl: invalid format: illegal conversion from hex string '0x6k' to 4 bits; expected 1 hex digits but got 2
 - in Ipv4Header headers[1]: total_length: missing
 - in Ipv4Header headers[1]: checksum: missing
 - in Ipv4Header headers[1]: ipv4_source: invalid format: Invalid IPv4 address: 'ffff:1::'
@@ -1790,9 +1903,9 @@ ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reas
 PadPacketToMinimumSize(packet) = true
 new payload: "Hi\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
 
-UpdateMissingComputedFields(packet) = INVALID_ARGUMENT: Ipv4Header: failed to compute packet.headers[1].checksum: illegal conversion from hex string '0x6k' to 4 bits; expected between 5 and 8 bits
+UpdateMissingComputedFields(packet) = INVALID_ARGUMENT: Ipv4Header: failed to compute packet.headers[1].checksum: illegal conversion from hex string '0x6k' to 4 bits; expected 1 hex digits but got 2
 
-Serialize(Packet) = INVALID_ARGUMENT: Ipv4Header: failed to compute packet.headers[1].checksum: illegal conversion from hex string '0x6k' to 4 bits; expected between 5 and 8 bits
+Serialize(Packet) = INVALID_ARGUMENT: Ipv4Header: failed to compute packet.headers[1].checksum: illegal conversion from hex string '0x6k' to 4 bits; expected 1 hex digits but got 2
 
 ================================================================================
 Proto packet test: IPv6 without computed fields
@@ -1887,9 +2000,9 @@ payload: "I am the payload"
 ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
 - in Ipv6Header headers[1]: dscp: invalid format: missing '0x'-prefix in hexadecimal string: '1b'
 - in Ipv6Header headers[1]: ecn: invalid format: missing '0x'-prefix in hexadecimal string: '0b01'
-- in Ipv6Header headers[1]: flow_label: invalid format: illegal conversion from hex string '0x1234' to 20 bits; expected between 13 and 16 bits
-- in Ipv6Header headers[1]: next_header: invalid format: illegal conversion from hex string '0x050' to 8 bits; expected between 9 and 12 bits
-- in Ipv6Header headers[1]: hop_limit: invalid format: illegal conversion from hex string '0x1' to 8 bits; expected between 1 and 4 bits
+- in Ipv6Header headers[1]: flow_label: invalid format: illegal conversion from hex string '0x1234' to 20 bits; expected 5 hex digits but got 4
+- in Ipv6Header headers[1]: next_header: invalid format: illegal conversion from hex string '0x050' to 8 bits; expected 2 hex digits but got 3
+- in Ipv6Header headers[1]: hop_limit: invalid format: illegal conversion from hex string '0x1' to 8 bits; expected 2 hex digits but got 1
 - in Ipv6Header headers[1]: ipv6_source: invalid format: invalid IPv6 address: '20.0.0.3'
 - in Ipv6Header headers[1]: ipv6_destination: invalid format: invalid IPv6 address: ':'
 - in Ipv6Header headers[1]: version: Must be 0x6, but was 0x4 instead.
@@ -1902,9 +2015,9 @@ UpdateMissingComputedFields(packet) = false
 Serialize(Packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
 - in Ipv6Header headers[1]: dscp: invalid format: missing '0x'-prefix in hexadecimal string: '1b'
 - in Ipv6Header headers[1]: ecn: invalid format: missing '0x'-prefix in hexadecimal string: '0b01'
-- in Ipv6Header headers[1]: flow_label: invalid format: illegal conversion from hex string '0x1234' to 20 bits; expected between 13 and 16 bits
-- in Ipv6Header headers[1]: next_header: invalid format: illegal conversion from hex string '0x050' to 8 bits; expected between 9 and 12 bits
-- in Ipv6Header headers[1]: hop_limit: invalid format: illegal conversion from hex string '0x1' to 8 bits; expected between 1 and 4 bits
+- in Ipv6Header headers[1]: flow_label: invalid format: illegal conversion from hex string '0x1234' to 20 bits; expected 5 hex digits but got 4
+- in Ipv6Header headers[1]: next_header: invalid format: illegal conversion from hex string '0x050' to 8 bits; expected 2 hex digits but got 3
+- in Ipv6Header headers[1]: hop_limit: invalid format: illegal conversion from hex string '0x1' to 8 bits; expected 2 hex digits but got 1
 - in Ipv6Header headers[1]: ipv6_source: invalid format: invalid IPv6 address: '20.0.0.3'
 - in Ipv6Header headers[1]: ipv6_destination: invalid format: invalid IPv6 address: ':'
 - in Ipv6Header headers[1]: version: Must be 0x6, but was 0x4 instead.
@@ -2434,3 +2547,234 @@ payload: "test packet #5: ROUTING_PINBALLL3TOGROUP_FLOW: ipv4_table_entry \t { m
 ValidatePacket(packet) = OK
 
 Serialize(Packet) = OK
+
+================================================================================
+Proto packet test: SAI P4 BMv2 packet_in Header (Valid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+packet =
+headers {
+  sai_p4_bmv2_packet_in_header {
+    ingress_port: "0x001"
+    target_egress_port: "0x002"
+    unused_pad: "0x00"
+  }
+}
+headers {
+  ethernet_header {
+    ethernet_destination: "ff:ff:ff:ff:ff:ff"
+    ethernet_source: "11:22:33:44:55:66"
+    ethertype: "0x0806"
+  }
+}
+headers {
+  arp_header {
+    operation: "0x0001"
+    sender_hardware_address: "11:22:33:44:55:66"
+    sender_protocol_address: "1.2.3.4"
+    target_hardware_address: "00:00:00:00:00:00"
+    target_protocol_address: "1.2.3.5"
+  }
+}
+
+-- OUTPUT ----------------------------------------------------------------------
+ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in EthernetHeader headers[1]: expected at least 46 bytes of Ethernet payload, but got only 28
+- in ArpHeader headers[2]: hardware_type: missing
+- in ArpHeader headers[2]: protocol_type: missing
+- in ArpHeader headers[2]: hardware_length: missing
+- in ArpHeader headers[2]: protocol_length: missing
+
+PadPacketToMinimumSize(packet) = true
+new payload: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+
+UpdateMissingComputedFields(packet) = true
+packet =
+headers {
+  sai_p4_bmv2_packet_in_header {
+    ingress_port: "0x001"
+    target_egress_port: "0x002"
+    unused_pad: "0x00"
+  }
+}
+headers {
+  ethernet_header {
+    ethernet_destination: "ff:ff:ff:ff:ff:ff"
+    ethernet_source: "11:22:33:44:55:66"
+    ethertype: "0x0806"
+  }
+}
+headers {
+  arp_header {
+    hardware_type: "0x0001"
+    protocol_type: "0x0800"
+    hardware_length: "0x06"
+    protocol_length: "0x04"
+    operation: "0x0001"
+    sender_hardware_address: "11:22:33:44:55:66"
+    sender_protocol_address: "1.2.3.4"
+    target_hardware_address: "00:00:00:00:00:00"
+    target_protocol_address: "1.2.3.5"
+  }
+}
+payload: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+
+ValidatePacket(packet) = OK
+
+Serialize(Packet) = OK
+
+================================================================================
+Proto packet test: SAI P4 BMv2 packet_in Header ingress_port number out of range (Invalid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+packet =
+headers {
+  sai_p4_bmv2_packet_in_header {
+    ingress_port: "0xf00"
+    target_egress_port: "0x002"
+    unused_pad: "0x00"
+  }
+}
+headers {
+  ethernet_header {
+    ethernet_destination: "ff:ff:ff:ff:ff:ff"
+    ethernet_source: "11:22:33:44:55:66"
+    ethertype: "0x0806"
+  }
+}
+headers {
+  arp_header {
+    operation: "0x0001"
+    sender_hardware_address: "11:22:33:44:55:66"
+    sender_protocol_address: "1.2.3.4"
+    target_hardware_address: "00:00:00:00:00:00"
+    target_protocol_address: "1.2.3.5"
+  }
+}
+
+-- OUTPUT ----------------------------------------------------------------------
+ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in SaiP4BMv2PacketInHeader headers[0]: ingress_port: invalid format: hex string '0xf00' has bit #10 set to 1; conversion to 9 bits would lose information
+- in EthernetHeader headers[1]: expected at least 46 bytes of Ethernet payload, but got only 28
+- in ArpHeader headers[2]: hardware_type: missing
+- in ArpHeader headers[2]: protocol_type: missing
+- in ArpHeader headers[2]: hardware_length: missing
+- in ArpHeader headers[2]: protocol_length: missing
+
+PadPacketToMinimumSize(packet) = true
+new payload: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+
+UpdateMissingComputedFields(packet) = true
+packet =
+headers {
+  sai_p4_bmv2_packet_in_header {
+    ingress_port: "0xf00"
+    target_egress_port: "0x002"
+    unused_pad: "0x00"
+  }
+}
+headers {
+  ethernet_header {
+    ethernet_destination: "ff:ff:ff:ff:ff:ff"
+    ethernet_source: "11:22:33:44:55:66"
+    ethertype: "0x0806"
+  }
+}
+headers {
+  arp_header {
+    hardware_type: "0x0001"
+    protocol_type: "0x0800"
+    hardware_length: "0x06"
+    protocol_length: "0x04"
+    operation: "0x0001"
+    sender_hardware_address: "11:22:33:44:55:66"
+    sender_protocol_address: "1.2.3.4"
+    target_hardware_address: "00:00:00:00:00:00"
+    target_protocol_address: "1.2.3.5"
+  }
+}
+payload: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+
+ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in SaiP4BMv2PacketInHeader headers[0]: ingress_port: invalid format: hex string '0xf00' has bit #10 set to 1; conversion to 9 bits would lose information
+
+Serialize(Packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in SaiP4BMv2PacketInHeader headers[0]: ingress_port: invalid format: hex string '0xf00' has bit #10 set to 1; conversion to 9 bits would lose information
+
+================================================================================
+Proto packet test: SAI P4 BMv2 packet_in Header target_egress_port number out of range (Invalid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+packet =
+headers {
+  sai_p4_bmv2_packet_in_header {
+    ingress_port: "0x001"
+    target_egress_port: "0xf00"
+    unused_pad: "0x00"
+  }
+}
+headers {
+  ethernet_header {
+    ethernet_destination: "ff:ff:ff:ff:ff:ff"
+    ethernet_source: "11:22:33:44:55:66"
+    ethertype: "0x0806"
+  }
+}
+headers {
+  arp_header {
+    operation: "0x0001"
+    sender_hardware_address: "11:22:33:44:55:66"
+    sender_protocol_address: "1.2.3.4"
+    target_hardware_address: "00:00:00:00:00:00"
+    target_protocol_address: "1.2.3.5"
+  }
+}
+
+-- OUTPUT ----------------------------------------------------------------------
+ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in SaiP4BMv2PacketInHeader headers[0]: target_egress_port: invalid format: hex string '0xf00' has bit #10 set to 1; conversion to 9 bits would lose information
+- in EthernetHeader headers[1]: expected at least 46 bytes of Ethernet payload, but got only 28
+- in ArpHeader headers[2]: hardware_type: missing
+- in ArpHeader headers[2]: protocol_type: missing
+- in ArpHeader headers[2]: hardware_length: missing
+- in ArpHeader headers[2]: protocol_length: missing
+
+PadPacketToMinimumSize(packet) = true
+new payload: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+
+UpdateMissingComputedFields(packet) = true
+packet =
+headers {
+  sai_p4_bmv2_packet_in_header {
+    ingress_port: "0x001"
+    target_egress_port: "0xf00"
+    unused_pad: "0x00"
+  }
+}
+headers {
+  ethernet_header {
+    ethernet_destination: "ff:ff:ff:ff:ff:ff"
+    ethernet_source: "11:22:33:44:55:66"
+    ethertype: "0x0806"
+  }
+}
+headers {
+  arp_header {
+    hardware_type: "0x0001"
+    protocol_type: "0x0800"
+    hardware_length: "0x06"
+    protocol_length: "0x04"
+    operation: "0x0001"
+    sender_hardware_address: "11:22:33:44:55:66"
+    sender_protocol_address: "1.2.3.4"
+    target_hardware_address: "00:00:00:00:00:00"
+    target_protocol_address: "1.2.3.5"
+  }
+}
+payload: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+
+ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in SaiP4BMv2PacketInHeader headers[0]: target_egress_port: invalid format: hex string '0xf00' has bit #10 set to 1; conversion to 9 bits would lose information
+
+Serialize(Packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in SaiP4BMv2PacketInHeader headers[0]: target_egress_port: invalid format: hex string '0xf00' has bit #10 set to 1; conversion to 9 bits would lose information

--- a/p4_pdpi/packetlib/packetlib_unit_test.cc
+++ b/p4_pdpi/packetlib/packetlib_unit_test.cc
@@ -1,0 +1,470 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <net/ethernet.h>
+#include <netinet/in.h>
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+#include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status_matchers.h"
+#include "p4_pdpi/packetlib/bit_widths.h"
+#include "p4_pdpi/packetlib/packetlib.h"
+#include "p4_pdpi/packetlib/packetlib.pb.h"
+
+namespace packetlib {
+namespace {
+
+using ::gutil::IsOkAndHolds;
+using ::testing::Eq;
+
+const absl::string_view kEthernetSourceAddress = "8:0:20:86:35:4b";
+const absl::string_view kEthernetDestinationAddress = "0:e0:f7:26:3f:e9";
+
+TEST(PacketLib, BitWidthTest) {
+  for (int bit_shift = 18; bit_shift >= 5; bit_shift -= 3) {
+    // Generate test input data with `bit_shift + 1` bits.
+    int input =
+        (1 << bit_shift) | (1 << (bit_shift - 3) | (1 << (bit_shift - 5)));
+    const std::string expected_error_message = absl::StrFormat(
+        "Input has been truncated because maximum allowable "
+        "bitwidth for this field is %d but input has %d bits: %d",
+        kIpVersionBitwidth, bit_shift + 1, input);
+    ASSERT_DEBUG_DEATH(IpVersion(input),
+                       testing::HasSubstr(expected_error_message));
+  }
+}
+
+TEST(PacketLib, UdpWithIpv4Header) {
+  Packet packet;
+
+  EthernetHeader* eth = packet.add_headers()->mutable_ethernet_header();
+  eth->set_ethertype(EtherType(ETHERTYPE_IP));
+  eth->set_ethernet_source(std::string(kEthernetSourceAddress));
+  eth->set_ethernet_destination(std::string(kEthernetDestinationAddress));
+
+  Ipv4Header* ipv4 = packet.add_headers()->mutable_ipv4_header();
+  ipv4->set_version(IpVersion(4));
+  ipv4->set_ihl(IpIhl(5));
+  ipv4->set_ipv4_source("192.168.0.31");
+  ipv4->set_ipv4_destination("192.168.0.30");
+  ipv4->set_ttl(IpTtl(0x10));
+  ipv4->set_dscp(IpDscp(3));
+  ipv4->set_protocol(IpProtocol(IPPROTO_UDP));
+  ipv4->set_ecn(IpEcn(2));
+  ipv4->set_identification(IpIdentification(0));
+  ipv4->set_flags(IpFlags(3));
+  ipv4->set_fragment_offset(IpFragmentOffset(1234));
+
+  UdpHeader* udp = packet.add_headers()->mutable_udp_header();
+  udp->set_source_port(UdpPort(0x0014));
+  udp->set_destination_port(UdpPort(0x000a));
+  udp->set_length(UdpLength(0x001a));
+  ASSERT_OK(SerializePacket(packet));
+}
+
+TEST(PacketLib, UdpWithIpv6Header) {
+  Packet packet;
+  EthernetHeader* eth = packet.add_headers()->mutable_ethernet_header();
+  eth->set_ethertype(EtherType(ETHERTYPE_IPV6));
+  eth->set_ethernet_source(std::string(kEthernetSourceAddress));
+  eth->set_ethernet_destination(std::string(kEthernetDestinationAddress));
+
+  Ipv6Header* ipv6 = packet.add_headers()->mutable_ipv6_header();
+  ipv6->set_ipv6_source("5:6:7:8::");
+  ipv6->set_ipv6_destination("2607:f8b0:c150:8114::");
+  ipv6->set_flow_label(IpFlowLabel(0x12345));
+  ipv6->set_next_header(IpNextHeader(17));
+  ipv6->set_hop_limit(IpHopLimit(32));
+  ipv6->set_dscp(IpDscp(3));
+  ipv6->set_ecn(IpEcn(0));
+  UdpHeader* udp = packet.add_headers()->mutable_udp_header();
+  udp->set_source_port(UdpPort(0));
+  udp->set_destination_port(UdpPort(0));
+  ASSERT_OK(SerializePacket(packet));
+}
+
+TEST(PacketLib, TcpWithIpv4Header) {
+  Packet packet;
+
+  EthernetHeader* eth = packet.add_headers()->mutable_ethernet_header();
+  eth->set_ethertype(EtherType(ETHERTYPE_IP));
+  eth->set_ethernet_source(std::string(kEthernetSourceAddress));
+  eth->set_ethernet_destination(std::string(kEthernetDestinationAddress));
+
+  Ipv4Header* ipv4 = packet.add_headers()->mutable_ipv4_header();
+  ipv4->set_ihl(IpIhl(0x5));
+  ipv4->set_ipv4_source("139.133.217.110");
+  ipv4->set_ipv4_destination("139.133.233.2");
+  ipv4->set_ttl(IpTtl(0xff));
+  ipv4->set_dscp(IpDscp(3));
+  ipv4->set_protocol(IpProtocol(IPPROTO_TCP));
+  ipv4->set_ecn(IpEcn(1));
+  ipv4->set_identification(IpIdentification(0x08b8));
+  ipv4->set_total_length(IpTotalLength(0x002e));
+  ipv4->set_flags(IpFlags(1));
+  ipv4->set_checksum(IpChecksum(0xae88));
+  ipv4->set_fragment_offset(IpFragmentOffset(0x0b00));
+
+  TcpHeader* tcp = packet.add_headers()->mutable_tcp_header();
+  tcp->set_source_port(TcpPort(0x9005));
+  tcp->set_destination_port(TcpPort(0x0017));
+  tcp->set_sequence_number(TcpSequenceNumber(12));
+  tcp->set_acknowledgement_number(TcpAcknowledgementNumber(55));
+  tcp->set_data_offset(TcpDataOffset(5));
+  tcp->set_rest_of_header(TcpRestOfHeader(0));
+  ASSERT_OK(SerializePacket(packet));
+}
+
+TEST(PacketLib, ArpWithIpv4Header) {
+  Packet packet;
+
+  EthernetHeader* eth = packet.add_headers()->mutable_ethernet_header();
+  eth->set_ethertype(EtherType(ETHERTYPE_ARP));
+  eth->set_ethernet_source(std::string(kEthernetSourceAddress));
+  eth->set_ethernet_destination(std::string(kEthernetDestinationAddress));
+
+  ArpHeader* arp = packet.add_headers()->mutable_arp_header();
+  arp->set_hardware_type(ArpType(0x0001));
+  arp->set_protocol_type(ArpType(ETHERTYPE_IP));
+  arp->set_hardware_length(ArpLength(0x06));
+  arp->set_protocol_length(ArpLength(0x04));
+  arp->set_operation(ArpOperation(0x0001));
+  arp->set_sender_hardware_address("00:53:ff:ff:aa:aa");
+  arp->set_sender_protocol_address("10.0.0.11");
+  arp->set_target_hardware_address("00:00:00:00:00:00");
+  arp->set_target_protocol_address("10.0.0.22");
+  ASSERT_OK(SerializePacket(packet));
+}
+
+TEST(PacketLib, ICMPWithIpv4Header) {
+  Packet packet;
+
+  EthernetHeader* eth = packet.add_headers()->mutable_ethernet_header();
+  eth->set_ethertype(EtherType(ETHERTYPE_IP));
+  eth->set_ethernet_source(std::string(kEthernetSourceAddress));
+  eth->set_ethernet_destination(std::string(kEthernetDestinationAddress));
+
+  Ipv4Header* ipv4 = packet.add_headers()->mutable_ipv4_header();
+  ipv4->set_ihl(IpIhl(0x5));
+  ipv4->set_ipv4_source("139.133.217.110");
+  ipv4->set_ipv4_destination("139.133.233.2");
+  ipv4->set_ttl(IpTtl(252));
+  ipv4->set_dscp(IpDscp(2));
+  ipv4->set_protocol(IpProtocol(IPPROTO_ICMP));
+  ipv4->set_ecn(IpEcn(2));
+  ipv4->set_identification(IpIdentification(0x08b8));
+  ipv4->set_total_length(IpTotalLength(0x002e));
+  ipv4->set_flags(IpFlags(2));
+  ipv4->set_fragment_offset(IpFragmentOffset(0));
+
+  IcmpHeader* icmp = packet.add_headers()->mutable_icmp_header();
+  icmp->set_type(IcmpType(0));
+  icmp->set_code(IcmpCode(10));
+  icmp->set_checksum(IcmpChecksum(0xfff5));
+  icmp->set_rest_of_header(IcmpRestOfHeader(0));
+  ASSERT_OK(SerializePacket(packet));
+}
+
+// TODO: Add unit test using example GRE header with checksum. This is not
+// done for now because it's difficult to find an exammple GRE header with
+// checksum.
+
+TEST(PacketLib, GreHeaderIpv4EncapsulatedWithIpv4) {
+  Packet packet;
+
+  EthernetHeader* eth = packet.add_headers()->mutable_ethernet_header();
+  eth->set_ethertype(EtherType(ETHERTYPE_IP));
+  eth->set_ethernet_source(std::string(kEthernetSourceAddress));
+  eth->set_ethernet_destination(std::string(kEthernetDestinationAddress));
+
+  Ipv4Header* ipv4 = packet.add_headers()->mutable_ipv4_header();
+  ipv4->set_ihl(IpIhl(0x5));
+  ipv4->set_ipv4_source("139.133.217.110");
+  ipv4->set_ipv4_destination("139.133.233.2");
+  ipv4->set_ttl(IpTtl(252));
+  ipv4->set_dscp(IpDscp(2));
+  ipv4->set_protocol(IpProtocol(IPPROTO_GRE));
+  ipv4->set_ecn(IpEcn(2));
+  ipv4->set_identification(IpIdentification(0x08b8));
+  ipv4->set_total_length(IpTotalLength(0x0034));
+  ipv4->set_flags(IpFlags(2));
+  ipv4->set_fragment_offset(IpFragmentOffset(0));
+
+  GreHeader* gre = packet.add_headers()->mutable_gre_header();
+  gre->set_checksum_present(GreChecksumPresent(0x0));
+  gre->set_reserved0(GreReserved0(0x0));
+  gre->set_version(GreVersion(0x0));
+  gre->set_protocol_type(EtherType(ETHERTYPE_IP));
+
+  Ipv4Header* encapsulated_ipv4 = packet.add_headers()->mutable_ipv4_header();
+  encapsulated_ipv4->set_ihl(IpIhl(0x5));
+  encapsulated_ipv4->set_ipv4_source("192.168.0.31");
+  encapsulated_ipv4->set_ipv4_destination("192.168.0.30");
+  encapsulated_ipv4->set_ttl(IpTtl(252));
+  encapsulated_ipv4->set_dscp(IpDscp(2));
+  encapsulated_ipv4->set_protocol(IpProtocol(IPPROTO_ICMP));
+  encapsulated_ipv4->set_ecn(IpEcn(2));
+  encapsulated_ipv4->set_identification(IpIdentification(0x08b8));
+  encapsulated_ipv4->set_total_length(IpTotalLength(0x001c));
+  encapsulated_ipv4->set_flags(IpFlags(2));
+  encapsulated_ipv4->set_fragment_offset(IpFragmentOffset(0));
+
+  IcmpHeader* icmp = packet.add_headers()->mutable_icmp_header();
+  icmp->set_type(IcmpType(0));
+  icmp->set_code(IcmpCode(10));
+  icmp->set_checksum(IcmpChecksum(0xfff5));
+  icmp->set_rest_of_header(IcmpRestOfHeader(0));
+
+  ASSERT_OK(SerializePacket(packet));
+}
+
+TEST(PacketLib, GreHeaderWithChecksumIpv4EncapsulatedWithIpv4) {
+  Packet packet;
+
+  EthernetHeader* eth = packet.add_headers()->mutable_ethernet_header();
+  eth->set_ethertype(EtherType(ETHERTYPE_IP));
+  eth->set_ethernet_source(std::string(kEthernetSourceAddress));
+  eth->set_ethernet_destination(std::string(kEthernetDestinationAddress));
+
+  Ipv4Header* ipv4 = packet.add_headers()->mutable_ipv4_header();
+  ipv4->set_ihl(IpIhl(0x5));
+  ipv4->set_ipv4_source("139.133.217.110");
+  ipv4->set_ipv4_destination("139.133.233.2");
+  ipv4->set_ttl(IpTtl(252));
+  ipv4->set_dscp(IpDscp(2));
+  ipv4->set_protocol(IpProtocol(IPPROTO_GRE));
+  ipv4->set_ecn(IpEcn(2));
+  ipv4->set_identification(IpIdentification(0x08b8));
+  ipv4->set_total_length(IpTotalLength(0x0038));
+  ipv4->set_flags(IpFlags(2));
+  ipv4->set_fragment_offset(IpFragmentOffset(0));
+
+  GreHeader* gre = packet.add_headers()->mutable_gre_header();
+  gre->set_checksum_present(GreChecksumPresent(0x1));
+  gre->set_reserved0(GreReserved0(0x0));
+  gre->set_version(GreVersion(0x0));
+  gre->set_protocol_type(EtherType(ETHERTYPE_IP));
+  gre->set_reserved1(GreReserved1(0x0));
+  gre->set_checksum(GreChecksum(0x77ff));
+
+  Ipv4Header* encapsulated_ipv4 = packet.add_headers()->mutable_ipv4_header();
+  encapsulated_ipv4->set_ihl(IpIhl(0x5));
+  encapsulated_ipv4->set_ipv4_source("192.168.0.31");
+  encapsulated_ipv4->set_ipv4_destination("192.168.0.30");
+  encapsulated_ipv4->set_ttl(IpTtl(252));
+  encapsulated_ipv4->set_dscp(IpDscp(2));
+  encapsulated_ipv4->set_protocol(IpProtocol(IPPROTO_ICMP));
+  encapsulated_ipv4->set_ecn(IpEcn(2));
+  encapsulated_ipv4->set_identification(IpIdentification(0x08b8));
+  encapsulated_ipv4->set_total_length(IpTotalLength(0x001c));
+  encapsulated_ipv4->set_flags(IpFlags(2));
+  encapsulated_ipv4->set_fragment_offset(IpFragmentOffset(0));
+
+  IcmpHeader* icmp = packet.add_headers()->mutable_icmp_header();
+  icmp->set_type(IcmpType(0));
+  icmp->set_code(IcmpCode(10));
+  icmp->set_checksum(IcmpChecksum(0xfff5));
+  icmp->set_rest_of_header(IcmpRestOfHeader(0));
+
+  ASSERT_OK(SerializePacket(packet));
+}
+
+TEST(PacketLib, GreHeaderIpv6EncapsulatedWithIpv6) {
+  Packet packet;
+  EthernetHeader* eth = packet.add_headers()->mutable_ethernet_header();
+  eth->set_ethertype(EtherType(ETHERTYPE_IPV6));
+  eth->set_ethernet_source(std::string(kEthernetSourceAddress));
+  eth->set_ethernet_destination(std::string(kEthernetDestinationAddress));
+
+  Ipv6Header* ipv6 = packet.add_headers()->mutable_ipv6_header();
+  ipv6->set_ipv6_source("5:6:7:8::");
+  ipv6->set_ipv6_destination("2607:f8b0:c150:8114::");
+  ipv6->set_flow_label(IpFlowLabel(0x12345));
+  ipv6->set_next_header(IpNextHeader(0x2f));
+  ipv6->set_hop_limit(IpHopLimit(32));
+  ipv6->set_dscp(IpDscp(3));
+  ipv6->set_ecn(IpEcn(0));
+
+  GreHeader* gre = packet.add_headers()->mutable_gre_header();
+  gre->set_checksum_present(GreChecksumPresent(0x0));
+  gre->set_reserved0(GreReserved0(0x0));
+  gre->set_version(GreVersion(0x0));
+  gre->set_protocol_type(EtherType(ETHERTYPE_IPV6));
+
+  Ipv6Header* encapsulated_ipv6 = packet.add_headers()->mutable_ipv6_header();
+  encapsulated_ipv6->set_ipv6_source("5:6:7:8::");
+  encapsulated_ipv6->set_ipv6_destination("2607:f8b0:c150:8115::");
+  encapsulated_ipv6->set_flow_label(IpFlowLabel(0x12345));
+  encapsulated_ipv6->set_next_header(IpNextHeader(17));
+  encapsulated_ipv6->set_hop_limit(IpHopLimit(32));
+  encapsulated_ipv6->set_dscp(IpDscp(3));
+  encapsulated_ipv6->set_ecn(IpEcn(0));
+  UdpHeader* udp = packet.add_headers()->mutable_udp_header();
+  udp->set_source_port(UdpPort(0));
+  udp->set_destination_port(UdpPort(0));
+
+  ASSERT_OK(SerializePacket(packet));
+}
+
+TEST(PacketLib, GreHeaderWithChecksumIpv6EncapsulatedWithIpv6) {
+  Packet packet;
+  EthernetHeader* eth = packet.add_headers()->mutable_ethernet_header();
+  eth->set_ethertype(EtherType(ETHERTYPE_IPV6));
+  eth->set_ethernet_source(std::string(kEthernetSourceAddress));
+  eth->set_ethernet_destination(std::string(kEthernetDestinationAddress));
+
+  Ipv6Header* ipv6 = packet.add_headers()->mutable_ipv6_header();
+  ipv6->set_ipv6_source("5:6:7:8::");
+  ipv6->set_ipv6_destination("2607:f8b0:c150:8114::");
+  ipv6->set_flow_label(IpFlowLabel(0x12345));
+  ipv6->set_next_header(IpNextHeader(0x2f));
+  ipv6->set_hop_limit(IpHopLimit(32));
+  ipv6->set_dscp(IpDscp(3));
+  ipv6->set_ecn(IpEcn(0));
+
+  GreHeader* gre = packet.add_headers()->mutable_gre_header();
+  gre->set_checksum_present(GreChecksumPresent(0x1));
+  gre->set_reserved0(GreReserved0(0x0));
+  gre->set_version(GreVersion(0x0));
+  gre->set_protocol_type(EtherType(ETHERTYPE_IPV6));
+  gre->set_reserved1(GreReserved1(0x0));
+  gre->set_checksum(GreChecksum(0x640c));
+
+  Ipv6Header* encapsulated_ipv6 = packet.add_headers()->mutable_ipv6_header();
+  encapsulated_ipv6->set_ipv6_source("5:6:7:8::");
+  encapsulated_ipv6->set_ipv6_destination("2607:f8b0:c150:8115::");
+  encapsulated_ipv6->set_flow_label(IpFlowLabel(0x12345));
+  encapsulated_ipv6->set_next_header(IpNextHeader(17));
+  encapsulated_ipv6->set_hop_limit(IpHopLimit(32));
+  encapsulated_ipv6->set_dscp(IpDscp(3));
+  encapsulated_ipv6->set_ecn(IpEcn(0));
+  UdpHeader* udp = packet.add_headers()->mutable_udp_header();
+  udp->set_source_port(UdpPort(0));
+  udp->set_destination_port(UdpPort(0));
+
+  ASSERT_OK(SerializePacket(packet));
+}
+
+TEST(PacketLib, GreHeaderIpv4EncapsulatedWithIpv6) {
+  Packet packet;
+  EthernetHeader* eth = packet.add_headers()->mutable_ethernet_header();
+  eth->set_ethertype(EtherType(ETHERTYPE_IPV6));
+  eth->set_ethernet_source(std::string(kEthernetSourceAddress));
+  eth->set_ethernet_destination(std::string(kEthernetDestinationAddress));
+
+  Ipv6Header* ipv6 = packet.add_headers()->mutable_ipv6_header();
+  ipv6->set_ipv6_source("2607:f8b0:c150:10::");
+  ipv6->set_ipv6_destination("2002:a05:6860:749::");
+  ipv6->set_flow_label(IpFlowLabel(0x0000));
+  ipv6->set_next_header(IpNextHeader(0x2f));
+  ipv6->set_hop_limit(IpHopLimit(63));
+  ipv6->set_dscp(IpDscp(0));
+  ipv6->set_ecn(IpEcn(0));
+
+  GreHeader* gre = packet.add_headers()->mutable_gre_header();
+  gre->set_checksum_present(GreChecksumPresent(0x0));
+  gre->set_reserved0(GreReserved0(0x0));
+  gre->set_version(GreVersion(0x0));
+  gre->set_protocol_type(EtherType(ETHERTYPE_IP));
+
+  Ipv4Header* encapsulated_ipv4 = packet.add_headers()->mutable_ipv4_header();
+  encapsulated_ipv4->set_ihl(IpIhl(0x5));
+  encapsulated_ipv4->set_ipv4_source("128.0.0.0");
+  encapsulated_ipv4->set_ipv4_destination("185.168.204.0");
+  encapsulated_ipv4->set_ttl(IpTtl(63));
+  encapsulated_ipv4->set_dscp(IpDscp(0));
+  encapsulated_ipv4->set_protocol(IpProtocol(IPPROTO_ICMP));
+  encapsulated_ipv4->set_ecn(IpEcn(0));
+  encapsulated_ipv4->set_identification(IpIdentification(0x0000));
+  encapsulated_ipv4->set_total_length(IpTotalLength(0x011a));
+  encapsulated_ipv4->set_flags(IpFlags(0));
+  encapsulated_ipv4->set_fragment_offset(IpFragmentOffset(0));
+  encapsulated_ipv4->set_checksum(IpChecksum(0x753a));
+
+  IcmpHeader* icmp = packet.add_headers()->mutable_icmp_header();
+  icmp->set_type(IcmpType(0x00));
+  icmp->set_code(IcmpCode(0x00));
+  icmp->set_checksum(IcmpChecksum(0x00e4));
+  icmp->set_rest_of_header(IcmpRestOfHeader(0x00000000));
+
+  packet.set_payload(
+      "test packet #5: ROUTING_PINBALLL3TOGROUP_FLOW: ipv4_table_entry \t { "
+      "match { vrf_id: \"vrf-210\" ipv4_dst { value: \"185.168.204.0\" "
+      "prefix_length: 28 } } action { set_wcmp_group_id_and_metadata { "
+      "wcmp_group_id: \"group-4294934578\" route_metadata: \"0x01\" } } }");
+
+  ASSERT_OK(packetlib::SerializePacket(packet));
+}
+
+TEST(PacketLib, SaiP4BMv2PacketInHeader) {
+  Packet packet;
+
+  SaiP4BMv2PacketInHeader* packet_in_header =
+      packet.add_headers()->mutable_sai_p4_bmv2_packet_in_header();
+  packet_in_header->set_ingress_port("0x001");
+  packet_in_header->set_target_egress_port("0x002");
+  packet_in_header->set_unused_pad("0x00");
+
+  EthernetHeader* eth = packet.add_headers()->mutable_ethernet_header();
+  eth->set_ethertype(EtherType(ETHERTYPE_ARP));
+  eth->set_ethernet_source(std::string(kEthernetSourceAddress));
+  eth->set_ethernet_destination(std::string(kEthernetDestinationAddress));
+
+  ArpHeader* arp = packet.add_headers()->mutable_arp_header();
+  arp->set_hardware_type(ArpType(0x0001));
+  arp->set_protocol_type(ArpType(ETHERTYPE_IP));
+  arp->set_hardware_length(ArpLength(0x06));
+  arp->set_protocol_length(ArpLength(0x04));
+  arp->set_operation(ArpOperation(0x0001));
+  arp->set_sender_hardware_address("00:53:ff:ff:aa:aa");
+  arp->set_sender_protocol_address("10.0.0.11");
+  arp->set_target_hardware_address("00:00:00:00:00:00");
+  arp->set_target_protocol_address("10.0.0.22");
+  ASSERT_OK(SerializePacket(packet));
+}
+
+TEST(PacketLib, PadPacket) {
+  Packet packet;
+
+  ASSERT_OK_AND_ASSIGN(int current_size, PacketSizeInBytes(packet));
+  ASSERT_THAT(PadPacket(current_size - 1, packet), IsOkAndHolds(Eq(false)));
+  ASSERT_THAT(PadPacket(current_size, packet), IsOkAndHolds(Eq(false)));
+  ASSERT_THAT(PadPacket(current_size + 1, packet), IsOkAndHolds(Eq(true)));
+  ASSERT_OK_AND_ASSIGN(int updated_size, PacketSizeInBytes(packet));
+  EXPECT_EQ(current_size + 1, updated_size);
+}
+
+TEST(PacketLib, PadPacketWithEthernetHeader) {
+  Packet packet;
+
+  EthernetHeader* eth = packet.add_headers()->mutable_ethernet_header();
+  eth->set_ethertype(EtherType(ETHERTYPE_IP));
+  eth->set_ethernet_source(std::string(kEthernetSourceAddress));
+  eth->set_ethernet_destination(std::string(kEthernetDestinationAddress));
+
+  ASSERT_OK_AND_ASSIGN(int current_size, PacketSizeInBytes(packet));
+  ASSERT_THAT(PadPacket(current_size - 1, packet), IsOkAndHolds(Eq(false)));
+  ASSERT_THAT(PadPacket(current_size, packet), IsOkAndHolds(Eq(false)));
+  ASSERT_THAT(PadPacket(current_size + 1, packet), IsOkAndHolds(Eq(true)));
+  ASSERT_OK_AND_ASSIGN(int updated_size, PacketSizeInBytes(packet));
+  EXPECT_EQ(current_size + 1, updated_size);
+}
+
+}  // namespace
+}  // namespace packetlib


### PR DESCRIPTION
PR Description :
[packetlib] Add SAI P4 BMv2 packet_in header support in packetlib.

Build Results :
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS p4_pdpi/...
2024/05/13 11:58:31 Downloading https://releases.bazel.build/4.2.0/release/bazel-4.2.0-linux-x86_64...
Downloading: 48 MB out of 48 MB (100%) 
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
INFO: Elapsed time: 1934.877s, Critical Path: 36.37s
INFO: 5254 processes: 818 internal, 4436 linux-sandbox.
INFO: Build completed successfully, 5254 total actions
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ 

bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS p4rt_app/...
INFO: Analyzed 100 targets (18 packages loaded, 485 targets configured).
INFO: Found 100 targets...
INFO: Elapsed time: 273.196s, Critical Path: 30.86s
INFO: 792 processes: 439 internal, 353 linux-sandbox.
INFO: Build completed successfully, 792 total actions
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ 

UT Results :
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4_pdpi/...
INFO: Analyzed 74 targets (0 packages loaded, 0 targets configured).
INFO: Found 43 targets and 31 test targets...
INFO: Elapsed time: 0.614s, Critical Path: 0.10s
INFO: 2 processes: 2 linux-sandbox.
INFO: Build completed successfully, 2 total actions
//p4_pdpi:ir_tools_test                                         (cached) PASSED in 0.4s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test         (cached) PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                             (cached) PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                              (cached) PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                       (cached) PASSED in 15.5s
//p4_pdpi/packetlib:packetlib_test_runner                       (cached) PASSED in 0.0s
//p4_pdpi/packetlib:packetlib_unit_test                         (cached) PASSED in 0.9s
//p4_pdpi/string_encodings:bit_string_test                      (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                     (cached) PASSED in 0.3s
//p4_pdpi/string_encodings:decimal_string_test                  (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner           (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                      (cached) PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner               (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test            (cached) PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                          (cached) PASSED in 0.4s
//p4_pdpi/testing:info_test                                     (cached) PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                              (cached) PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                  (cached) PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                   (cached) PASSED in 0.3s
//p4_pdpi/testing:packet_io_test                                (cached) PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                         (cached) PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                      (cached) PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                        (cached) PASSED in 0.2s
//p4_pdpi/testing:table_entry_gunit_test                        (cached) PASSED in 0.3s
//p4_pdpi/testing:table_entry_test                              (cached) PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                          (cached) PASSED in 0.2s
//p4_pdpi/utils:ir_test                                         (cached) PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s

Executed 1 out of 31 tests: 31 tests pass.
INFO: Build completed successfully, 2 total actions
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ 

bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4rt_app/...
INFO: Analyzed 100 targets (0 packages loaded, 0 targets configured).
INFO: Found 65 targets and 35 test targets...
INFO: Elapsed time: 27.473s, Critical Path: 5.03s
INFO: 36 processes: 1 internal, 21 linux-sandbox, 14 local.
INFO: Build completed successfully, 36 total actions
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.4s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.4s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.4s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.2s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.3s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.2s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.3s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.0s
//p4rt_app/tests:action_set_test                                         PASSED in 0.6s
//p4rt_app/tests:api_access_test                                         PASSED in 0.6s
//p4rt_app/tests:arbitration_test                                        PASSED in 0.7s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.5s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.0s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.3s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.1s
//p4rt_app/tests:packetio_test                                           PASSED in 3.3s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 0.8s
//p4rt_app/tests:response_path_test                                      PASSED in 1.8s
//p4rt_app/tests:role_test                                               PASSED in 0.8s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.1s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.3s

Executed 35 out of 35 tests: 35 tests pass.
INFO: Build completed successfully, 36 total actions
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$
