### PR TITLE
Use a canonical key when updating the read cache. Map SWSS_RC_NOT_EXECUTED to ABORTED in p4rt.

### DIFF
--- a/p4rt_app/sonic/response_handler.cc
+++ b/p4rt_app/sonic/response_handler.cc
@@ -65,6 +65,8 @@ google::rpc::Code SwssToP4RTErrorCode(const std::string& status_str) {
       return google::rpc::Code::INTERNAL;
     case swss::StatusCode::SWSS_RC_UNAVAIL:
       return google::rpc::Code::UNAVAILABLE;
+    case swss::StatusCode::SWSS_RC_NOT_EXECUTED:
+      return google::rpc::Code::ABORTED;
     default:
       return google::rpc::Code::UNKNOWN;
   }

--- a/p4rt_app/sonic/response_handler_test.cc
+++ b/p4rt_app/sonic/response_handler_test.cc
@@ -428,6 +428,10 @@ INSTANTIATE_TEST_SUITE_P(
             .swss_error = "SWSS_RC_UNIMPLEMENTED",
             .p4rt_error = google::rpc::Code::UNIMPLEMENTED,
         },
+        {
+            .swss_error = "SWSS_RC_NOT_EXECUTED",
+            .p4rt_error = google::rpc::Code::ABORTED,
+        },
     }),
     [](const testing::TestParamInfo<ResponseHandlerErrorCodeTest::ParamType>&
            info) { return info.param.swss_error; });

--- a/pins_infra_deps.bzl
+++ b/pins_infra_deps.bzl
@@ -172,8 +172,8 @@ def pins_infra_deps():
     if not native.existing_rule("sonic_swss_common"):
         http_archive(
             name = "sonic_swss_common",
-            url = "https://github.com/azure/sonic-swss-common/archive/5d1fe2da5fc4a6b1daebdb5df9b04c05805f8ad7.zip",
-            strip_prefix = "sonic-swss-common-5d1fe2da5fc4a6b1daebdb5df9b04c05805f8ad7",
+            url = "https://github.com/azure/sonic-swss-common/archive/e7917acd2d4a9c0121802437e3c899bd513ac888.zip",
+            strip_prefix = "sonic-swss-common-e7917acd2d4a9c0121802437e3c899bd513ac888",
         )
     if not native.existing_rule("rules_pkg"):
         http_archive(


### PR DESCRIPTION
Use a canonical key when updating the read cache. Map SWSS_RC_NOT_EXECUTED to ABORTED in p4rt.

rkavitha@0c0d9cfbd72e:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 233 targets (4 packages loaded, 511 targets configured).
INFO: Found 233 targets...
INFO: Elapsed time: 32.502s, Critical Path: 29.76s
INFO: 36 processes: 4 internal, 32 linux-sandbox.
INFO: Build completed successfully, 36 total actions
rkavitha@0c0d9cfbd72e:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Analyzed 233 targets (0 packages loaded, 0 targets configured).
INFO: Found 151 targets and 82 test targets...
INFO: Elapsed time: 19.595s, Critical Path: 4.97s
INFO: 23 processes: 1 internal, 8 linux-sandbox, 14 local.
INFO: Build completed successfully, 23 total actions
//gutil:collections_test                                        (cached) PASSED in 0.2s
//gutil:io_test                                                 (cached) PASSED in 0.2s
//gutil:proto_matchers_test                                     (cached) PASSED in 0.3s
//gutil:proto_test                                              (cached) PASSED in 0.3s
//gutil:status_matchers_test                                    (cached) PASSED in 0.2s
//gutil:table_entry_key_test                                    (cached) PASSED in 0.1s
//p4_pdpi:ir_tools_test                                         (cached) PASSED in 0.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test         (cached) PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                             (cached) PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                              (cached) PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_fuzzer_test                       (cached) PASSED in 15.3s
//p4_pdpi/packetlib:packetlib_test                              (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                         (cached) PASSED in 0.8s
//p4_pdpi/string_encodings:bit_string_test                      (cached) PASSED in 0.3s
//p4_pdpi/string_encodings:byte_string_test                     (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                  (cached) PASSED in 0.3s
//p4_pdpi/string_encodings:decimal_string_test_runner           (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                      (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner               (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test            (cached) PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                          (cached) PASSED in 0.4s
//p4_pdpi/testing:info_test                                     (cached) PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                              (cached) PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                  (cached) PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                   (cached) PASSED in 0.3s
//p4_pdpi/testing:packet_io_test                                (cached) PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                         (cached) PASSED in 0.0s
//p4_pdpi/testing:rpc_test                                      (cached) PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                        (cached) PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                        (cached) PASSED in 0.4s
//p4_pdpi/testing:table_entry_test                              (cached) PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                          (cached) PASSED in 0.2s
//p4_pdpi/utils:ir_test                                         (cached) PASSED in 0.3s
//p4rt_app/p4runtime:ir_translation_test                        (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test            (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                   (cached) PASSED in 0.4s
//p4rt_app/p4runtime:packetio_helpers_test                      (cached) PASSED in 0.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test              (cached) PASSED in 0.5s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test              (cached) PASSED in 0.5s
//p4rt_app/sonic:packetio_impl_test                             (cached) PASSED in 0.4s
//p4rt_app/sonic:packetio_port_test                             (cached) PASSED in 0.3s
//p4rt_app/sonic:state_verification_test                        (cached) PASSED in 0.2s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test              (cached) PASSED in 0.0s
//p4rt_app/tests/lib:app_db_entry_builder_test                  (cached) PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                        (cached) PASSED in 0.0s
//p4rt_app/utils:table_utility_test                             (cached) PASSED in 0.4s
//sai_p4/instantiations/google:clos_stage_test                  (cached) PASSED in 0.2s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test (cached) PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test (cached) PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test          (cached) PASSED in 0.3s
//sai_p4/instantiations/google:sai_p4info_test                  (cached) PASSED in 0.5s
//sai_p4/instantiations/google:sai_pd_proto_test                (cached) PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                 (cached) PASSED in 0.2s
//sai_p4/instantiations/google:union_p4info_up_to_date_test     (cached) PASSED in 0.0s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test       (cached) PASSED in 0.1s
//sai_p4/tools:p4info_tools_test                                (cached) PASSED in 0.3s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.5s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.4s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.3s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.4s
//p4rt_app/tests:acl_table_test                                          PASSED in 0.8s
//p4rt_app/tests:action_set_test                                         PASSED in 0.6s
//p4rt_app/tests:api_access_test                                         PASSED in 0.5s
//p4rt_app/tests:arbitration_test                                        PASSED in 0.6s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 1.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 2.0s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.0s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.1s
//p4rt_app/tests:p4_programs_test                                        PASSED in 0.8s
//p4rt_app/tests:packetio_test                                           PASSED in 2.9s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 0.7s
//p4rt_app/tests:response_path_test                                      PASSED in 1.3s
//p4rt_app/tests:role_test                                               PASSED in 0.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 0.7s

Executed 22 out of 82 tests: 82 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeoutINFO: Build completed successfully, 23 total actions