### PR TITLE
[p4rt-session] Add convenience functions for installing entities.

### DIFF
--- a/p4_pdpi/BUILD.bazel
+++ b/p4_pdpi/BUILD.bazel
@@ -199,6 +199,17 @@ proto_library(
     ],
 )
 
+proto_library(
+    name = "p4_runtime_session_extras_proto",
+    srcs = ["p4_runtime_session_extras.proto"],
+    deps = ["@com_github_p4lang_p4runtime//:p4runtime_proto"],
+)
+
+cc_proto_library(
+    name = "p4_runtime_session_extras_cc_proto",
+    deps = [":p4_runtime_session_extras_proto"],
+)
+
 cc_proto_library(
     name = "ir_cc_proto",
     deps = [":ir_proto"],
@@ -301,6 +312,7 @@ cc_library(
         ":ir",
         ":ir_cc_proto",
         ":p4_runtime_session",
+        ":p4_runtime_session_extras_cc_proto",
         ":pd",
         "//gutil:proto",
         "//gutil:table_entry_key",

--- a/p4_pdpi/p4_runtime_session_extras.cc
+++ b/p4_pdpi/p4_runtime_session_extras.cc
@@ -1,6 +1,8 @@
 #include "p4_pdpi/p4_runtime_session_extras.h"
 
 #include "absl/algorithm/container.h"
+#include "absl/status/status.h"
+#include "gutil/proto.h"
 #include "gutil/status.h"
 #include "gutil/table_entry_key.h"
 #include "p4/v1/p4runtime.pb.h"
@@ -65,6 +67,21 @@ absl::Status InstallIrTableEntry(P4RuntimeSession& p4rt,
 
   // Install entry.
   return InstallPiTableEntry(&p4rt, pi_entry);
+}
+
+absl::Status InstallPiEntities(P4RuntimeSession& p4rt,
+                               const PiEntities& entities) {
+  for (const p4::v1::Entity& entity : entities.entities()) {
+    RETURN_IF_ERROR(InstallPiEntity(&p4rt, entity));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status InstallPiEntities(P4RuntimeSession& p4rt,
+                               absl::string_view entities) {
+  ASSIGN_OR_RETURN(auto parsed_entities,
+                   gutil::ParseTextProto<PiEntities>(entities));
+  return InstallPiEntities(p4rt, parsed_entities);
 }
 
 absl::StatusOr<std::vector<p4::v1::TableEntry>> ReadPiTableEntriesSorted(

--- a/p4_pdpi/p4_runtime_session_extras.h
+++ b/p4_pdpi/p4_runtime_session_extras.h
@@ -36,6 +36,7 @@
 #include "p4/v1/p4runtime.pb.h"
 #include "p4_pdpi/ir.pb.h"
 #include "p4_pdpi/p4_runtime_session.h"
+#include "p4_pdpi/p4_runtime_session_extras.pb.h"
 
 namespace pdpi {
 
@@ -79,6 +80,15 @@ absl::Status InstallIrTableEntries(P4RuntimeSession& p4rt,
 // Like `InstallIrTableEntries`, but for a single entry.
 absl::Status InstallIrTableEntry(P4RuntimeSession& p4rt,
                                  const IrTableEntry& ir_table_entry);
+
+// Installs the given `entities` via the given `P4RuntimeSession`.
+absl::Status InstallPiEntities(P4RuntimeSession& p4rt,
+                               const PiEntities& entities);
+
+// Like the `InstallPiEntities` above, but takes in the `PiEntities` message in
+// text format.
+absl::Status InstallPiEntities(P4RuntimeSession& p4rt,
+                               absl::string_view entities);
 
 // Reads table entries from the switch using `p4rt` and returns them in PI
 // representation in an order determined by gutil::TableEntryKey.

--- a/p4_pdpi/p4_runtime_session_extras.proto
+++ b/p4_pdpi/p4_runtime_session_extras.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package pdpi;
+
+import "p4/v1/p4runtime.proto";
+
+message PiEntities {
+  repeated p4.v1.Entity entities = 1;
+}


### PR DESCRIPTION
### PR Description :
[p4rt-session] Add convenience functions for installing entities.

### Build Results :
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS p4_pdpi/...
INFO: Analyzed 76 targets (1 packages loaded, 71 targets configured).
INFO: Found 76 targets...
INFO: Elapsed time: 4.356s, Critical Path: 3.71s
INFO: 11 processes: 3 internal, 8 linux-sandbox.
INFO: Build completed successfully, 11 total actions
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS p4rt_app/...
INFO: Analyzed 100 targets (1 packages loaded, 107 targets configured).
INFO: Found 100 targets...
INFO: Elapsed time: 1.107s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ 
### 
UT Results :
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4_pdpi/...
INFO: Analyzed 76 targets (0 packages loaded, 0 targets configured).
INFO: Found 45 targets and 31 test targets...
INFO: Elapsed time: 0.381s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//p4_pdpi:ir_tools_test                                         (cached) PASSED in 0.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test         (cached) PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                             (cached) PASSED in 0.3s
//p4_pdpi/netaddr:mac_address_test                              (cached) PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                       (cached) PASSED in 15.5s
//p4_pdpi/packetlib:packetlib_test                              (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                         (cached) PASSED in 1.1s
//p4_pdpi/string_encodings:bit_string_test                      (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                     (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                  (cached) PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner           (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                      (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner               (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test            (cached) PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                          (cached) PASSED in 0.4s
//p4_pdpi/testing:info_test                                     (cached) PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                              (cached) PASSED in 0.0s
//p4_pdpi/testing:main_pd_test                                  (cached) PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                   (cached) PASSED in 0.4s
//p4_pdpi/testing:packet_io_test                                (cached) PASSED in 0.0s
//p4_pdpi/testing:packet_io_test_runner                         (cached) PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                      (cached) PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                        (cached) PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                        (cached) PASSED in 0.3s
//p4_pdpi/testing:table_entry_test                              (cached) PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                          (cached) PASSED in 0.2s
//p4_pdpi/utils:ir_test                                         (cached) PASSED in 0.3s

Executed 0 out of 31 tests: 31 tests pass.
INFO: Build completed successfully, 1 total action
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4rt_app/...
INFO: Analyzed 100 targets (0 packages loaded, 0 targets configured).
INFO: Found 65 targets and 35 test targets...
INFO: Elapsed time: 0.431s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//p4rt_app/event_monitoring:app_state_db_port_table_event_test  (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test     (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test      (cached) PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                        (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test            (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                   (cached) PASSED in 0.4s
//p4rt_app/p4runtime:packetio_helpers_test                      (cached) PASSED in 0.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test              (cached) PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                            (cached) PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test              (cached) PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                             (cached) PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                             (cached) PASSED in 0.3s
//p4rt_app/sonic:response_handler_test                          (cached) PASSED in 0.4s
//p4rt_app/sonic:state_verification_test                        (cached) PASSED in 0.2s
//p4rt_app/sonic:vrf_entry_translation_test                     (cached) PASSED in 0.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test              (cached) PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                 (cached) PASSED in 0.9s
//p4rt_app/tests:action_set_test                                (cached) PASSED in 0.7s
//p4rt_app/tests:api_access_test                                (cached) PASSED in 0.6s
//p4rt_app/tests:arbitration_test                               (cached) PASSED in 0.8s
//p4rt_app/tests:fixed_l3_tables_test                           (cached) PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test                (cached) PASSED in 3.3s
//p4rt_app/tests:grpc_behavior_test                             (cached) PASSED in 5.1s
//p4rt_app/tests:p4_constraints_test                            (cached) PASSED in 0.1s
//p4rt_app/tests:p4_constraints_test_runner                     (cached) PASSED in 0.1s
//p4rt_app/tests:p4_programs_test                               (cached) PASSED in 0.9s
//p4rt_app/tests:packetio_test                                  (cached) PASSED in 3.1s
//p4rt_app/tests:port_name_and_id_test                          (cached) PASSED in 0.7s
//p4rt_app/tests:response_path_test                             (cached) PASSED in 1.3s
//p4rt_app/tests:role_test                                      (cached) PASSED in 0.6s
//p4rt_app/tests:state_verification_test                        (cached) PASSED in 0.8s
//p4rt_app/tests/lib:app_db_entry_builder_test                  (cached) PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                        (cached) PASSED in 0.0s
//p4rt_app/utils:table_utility_test                             (cached) PASSED in 0.4s

Executed 0 out of 35 tests: 35 tests pass.
INFO: Build completed successfully, 1 total action
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ 
