### PR TITLE
[PDPI] Add convenience functions to P4 Runtime Session.

### DIFF
--- a/gutil/BUILD.bazel
+++ b/gutil/BUILD.bazel
@@ -224,3 +224,18 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "version",
+    srcs = ["version.cc"],
+    hdrs = ["version.h"],
+    deps = [
+        ":status",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_googlesource_code_re2//:re2",
+    ],
+)
+

--- a/gutil/version.cc
+++ b/gutil/version.cc
@@ -1,0 +1,86 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gutil/version.h"
+
+#include <ostream>
+#include <string>
+#include <tuple>
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "gutil/status.h"
+#include "re2/re2.h"
+
+namespace gutil {
+
+namespace {
+
+// Returns the given version as a tuple.
+inline constexpr std::tuple<int, int, int> Tupled(Version v) {
+  return std::make_tuple(v.major_version, v.minor_version, v.patch_version);
+}
+
+}  // namespace
+
+bool operator==(const Version& x, const Version& y) {
+  return Tupled(x) == Tupled(y);
+}
+bool operator!=(const Version& x, const Version& y) {
+  return Tupled(x) != Tupled(y);
+}
+bool operator<=(const Version& x, const Version& y) {
+  return Tupled(x) <= Tupled(y);
+}
+bool operator<(const Version& x, const Version& y) {
+  return Tupled(x) < Tupled(y);
+}
+bool operator>=(const Version& x, const Version& y) {
+  return Tupled(x) >= Tupled(y);
+}
+bool operator>(const Version& x, const Version& y) {
+  return Tupled(x) > Tupled(y);
+}
+
+absl::StatusOr<Version> ParseVersion(absl::string_view version_string) {
+  static const LazyRE2 kSemanticVersionRegex = {R"((\d+).(\d+).(\d+))"};
+  Version version;
+  if (!RE2::FullMatch(version_string, *kSemanticVersionRegex,
+                      &version.major_version, &version.minor_version,
+                      &version.patch_version)) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "unable to parse '" << version_string
+           << "' as a semantic version string; expected string of the form "
+              "`MAJOR.MINOR.PATCH`, where each sub-string is a decimal string";
+  }
+  return version;
+}
+
+std::string VersionToString(const Version& v) {
+  // TODO: Use this simpler implementation once Abseil has been
+  // upgraded upstream.
+  // return absl::StrCat(v);
+  return absl::StrFormat("%d.%d.%d", v.major_version, v.minor_version,
+                         v.patch_version);
+}
+
+std::ostream& operator<<(std::ostream& os, const Version& v) {
+  // TODO: Use this simpler implementation once Abseil has been
+  // upgraded upstream.
+  // return os << absl::StrCat(v);
+  return os << absl::StreamFormat("%d.%d.%d", v.major_version, v.minor_version,
+                                  v.patch_version);
+}
+
+}  // namespace gutil

--- a/gutil/version.h
+++ b/gutil/version.h
@@ -1,0 +1,73 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_GUTIL_VERSION_H_
+#define GOOGLE_GUTIL_VERSION_H_
+
+#include <ostream>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
+
+namespace gutil {
+
+// Semantic version number (see https://semver.org/), consisting of:
+// - `major_version` - incremented when making breaking API changes.
+// - `minor_version` - incremented when adding functionality in
+//                     backward-compatible manner.
+// - `patch_version` - incremented when making backward-compatible bug fixes.
+//
+// We don't support extensions such as pre-release and build metadata labels at
+// this time.
+struct Version {
+  int major_version = 0;
+  int minor_version = 0;
+  int patch_version = 0;
+};
+
+// Parses semantic version string of the form `MAJOR.MINOR.PATCH`, where each
+// of `MAJOR`, `MINOR`, and `PATCH` is an unsigned decimal string.
+absl::StatusOr<Version> ParseVersion(absl::string_view version_string);
+
+// Returns semantic version string of the form `MAJOR.MINOR.PATCH`.
+std::string VersionToString(const Version& v);
+
+// Pretty printer.
+std::ostream& operator<<(std::ostream& os, const Version& v);
+
+// Absl pretty printer (https://abseil.io/blog/20221115-stringify).
+template <class Sink>
+void AbslStringify(Sink& sink, const Version& v);
+
+// Comparison operators.
+bool operator==(const Version& x, const Version& y);
+bool operator!=(const Version& x, const Version& y);
+bool operator<=(const Version& x, const Version& y);
+bool operator<(const Version& x, const Version& y);
+bool operator>=(const Version& x, const Version& y);
+bool operator>(const Version& x, const Version& y);
+
+// -- END OF PUBLIC INTERFACE -- implementation details follow -----------------
+
+template <class Sink>
+void AbslStringify(Sink& sink, const Version& v) {
+  absl::Format(&sink, "%d.%d.%d", v.major_version, v.minor_version,
+               v.patch_version);
+}
+
+}  // namespace gutil
+
+#endif  // GOOGLE_GUTIL_VERSION_H_

--- a/p4_pdpi/BUILD.bazel
+++ b/p4_pdpi/BUILD.bazel
@@ -217,6 +217,7 @@ cc_library(
         ":ir_cc_proto",
         ":sequencing",
         "//gutil:status",
+        "//gutil:version",
         "//sai_p4/fixed:p4_roles",
         "@com_github_google_glog//:glog",
         "@com_github_grpc_grpc//:grpc++",

--- a/p4_pdpi/p4_runtime_session.h
+++ b/p4_pdpi/p4_runtime_session.h
@@ -36,6 +36,7 @@
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
 #include "grpcpp/security/credentials.h"
+#include "gutil/version.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
 #include "p4_pdpi/ir.pb.h"
@@ -316,12 +317,16 @@ absl::Status ClearTableEntries(
 
 // Installs the given PI (program independent) table entry on the switch.
 absl::Status InstallPiTableEntry(P4RuntimeSession* session,
-                                 const p4::v1::TableEntry& pi_entry);
+                                 p4::v1::TableEntry pi_entry);
 
 // Installs the given PI (program independent) table entries on the switch.
 absl::Status InstallPiTableEntries(
     P4RuntimeSession* session, const IrP4Info& info,
     absl::Span<const p4::v1::TableEntry> pi_entries);
+
+// Installs the given PI (program independent) entity on the switch.
+absl::Status InstallPiEntity(P4RuntimeSession* session,
+                             p4::v1::Entity pi_entity);
 
 // Sends the given PI updates to the switch.
 absl::Status SendPiUpdates(P4RuntimeSession* session,
@@ -347,6 +352,12 @@ GetForwardingPipelineConfig(
     P4RuntimeSession* session,
     p4::v1::GetForwardingPipelineConfigRequest::ResponseType type =
         p4::v1::GetForwardingPipelineConfigRequest::ALL);
+
+// Gets the P4 Info from the device, then parses and returns the `version` field
+// specified in the `PkgInfo` message.
+// Assumes semantic versioning, i.e. that the `version` field is a string of the
+// the form `MAJOR.MINOR.PATCH`.
+absl::StatusOr<gutil::Version> GetPkgInfoVersion(P4RuntimeSession* session);
 
 }  // namespace pdpi
 #endif  // GOOGLE_P4_PDPI_P4_RUNTIME_SESSION_H_


### PR DESCRIPTION
PR Description : 
[PDPI] Add convenience functions to P4 Runtime Session.

Build Results :
ibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ 
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS p4_pdpi/...
INFO: Analyzed 74 targets (2 packages loaded, 122 targets configured).
INFO: Found 74 targets...
INFO: Elapsed time: 6.428s, Critical Path: 4.97s
INFO: 8 processes: 1 internal, 7 linux-sandbox.
INFO: Build completed successfully, 8 total actions

bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS p4rt_app/...
INFO: Analyzed 100 targets (1 packages loaded, 122 targets configured).
INFO: Found 100 targets...
INFO: Elapsed time: 81.049s, Critical Path: 25.87s
INFO: 83 processes: 42 internal, 41 linux-sandbox.
INFO: Build completed successfully, 83 total actions
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ 

UT Results :

bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4_pdpi/...
INFO: Analyzed 74 targets (0 packages loaded, 0 targets configured).
INFO: Found 43 targets and 31 test targets...
INFO: Elapsed time: 0.414s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//p4_pdpi:ir_tools_test                                         (cached) PASSED in 0.4s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test         (cached) PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                             (cached) PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                              (cached) PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                       (cached) PASSED in 15.5s
//p4_pdpi/packetlib:packetlib_test                              (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                       (cached) PASSED in 0.0s
//p4_pdpi/packetlib:packetlib_unit_test                         (cached) PASSED in 0.9s
//p4_pdpi/string_encodings:bit_string_test                      (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                     (cached) PASSED in 0.3s
//p4_pdpi/string_encodings:decimal_string_test                  (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner           (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                      (cached) PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner               (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test            (cached) PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                          (cached) PASSED in 0.4s
//p4_pdpi/testing:info_test                                     (cached) PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                              (cached) PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                  (cached) PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                   (cached) PASSED in 0.3s
//p4_pdpi/testing:packet_io_test                                (cached) PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                         (cached) PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                      (cached) PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                        (cached) PASSED in 0.2s
//p4_pdpi/testing:table_entry_gunit_test                        (cached) PASSED in 0.3s
//p4_pdpi/testing:table_entry_test                              (cached) PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                          (cached) PASSED in 0.2s
//p4_pdpi/utils:ir_test                                         (cached) PASSED in 0.3s

Executed 0 out of 31 tests: 31 tests pass.
INFO: Build completed successfully, 1 total action
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4rt_app/...
INFO: Analyzed 100 targets (0 packages loaded, 0 targets configured).
INFO: Found 65 targets and 35 test targets...
INFO: Elapsed time: 17.179s, Critical Path: 3.46s
INFO: 13 processes: 1 internal, 1 linux-sandbox, 11 local.
INFO: Build completed successfully, 13 total actions
//p4rt_app/event_monitoring:app_state_db_port_table_event_test  (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test     (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test      (cached) PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                        (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test            (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                   (cached) PASSED in 0.4s
//p4rt_app/p4runtime:packetio_helpers_test                      (cached) PASSED in 0.4s
//p4rt_app/sonic:app_db_acl_def_table_manager_test              (cached) PASSED in 0.4s
//p4rt_app/sonic:app_db_manager_test                            (cached) PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test              (cached) PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                             (cached) PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                             (cached) PASSED in 0.2s
//p4rt_app/sonic:response_handler_test                          (cached) PASSED in 0.3s
//p4rt_app/sonic:state_verification_test                        (cached) PASSED in 0.2s
//p4rt_app/sonic:vrf_entry_translation_test                     (cached) PASSED in 0.3s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test              (cached) PASSED in 0.1s
//p4rt_app/tests:api_access_test                                (cached) PASSED in 0.6s
//p4rt_app/tests:arbitration_test                               (cached) PASSED in 0.7s
//p4rt_app/tests:grpc_behavior_test                             (cached) PASSED in 5.0s
//p4rt_app/tests/lib:app_db_entry_builder_test                  (cached) PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                        (cached) PASSED in 0.0s
//p4rt_app/utils:table_utility_test                             (cached) PASSED in 0.3s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.0s
//p4rt_app/tests:action_set_test                                         PASSED in 0.6s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.3s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.1s
//p4rt_app/tests:packetio_test                                           PASSED in 3.4s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 0.9s
//p4rt_app/tests:response_path_test                                      PASSED in 1.7s
//p4rt_app/tests:role_test                                               PASSED in 0.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.1s

Executed 12 out of 35 tests: 35 tests pass.
INFO: Build completed successfully, 13 total actions
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ 