### PR TITLE
[PDPI] Transition numerous functions to use a proto IrTableEntries instead of a vector.

### DIFF
--- a/p4_pdpi/ir.cc
+++ b/p4_pdpi/ir.cc
@@ -1802,6 +1802,16 @@ StatusOr<IrStreamMessageResponse> PiStreamMessageResponseToIr(
 }
 
 absl::StatusOr<std::vector<p4::v1::TableEntry>> IrTableEntriesToPi(
+    const IrP4Info &info, const IrTableEntries &ir, bool key_only) {
+  std::vector<p4::v1::TableEntry> pi;
+  pi.reserve(ir.entries_size());
+  for (const IrTableEntry &ir_entry : ir.entries()) {
+    ASSIGN_OR_RETURN(pi.emplace_back(),
+                     IrTableEntryToPi(info, ir_entry, key_only));
+  }
+  return pi;
+}
+absl::StatusOr<std::vector<p4::v1::TableEntry>> IrTableEntriesToPi(
     const IrP4Info &info, absl::Span<const IrTableEntry> ir, bool key_only) {
   std::vector<p4::v1::TableEntry> pi;
   pi.reserve(ir.size());
@@ -1812,13 +1822,13 @@ absl::StatusOr<std::vector<p4::v1::TableEntry>> IrTableEntriesToPi(
   return pi;
 }
 
-absl::StatusOr<std::vector<IrTableEntry>> PiTableEntriesToIr(
+absl::StatusOr<IrTableEntries> PiTableEntriesToIr(
     const IrP4Info &info, absl::Span<const p4::v1::TableEntry> pi,
     bool key_only) {
-  std::vector<IrTableEntry> ir;
-  ir.reserve(pi.size());
+  IrTableEntries ir;
+  ir.mutable_entries()->Reserve(pi.size());
   for (const auto &pi_entry : pi) {
-    ASSIGN_OR_RETURN(ir.emplace_back(),
+    ASSIGN_OR_RETURN(*ir.add_entries(),
                      PiTableEntryToIr(info, pi_entry, key_only));
   }
   return ir;

--- a/p4_pdpi/ir.h
+++ b/p4_pdpi/ir.h
@@ -37,7 +37,7 @@ absl::StatusOr<IrP4Info> CreateIrP4Info(const p4::config::v1::P4Info& p4_info);
 absl::StatusOr<IrTableEntry> PiTableEntryToIr(const IrP4Info& info,
                                               const p4::v1::TableEntry& pi,
                                               bool key_only = false);
-absl::StatusOr<std::vector<IrTableEntry>> PiTableEntriesToIr(
+absl::StatusOr<IrTableEntries> PiTableEntriesToIr(
     const IrP4Info& info, absl::Span<const p4::v1::TableEntry> pi,
     bool key_only = false);
 
@@ -71,6 +71,8 @@ absl::StatusOr<IrStreamMessageResponse> PiStreamMessageResponseToIr(
 absl::StatusOr<p4::v1::TableEntry> IrTableEntryToPi(const IrP4Info& info,
                                                     const IrTableEntry& ir,
                                                     bool key_only = false);
+absl::StatusOr<std::vector<p4::v1::TableEntry>> IrTableEntriesToPi(
+    const IrP4Info& info, const IrTableEntries& ir, bool key_only = false);
 absl::StatusOr<std::vector<p4::v1::TableEntry>> IrTableEntriesToPi(
     const IrP4Info& info, absl::Span<const IrTableEntry> ir,
     bool key_only = false);

--- a/p4_pdpi/ir.proto
+++ b/p4_pdpi/ir.proto
@@ -282,6 +282,11 @@ message IrTableEntry {
   bytes controller_metadata = 8;
 }
 
+// Describes a list of table entries.
+message IrTableEntries {
+  repeated IrTableEntry entries = 1;
+}
+
 // -- Packet IO ----------------------------------------------------------------
 
 // Describes a packet in.

--- a/p4_pdpi/p4_runtime_session_extras.h
+++ b/p4_pdpi/p4_runtime_session_extras.h
@@ -34,6 +34,7 @@
 #include "gutil/proto.h"
 #include "gutil/status.h"
 #include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/ir.pb.h"
 #include "p4_pdpi/p4_runtime_session.h"
 
 namespace pdpi {
@@ -72,13 +73,12 @@ absl::Status InstallPdTableEntry(P4RuntimeSession& p4rt,
 
 // Like `InstallPdTableEntries`, but for IR table entries. Reads the P4Info used
 // in translation from the switch.
-absl::Status InstallIrTableEntries(
-    pdpi::P4RuntimeSession& p4rt,
-    absl::Span<const pdpi::IrTableEntry> ir_table_entries);
+absl::Status InstallIrTableEntries(P4RuntimeSession& p4rt,
+                                   const IrTableEntries& ir_table_entries);
 
 // Like `InstallIrTableEntries`, but for a single entry.
-absl::Status InstallIrTableEntry(pdpi::P4RuntimeSession& p4rt,
-                                 const pdpi::IrTableEntry& ir_table_entry);
+absl::Status InstallIrTableEntry(P4RuntimeSession& p4rt,
+                                 const IrTableEntry& ir_table_entry);
 
 // Reads table entries from the switch using `p4rt` and returns them in PI
 // representation in an order determined by gutil::TableEntryKey.
@@ -87,22 +87,20 @@ absl::StatusOr<std::vector<p4::v1::TableEntry>> ReadPiTableEntriesSorted(
 
 // Reads table entries from the switch using `p4rt` and returns them in IR
 // representation. Reads the P4Info used in translation from the switch.
-absl::StatusOr<std::vector<IrTableEntry>> ReadIrTableEntries(
-    P4RuntimeSession& p4rt);
+absl::StatusOr<IrTableEntries> ReadIrTableEntries(P4RuntimeSession& p4rt);
 
 // Reads table entries from the switch using `p4rt` and returns them in IR
 // representation in an order determined by gutil::TableEntryKey on the
 // corresponding PI representation. Reads the P4Info used in translation from
 // the switch.
-absl::StatusOr<std::vector<IrTableEntry>> ReadIrTableEntriesSorted(
-    P4RuntimeSession& p4rt);
+absl::StatusOr<IrTableEntries> ReadIrTableEntriesSorted(P4RuntimeSession& p4rt);
 
 // Constructs a write request with metadata from `p4rt` and sends it to the
 // switch, returning a response containing the per-update status (in the same
 // order as the input `updates`).
-absl::StatusOr<pdpi::IrWriteRpcStatus> SendPiUpdatesAndReturnPerUpdateStatus(
+absl::StatusOr<IrWriteRpcStatus> SendPiUpdatesAndReturnPerUpdateStatus(
     P4RuntimeSession& p4rt, absl::Span<const p4::v1::Update> updates);
-absl::StatusOr<pdpi::IrWriteRpcStatus> SendPiUpdatesAndReturnPerUpdateStatus(
+absl::StatusOr<IrWriteRpcStatus> SendPiUpdatesAndReturnPerUpdateStatus(
     P4RuntimeSession& p4rt,
     const google::protobuf::RepeatedPtrField<p4::v1::Update>& updates);
 

--- a/p4_pdpi/pd.h
+++ b/p4_pdpi/pd.h
@@ -153,6 +153,10 @@ absl::Status IrTableEntryToPd(const IrP4Info &ir_p4info, const IrTableEntry &ir,
                               google::protobuf::Message *pd,
                               bool key_only = false);
 absl::Status IrTableEntriesToPd(const IrP4Info &ir_p4info,
+                                const IrTableEntries &ir,
+                                google::protobuf::Message *pd,
+                                bool key_only = false);
+absl::Status IrTableEntriesToPd(const IrP4Info &ir_p4info,
                                 absl::Span<const IrTableEntry> ir,
                                 google::protobuf::Message *pd,
                                 bool key_only = false);
@@ -194,7 +198,7 @@ absl::Status IrWriteRpcStatusToPd(const IrWriteRpcStatus &ir_write_status,
 absl::StatusOr<IrTableEntry> PdTableEntryToIr(
     const IrP4Info &ir_p4info, const google::protobuf::Message &pd,
     bool key_only = false);
-absl::StatusOr<std::vector<IrTableEntry>> PdTableEntriesToIr(
+absl::StatusOr<IrTableEntries> PdTableEntriesToIr(
     const IrP4Info &ir_p4info, const google::protobuf::Message &pd,
     bool key_only = false);
 


### PR DESCRIPTION
### PR Description :
[PDPI] Transition numerous functions to use a proto IrTableEntries instead of a vector.

### Build Results :
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS p4_pdpi/...
INFO: Analyzed 74 targets (0 packages loaded, 0 targets configured).
INFO: Found 74 targets...
INFO: Elapsed time: 67.244s, Critical Path: 12.61s
INFO: 55 processes: 4 internal, 51 linux-sandbox.
INFO: Build completed successfully, 55 total actions
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ 
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS p4rt_app/...
INFO: Analyzed 100 targets (0 packages loaded, 0 targets configured).
INFO: Found 100 targets...
INFO: Elapsed time: 196.281s, Critical Path: 29.62s
INFO: 107 processes: 2 internal, 105 linux-sandbox.
INFO: Build completed successfully, 107 total actions
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ 

### UT Results :
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4_pdpi/...
INFO: Analyzed 74 targets (0 packages loaded, 0 targets configured).
INFO: Found 43 targets and 31 test targets...
INFO: Elapsed time: 2.063s, Critical Path: 0.41s
INFO: 15 processes: 24 linux-sandbox.
INFO: Build completed successfully, 15 total actions
//p4_pdpi/netaddr:ipv4_address_and_network_address_test         (cached) PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                             (cached) PASSED in 0.3s
//p4_pdpi/netaddr:mac_address_test                              (cached) PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                       (cached) PASSED in 15.5s
//p4_pdpi/packetlib:packetlib_test                              (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                         (cached) PASSED in 2.0s
//p4_pdpi/string_encodings:bit_string_test                      (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                     (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                  (cached) PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner           (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                      (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner               (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test            (cached) PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                  (cached) PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                   (cached) PASSED in 0.4s
//p4_pdpi/utils:annotation_parser_test                          (cached) PASSED in 0.2s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.4s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.4s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.0s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.0s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.4s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.3s

Executed 14 out of 31 tests: 31 tests pass.
INFO: Build completed successfully, 15 total actions
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4rt_app/...
INFO: Analyzed 100 targets (0 packages loaded, 0 targets configured).
INFO: Found 65 targets and 35 test targets...
INFO: Elapsed time: 27.425s, Critical Path: 5.06s
INFO: 32 processes: 1 internal, 17 linux-sandbox, 14 local.
INFO: Build completed successfully, 32 total actions
//p4rt_app/sonic:state_verification_test                        (cached) PASSED in 0.2s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test              (cached) PASSED in 0.1s
//p4rt_app/tests/lib:app_db_entry_builder_test                  (cached) PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                        (cached) PASSED in 0.0s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.4s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.6s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.3s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.4s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.4s
//p4rt_app/tests:acl_table_test                                          PASSED in 0.9s
//p4rt_app/tests:action_set_test                                         PASSED in 0.7s
//p4rt_app/tests:api_access_test                                         PASSED in 0.6s
//p4rt_app/tests:arbitration_test                                        PASSED in 0.7s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.1s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.5s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.0s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.1s
//p4rt_app/tests:packetio_test                                           PASSED in 3.3s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 0.9s
//p4rt_app/tests:response_path_test                                      PASSED in 2.2s
//p4rt_app/tests:role_test                                               PASSED in 0.7s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.4s

Executed 31 out of 35 tests: 35 tests pass.
INFO: Build completed successfully, 32 total actions
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ 

