### PR TITLE
Refactor the test P4 program with tables and actions that make more sense with reference annotation.

### DIFF
--- a/p4_pdpi/ir_tools_test.cc
+++ b/p4_pdpi/ir_tools_test.cc
@@ -39,7 +39,7 @@ TEST(TransformValuesOfTypeTest, RewriteMatchString) {
   ASSERT_OK_AND_ASSIGN(
       IrTableEntry original_entry,
       PdTableEntryToIr(info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
-                         referred_table_entry {
+                         one_match_field_table_entry {
                            match { id: "string" }
                            action { do_thing_4 {} }
                          }
@@ -48,7 +48,7 @@ TEST(TransformValuesOfTypeTest, RewriteMatchString) {
   ASSERT_OK_AND_ASSIGN(
       IrTableEntry goal_entry,
       PdTableEntryToIr(info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
-                         referred_table_entry {
+                         one_match_field_table_entry {
                            match { id: "another_string" }
                            action { do_thing_4 {} }
                          }
@@ -69,12 +69,12 @@ TEST(TransformValuesOfTypeTest, RewriteActionStrings) {
   ASSERT_OK_AND_ASSIGN(
       IrTableEntry original_entry,
       PdTableEntryToIr(info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
-                         referring_table_entry {
+                         referring_by_action_table_entry {
                            match { val: "0x001" }
                            action {
-                             referring_action {
+                             referring_to_two_match_fields_action {
                                referring_id_1: "string1",
-                               referring_id_2: "string2",
+                               referring_id_2: "0x004",
                              }
                            }
                          }
@@ -83,12 +83,12 @@ TEST(TransformValuesOfTypeTest, RewriteActionStrings) {
   ASSERT_OK_AND_ASSIGN(
       IrTableEntry goal_entry,
       PdTableEntryToIr(info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
-                         referring_table_entry {
+                         referring_by_action_table_entry {
                            match { val: "0x001" }
                            action {
-                             referring_action {
+                             referring_to_two_match_fields_action {
                                referring_id_1: "another_string1",
-                               referring_id_2: "another_string2",
+                               referring_id_2: "0x004",
                              }
                            }
                          }
@@ -109,7 +109,7 @@ TEST(VisitValuesOfTypeTest, CollectStrings) {
   ASSERT_OK_AND_ASSIGN(
       IrTableEntry entry1,
       PdTableEntryToIr(info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
-                         referred_table_entry {
+                         one_match_field_table_entry {
                            match { id: "string1" }
                            action { do_thing_4 {} }
                          }
@@ -117,12 +117,12 @@ TEST(VisitValuesOfTypeTest, CollectStrings) {
   ASSERT_OK_AND_ASSIGN(
       IrTableEntry entry2,
       PdTableEntryToIr(info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
-                         referring_table_entry {
+                         referring_by_action_table_entry {
                            match { val: "0x001" }
                            action {
-                             referring_action {
+                             referring_to_two_match_fields_action {
                                referring_id_1: "string2",
-                               referring_id_2: "string3",
+                               referring_id_2: "0x003",
                              }
                            }
                          }
@@ -137,8 +137,10 @@ TEST(VisitValuesOfTypeTest, CollectStrings) {
                                 return absl::OkStatus();
                               }));
 
-  EXPECT_THAT(string_collection,
-              UnorderedElementsAreArray({"string1", "string2", "string3"}));
+  EXPECT_THAT(string_collection, UnorderedElementsAreArray({
+                                     "string1",
+                                     "string2",
+                                 }));
 }
 
 }  // namespace

--- a/p4_pdpi/testing/testdata/info.expected
+++ b/p4_pdpi/testing/testdata/info.expected
@@ -294,6 +294,9 @@ tables {
     name: "normal"
     bitwidth: 10
     match_type: EXACT
+    type_name {
+      name: "normal_id_t"
+    }
   }
   match_fields {
     id: 2
@@ -342,6 +345,9 @@ tables {
     name: "normal"
     bitwidth: 10
     match_type: TERNARY
+    type_name {
+      name: "normal_id_t"
+    }
   }
   match_fields {
     id: 2
@@ -569,9 +575,44 @@ tables {
 }
 tables {
   preamble {
-    id: 33554442
-    name: "ingress.referred_table"
-    alias: "referred_table"
+    id: 34805412
+    name: "ingress.two_match_fields_table"
+    alias: "two_match_fields_table"
+  }
+  match_fields {
+    id: 1
+    name: "id_1"
+    match_type: EXACT
+    type_name {
+      name: "string_id_t"
+    }
+  }
+  match_fields {
+    id: 2
+    name: "id_2"
+    bitwidth: 10
+    match_type: EXACT
+    type_name {
+      name: "normal_id_t"
+    }
+  }
+  action_refs {
+    id: 16777221
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 1024
+}
+tables {
+  preamble {
+    id: 46253494
+    name: "ingress.one_match_field_table"
+    alias: "one_match_field_table"
   }
   match_fields {
     id: 1
@@ -595,19 +636,26 @@ tables {
 }
 tables {
   preamble {
-    id: 33554443
-    name: "ingress.referring_table"
-    alias: "referring_table"
+    id: 48112979
+    name: "ingress.referring_by_action_table"
+    alias: "referring_by_action_table"
   }
   match_fields {
     id: 1
     name: "val"
     bitwidth: 10
     match_type: EXACT
+    type_name {
+      name: "normal_id_t"
+    }
   }
   action_refs {
-    id: 16777222
+    id: 23923420
     annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 31920929
+    annotations: "@proto_id(2)"
   }
   action_refs {
     id: 21257015
@@ -619,17 +667,27 @@ tables {
 }
 tables {
   preamble {
-    id: 33554444
-    name: "ingress.referring2_table"
-    alias: "referring2_table"
+    id: 49592401
+    name: "ingress.referring_by_match_field_table"
+    alias: "referring_by_match_field_table"
   }
   match_fields {
     id: 1
-    name: "referring_id"
-    annotations: "@refers_to(referred_table , id)"
+    name: "referring_id_1"
+    annotations: "@refers_to(two_match_fields_table , id_1)"
     match_type: EXACT
     type_name {
       name: "string_id_t"
+    }
+  }
+  match_fields {
+    id: 2
+    name: "referring_id_2"
+    annotations: "@refers_to(two_match_fields_table , id_2)"
+    bitwidth: 10
+    match_type: OPTIONAL
+    type_name {
+      name: "normal_id_t"
     }
   }
   action_refs {
@@ -673,14 +731,14 @@ tables {
 }
 tables {
   preamble {
-    id: 33554446
-    name: "ingress.referring_to_referring2_table"
-    alias: "referring_to_referring2_table"
+    id: 41122256
+    name: "ingress.referring_to_referring_by_match_field_table"
+    alias: "referring_to_referring_by_match_field_table"
   }
   match_fields {
     id: 1
-    name: "referring2_table_id"
-    annotations: "@refers_to(referring2_table , referring_id)"
+    name: "referring_to_referring_id_1"
+    annotations: "@refers_to(referring_by_match_field_table , referring_id_1)"
     match_type: EXACT
     type_name {
       name: "string_id_t"
@@ -841,6 +899,9 @@ tables {
     name: "normal"
     bitwidth: 10
     match_type: EXACT
+    type_name {
+      name: "normal_id_t"
+    }
   }
   match_fields {
     id: 8
@@ -872,7 +933,7 @@ tables {
   match_fields {
     id: 6
     name: "referring_str"
-    annotations: "@refers_to(referred_table , id)"
+    annotations: "@refers_to(one_match_field_table , id)"
     match_type: OPTIONAL
     type_name {
       name: "string_id_t"
@@ -1001,14 +1062,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16777222
-    name: "ingress.referring_action"
-    alias: "referring_action"
+    id: 23923420
+    name: "ingress.referring_to_two_match_fields_action"
+    alias: "referring_to_two_match_fields_action"
   }
   params {
     id: 1
     name: "referring_id_1"
-    annotations: "@refers_to(referred_table , id)"
+    annotations: "@refers_to(two_match_fields_table , id_1)"
     type_name {
       name: "string_id_t"
     }
@@ -1016,7 +1077,24 @@ actions {
   params {
     id: 2
     name: "referring_id_2"
-    annotations: "@refers_to(referred_table , id)"
+    annotations: "@refers_to(two_match_fields_table , id_2)"
+    bitwidth: 10
+    type_name {
+      name: "normal_id_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 31920929
+    name: "ingress.referring_to_one_match_field_action"
+    alias: "referring_to_one_match_field_action"
+  }
+  params {
+    id: 1
+    name: "referring_id_1"
+    annotations: "@refers_to(one_match_field_table , id)"
+    annotations: "@refers_to(two_match_fields_table , id_1)"
     type_name {
       name: "string_id_t"
     }
@@ -1154,6 +1232,18 @@ controller_packet_metadata {
   }
 }
 type_info {
+  new_types {
+    key: "normal_id_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 10
+          }
+        }
+      }
+    }
+  }
   new_types {
     key: "string_id_t"
     value {
@@ -1457,6 +1547,9 @@ tables_by_id {
           name: "normal"
           bitwidth: 10
           match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
         }
       }
     }
@@ -1560,6 +1653,9 @@ tables_by_id {
           name: "normal"
           bitwidth: 10
           match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
         }
       }
     }
@@ -1619,6 +1715,9 @@ tables_by_id {
           name: "normal"
           bitwidth: 10
           match_type: TERNARY
+          type_name {
+            name: "normal_id_t"
+          }
         }
       }
     }
@@ -1772,6 +1871,9 @@ tables_by_id {
           name: "normal"
           bitwidth: 10
           match_type: TERNARY
+          type_name {
+            name: "normal_id_t"
+          }
         }
       }
     }
@@ -2606,310 +2708,6 @@ tables_by_id {
   }
 }
 tables_by_id {
-  key: 33554442
-  value {
-    preamble {
-      id: 33554442
-      name: "ingress.referred_table"
-      alias: "referred_table"
-    }
-    match_fields_by_id {
-      key: 1
-      value {
-        match_field {
-          id: 1
-          name: "id"
-          match_type: EXACT
-          type_name {
-            name: "string_id_t"
-          }
-        }
-        format: STRING
-      }
-    }
-    match_fields_by_name {
-      key: "id"
-      value {
-        match_field {
-          id: 1
-          name: "id"
-          match_type: EXACT
-          type_name {
-            name: "string_id_t"
-          }
-        }
-        format: STRING
-      }
-    }
-    entry_actions {
-      ref {
-        id: 16777221
-        annotations: "@proto_id(1)"
-      }
-      action {
-        preamble {
-          id: 16777221
-          name: "do_thing_4"
-          alias: "do_thing_4"
-        }
-      }
-      proto_id: 1
-    }
-    default_only_actions {
-      ref {
-        id: 21257015
-        annotations: "@defaultonly"
-        scope: DEFAULT_ONLY
-      }
-      action {
-        preamble {
-          id: 21257015
-          name: "NoAction"
-          alias: "NoAction"
-          annotations: "@noWarn(\"unused\")"
-        }
-      }
-    }
-    size: 1024
-    const_default_action {
-      preamble {
-        id: 21257015
-        name: "NoAction"
-        alias: "NoAction"
-        annotations: "@noWarn(\"unused\")"
-      }
-    }
-  }
-}
-tables_by_id {
-  key: 33554443
-  value {
-    preamble {
-      id: 33554443
-      name: "ingress.referring_table"
-      alias: "referring_table"
-    }
-    match_fields_by_id {
-      key: 1
-      value {
-        match_field {
-          id: 1
-          name: "val"
-          bitwidth: 10
-          match_type: EXACT
-        }
-      }
-    }
-    match_fields_by_name {
-      key: "val"
-      value {
-        match_field {
-          id: 1
-          name: "val"
-          bitwidth: 10
-          match_type: EXACT
-        }
-      }
-    }
-    entry_actions {
-      ref {
-        id: 16777222
-        annotations: "@proto_id(1)"
-      }
-      action {
-        preamble {
-          id: 16777222
-          name: "ingress.referring_action"
-          alias: "referring_action"
-        }
-        params_by_id {
-          key: 1
-          value {
-            param {
-              id: 1
-              name: "referring_id_1"
-              annotations: "@refers_to(referred_table , id)"
-              type_name {
-                name: "string_id_t"
-              }
-            }
-            format: STRING
-            references {
-              table: "referred_table"
-              match_field: "id"
-            }
-          }
-        }
-        params_by_id {
-          key: 2
-          value {
-            param {
-              id: 2
-              name: "referring_id_2"
-              annotations: "@refers_to(referred_table , id)"
-              type_name {
-                name: "string_id_t"
-              }
-            }
-            format: STRING
-            references {
-              table: "referred_table"
-              match_field: "id"
-            }
-          }
-        }
-        params_by_name {
-          key: "referring_id_1"
-          value {
-            param {
-              id: 1
-              name: "referring_id_1"
-              annotations: "@refers_to(referred_table , id)"
-              type_name {
-                name: "string_id_t"
-              }
-            }
-            format: STRING
-            references {
-              table: "referred_table"
-              match_field: "id"
-            }
-          }
-        }
-        params_by_name {
-          key: "referring_id_2"
-          value {
-            param {
-              id: 2
-              name: "referring_id_2"
-              annotations: "@refers_to(referred_table , id)"
-              type_name {
-                name: "string_id_t"
-              }
-            }
-            format: STRING
-            references {
-              table: "referred_table"
-              match_field: "id"
-            }
-          }
-        }
-      }
-      proto_id: 1
-    }
-    default_only_actions {
-      ref {
-        id: 21257015
-        annotations: "@defaultonly"
-        scope: DEFAULT_ONLY
-      }
-      action {
-        preamble {
-          id: 21257015
-          name: "NoAction"
-          alias: "NoAction"
-          annotations: "@noWarn(\"unused\")"
-        }
-      }
-    }
-    size: 1024
-    const_default_action {
-      preamble {
-        id: 21257015
-        name: "NoAction"
-        alias: "NoAction"
-        annotations: "@noWarn(\"unused\")"
-      }
-    }
-  }
-}
-tables_by_id {
-  key: 33554444
-  value {
-    preamble {
-      id: 33554444
-      name: "ingress.referring2_table"
-      alias: "referring2_table"
-    }
-    match_fields_by_id {
-      key: 1
-      value {
-        match_field {
-          id: 1
-          name: "referring_id"
-          annotations: "@refers_to(referred_table , id)"
-          match_type: EXACT
-          type_name {
-            name: "string_id_t"
-          }
-        }
-        format: STRING
-        references {
-          table: "referred_table"
-          match_field: "id"
-        }
-      }
-    }
-    match_fields_by_name {
-      key: "referring_id"
-      value {
-        match_field {
-          id: 1
-          name: "referring_id"
-          annotations: "@refers_to(referred_table , id)"
-          match_type: EXACT
-          type_name {
-            name: "string_id_t"
-          }
-        }
-        format: STRING
-        references {
-          table: "referred_table"
-          match_field: "id"
-        }
-      }
-    }
-    entry_actions {
-      ref {
-        id: 16777221
-        annotations: "@proto_id(1)"
-      }
-      action {
-        preamble {
-          id: 16777221
-          name: "do_thing_4"
-          alias: "do_thing_4"
-        }
-      }
-      proto_id: 1
-    }
-    default_only_actions {
-      ref {
-        id: 21257015
-        annotations: "@defaultonly"
-        scope: DEFAULT_ONLY
-      }
-      action {
-        preamble {
-          id: 21257015
-          name: "NoAction"
-          alias: "NoAction"
-          annotations: "@noWarn(\"unused\")"
-        }
-      }
-    }
-    size: 1024
-    const_default_action {
-      preamble {
-        id: 21257015
-        name: "NoAction"
-        alias: "NoAction"
-        annotations: "@noWarn(\"unused\")"
-      }
-    }
-  }
-}
-tables_by_id {
   key: 33554445
   value {
     preamble {
@@ -2985,92 +2783,6 @@ tables_by_id {
       }
     }
     size: 1024
-  }
-}
-tables_by_id {
-  key: 33554446
-  value {
-    preamble {
-      id: 33554446
-      name: "ingress.referring_to_referring2_table"
-      alias: "referring_to_referring2_table"
-    }
-    match_fields_by_id {
-      key: 1
-      value {
-        match_field {
-          id: 1
-          name: "referring2_table_id"
-          annotations: "@refers_to(referring2_table , referring_id)"
-          match_type: EXACT
-          type_name {
-            name: "string_id_t"
-          }
-        }
-        format: STRING
-        references {
-          table: "referring2_table"
-          match_field: "referring_id"
-        }
-      }
-    }
-    match_fields_by_name {
-      key: "referring2_table_id"
-      value {
-        match_field {
-          id: 1
-          name: "referring2_table_id"
-          annotations: "@refers_to(referring2_table , referring_id)"
-          match_type: EXACT
-          type_name {
-            name: "string_id_t"
-          }
-        }
-        format: STRING
-        references {
-          table: "referring2_table"
-          match_field: "referring_id"
-        }
-      }
-    }
-    entry_actions {
-      ref {
-        id: 16777221
-        annotations: "@proto_id(1)"
-      }
-      action {
-        preamble {
-          id: 16777221
-          name: "do_thing_4"
-          alias: "do_thing_4"
-        }
-      }
-      proto_id: 1
-    }
-    default_only_actions {
-      ref {
-        id: 21257015
-        annotations: "@defaultonly"
-        scope: DEFAULT_ONLY
-      }
-      action {
-        preamble {
-          id: 21257015
-          name: "NoAction"
-          alias: "NoAction"
-          annotations: "@noWarn(\"unused\")"
-        }
-      }
-    }
-    size: 1024
-    const_default_action {
-      preamble {
-        id: 21257015
-        name: "NoAction"
-        alias: "NoAction"
-        annotations: "@noWarn(\"unused\")"
-      }
-    }
   }
 }
 tables_by_id {
@@ -3323,6 +3035,196 @@ tables_by_id {
   }
 }
 tables_by_id {
+  key: 34805412
+  value {
+    preamble {
+      id: 34805412
+      name: "ingress.two_match_fields_table"
+      alias: "two_match_fields_table"
+    }
+    match_fields_by_id {
+      key: 1
+      value {
+        match_field {
+          id: 1
+          name: "id_1"
+          match_type: EXACT
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+    match_fields_by_id {
+      key: 2
+      value {
+        match_field {
+          id: 2
+          name: "id_2"
+          bitwidth: 10
+          match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
+        }
+      }
+    }
+    match_fields_by_name {
+      key: "id_1"
+      value {
+        match_field {
+          id: 1
+          name: "id_1"
+          match_type: EXACT
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+    match_fields_by_name {
+      key: "id_2"
+      value {
+        match_field {
+          id: 2
+          name: "id_2"
+          bitwidth: 10
+          match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
+        }
+      }
+    }
+    entry_actions {
+      ref {
+        id: 16777221
+        annotations: "@proto_id(1)"
+      }
+      action {
+        preamble {
+          id: 16777221
+          name: "do_thing_4"
+          alias: "do_thing_4"
+        }
+      }
+      proto_id: 1
+    }
+    default_only_actions {
+      ref {
+        id: 21257015
+        annotations: "@defaultonly"
+        scope: DEFAULT_ONLY
+      }
+      action {
+        preamble {
+          id: 21257015
+          name: "NoAction"
+          alias: "NoAction"
+          annotations: "@noWarn(\"unused\")"
+        }
+      }
+    }
+    size: 1024
+    const_default_action {
+      preamble {
+        id: 21257015
+        name: "NoAction"
+        alias: "NoAction"
+        annotations: "@noWarn(\"unused\")"
+      }
+    }
+  }
+}
+tables_by_id {
+  key: 41122256
+  value {
+    preamble {
+      id: 41122256
+      name: "ingress.referring_to_referring_by_match_field_table"
+      alias: "referring_to_referring_by_match_field_table"
+    }
+    match_fields_by_id {
+      key: 1
+      value {
+        match_field {
+          id: 1
+          name: "referring_to_referring_id_1"
+          annotations: "@refers_to(referring_by_match_field_table , referring_id_1)"
+          match_type: EXACT
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+        references {
+          table: "referring_by_match_field_table"
+          match_field: "referring_id_1"
+        }
+      }
+    }
+    match_fields_by_name {
+      key: "referring_to_referring_id_1"
+      value {
+        match_field {
+          id: 1
+          name: "referring_to_referring_id_1"
+          annotations: "@refers_to(referring_by_match_field_table , referring_id_1)"
+          match_type: EXACT
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+        references {
+          table: "referring_by_match_field_table"
+          match_field: "referring_id_1"
+        }
+      }
+    }
+    entry_actions {
+      ref {
+        id: 16777221
+        annotations: "@proto_id(1)"
+      }
+      action {
+        preamble {
+          id: 16777221
+          name: "do_thing_4"
+          alias: "do_thing_4"
+        }
+      }
+      proto_id: 1
+    }
+    default_only_actions {
+      ref {
+        id: 21257015
+        annotations: "@defaultonly"
+        scope: DEFAULT_ONLY
+      }
+      action {
+        preamble {
+          id: 21257015
+          name: "NoAction"
+          alias: "NoAction"
+          annotations: "@noWarn(\"unused\")"
+        }
+      }
+    }
+    size: 1024
+    const_default_action {
+      preamble {
+        id: 21257015
+        name: "NoAction"
+        alias: "NoAction"
+        annotations: "@noWarn(\"unused\")"
+      }
+    }
+  }
+}
+tables_by_id {
   key: 41962453
   value {
     preamble {
@@ -3350,6 +3252,9 @@ tables_by_id {
           name: "normal"
           bitwidth: 10
           match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
         }
       }
     }
@@ -3398,7 +3303,7 @@ tables_by_id {
         match_field {
           id: 6
           name: "referring_str"
-          annotations: "@refers_to(referred_table , id)"
+          annotations: "@refers_to(one_match_field_table , id)"
           match_type: OPTIONAL
           type_name {
             name: "string_id_t"
@@ -3406,7 +3311,7 @@ tables_by_id {
         }
         format: STRING
         references {
-          table: "referred_table"
+          table: "one_match_field_table"
           match_field: "id"
         }
       }
@@ -3508,6 +3413,9 @@ tables_by_id {
           name: "normal"
           bitwidth: 10
           match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
         }
       }
     }
@@ -3517,7 +3425,7 @@ tables_by_id {
         match_field {
           id: 6
           name: "referring_str"
-          annotations: "@refers_to(referred_table , id)"
+          annotations: "@refers_to(one_match_field_table , id)"
           match_type: OPTIONAL
           type_name {
             name: "string_id_t"
@@ -3525,7 +3433,7 @@ tables_by_id {
         }
         format: STRING
         references {
-          table: "referred_table"
+          table: "one_match_field_table"
           match_field: "id"
         }
       }
@@ -3711,6 +3619,415 @@ tables_by_id {
     }
   }
 }
+tables_by_id {
+  key: 46253494
+  value {
+    preamble {
+      id: 46253494
+      name: "ingress.one_match_field_table"
+      alias: "one_match_field_table"
+    }
+    match_fields_by_id {
+      key: 1
+      value {
+        match_field {
+          id: 1
+          name: "id"
+          match_type: EXACT
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+    match_fields_by_name {
+      key: "id"
+      value {
+        match_field {
+          id: 1
+          name: "id"
+          match_type: EXACT
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+    entry_actions {
+      ref {
+        id: 16777221
+        annotations: "@proto_id(1)"
+      }
+      action {
+        preamble {
+          id: 16777221
+          name: "do_thing_4"
+          alias: "do_thing_4"
+        }
+      }
+      proto_id: 1
+    }
+    default_only_actions {
+      ref {
+        id: 21257015
+        annotations: "@defaultonly"
+        scope: DEFAULT_ONLY
+      }
+      action {
+        preamble {
+          id: 21257015
+          name: "NoAction"
+          alias: "NoAction"
+          annotations: "@noWarn(\"unused\")"
+        }
+      }
+    }
+    size: 1024
+    const_default_action {
+      preamble {
+        id: 21257015
+        name: "NoAction"
+        alias: "NoAction"
+        annotations: "@noWarn(\"unused\")"
+      }
+    }
+  }
+}
+tables_by_id {
+  key: 48112979
+  value {
+    preamble {
+      id: 48112979
+      name: "ingress.referring_by_action_table"
+      alias: "referring_by_action_table"
+    }
+    match_fields_by_id {
+      key: 1
+      value {
+        match_field {
+          id: 1
+          name: "val"
+          bitwidth: 10
+          match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
+        }
+      }
+    }
+    match_fields_by_name {
+      key: "val"
+      value {
+        match_field {
+          id: 1
+          name: "val"
+          bitwidth: 10
+          match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
+        }
+      }
+    }
+    entry_actions {
+      ref {
+        id: 23923420
+        annotations: "@proto_id(1)"
+      }
+      action {
+        preamble {
+          id: 23923420
+          name: "ingress.referring_to_two_match_fields_action"
+          alias: "referring_to_two_match_fields_action"
+        }
+        params_by_id {
+          key: 1
+          value {
+            param {
+              id: 1
+              name: "referring_id_1"
+              annotations: "@refers_to(two_match_fields_table , id_1)"
+              type_name {
+                name: "string_id_t"
+              }
+            }
+            format: STRING
+            references {
+              table: "two_match_fields_table"
+              match_field: "id_1"
+            }
+          }
+        }
+        params_by_id {
+          key: 2
+          value {
+            param {
+              id: 2
+              name: "referring_id_2"
+              annotations: "@refers_to(two_match_fields_table , id_2)"
+              bitwidth: 10
+              type_name {
+                name: "normal_id_t"
+              }
+            }
+            references {
+              table: "two_match_fields_table"
+              match_field: "id_2"
+            }
+          }
+        }
+        params_by_name {
+          key: "referring_id_1"
+          value {
+            param {
+              id: 1
+              name: "referring_id_1"
+              annotations: "@refers_to(two_match_fields_table , id_1)"
+              type_name {
+                name: "string_id_t"
+              }
+            }
+            format: STRING
+            references {
+              table: "two_match_fields_table"
+              match_field: "id_1"
+            }
+          }
+        }
+        params_by_name {
+          key: "referring_id_2"
+          value {
+            param {
+              id: 2
+              name: "referring_id_2"
+              annotations: "@refers_to(two_match_fields_table , id_2)"
+              bitwidth: 10
+              type_name {
+                name: "normal_id_t"
+              }
+            }
+            references {
+              table: "two_match_fields_table"
+              match_field: "id_2"
+            }
+          }
+        }
+      }
+      proto_id: 1
+    }
+    entry_actions {
+      ref {
+        id: 31920929
+        annotations: "@proto_id(2)"
+      }
+      action {
+        preamble {
+          id: 31920929
+          name: "ingress.referring_to_one_match_field_action"
+          alias: "referring_to_one_match_field_action"
+        }
+        params_by_id {
+          key: 1
+          value {
+            param {
+              id: 1
+              name: "referring_id_1"
+              annotations: "@refers_to(one_match_field_table , id)"
+              annotations: "@refers_to(two_match_fields_table , id_1)"
+              type_name {
+                name: "string_id_t"
+              }
+            }
+            format: STRING
+            references {
+              table: "one_match_field_table"
+              match_field: "id"
+            }
+            references {
+              table: "two_match_fields_table"
+              match_field: "id_1"
+            }
+          }
+        }
+        params_by_name {
+          key: "referring_id_1"
+          value {
+            param {
+              id: 1
+              name: "referring_id_1"
+              annotations: "@refers_to(one_match_field_table , id)"
+              annotations: "@refers_to(two_match_fields_table , id_1)"
+              type_name {
+                name: "string_id_t"
+              }
+            }
+            format: STRING
+            references {
+              table: "one_match_field_table"
+              match_field: "id"
+            }
+            references {
+              table: "two_match_fields_table"
+              match_field: "id_1"
+            }
+          }
+        }
+      }
+      proto_id: 2
+    }
+    default_only_actions {
+      ref {
+        id: 21257015
+        annotations: "@defaultonly"
+        scope: DEFAULT_ONLY
+      }
+      action {
+        preamble {
+          id: 21257015
+          name: "NoAction"
+          alias: "NoAction"
+          annotations: "@noWarn(\"unused\")"
+        }
+      }
+    }
+    size: 1024
+    const_default_action {
+      preamble {
+        id: 21257015
+        name: "NoAction"
+        alias: "NoAction"
+        annotations: "@noWarn(\"unused\")"
+      }
+    }
+  }
+}
+tables_by_id {
+  key: 49592401
+  value {
+    preamble {
+      id: 49592401
+      name: "ingress.referring_by_match_field_table"
+      alias: "referring_by_match_field_table"
+    }
+    match_fields_by_id {
+      key: 1
+      value {
+        match_field {
+          id: 1
+          name: "referring_id_1"
+          annotations: "@refers_to(two_match_fields_table , id_1)"
+          match_type: EXACT
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_1"
+        }
+      }
+    }
+    match_fields_by_id {
+      key: 2
+      value {
+        match_field {
+          id: 2
+          name: "referring_id_2"
+          annotations: "@refers_to(two_match_fields_table , id_2)"
+          bitwidth: 10
+          match_type: OPTIONAL
+          type_name {
+            name: "normal_id_t"
+          }
+        }
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_2"
+        }
+      }
+    }
+    match_fields_by_name {
+      key: "referring_id_1"
+      value {
+        match_field {
+          id: 1
+          name: "referring_id_1"
+          annotations: "@refers_to(two_match_fields_table , id_1)"
+          match_type: EXACT
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_1"
+        }
+      }
+    }
+    match_fields_by_name {
+      key: "referring_id_2"
+      value {
+        match_field {
+          id: 2
+          name: "referring_id_2"
+          annotations: "@refers_to(two_match_fields_table , id_2)"
+          bitwidth: 10
+          match_type: OPTIONAL
+          type_name {
+            name: "normal_id_t"
+          }
+        }
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_2"
+        }
+      }
+    }
+    entry_actions {
+      ref {
+        id: 16777221
+        annotations: "@proto_id(1)"
+      }
+      action {
+        preamble {
+          id: 16777221
+          name: "do_thing_4"
+          alias: "do_thing_4"
+        }
+      }
+      proto_id: 1
+    }
+    default_only_actions {
+      ref {
+        id: 21257015
+        annotations: "@defaultonly"
+        scope: DEFAULT_ONLY
+      }
+      action {
+        preamble {
+          id: 21257015
+          name: "NoAction"
+          alias: "NoAction"
+          annotations: "@noWarn(\"unused\")"
+        }
+      }
+    }
+    size: 1024
+    requires_priority: true
+    const_default_action {
+      preamble {
+        id: 21257015
+        name: "NoAction"
+        alias: "NoAction"
+        annotations: "@noWarn(\"unused\")"
+      }
+    }
+  }
+}
 tables_by_name {
   key: "byte_count_and_meter_table"
   value {
@@ -3820,6 +4137,9 @@ tables_by_name {
           name: "normal"
           bitwidth: 10
           match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
         }
       }
     }
@@ -3868,7 +4188,7 @@ tables_by_name {
         match_field {
           id: 6
           name: "referring_str"
-          annotations: "@refers_to(referred_table , id)"
+          annotations: "@refers_to(one_match_field_table , id)"
           match_type: OPTIONAL
           type_name {
             name: "string_id_t"
@@ -3876,7 +4196,7 @@ tables_by_name {
         }
         format: STRING
         references {
-          table: "referred_table"
+          table: "one_match_field_table"
           match_field: "id"
         }
       }
@@ -3978,6 +4298,9 @@ tables_by_name {
           name: "normal"
           bitwidth: 10
           match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
         }
       }
     }
@@ -3987,7 +4310,7 @@ tables_by_name {
         match_field {
           id: 6
           name: "referring_str"
-          annotations: "@refers_to(referred_table , id)"
+          annotations: "@refers_to(one_match_field_table , id)"
           match_type: OPTIONAL
           type_name {
             name: "string_id_t"
@@ -3995,7 +4318,7 @@ tables_by_name {
         }
         format: STRING
         references {
-          table: "referred_table"
+          table: "one_match_field_table"
           match_field: "id"
         }
       }
@@ -4278,6 +4601,9 @@ tables_by_name {
           name: "normal"
           bitwidth: 10
           match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
         }
       }
     }
@@ -4381,6 +4707,9 @@ tables_by_name {
           name: "normal"
           bitwidth: 10
           match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
         }
       }
     }
@@ -4895,6 +5224,82 @@ tables_by_name {
   }
 }
 tables_by_name {
+  key: "one_match_field_table"
+  value {
+    preamble {
+      id: 46253494
+      name: "ingress.one_match_field_table"
+      alias: "one_match_field_table"
+    }
+    match_fields_by_id {
+      key: 1
+      value {
+        match_field {
+          id: 1
+          name: "id"
+          match_type: EXACT
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+    match_fields_by_name {
+      key: "id"
+      value {
+        match_field {
+          id: 1
+          name: "id"
+          match_type: EXACT
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+    entry_actions {
+      ref {
+        id: 16777221
+        annotations: "@proto_id(1)"
+      }
+      action {
+        preamble {
+          id: 16777221
+          name: "do_thing_4"
+          alias: "do_thing_4"
+        }
+      }
+      proto_id: 1
+    }
+    default_only_actions {
+      ref {
+        id: 21257015
+        annotations: "@defaultonly"
+        scope: DEFAULT_ONLY
+      }
+      action {
+        preamble {
+          id: 21257015
+          name: "NoAction"
+          alias: "NoAction"
+          annotations: "@noWarn(\"unused\")"
+        }
+      }
+    }
+    size: 1024
+    const_default_action {
+      preamble {
+        id: 21257015
+        name: "NoAction"
+        alias: "NoAction"
+        annotations: "@noWarn(\"unused\")"
+      }
+    }
+  }
+}
+tables_by_name {
   key: "optional_table"
   value {
     preamble {
@@ -5145,174 +5550,12 @@ tables_by_name {
   }
 }
 tables_by_name {
-  key: "referred_table"
+  key: "referring_by_action_table"
   value {
     preamble {
-      id: 33554442
-      name: "ingress.referred_table"
-      alias: "referred_table"
-    }
-    match_fields_by_id {
-      key: 1
-      value {
-        match_field {
-          id: 1
-          name: "id"
-          match_type: EXACT
-          type_name {
-            name: "string_id_t"
-          }
-        }
-        format: STRING
-      }
-    }
-    match_fields_by_name {
-      key: "id"
-      value {
-        match_field {
-          id: 1
-          name: "id"
-          match_type: EXACT
-          type_name {
-            name: "string_id_t"
-          }
-        }
-        format: STRING
-      }
-    }
-    entry_actions {
-      ref {
-        id: 16777221
-        annotations: "@proto_id(1)"
-      }
-      action {
-        preamble {
-          id: 16777221
-          name: "do_thing_4"
-          alias: "do_thing_4"
-        }
-      }
-      proto_id: 1
-    }
-    default_only_actions {
-      ref {
-        id: 21257015
-        annotations: "@defaultonly"
-        scope: DEFAULT_ONLY
-      }
-      action {
-        preamble {
-          id: 21257015
-          name: "NoAction"
-          alias: "NoAction"
-          annotations: "@noWarn(\"unused\")"
-        }
-      }
-    }
-    size: 1024
-    const_default_action {
-      preamble {
-        id: 21257015
-        name: "NoAction"
-        alias: "NoAction"
-        annotations: "@noWarn(\"unused\")"
-      }
-    }
-  }
-}
-tables_by_name {
-  key: "referring2_table"
-  value {
-    preamble {
-      id: 33554444
-      name: "ingress.referring2_table"
-      alias: "referring2_table"
-    }
-    match_fields_by_id {
-      key: 1
-      value {
-        match_field {
-          id: 1
-          name: "referring_id"
-          annotations: "@refers_to(referred_table , id)"
-          match_type: EXACT
-          type_name {
-            name: "string_id_t"
-          }
-        }
-        format: STRING
-        references {
-          table: "referred_table"
-          match_field: "id"
-        }
-      }
-    }
-    match_fields_by_name {
-      key: "referring_id"
-      value {
-        match_field {
-          id: 1
-          name: "referring_id"
-          annotations: "@refers_to(referred_table , id)"
-          match_type: EXACT
-          type_name {
-            name: "string_id_t"
-          }
-        }
-        format: STRING
-        references {
-          table: "referred_table"
-          match_field: "id"
-        }
-      }
-    }
-    entry_actions {
-      ref {
-        id: 16777221
-        annotations: "@proto_id(1)"
-      }
-      action {
-        preamble {
-          id: 16777221
-          name: "do_thing_4"
-          alias: "do_thing_4"
-        }
-      }
-      proto_id: 1
-    }
-    default_only_actions {
-      ref {
-        id: 21257015
-        annotations: "@defaultonly"
-        scope: DEFAULT_ONLY
-      }
-      action {
-        preamble {
-          id: 21257015
-          name: "NoAction"
-          alias: "NoAction"
-          annotations: "@noWarn(\"unused\")"
-        }
-      }
-    }
-    size: 1024
-    const_default_action {
-      preamble {
-        id: 21257015
-        name: "NoAction"
-        alias: "NoAction"
-        annotations: "@noWarn(\"unused\")"
-      }
-    }
-  }
-}
-tables_by_name {
-  key: "referring_table"
-  value {
-    preamble {
-      id: 33554443
-      name: "ingress.referring_table"
-      alias: "referring_table"
+      id: 48112979
+      name: "ingress.referring_by_action_table"
+      alias: "referring_by_action_table"
     }
     match_fields_by_id {
       key: 1
@@ -5322,6 +5565,9 @@ tables_by_name {
           name: "val"
           bitwidth: 10
           match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
         }
       }
     }
@@ -5333,19 +5579,22 @@ tables_by_name {
           name: "val"
           bitwidth: 10
           match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
         }
       }
     }
     entry_actions {
       ref {
-        id: 16777222
+        id: 23923420
         annotations: "@proto_id(1)"
       }
       action {
         preamble {
-          id: 16777222
-          name: "ingress.referring_action"
-          alias: "referring_action"
+          id: 23923420
+          name: "ingress.referring_to_two_match_fields_action"
+          alias: "referring_to_two_match_fields_action"
         }
         params_by_id {
           key: 1
@@ -5353,15 +5602,15 @@ tables_by_name {
             param {
               id: 1
               name: "referring_id_1"
-              annotations: "@refers_to(referred_table , id)"
+              annotations: "@refers_to(two_match_fields_table , id_1)"
               type_name {
                 name: "string_id_t"
               }
             }
             format: STRING
             references {
-              table: "referred_table"
-              match_field: "id"
+              table: "two_match_fields_table"
+              match_field: "id_1"
             }
           }
         }
@@ -5371,15 +5620,15 @@ tables_by_name {
             param {
               id: 2
               name: "referring_id_2"
-              annotations: "@refers_to(referred_table , id)"
+              annotations: "@refers_to(two_match_fields_table , id_2)"
+              bitwidth: 10
               type_name {
-                name: "string_id_t"
+                name: "normal_id_t"
               }
             }
-            format: STRING
             references {
-              table: "referred_table"
-              match_field: "id"
+              table: "two_match_fields_table"
+              match_field: "id_2"
             }
           }
         }
@@ -5389,15 +5638,15 @@ tables_by_name {
             param {
               id: 1
               name: "referring_id_1"
-              annotations: "@refers_to(referred_table , id)"
+              annotations: "@refers_to(two_match_fields_table , id_1)"
               type_name {
                 name: "string_id_t"
               }
             }
             format: STRING
             references {
-              table: "referred_table"
-              match_field: "id"
+              table: "two_match_fields_table"
+              match_field: "id_1"
             }
           }
         }
@@ -5407,20 +5656,80 @@ tables_by_name {
             param {
               id: 2
               name: "referring_id_2"
-              annotations: "@refers_to(referred_table , id)"
+              annotations: "@refers_to(two_match_fields_table , id_2)"
+              bitwidth: 10
+              type_name {
+                name: "normal_id_t"
+              }
+            }
+            references {
+              table: "two_match_fields_table"
+              match_field: "id_2"
+            }
+          }
+        }
+      }
+      proto_id: 1
+    }
+    entry_actions {
+      ref {
+        id: 31920929
+        annotations: "@proto_id(2)"
+      }
+      action {
+        preamble {
+          id: 31920929
+          name: "ingress.referring_to_one_match_field_action"
+          alias: "referring_to_one_match_field_action"
+        }
+        params_by_id {
+          key: 1
+          value {
+            param {
+              id: 1
+              name: "referring_id_1"
+              annotations: "@refers_to(one_match_field_table , id)"
+              annotations: "@refers_to(two_match_fields_table , id_1)"
               type_name {
                 name: "string_id_t"
               }
             }
             format: STRING
             references {
-              table: "referred_table"
+              table: "one_match_field_table"
               match_field: "id"
+            }
+            references {
+              table: "two_match_fields_table"
+              match_field: "id_1"
+            }
+          }
+        }
+        params_by_name {
+          key: "referring_id_1"
+          value {
+            param {
+              id: 1
+              name: "referring_id_1"
+              annotations: "@refers_to(one_match_field_table , id)"
+              annotations: "@refers_to(two_match_fields_table , id_1)"
+              type_name {
+                name: "string_id_t"
+              }
+            }
+            format: STRING
+            references {
+              table: "one_match_field_table"
+              match_field: "id"
+            }
+            references {
+              table: "two_match_fields_table"
+              match_field: "id_1"
             }
           }
         }
       }
-      proto_id: 1
+      proto_id: 2
     }
     default_only_actions {
       ref {
@@ -5449,20 +5758,20 @@ tables_by_name {
   }
 }
 tables_by_name {
-  key: "referring_to_referring2_table"
+  key: "referring_by_match_field_table"
   value {
     preamble {
-      id: 33554446
-      name: "ingress.referring_to_referring2_table"
-      alias: "referring_to_referring2_table"
+      id: 49592401
+      name: "ingress.referring_by_match_field_table"
+      alias: "referring_by_match_field_table"
     }
     match_fields_by_id {
       key: 1
       value {
         match_field {
           id: 1
-          name: "referring2_table_id"
-          annotations: "@refers_to(referring2_table , referring_id)"
+          name: "referring_id_1"
+          annotations: "@refers_to(two_match_fields_table , id_1)"
           match_type: EXACT
           type_name {
             name: "string_id_t"
@@ -5470,18 +5779,37 @@ tables_by_name {
         }
         format: STRING
         references {
-          table: "referring2_table"
-          match_field: "referring_id"
+          table: "two_match_fields_table"
+          match_field: "id_1"
+        }
+      }
+    }
+    match_fields_by_id {
+      key: 2
+      value {
+        match_field {
+          id: 2
+          name: "referring_id_2"
+          annotations: "@refers_to(two_match_fields_table , id_2)"
+          bitwidth: 10
+          match_type: OPTIONAL
+          type_name {
+            name: "normal_id_t"
+          }
+        }
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_2"
         }
       }
     }
     match_fields_by_name {
-      key: "referring2_table_id"
+      key: "referring_id_1"
       value {
         match_field {
           id: 1
-          name: "referring2_table_id"
-          annotations: "@refers_to(referring2_table , referring_id)"
+          name: "referring_id_1"
+          annotations: "@refers_to(two_match_fields_table , id_1)"
           match_type: EXACT
           type_name {
             name: "string_id_t"
@@ -5489,8 +5817,114 @@ tables_by_name {
         }
         format: STRING
         references {
-          table: "referring2_table"
-          match_field: "referring_id"
+          table: "two_match_fields_table"
+          match_field: "id_1"
+        }
+      }
+    }
+    match_fields_by_name {
+      key: "referring_id_2"
+      value {
+        match_field {
+          id: 2
+          name: "referring_id_2"
+          annotations: "@refers_to(two_match_fields_table , id_2)"
+          bitwidth: 10
+          match_type: OPTIONAL
+          type_name {
+            name: "normal_id_t"
+          }
+        }
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_2"
+        }
+      }
+    }
+    entry_actions {
+      ref {
+        id: 16777221
+        annotations: "@proto_id(1)"
+      }
+      action {
+        preamble {
+          id: 16777221
+          name: "do_thing_4"
+          alias: "do_thing_4"
+        }
+      }
+      proto_id: 1
+    }
+    default_only_actions {
+      ref {
+        id: 21257015
+        annotations: "@defaultonly"
+        scope: DEFAULT_ONLY
+      }
+      action {
+        preamble {
+          id: 21257015
+          name: "NoAction"
+          alias: "NoAction"
+          annotations: "@noWarn(\"unused\")"
+        }
+      }
+    }
+    size: 1024
+    requires_priority: true
+    const_default_action {
+      preamble {
+        id: 21257015
+        name: "NoAction"
+        alias: "NoAction"
+        annotations: "@noWarn(\"unused\")"
+      }
+    }
+  }
+}
+tables_by_name {
+  key: "referring_to_referring_by_match_field_table"
+  value {
+    preamble {
+      id: 41122256
+      name: "ingress.referring_to_referring_by_match_field_table"
+      alias: "referring_to_referring_by_match_field_table"
+    }
+    match_fields_by_id {
+      key: 1
+      value {
+        match_field {
+          id: 1
+          name: "referring_to_referring_id_1"
+          annotations: "@refers_to(referring_by_match_field_table , referring_id_1)"
+          match_type: EXACT
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+        references {
+          table: "referring_by_match_field_table"
+          match_field: "referring_id_1"
+        }
+      }
+    }
+    match_fields_by_name {
+      key: "referring_to_referring_id_1"
+      value {
+        match_field {
+          id: 1
+          name: "referring_to_referring_id_1"
+          annotations: "@refers_to(referring_by_match_field_table , referring_id_1)"
+          match_type: EXACT
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+        references {
+          table: "referring_by_match_field_table"
+          match_field: "referring_id_1"
         }
       }
     }
@@ -5550,6 +5984,9 @@ tables_by_name {
           name: "normal"
           bitwidth: 10
           match_type: TERNARY
+          type_name {
+            name: "normal_id_t"
+          }
         }
       }
     }
@@ -5703,6 +6140,9 @@ tables_by_name {
           name: "normal"
           bitwidth: 10
           match_type: TERNARY
+          type_name {
+            name: "normal_id_t"
+          }
         }
       }
     }
@@ -5804,6 +6244,110 @@ tables_by_name {
     }
     size: 1024
     requires_priority: true
+    const_default_action {
+      preamble {
+        id: 21257015
+        name: "NoAction"
+        alias: "NoAction"
+        annotations: "@noWarn(\"unused\")"
+      }
+    }
+  }
+}
+tables_by_name {
+  key: "two_match_fields_table"
+  value {
+    preamble {
+      id: 34805412
+      name: "ingress.two_match_fields_table"
+      alias: "two_match_fields_table"
+    }
+    match_fields_by_id {
+      key: 1
+      value {
+        match_field {
+          id: 1
+          name: "id_1"
+          match_type: EXACT
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+    match_fields_by_id {
+      key: 2
+      value {
+        match_field {
+          id: 2
+          name: "id_2"
+          bitwidth: 10
+          match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
+        }
+      }
+    }
+    match_fields_by_name {
+      key: "id_1"
+      value {
+        match_field {
+          id: 1
+          name: "id_1"
+          match_type: EXACT
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+    match_fields_by_name {
+      key: "id_2"
+      value {
+        match_field {
+          id: 2
+          name: "id_2"
+          bitwidth: 10
+          match_type: EXACT
+          type_name {
+            name: "normal_id_t"
+          }
+        }
+      }
+    }
+    entry_actions {
+      ref {
+        id: 16777221
+        annotations: "@proto_id(1)"
+      }
+      action {
+        preamble {
+          id: 16777221
+          name: "do_thing_4"
+          alias: "do_thing_4"
+        }
+      }
+      proto_id: 1
+    }
+    default_only_actions {
+      ref {
+        id: 21257015
+        annotations: "@defaultonly"
+        scope: DEFAULT_ONLY
+      }
+      action {
+        preamble {
+          id: 21257015
+          name: "NoAction"
+          alias: "NoAction"
+          annotations: "@noWarn(\"unused\")"
+        }
+      }
+    }
+    size: 1024
     const_default_action {
       preamble {
         id: 21257015
@@ -6502,88 +7046,6 @@ actions_by_id {
   }
 }
 actions_by_id {
-  key: 16777222
-  value {
-    preamble {
-      id: 16777222
-      name: "ingress.referring_action"
-      alias: "referring_action"
-    }
-    params_by_id {
-      key: 1
-      value {
-        param {
-          id: 1
-          name: "referring_id_1"
-          annotations: "@refers_to(referred_table , id)"
-          type_name {
-            name: "string_id_t"
-          }
-        }
-        format: STRING
-        references {
-          table: "referred_table"
-          match_field: "id"
-        }
-      }
-    }
-    params_by_id {
-      key: 2
-      value {
-        param {
-          id: 2
-          name: "referring_id_2"
-          annotations: "@refers_to(referred_table , id)"
-          type_name {
-            name: "string_id_t"
-          }
-        }
-        format: STRING
-        references {
-          table: "referred_table"
-          match_field: "id"
-        }
-      }
-    }
-    params_by_name {
-      key: "referring_id_1"
-      value {
-        param {
-          id: 1
-          name: "referring_id_1"
-          annotations: "@refers_to(referred_table , id)"
-          type_name {
-            name: "string_id_t"
-          }
-        }
-        format: STRING
-        references {
-          table: "referred_table"
-          match_field: "id"
-        }
-      }
-    }
-    params_by_name {
-      key: "referring_id_2"
-      value {
-        param {
-          id: 2
-          name: "referring_id_2"
-          annotations: "@refers_to(referred_table , id)"
-          type_name {
-            name: "string_id_t"
-          }
-        }
-        format: STRING
-        references {
-          table: "referred_table"
-          match_field: "id"
-        }
-      }
-    }
-  }
-}
-actions_by_id {
   key: 16777223
   value {
     preamble {
@@ -6622,6 +7084,144 @@ actions_by_id {
       name: "NoAction"
       alias: "NoAction"
       annotations: "@noWarn(\"unused\")"
+    }
+  }
+}
+actions_by_id {
+  key: 23923420
+  value {
+    preamble {
+      id: 23923420
+      name: "ingress.referring_to_two_match_fields_action"
+      alias: "referring_to_two_match_fields_action"
+    }
+    params_by_id {
+      key: 1
+      value {
+        param {
+          id: 1
+          name: "referring_id_1"
+          annotations: "@refers_to(two_match_fields_table , id_1)"
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_1"
+        }
+      }
+    }
+    params_by_id {
+      key: 2
+      value {
+        param {
+          id: 2
+          name: "referring_id_2"
+          annotations: "@refers_to(two_match_fields_table , id_2)"
+          bitwidth: 10
+          type_name {
+            name: "normal_id_t"
+          }
+        }
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_2"
+        }
+      }
+    }
+    params_by_name {
+      key: "referring_id_1"
+      value {
+        param {
+          id: 1
+          name: "referring_id_1"
+          annotations: "@refers_to(two_match_fields_table , id_1)"
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_1"
+        }
+      }
+    }
+    params_by_name {
+      key: "referring_id_2"
+      value {
+        param {
+          id: 2
+          name: "referring_id_2"
+          annotations: "@refers_to(two_match_fields_table , id_2)"
+          bitwidth: 10
+          type_name {
+            name: "normal_id_t"
+          }
+        }
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_2"
+        }
+      }
+    }
+  }
+}
+actions_by_id {
+  key: 31920929
+  value {
+    preamble {
+      id: 31920929
+      name: "ingress.referring_to_one_match_field_action"
+      alias: "referring_to_one_match_field_action"
+    }
+    params_by_id {
+      key: 1
+      value {
+        param {
+          id: 1
+          name: "referring_id_1"
+          annotations: "@refers_to(one_match_field_table , id)"
+          annotations: "@refers_to(two_match_fields_table , id_1)"
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+        references {
+          table: "one_match_field_table"
+          match_field: "id"
+        }
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_1"
+        }
+      }
+    }
+    params_by_name {
+      key: "referring_id_1"
+      value {
+        param {
+          id: 1
+          name: "referring_id_1"
+          annotations: "@refers_to(one_match_field_table , id)"
+          annotations: "@refers_to(two_match_fields_table , id_1)"
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+        references {
+          table: "one_match_field_table"
+          match_field: "id"
+        }
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_1"
+        }
+      }
     }
   }
 }
@@ -6905,12 +7505,12 @@ actions_by_name {
   }
 }
 actions_by_name {
-  key: "referring_action"
+  key: "referring_to_one_match_field_action"
   value {
     preamble {
-      id: 16777222
-      name: "ingress.referring_action"
-      alias: "referring_action"
+      id: 31920929
+      name: "ingress.referring_to_one_match_field_action"
+      alias: "referring_to_one_match_field_action"
     }
     params_by_id {
       key: 1
@@ -6918,33 +7518,20 @@ actions_by_name {
         param {
           id: 1
           name: "referring_id_1"
-          annotations: "@refers_to(referred_table , id)"
+          annotations: "@refers_to(one_match_field_table , id)"
+          annotations: "@refers_to(two_match_fields_table , id_1)"
           type_name {
             name: "string_id_t"
           }
         }
         format: STRING
         references {
-          table: "referred_table"
+          table: "one_match_field_table"
           match_field: "id"
         }
-      }
-    }
-    params_by_id {
-      key: 2
-      value {
-        param {
-          id: 2
-          name: "referring_id_2"
-          annotations: "@refers_to(referred_table , id)"
-          type_name {
-            name: "string_id_t"
-          }
-        }
-        format: STRING
         references {
-          table: "referred_table"
-          match_field: "id"
+          table: "two_match_fields_table"
+          match_field: "id_1"
         }
       }
     }
@@ -6954,15 +7541,84 @@ actions_by_name {
         param {
           id: 1
           name: "referring_id_1"
-          annotations: "@refers_to(referred_table , id)"
+          annotations: "@refers_to(one_match_field_table , id)"
+          annotations: "@refers_to(two_match_fields_table , id_1)"
           type_name {
             name: "string_id_t"
           }
         }
         format: STRING
         references {
-          table: "referred_table"
+          table: "one_match_field_table"
           match_field: "id"
+        }
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_1"
+        }
+      }
+    }
+  }
+}
+actions_by_name {
+  key: "referring_to_two_match_fields_action"
+  value {
+    preamble {
+      id: 23923420
+      name: "ingress.referring_to_two_match_fields_action"
+      alias: "referring_to_two_match_fields_action"
+    }
+    params_by_id {
+      key: 1
+      value {
+        param {
+          id: 1
+          name: "referring_id_1"
+          annotations: "@refers_to(two_match_fields_table , id_1)"
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_1"
+        }
+      }
+    }
+    params_by_id {
+      key: 2
+      value {
+        param {
+          id: 2
+          name: "referring_id_2"
+          annotations: "@refers_to(two_match_fields_table , id_2)"
+          bitwidth: 10
+          type_name {
+            name: "normal_id_t"
+          }
+        }
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_2"
+        }
+      }
+    }
+    params_by_name {
+      key: "referring_id_1"
+      value {
+        param {
+          id: 1
+          name: "referring_id_1"
+          annotations: "@refers_to(two_match_fields_table , id_1)"
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+        references {
+          table: "two_match_fields_table"
+          match_field: "id_1"
         }
       }
     }
@@ -6972,15 +7628,15 @@ actions_by_name {
         param {
           id: 2
           name: "referring_id_2"
-          annotations: "@refers_to(referred_table , id)"
+          annotations: "@refers_to(two_match_fields_table , id_2)"
+          bitwidth: 10
           type_name {
-            name: "string_id_t"
+            name: "normal_id_t"
           }
         }
-        format: STRING
         references {
-          table: "referred_table"
-          match_field: "id"
+          table: "two_match_fields_table"
+          match_field: "id_2"
         }
       }
     }
@@ -7090,12 +7746,20 @@ packet_out_metadata_by_name {
   }
 }
 references {
-  table: "referred_table"
+  table: "two_match_fields_table"
+  match_field: "id_1"
+}
+references {
+  table: "two_match_fields_table"
+  match_field: "id_2"
+}
+references {
+  table: "one_match_field_table"
   match_field: "id"
 }
 references {
-  table: "referring2_table"
-  match_field: "referring_id"
+  table: "referring_by_match_field_table"
+  match_field: "referring_id_1"
 }
 action_profiles_by_id {
   key: 290772822

--- a/p4_pdpi/testing/testdata/main_p4_pd.expected
+++ b/p4_pdpi/testing/testdata/main_p4_pd.expected
@@ -187,43 +187,6 @@ message OptionalTableEntry {
   bytes controller_metadata = 8;
 }
 
-message ReferredTableEntry {
-  message Match {
-    string id = 1; // exact match / Format::STRING
-  }
-  Match match = 1;
-  message Action {
-    DoThing4Action do_thing_4 = 1;
-  }
-  Action action = 2;
-  bytes controller_metadata = 8;
-}
-
-message ReferringTableEntry {
-  message Match {
-    string val = 1; // exact match / Format::HEX_STRING / 10 bits
-  }
-  Match match = 1;
-  message Action {
-    ReferringAction referring_action = 1;
-  }
-  Action action = 2;
-  bytes controller_metadata = 8;
-}
-
-message Referring2TableEntry {
-  message Match {
-    // Refers to 'referred_table.id'.
-    string referring_id = 1; // exact match / Format::STRING
-  }
-  Match match = 1;
-  message Action {
-    DoThing4Action do_thing_4 = 1;
-  }
-  Action action = 2;
-  bytes controller_metadata = 8;
-}
-
 message NoActionTableEntry {
   message Match {
     string ipv6 = 1; // exact match / Format::IPV6 / 128 bits
@@ -231,19 +194,6 @@ message NoActionTableEntry {
   }
   Match match = 1;
   message Action {
-  }
-  Action action = 2;
-  bytes controller_metadata = 8;
-}
-
-message ReferringToReferring2TableEntry {
-  message Match {
-    // Refers to 'referring2_table.referring_id'.
-    string referring2_table_id = 1; // exact match / Format::STRING
-  }
-  Match match = 1;
-  message Action {
-    DoThing4Action do_thing_4 = 1;
   }
   Action action = 2;
   bytes controller_metadata = 8;
@@ -291,6 +241,32 @@ message ByteCountAndMeterTableEntry {
   bytes controller_metadata = 8;
 }
 
+message TwoMatchFieldsTableEntry {
+  message Match {
+    string id_1 = 1; // exact match / Format::STRING
+    string id_2 = 2; // exact match / Format::HEX_STRING / 10 bits
+  }
+  Match match = 1;
+  message Action {
+    DoThing4Action do_thing_4 = 1;
+  }
+  Action action = 2;
+  bytes controller_metadata = 8;
+}
+
+message ReferringToReferringByMatchFieldTableEntry {
+  message Match {
+    // Refers to 'referring_by_match_field_table.referring_id_1'.
+    string referring_to_referring_id_1 = 1; // exact match / Format::STRING
+  }
+  Match match = 1;
+  message Action {
+    DoThing4Action do_thing_4 = 1;
+  }
+  Action action = 2;
+  bytes controller_metadata = 8;
+}
+
 // Table entry restrictions:
 // ## Exact constraint with OR.
 //   normal == 5 || normal == 6;
@@ -323,7 +299,7 @@ message ConstrainedTableEntry {
     Lpm ipv4 = 3; // lpm match / Format::IPV4
     Ternary ipv6 = 4; // ternary match / Format::IPV6 / 128 bits
     Ternary mac = 5; // ternary match / Format::MAC
-    // Refers to 'referred_table.id'.
+    // Refers to 'one_match_field_table.id'.
     Optional referring_str = 6; // optional match / Format::STRING
     Optional nonreferring_str = 7; // optional match / Format::STRING
     Ternary field10bit = 8; // ternary match / Format::HEX_STRING / 10 bits
@@ -342,6 +318,49 @@ message ExactAndOptionalTableEntry {
     string ipv6 = 1; // exact match / Format::IPV6 / 128 bits
     string ipv4 = 2; // exact match / Format::IPV4
     Optional str = 3; // optional match / Format::STRING
+  }
+  Match match = 1;
+  message Action {
+    DoThing4Action do_thing_4 = 1;
+  }
+  Action action = 2;
+  int32 priority = 3;
+  bytes controller_metadata = 8;
+}
+
+message OneMatchFieldTableEntry {
+  message Match {
+    string id = 1; // exact match / Format::STRING
+  }
+  Match match = 1;
+  message Action {
+    DoThing4Action do_thing_4 = 1;
+  }
+  Action action = 2;
+  bytes controller_metadata = 8;
+}
+
+message ReferringByActionTableEntry {
+  message Match {
+    string val = 1; // exact match / Format::HEX_STRING / 10 bits
+  }
+  Match match = 1;
+  message Action {
+  oneof action {
+    ReferringToTwoMatchFieldsAction referring_to_two_match_fields_action = 1;
+    ReferringToOneMatchFieldAction referring_to_one_match_field_action = 2;
+  }
+  }
+  Action action = 2;
+  bytes controller_metadata = 8;
+}
+
+message ReferringByMatchFieldTableEntry {
+  message Match {
+    // Refers to 'two_match_fields_table.id_1'.
+    string referring_id_1 = 1; // exact match / Format::STRING
+    // Refers to 'two_match_fields_table.id_2'.
+    Optional referring_id_2 = 2; // optional match / Format::HEX_STRING / 10 bits
   }
   Match match = 1;
   message Action {
@@ -379,13 +398,6 @@ message CountAndMeterAction {
 message DoThing4Action {
 }
 
-message ReferringAction {
-  // Refers to 'referred_table.id'.
-  string referring_id_1 = 1; // Format::STRING
-  // Refers to 'referred_table.id'.
-  string referring_id_2 = 2; // Format::STRING
-}
-
 message UnusedAction {
 }
 
@@ -396,6 +408,19 @@ message ByteCountAndMeterAction {
 }
 
 message NoAction {
+}
+
+message ReferringToTwoMatchFieldsAction {
+  // Refers to 'two_match_fields_table.id_1'.
+  string referring_id_1 = 1; // Format::STRING
+  // Refers to 'two_match_fields_table.id_2'.
+  string referring_id_2 = 2; // Format::HEX_STRING / 10 bits
+}
+
+message ReferringToOneMatchFieldAction {
+  // Refers to 'one_match_field_table.id'.
+  // Refers to 'two_match_fields_table.id_1'.
+  string referring_id_1 = 1; // Format::STRING
 }
 
 
@@ -412,16 +437,17 @@ message TableEntry {
     CountAndMeterTableEntry count_and_meter_table_entry = 7;
     Wcmp2TableEntry wcmp2_table_entry = 8;
     OptionalTableEntry optional_table_entry = 9;
-    ReferredTableEntry referred_table_entry = 10;
-    ReferringTableEntry referring_table_entry = 11;
-    Referring2TableEntry referring2_table_entry = 12;
     NoActionTableEntry no_action_table_entry = 13;
-    ReferringToReferring2TableEntry referring_to_referring2_table_entry = 14;
     UnusedTableEntry unused_table_entry = 15;
     PacketCountAndMeterTableEntry packet_count_and_meter_table_entry = 19;
     ByteCountAndMeterTableEntry byte_count_and_meter_table_entry = 23;
+    TwoMatchFieldsTableEntry two_match_fields_table_entry = 1250980;
+    ReferringToReferringByMatchFieldTableEntry referring_to_referring_by_match_field_table_entry = 7567824;
     ConstrainedTableEntry constrained_table_entry = 8408021;
     ExactAndOptionalTableEntry exact_and_optional_table_entry = 12300347;
+    OneMatchFieldTableEntry one_match_field_table_entry = 12699062;
+    ReferringByActionTableEntry referring_by_action_table_entry = 14558547;
+    ReferringByMatchFieldTableEntry referring_by_match_field_table_entry = 16037969;
   }
 }
 

--- a/p4_pdpi/testing/testdata/sequencing.expected
+++ b/p4_pdpi/testing/testdata/sequencing.expected
@@ -9,20 +9,19 @@ SequenceTest: Empty input
 <empty>
 
 =========================================================================
-SequenceTest: Insert(a) -> Insert(a)
+SequenceTest: INSERT EntryWithOneKey{key-a} -> INSERT EntryThatRefersTo{key-a}
 =========================================================================
 
 --- PD updates (input):
 type: INSERT
 table_entry {
-  referring_table_entry {
+  referring_by_action_table_entry {
     match {
       val: "0x001"
     }
     action {
-      referring_action {
+      referring_to_one_match_field_action {
         referring_id_1: "key-a"
-        referring_id_2: "non-existent"
       }
     }
   }
@@ -30,7 +29,7 @@ table_entry {
 
 type: INSERT
 table_entry {
-  referred_table_entry {
+  one_match_field_table_entry {
     match {
       id: "key-a"
     }
@@ -46,7 +45,7 @@ WriteRequest #0
 updates {
   type: INSERT
   table_entry {
-    referred_table_entry {
+    one_match_field_table_entry {
       match {
         id: "key-a"
       }
@@ -62,14 +61,13 @@ WriteRequest #1
 updates {
   type: INSERT
   table_entry {
-    referring_table_entry {
+    referring_by_action_table_entry {
       match {
         val: "0x001"
       }
       action {
-        referring_action {
+        referring_to_one_match_field_action {
           referring_id_1: "key-a"
-          referring_id_2: "non-existent"
         }
       }
     }
@@ -77,96 +75,13 @@ updates {
 }
 
 =========================================================================
-SequenceTest: Delete(a) -> Delete(a)
+SequenceTest: DELETE EntryThatRefersTo{key-a} -> DELETE EntryWithOneKey{key-a}
 =========================================================================
 
 --- PD updates (input):
 type: DELETE
 table_entry {
-  referring_table_entry {
-    match {
-      val: "0x001"
-    }
-    action {
-      referring_action {
-        referring_id_1: "key-a"
-        referring_id_2: "non-existent"
-      }
-    }
-  }
-}
-
-type: DELETE
-table_entry {
-  referred_table_entry {
-    match {
-      id: "key-a"
-    }
-    action {
-      do_thing_4 {
-      }
-    }
-  }
-}
-
---- Write requests (output):
-WriteRequest #0
-updates {
-  type: DELETE
-  table_entry {
-    referring_table_entry {
-      match {
-        val: "0x001"
-      }
-      action {
-        referring_action {
-          referring_id_1: "key-a"
-          referring_id_2: "non-existent"
-        }
-      }
-    }
-  }
-}
-
-WriteRequest #1
-updates {
-  type: DELETE
-  table_entry {
-    referred_table_entry {
-      match {
-        id: "key-a"
-      }
-      action {
-        do_thing_4 {
-        }
-      }
-    }
-  }
-}
-
-=========================================================================
-SequenceTest: Test case with 1 entry in the first batch and multiple ones in the second batch. Used to verify the API is stable.
-=========================================================================
-
---- PD updates (input):
-type: DELETE
-table_entry {
-  referring_table_entry {
-    match {
-      val: "0x001"
-    }
-    action {
-      referring_action {
-        referring_id_1: "key-a"
-        referring_id_2: "key-b"
-      }
-    }
-  }
-}
-
-type: DELETE
-table_entry {
-  referred_table_entry {
+  one_match_field_table_entry {
     match {
       id: "key-a"
     }
@@ -179,12 +94,13 @@ table_entry {
 
 type: DELETE
 table_entry {
-  referred_table_entry {
+  referring_by_action_table_entry {
     match {
-      id: "key-b"
+      val: "0x001"
     }
     action {
-      do_thing_4 {
+      referring_to_one_match_field_action {
+        referring_id_1: "key-a"
       }
     }
   }
@@ -195,14 +111,13 @@ WriteRequest #0
 updates {
   type: DELETE
   table_entry {
-    referring_table_entry {
+    referring_by_action_table_entry {
       match {
         val: "0x001"
       }
       action {
-        referring_action {
+        referring_to_one_match_field_action {
           referring_id_1: "key-a"
-          referring_id_2: "key-b"
         }
       }
     }
@@ -213,7 +128,7 @@ WriteRequest #1
 updates {
   type: DELETE
   table_entry {
-    referred_table_entry {
+    one_match_field_table_entry {
       match {
         id: "key-a"
       }
@@ -224,36 +139,22 @@ updates {
     }
   }
 }
-updates {
-  type: DELETE
-  table_entry {
-    referred_table_entry {
-      match {
-        id: "key-b"
-      }
-      action {
-        do_thing_4 {
-        }
-      }
-    }
-  }
-}
 
 =========================================================================
-SequenceTest: Insert(a), Insert(not-a)
+SequenceTest: INSERT EntryWithTwoKeys{key-a, 0x002} -> INSERT EntryThatRefersTo{key-a, 0x002}
 =========================================================================
 
 --- PD updates (input):
 type: INSERT
 table_entry {
-  referring_table_entry {
+  referring_by_action_table_entry {
     match {
       val: "0x001"
     }
     action {
-      referring_action {
+      referring_to_two_match_fields_action {
         referring_id_1: "key-a"
-        referring_id_2: "non-existent"
+        referring_id_2: "0x002"
       }
     }
   }
@@ -261,9 +162,10 @@ table_entry {
 
 type: INSERT
 table_entry {
-  referred_table_entry {
+  two_match_fields_table_entry {
     match {
-      id: "not-key-a"
+      id_1: "key-a"
+      id_2: "0x002"
     }
     action {
       do_thing_4 {
@@ -277,25 +179,98 @@ WriteRequest #0
 updates {
   type: INSERT
   table_entry {
-    referring_table_entry {
+    two_match_fields_table_entry {
       match {
-        val: "0x001"
+        id_1: "key-a"
+        id_2: "0x002"
       }
       action {
-        referring_action {
-          referring_id_1: "key-a"
-          referring_id_2: "non-existent"
+        do_thing_4 {
         }
       }
     }
   }
 }
+
+WriteRequest #1
 updates {
   type: INSERT
   table_entry {
-    referred_table_entry {
+    referring_by_action_table_entry {
       match {
-        id: "not-key-a"
+        val: "0x001"
+      }
+      action {
+        referring_to_two_match_fields_action {
+          referring_id_1: "key-a"
+          referring_id_2: "0x002"
+        }
+      }
+    }
+  }
+}
+
+=========================================================================
+SequenceTest: DELETE EntryThatRefersTo{key-a, 0x002} -> DELETE EntryWithTwoKeys{key-a, 0x002}
+=========================================================================
+
+--- PD updates (input):
+type: DELETE
+table_entry {
+  two_match_fields_table_entry {
+    match {
+      id_1: "key-a"
+      id_2: "0x002"
+    }
+    action {
+      do_thing_4 {
+      }
+    }
+  }
+}
+
+type: DELETE
+table_entry {
+  referring_by_action_table_entry {
+    match {
+      val: "0x001"
+    }
+    action {
+      referring_to_two_match_fields_action {
+        referring_id_1: "key-a"
+        referring_id_2: "0x002"
+      }
+    }
+  }
+}
+
+--- Write requests (output):
+WriteRequest #0
+updates {
+  type: DELETE
+  table_entry {
+    referring_by_action_table_entry {
+      match {
+        val: "0x001"
+      }
+      action {
+        referring_to_two_match_fields_action {
+          referring_id_1: "key-a"
+          referring_id_2: "0x002"
+        }
+      }
+    }
+  }
+}
+
+WriteRequest #1
+updates {
+  type: DELETE
+  table_entry {
+    two_match_fields_table_entry {
+      match {
+        id_1: "key-a"
+        id_2: "0x002"
       }
       action {
         do_thing_4 {
@@ -306,20 +281,20 @@ updates {
 }
 
 =========================================================================
-SequenceTest: Insert(a) -> Insert(a), Insert(different table)
+SequenceTest: INSERT EntryThatRefersTo{key-a, 0x002}, INSERT EntryWithTwoKeys{key-c, 0x004}
 =========================================================================
 
 --- PD updates (input):
 type: INSERT
 table_entry {
-  referring_table_entry {
+  referring_by_action_table_entry {
     match {
       val: "0x001"
     }
     action {
-      referring_action {
+      referring_to_two_match_fields_action {
         referring_id_1: "key-a"
-        referring_id_2: "non-existent"
+        referring_id_2: "0x002"
       }
     }
   }
@@ -327,7 +302,476 @@ table_entry {
 
 type: INSERT
 table_entry {
-  referred_table_entry {
+  two_match_fields_table_entry {
+    match {
+      id_1: "key-c"
+      id_2: "0x004"
+    }
+    action {
+      do_thing_4 {
+      }
+    }
+  }
+}
+
+--- Write requests (output):
+WriteRequest #0
+updates {
+  type: INSERT
+  table_entry {
+    referring_by_action_table_entry {
+      match {
+        val: "0x001"
+      }
+      action {
+        referring_to_two_match_fields_action {
+          referring_id_1: "key-a"
+          referring_id_2: "0x002"
+        }
+      }
+    }
+  }
+}
+updates {
+  type: INSERT
+  table_entry {
+    two_match_fields_table_entry {
+      match {
+        id_1: "key-c"
+        id_2: "0x004"
+      }
+      action {
+        do_thing_4 {
+        }
+      }
+    }
+  }
+}
+
+=========================================================================
+SequenceTest: DELETE EntryThatRefersTo{key-a, 0x002}, DELETE EntryWithTwoKeys{key-c, 0x004}
+=========================================================================
+
+--- PD updates (input):
+type: DELETE
+table_entry {
+  referring_by_action_table_entry {
+    match {
+      val: "0x001"
+    }
+    action {
+      referring_to_two_match_fields_action {
+        referring_id_1: "key-a"
+        referring_id_2: "0x002"
+      }
+    }
+  }
+}
+
+type: DELETE
+table_entry {
+  two_match_fields_table_entry {
+    match {
+      id_1: "key-c"
+      id_2: "0x004"
+    }
+    action {
+      do_thing_4 {
+      }
+    }
+  }
+}
+
+--- Write requests (output):
+WriteRequest #0
+updates {
+  type: DELETE
+  table_entry {
+    referring_by_action_table_entry {
+      match {
+        val: "0x001"
+      }
+      action {
+        referring_to_two_match_fields_action {
+          referring_id_1: "key-a"
+          referring_id_2: "0x002"
+        }
+      }
+    }
+  }
+}
+updates {
+  type: DELETE
+  table_entry {
+    two_match_fields_table_entry {
+      match {
+        id_1: "key-c"
+        id_2: "0x004"
+      }
+      action {
+        do_thing_4 {
+        }
+      }
+    }
+  }
+}
+
+=========================================================================
+SequenceTest: [INCORRECT due to false dependency] INSERT EntryThatRefersTo{key-a, 0x002}, INSERT EntryWithTwoKeys{key-a, 0x004} should be in a single batch and no change in orders
+=========================================================================
+
+--- PD updates (input):
+type: INSERT
+table_entry {
+  referring_by_action_table_entry {
+    match {
+      val: "0x001"
+    }
+    action {
+      referring_to_two_match_fields_action {
+        referring_id_1: "key-a"
+        referring_id_2: "0x002"
+      }
+    }
+  }
+}
+
+type: INSERT
+table_entry {
+  two_match_fields_table_entry {
+    match {
+      id_1: "key-a"
+      id_2: "0x004"
+    }
+    action {
+      do_thing_4 {
+      }
+    }
+  }
+}
+
+--- Write requests (output):
+WriteRequest #0
+updates {
+  type: INSERT
+  table_entry {
+    two_match_fields_table_entry {
+      match {
+        id_1: "key-a"
+        id_2: "0x004"
+      }
+      action {
+        do_thing_4 {
+        }
+      }
+    }
+  }
+}
+
+WriteRequest #1
+updates {
+  type: INSERT
+  table_entry {
+    referring_by_action_table_entry {
+      match {
+        val: "0x001"
+      }
+      action {
+        referring_to_two_match_fields_action {
+          referring_id_1: "key-a"
+          referring_id_2: "0x002"
+        }
+      }
+    }
+  }
+}
+
+=========================================================================
+SequenceTest: [INCORRECT due to false dependency] DELETE EntryWithTwoKeys{key-a, 0x004}, DELETE EntryThatRefersTo{key-a, 0x002} should be in a single batch no change in orders
+=========================================================================
+
+--- PD updates (input):
+type: DELETE
+table_entry {
+  two_match_fields_table_entry {
+    match {
+      id_1: "key-a"
+      id_2: "0x004"
+    }
+    action {
+      do_thing_4 {
+      }
+    }
+  }
+}
+
+type: DELETE
+table_entry {
+  referring_by_action_table_entry {
+    match {
+      val: "0x001"
+    }
+    action {
+      referring_to_two_match_fields_action {
+        referring_id_1: "key-a"
+        referring_id_2: "0x002"
+      }
+    }
+  }
+}
+
+--- Write requests (output):
+WriteRequest #0
+updates {
+  type: DELETE
+  table_entry {
+    referring_by_action_table_entry {
+      match {
+        val: "0x001"
+      }
+      action {
+        referring_to_two_match_fields_action {
+          referring_id_1: "key-a"
+          referring_id_2: "0x002"
+        }
+      }
+    }
+  }
+}
+
+WriteRequest #1
+updates {
+  type: DELETE
+  table_entry {
+    two_match_fields_table_entry {
+      match {
+        id_1: "key-a"
+        id_2: "0x004"
+      }
+      action {
+        do_thing_4 {
+        }
+      }
+    }
+  }
+}
+
+=========================================================================
+SequenceTest: [INCORRECT due to false dependency] INSERT Entries that don't refer to each other should be in one batch and maintain the original orders.
+=========================================================================
+
+--- PD updates (input):
+type: INSERT
+table_entry {
+  referring_by_action_table_entry {
+    match {
+      val: "0x001"
+    }
+    action {
+      referring_to_two_match_fields_action {
+        referring_id_1: "key-a"
+        referring_id_2: "0x002"
+      }
+    }
+  }
+}
+
+type: INSERT
+table_entry {
+  two_match_fields_table_entry {
+    match {
+      id_1: "key-a"
+      id_2: "0x003"
+    }
+    action {
+      do_thing_4 {
+      }
+    }
+  }
+}
+
+type: INSERT
+table_entry {
+  one_match_field_table_entry {
+    match {
+      id: "key-c"
+    }
+    action {
+      do_thing_4 {
+      }
+    }
+  }
+}
+
+--- Write requests (output):
+WriteRequest #0
+updates {
+  type: INSERT
+  table_entry {
+    two_match_fields_table_entry {
+      match {
+        id_1: "key-a"
+        id_2: "0x003"
+      }
+      action {
+        do_thing_4 {
+        }
+      }
+    }
+  }
+}
+updates {
+  type: INSERT
+  table_entry {
+    one_match_field_table_entry {
+      match {
+        id: "key-c"
+      }
+      action {
+        do_thing_4 {
+        }
+      }
+    }
+  }
+}
+
+WriteRequest #1
+updates {
+  type: INSERT
+  table_entry {
+    referring_by_action_table_entry {
+      match {
+        val: "0x001"
+      }
+      action {
+        referring_to_two_match_fields_action {
+          referring_id_1: "key-a"
+          referring_id_2: "0x002"
+        }
+      }
+    }
+  }
+}
+
+=========================================================================
+SequenceTest: [INCORRECT due to false dependency] DELETE Entries that don't refer to each other should be in one batch and maintain the original orders.
+=========================================================================
+
+--- PD updates (input):
+type: DELETE
+table_entry {
+  referring_by_action_table_entry {
+    match {
+      val: "0x001"
+    }
+    action {
+      referring_to_two_match_fields_action {
+        referring_id_1: "key-a"
+        referring_id_2: "0x002"
+      }
+    }
+  }
+}
+
+type: DELETE
+table_entry {
+  two_match_fields_table_entry {
+    match {
+      id_1: "key-a"
+      id_2: "0x003"
+    }
+    action {
+      do_thing_4 {
+      }
+    }
+  }
+}
+
+type: DELETE
+table_entry {
+  one_match_field_table_entry {
+    match {
+      id: "key-c"
+    }
+    action {
+      do_thing_4 {
+      }
+    }
+  }
+}
+
+--- Write requests (output):
+WriteRequest #0
+updates {
+  type: DELETE
+  table_entry {
+    referring_by_action_table_entry {
+      match {
+        val: "0x001"
+      }
+      action {
+        referring_to_two_match_fields_action {
+          referring_id_1: "key-a"
+          referring_id_2: "0x002"
+        }
+      }
+    }
+  }
+}
+updates {
+  type: DELETE
+  table_entry {
+    one_match_field_table_entry {
+      match {
+        id: "key-c"
+      }
+      action {
+        do_thing_4 {
+        }
+      }
+    }
+  }
+}
+
+WriteRequest #1
+updates {
+  type: DELETE
+  table_entry {
+    two_match_fields_table_entry {
+      match {
+        id_1: "key-a"
+        id_2: "0x003"
+      }
+      action {
+        do_thing_4 {
+        }
+      }
+    }
+  }
+}
+
+=========================================================================
+SequenceTest: INSERT EntryWithOneKey{key-a} ->INSERT EntryThatRefersTo{key-a} , another entry
+=========================================================================
+
+--- PD updates (input):
+type: INSERT
+table_entry {
+  referring_by_action_table_entry {
+    match {
+      val: "0x001"
+    }
+    action {
+      referring_to_one_match_field_action {
+        referring_id_1: "key-a"
+      }
+    }
+  }
+}
+
+type: INSERT
+table_entry {
+  one_match_field_table_entry {
     match {
       id: "key-a"
     }
@@ -359,7 +803,7 @@ WriteRequest #0
 updates {
   type: INSERT
   table_entry {
-    referred_table_entry {
+    one_match_field_table_entry {
       match {
         id: "key-a"
       }
@@ -392,14 +836,13 @@ WriteRequest #1
 updates {
   type: INSERT
   table_entry {
-    referring_table_entry {
+    referring_by_action_table_entry {
       match {
         val: "0x001"
       }
       action {
-        referring_action {
+        referring_to_one_match_field_action {
           referring_id_1: "key-a"
-          referring_id_2: "non-existent"
         }
       }
     }
@@ -407,20 +850,19 @@ updates {
 }
 
 =========================================================================
-SequenceTest: Insert(a) -> Insert(a), Insert(b) -> Insert(b)
+SequenceTest: INSERT EntryWithOneKey{key-a} -> INSERTEntryThatRefersTo{key-a} ,INSERT EntryWithOneKey{key-b} -> INSERTEntryThatRefersTo{key-b}
 =========================================================================
 
 --- PD updates (input):
 type: INSERT
 table_entry {
-  referring_table_entry {
+  referring_by_action_table_entry {
     match {
       val: "0x001"
     }
     action {
-      referring_action {
+      referring_to_one_match_field_action {
         referring_id_1: "key-a"
-        referring_id_2: "non-existent"
       }
     }
   }
@@ -428,7 +870,7 @@ table_entry {
 
 type: INSERT
 table_entry {
-  referred_table_entry {
+  one_match_field_table_entry {
     match {
       id: "key-a"
     }
@@ -441,14 +883,13 @@ table_entry {
 
 type: INSERT
 table_entry {
-  referring_table_entry {
+  referring_by_action_table_entry {
     match {
       val: "0x002"
     }
     action {
-      referring_action {
+      referring_to_one_match_field_action {
         referring_id_1: "key-b"
-        referring_id_2: "non-existent"
       }
     }
   }
@@ -456,7 +897,7 @@ table_entry {
 
 type: INSERT
 table_entry {
-  referred_table_entry {
+  one_match_field_table_entry {
     match {
       id: "key-b"
     }
@@ -472,7 +913,7 @@ WriteRequest #0
 updates {
   type: INSERT
   table_entry {
-    referred_table_entry {
+    one_match_field_table_entry {
       match {
         id: "key-a"
       }
@@ -486,7 +927,7 @@ updates {
 updates {
   type: INSERT
   table_entry {
-    referred_table_entry {
+    one_match_field_table_entry {
       match {
         id: "key-b"
       }
@@ -502,14 +943,13 @@ WriteRequest #1
 updates {
   type: INSERT
   table_entry {
-    referring_table_entry {
+    referring_by_action_table_entry {
       match {
         val: "0x001"
       }
       action {
-        referring_action {
+        referring_to_one_match_field_action {
           referring_id_1: "key-a"
-          referring_id_2: "non-existent"
         }
       }
     }
@@ -518,14 +958,13 @@ updates {
 updates {
   type: INSERT
   table_entry {
-    referring_table_entry {
+    referring_by_action_table_entry {
       match {
         val: "0x002"
       }
       action {
-        referring_action {
+        referring_to_one_match_field_action {
           referring_id_1: "key-b"
-          referring_id_2: "non-existent"
         }
       }
     }
@@ -533,20 +972,19 @@ updates {
 }
 
 =========================================================================
-SequenceTest: Insert(a) -> Insert(a), Insert(a) -> Insert(a) (i.e., two inserts pointing to the same insert)
+SequenceTest: INSERT EntryThatRefersTo{key-a}<- INSERT EntryWithOneKey{key-a} -> INSERT EntryThatRefersTo{key-a}. Two INSERT refers to the same referred entry.
 =========================================================================
 
 --- PD updates (input):
 type: INSERT
 table_entry {
-  referring_table_entry {
+  referring_by_action_table_entry {
     match {
       val: "0x001"
     }
     action {
-      referring_action {
+      referring_to_one_match_field_action {
         referring_id_1: "key-a"
-        referring_id_2: "non-existent"
       }
     }
   }
@@ -554,7 +992,7 @@ table_entry {
 
 type: INSERT
 table_entry {
-  referred_table_entry {
+  one_match_field_table_entry {
     match {
       id: "key-a"
     }
@@ -567,14 +1005,13 @@ table_entry {
 
 type: INSERT
 table_entry {
-  referring_table_entry {
+  referring_by_action_table_entry {
     match {
       val: "0x002"
     }
     action {
-      referring_action {
+      referring_to_one_match_field_action {
         referring_id_1: "key-a"
-        referring_id_2: "non-existent"
       }
     }
   }
@@ -585,7 +1022,7 @@ WriteRequest #0
 updates {
   type: INSERT
   table_entry {
-    referred_table_entry {
+    one_match_field_table_entry {
       match {
         id: "key-a"
       }
@@ -601,14 +1038,13 @@ WriteRequest #1
 updates {
   type: INSERT
   table_entry {
-    referring_table_entry {
+    referring_by_action_table_entry {
       match {
         val: "0x001"
       }
       action {
-        referring_action {
+        referring_to_one_match_field_action {
           referring_id_1: "key-a"
-          referring_id_2: "non-existent"
         }
       }
     }
@@ -617,14 +1053,13 @@ updates {
 updates {
   type: INSERT
   table_entry {
-    referring_table_entry {
+    referring_by_action_table_entry {
       match {
         val: "0x002"
       }
       action {
-        referring_action {
+        referring_to_one_match_field_action {
           referring_id_1: "key-a"
-          referring_id_2: "non-existent"
         }
       }
     }
@@ -632,26 +1067,27 @@ updates {
 }
 
 =========================================================================
-SequenceTest: A referring to B using a match field
+SequenceTest: referring via one match field for INSERT
 =========================================================================
 
 --- PD updates (input):
 type: INSERT
 table_entry {
-  referring2_table_entry {
+  referring_by_match_field_table_entry {
     match {
-      referring_id: "key-a"
+      referring_id_1: "key-a"
     }
     action {
       do_thing_4 {
       }
     }
+    priority: 32
   }
 }
 
 type: INSERT
 table_entry {
-  referred_table_entry {
+  one_match_field_table_entry {
     match {
       id: "key-a"
     }
@@ -667,9 +1103,78 @@ WriteRequest #0
 updates {
   type: INSERT
   table_entry {
-    referred_table_entry {
+    referring_by_match_field_table_entry {
+      match {
+        referring_id_1: "key-a"
+      }
+      action {
+        do_thing_4 {
+        }
+      }
+      priority: 32
+    }
+  }
+}
+updates {
+  type: INSERT
+  table_entry {
+    one_match_field_table_entry {
       match {
         id: "key-a"
+      }
+      action {
+        do_thing_4 {
+        }
+      }
+    }
+  }
+}
+
+=========================================================================
+SequenceTest: referring via two match fields for INSERT
+=========================================================================
+
+--- PD updates (input):
+type: INSERT
+table_entry {
+  referring_by_match_field_table_entry {
+    match {
+      referring_id_1: "key-a"
+      referring_id_2 {
+        value: "0x001"
+      }
+    }
+    action {
+      do_thing_4 {
+      }
+    }
+    priority: 32
+  }
+}
+
+type: INSERT
+table_entry {
+  two_match_fields_table_entry {
+    match {
+      id_1: "key-a"
+      id_2: "0x001"
+    }
+    action {
+      do_thing_4 {
+      }
+    }
+  }
+}
+
+--- Write requests (output):
+WriteRequest #0
+updates {
+  type: INSERT
+  table_entry {
+    two_match_fields_table_entry {
+      match {
+        id_1: "key-a"
+        id_2: "0x001"
       }
       action {
         do_thing_4 {
@@ -683,9 +1188,62 @@ WriteRequest #1
 updates {
   type: INSERT
   table_entry {
-    referring2_table_entry {
+    referring_by_match_field_table_entry {
       match {
-        referring_id: "key-a"
+        referring_id_1: "key-a"
+        referring_id_2 {
+          value: "0x001"
+        }
+      }
+      action {
+        do_thing_4 {
+        }
+      }
+      priority: 32
+    }
+  }
+}
+
+=========================================================================
+SequenceTest: referring via one match field for DELETE
+=========================================================================
+
+--- PD updates (input):
+type: DELETE
+table_entry {
+  one_match_field_table_entry {
+    match {
+      id: "key-a"
+    }
+    action {
+      do_thing_4 {
+      }
+    }
+  }
+}
+
+type: DELETE
+table_entry {
+  referring_by_match_field_table_entry {
+    match {
+      referring_id_1: "key-a"
+    }
+    action {
+      do_thing_4 {
+      }
+    }
+    priority: 32
+  }
+}
+
+--- Write requests (output):
+WriteRequest #0
+updates {
+  type: DELETE
+  table_entry {
+    one_match_field_table_entry {
+      match {
+        id: "key-a"
       }
       action {
         do_thing_4 {
@@ -694,103 +1252,92 @@ updates {
     }
   }
 }
-
-=========================================================================
-SortTest: A referring to B
-=========================================================================
-
---- PD entries (input):
-referring_table_entry {
-  match {
-    val: "0x001"
-  }
-  action {
-    referring_action {
-      referring_id_1: "key-a"
-      referring_id_2: "non-existent"
-    }
-  }
-}
-
-referred_table_entry {
-  match {
-    id: "key-a"
-  }
-  action {
-    do_thing_4 {
-    }
-  }
-}
-
---- Sorted entries (output):
-referred_table_entry {
-  match {
-    id: "key-a"
-  }
-  action {
-    do_thing_4 {
-    }
-  }
-}
-
-referring_table_entry {
-  match {
-    val: "0x001"
-  }
-  action {
-    referring_action {
-      referring_id_1: "key-a"
-      referring_id_2: "non-existent"
+updates {
+  type: DELETE
+  table_entry {
+    referring_by_match_field_table_entry {
+      match {
+        referring_id_1: "key-a"
+      }
+      action {
+        do_thing_4 {
+        }
+      }
+      priority: 32
     }
   }
 }
 
 =========================================================================
-SortTest: A referring to B twice
+SequenceTest: referring via two match fields for DELETE
 =========================================================================
 
---- PD entries (input):
-referring_table_entry {
-  match {
-    val: "0x001"
+--- PD updates (input):
+type: DELETE
+table_entry {
+  two_match_fields_table_entry {
+    match {
+      id_1: "key-a"
+      id_2: "0x001"
+    }
+    action {
+      do_thing_4 {
+      }
+    }
   }
-  action {
-    referring_action {
+}
+
+type: DELETE
+table_entry {
+  referring_by_match_field_table_entry {
+    match {
       referring_id_1: "key-a"
-      referring_id_2: "key-a"
+      referring_id_2 {
+        value: "0x001"
+      }
+    }
+    action {
+      do_thing_4 {
+      }
+    }
+    priority: 32
+  }
+}
+
+--- Write requests (output):
+WriteRequest #0
+updates {
+  type: DELETE
+  table_entry {
+    referring_by_match_field_table_entry {
+      match {
+        referring_id_1: "key-a"
+        referring_id_2 {
+          value: "0x001"
+        }
+      }
+      action {
+        do_thing_4 {
+        }
+      }
+      priority: 32
     }
   }
 }
 
-referred_table_entry {
-  match {
-    id: "key-a"
-  }
-  action {
-    do_thing_4 {
-    }
-  }
-}
-
---- Sorted entries (output):
-referred_table_entry {
-  match {
-    id: "key-a"
-  }
-  action {
-    do_thing_4 {
-    }
-  }
-}
-
-referring_table_entry {
-  match {
-    val: "0x001"
-  }
-  action {
-    referring_action {
-      referring_id_1: "key-a"
-      referring_id_2: "key-a"
+WriteRequest #1
+updates {
+  type: DELETE
+  table_entry {
+    two_match_fields_table_entry {
+      match {
+        id_1: "key-a"
+        id_2: "0x001"
+      }
+      action {
+        do_thing_4 {
+        }
+      }
     }
   }
 }
@@ -810,27 +1357,27 @@ GetEntriesUnreachableFromRootsTest: All root entries means no garbage.
 =========================================================================
 
 --- PD entries (input):
-referring_table_entry {
+referring_by_action_table_entry {
   match {
     val: "0x001"
   }
   action {
-    referring_action {
+    referring_to_two_match_fields_action {
       referring_id_1: "key-a"
-      referring_id_2: "key-a"
+      referring_id_2: "0x003"
     }
   }
   controller_metadata: "Root"
 }
 
-referring_table_entry {
+referring_by_action_table_entry {
   match {
     val: "0x002"
   }
   action {
-    referring_action {
+    referring_to_two_match_fields_action {
       referring_id_1: "key-a"
-      referring_id_2: "key-b"
+      referring_id_2: "0x002"
     }
   }
   controller_metadata: "Root"
@@ -844,65 +1391,21 @@ GetEntriesUnreachableFromRootsTest: Root referring to the only entry generates n
 =========================================================================
 
 --- PD entries (input):
-referring_table_entry {
+referring_by_action_table_entry {
   match {
     val: "0x001"
   }
   action {
-    referring_action {
+    referring_to_one_match_field_action {
       referring_id_1: "key-a"
-      referring_id_2: "key-a"
     }
   }
   controller_metadata: "Root"
 }
 
-referred_table_entry {
+one_match_field_table_entry {
   match {
     id: "key-a"
-  }
-  action {
-    do_thing_4 {
-    }
-  }
-  controller_metadata: "Dependency"
-}
-
---- Unreachable entries from roots (output):
-<empty>
-
-=========================================================================
-GetEntriesUnreachableFromRootsTest: Root referring to all dependencies generates no garbage.
-=========================================================================
-
---- PD entries (input):
-referring_table_entry {
-  match {
-    val: "0x001"
-  }
-  action {
-    referring_action {
-      referring_id_1: "key-a"
-      referring_id_2: "key-b"
-    }
-  }
-  controller_metadata: "Root"
-}
-
-referred_table_entry {
-  match {
-    id: "key-a"
-  }
-  action {
-    do_thing_4 {
-    }
-  }
-  controller_metadata: "Dependency"
-}
-
-referred_table_entry {
-  match {
-    id: "key-b"
   }
   action {
     do_thing_4 {
@@ -919,20 +1422,19 @@ GetEntriesUnreachableFromRootsTest: Garbage is unreachable.
 =========================================================================
 
 --- PD entries (input):
-referring_table_entry {
+referring_by_action_table_entry {
   match {
     val: "0x001"
   }
   action {
-    referring_action {
+    referring_to_one_match_field_action {
       referring_id_1: "key-a"
-      referring_id_2: "key-b"
     }
   }
   controller_metadata: "Root"
 }
 
-referred_table_entry {
+one_match_field_table_entry {
   match {
     id: "key-a"
   }
@@ -943,7 +1445,7 @@ referred_table_entry {
   controller_metadata: "Dependency"
 }
 
-referred_table_entry {
+one_match_field_table_entry {
   match {
     id: "key-c"
   }
@@ -955,7 +1457,7 @@ referred_table_entry {
 }
 
 --- Unreachable entries from roots (output):
-referred_table_entry {
+one_match_field_table_entry {
   match {
     id: "key-c"
   }
@@ -971,20 +1473,19 @@ GetEntriesUnreachableFromRootsTest: Root referring to dependency and a standalon
 =========================================================================
 
 --- PD entries (input):
-referring_table_entry {
+referring_by_action_table_entry {
   match {
     val: "0x001"
   }
   action {
-    referring_action {
+    referring_to_one_match_field_action {
       referring_id_1: "key-a"
-      referring_id_2: "key-b"
     }
   }
   controller_metadata: "Root"
 }
 
-referred_table_entry {
+one_match_field_table_entry {
   match {
     id: "key-a"
   }
@@ -995,14 +1496,14 @@ referred_table_entry {
   controller_metadata: "Dependency"
 }
 
-referring_table_entry {
+referring_by_action_table_entry {
   match {
     val: "0x001"
   }
   action {
-    referring_action {
+    referring_to_two_match_fields_action {
       referring_id_1: "non-exist"
-      referring_id_2: "non-exist"
+      referring_id_2: "0x000"
     }
   }
   controller_metadata: "Root"
@@ -1016,7 +1517,7 @@ GetEntriesUnreachableFromRootsTest: All entries are garbage.
 =========================================================================
 
 --- PD entries (input):
-referred_table_entry {
+one_match_field_table_entry {
   match {
     id: "key-a"
   }
@@ -1027,7 +1528,7 @@ referred_table_entry {
   controller_metadata: "Garbage"
 }
 
-referred_table_entry {
+one_match_field_table_entry {
   match {
     id: "key-c"
   }
@@ -1039,7 +1540,7 @@ referred_table_entry {
 }
 
 --- Unreachable entries from roots (output):
-referred_table_entry {
+one_match_field_table_entry {
   match {
     id: "key-a"
   }
@@ -1050,7 +1551,7 @@ referred_table_entry {
   controller_metadata: "Garbage"
 }
 
-referred_table_entry {
+one_match_field_table_entry {
   match {
     id: "key-c"
   }
@@ -1066,35 +1567,36 @@ GetEntriesUnreachableFromRootsTest: Two roots referring to one dependency genera
 =========================================================================
 
 --- PD entries (input):
-referring_table_entry {
+referring_by_action_table_entry {
   match {
     val: "0x001"
   }
   action {
-    referring_action {
+    referring_to_two_match_fields_action {
       referring_id_1: "key-a"
-      referring_id_2: "key-a"
+      referring_id_2: "0x002"
     }
   }
   controller_metadata: "Root"
 }
 
-referring_table_entry {
+referring_by_action_table_entry {
   match {
     val: "0x002"
   }
   action {
-    referring_action {
+    referring_to_two_match_fields_action {
       referring_id_1: "key-a"
-      referring_id_2: "key-a"
+      referring_id_2: "0x002"
     }
   }
   controller_metadata: "Root"
 }
 
-referred_table_entry {
+two_match_fields_table_entry {
   match {
-    id: "key-a"
+    id_1: "key-a"
+    id_2: "0x002"
   }
   action {
     do_thing_4 {
@@ -1111,9 +1613,9 @@ GetEntriesUnreachableFromRootsTest: Children and grand children of the root are 
 =========================================================================
 
 --- PD entries (input):
-referring_to_referring2_table_entry {
+referring_to_referring_by_match_field_table_entry {
   match {
-    referring2_table_id: "key-a"
+    referring_to_referring_id_1: "key-a"
   }
   action {
     do_thing_4 {
@@ -1122,18 +1624,19 @@ referring_to_referring2_table_entry {
   controller_metadata: "Root"
 }
 
-referring2_table_entry {
+referring_by_match_field_table_entry {
   match {
-    referring_id: "key-a"
+    referring_id_1: "key-a"
   }
   action {
     do_thing_4 {
     }
   }
+  priority: 32
   controller_metadata: "Child dependency"
 }
 
-referred_table_entry {
+one_match_field_table_entry {
   match {
     id: "key-a"
   }
@@ -1145,57 +1648,64 @@ referred_table_entry {
 }
 
 --- Unreachable entries from roots (output):
-<empty>
+one_match_field_table_entry {
+  match {
+    id: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+  controller_metadata: "Grand child Dependency"
+}
 
 =========================================================================
 GetEntriesUnreachableFromRootsTest: NonRoot referring to other NonRoot is garbage.
 =========================================================================
 
 --- PD entries (input):
-referred_table_entry {
+referring_by_match_field_table_entry {
   match {
-    id: "key-a"
+    referring_id_1: "key-a"
   }
   action {
     do_thing_4 {
     }
   }
+  priority: 32
   controller_metadata: "NonRoot garbage"
 }
 
-referring_table_entry {
+one_match_field_table_entry {
   match {
-    val: "0x001"
+    id: "key-a"
   }
   action {
-    referring_action {
-      referring_id_1: "key-a"
-      referring_id_2: "non-existent"
+    do_thing_4 {
     }
   }
   controller_metadata: "NonRoot garbage"
 }
 
 --- Unreachable entries from roots (output):
-referred_table_entry {
+referring_by_match_field_table_entry {
   match {
-    id: "key-a"
+    referring_id_1: "key-a"
   }
   action {
     do_thing_4 {
     }
   }
+  priority: 32
   controller_metadata: "NonRoot garbage"
 }
 
-referring_table_entry {
+one_match_field_table_entry {
   match {
-    val: "0x001"
+    id: "key-a"
   }
   action {
-    referring_action {
-      referring_id_1: "key-a"
-      referring_id_2: "non-existent"
+    do_thing_4 {
     }
   }
   controller_metadata: "NonRoot garbage"
@@ -1206,9 +1716,9 @@ GetEntriesUnreachableFromRootsTest: NonRoot referring to other dependency is gar
 =========================================================================
 
 --- PD entries (input):
-referring_to_referring2_table_entry {
+referring_to_referring_by_match_field_table_entry {
   match {
-    referring2_table_id: "key-a"
+    referring_to_referring_id_1: "key-a"
   }
   action {
     do_thing_4 {
@@ -1217,18 +1727,19 @@ referring_to_referring2_table_entry {
   controller_metadata: "Root"
 }
 
-referring2_table_entry {
+referring_by_match_field_table_entry {
   match {
-    referring_id: "key-a"
+    referring_id_1: "key-a"
   }
   action {
     do_thing_4 {
     }
   }
+  priority: 32
   controller_metadata: "Child dependency"
 }
 
-referred_table_entry {
+one_match_field_table_entry {
   match {
     id: "key-a"
   }
@@ -1239,28 +1750,37 @@ referred_table_entry {
   controller_metadata: "Grand child Dependency"
 }
 
-referring_table_entry {
+referring_by_action_table_entry {
   match {
     val: "0x001"
   }
   action {
-    referring_action {
+    referring_to_one_match_field_action {
       referring_id_1: "key-a"
-      referring_id_2: "non-existent"
     }
   }
   controller_metadata: "NonRoot garbage"
 }
 
 --- Unreachable entries from roots (output):
-referring_table_entry {
+one_match_field_table_entry {
+  match {
+    id: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+  controller_metadata: "Grand child Dependency"
+}
+
+referring_by_action_table_entry {
   match {
     val: "0x001"
   }
   action {
-    referring_action {
+    referring_to_one_match_field_action {
       referring_id_1: "key-a"
-      referring_id_2: "non-existent"
     }
   }
   controller_metadata: "NonRoot garbage"
@@ -1271,9 +1791,9 @@ GetEntriesUnreachableFromRootsTest: Conglomeration test.
 =========================================================================
 
 --- PD entries (input):
-referring_to_referring2_table_entry {
+referring_to_referring_by_match_field_table_entry {
   match {
-    referring2_table_id: "key-a"
+    referring_to_referring_id_1: "key-a"
   }
   action {
     do_thing_4 {
@@ -1282,18 +1802,19 @@ referring_to_referring2_table_entry {
   controller_metadata: "Root"
 }
 
-referring2_table_entry {
+referring_by_match_field_table_entry {
   match {
-    referring_id: "key-a"
+    referring_id_1: "key-a"
   }
   action {
     do_thing_4 {
     }
   }
+  priority: 32
   controller_metadata: "Child dependency"
 }
 
-referred_table_entry {
+one_match_field_table_entry {
   match {
     id: "key-a"
   }
@@ -1304,20 +1825,20 @@ referred_table_entry {
   controller_metadata: "Grand child Dependency"
 }
 
-referring_table_entry {
+referring_by_action_table_entry {
   match {
     val: "0x001"
   }
   action {
-    referring_action {
+    referring_to_two_match_fields_action {
       referring_id_1: "key-a"
-      referring_id_2: "non-existent"
+      referring_id_2: "0x000"
     }
   }
   controller_metadata: "NonRoot garbage"
 }
 
-referred_table_entry {
+one_match_field_table_entry {
   match {
     id: "key-b"
   }
@@ -1328,33 +1849,33 @@ referred_table_entry {
   controller_metadata: "NonRoot garbage"
 }
 
-referring_table_entry {
+referring_by_action_table_entry {
   match {
     val: "0x001"
   }
   action {
-    referring_action {
+    referring_to_two_match_fields_action {
       referring_id_1: "key-b"
-      referring_id_2: "non-existent"
+      referring_id_2: "0x000"
     }
   }
   controller_metadata: "NonRoot garbage"
 }
 
-referring_table_entry {
+referring_by_action_table_entry {
   match {
     val: "0x001"
   }
   action {
-    referring_action {
+    referring_to_two_match_fields_action {
       referring_id_1: "key-c"
-      referring_id_2: "non-exist"
+      referring_id_2: "0x000"
     }
   }
   controller_metadata: "Root"
 }
 
-referred_table_entry {
+one_match_field_table_entry {
   match {
     id: "key-c"
   }
@@ -1365,34 +1886,45 @@ referred_table_entry {
   controller_metadata: "Dependency"
 }
 
-referring_table_entry {
+referring_by_action_table_entry {
   match {
     val: "0x001"
   }
   action {
-    referring_action {
+    referring_to_two_match_fields_action {
       referring_id_1: "non-exist"
-      referring_id_2: "non-exist"
+      referring_id_2: "0x000"
     }
   }
   controller_metadata: "Root"
 }
 
 --- Unreachable entries from roots (output):
-referring_table_entry {
+one_match_field_table_entry {
+  match {
+    id: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+  controller_metadata: "Grand child Dependency"
+}
+
+referring_by_action_table_entry {
   match {
     val: "0x001"
   }
   action {
-    referring_action {
+    referring_to_two_match_fields_action {
       referring_id_1: "key-a"
-      referring_id_2: "non-existent"
+      referring_id_2: "0x000"
     }
   }
   controller_metadata: "NonRoot garbage"
 }
 
-referred_table_entry {
+one_match_field_table_entry {
   match {
     id: "key-b"
   }
@@ -1403,15 +1935,26 @@ referred_table_entry {
   controller_metadata: "NonRoot garbage"
 }
 
-referring_table_entry {
+referring_by_action_table_entry {
   match {
     val: "0x001"
   }
   action {
-    referring_action {
+    referring_to_two_match_fields_action {
       referring_id_1: "key-b"
-      referring_id_2: "non-existent"
+      referring_id_2: "0x000"
     }
   }
   controller_metadata: "NonRoot garbage"
+}
+
+one_match_field_table_entry {
+  match {
+    id: "key-c"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+  controller_metadata: "Dependency"
 }


### PR DESCRIPTION
### PR Description :
Refactor the test P4 program with tables and actions that make more sense with reference annotation.

### Build Results :
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS p4_pdpi/...
INFO: Analyzed 76 targets (6 packages loaded, 447 targets configured).
INFO: Found 76 targets...
INFO: Elapsed time: 26.937s, Critical Path: 7.40s
INFO: 39 processes: 7 internal, 32 linux-sandbox.
INFO: Build completed successfully, 39 total actions
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS p4rt_app/...
INFO: Analyzed 102 targets (18 packages loaded, 487 targets configured).
INFO: Found 102 targets...
INFO: Elapsed time: 1.108s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ 

### UT Results :
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4_pdpi/...
INFO: Analyzed 76 targets (0 packages loaded, 0 targets configured).
INFO: Found 45 targets and 31 test targets...
INFO: Elapsed time: 1.420s, Critical Path: 0.38s
INFO: 15 processes: 25 linux-sandbox.
INFO: Build completed successfully, 15 total actions
//p4_pdpi/netaddr:ipv4_address_and_network_address_test         (cached) PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                             (cached) PASSED in 0.3s
//p4_pdpi/netaddr:mac_address_test                              (cached) PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                       (cached) PASSED in 15.6s
//p4_pdpi/packetlib:packetlib_test                              (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                         (cached) PASSED in 1.0s
//p4_pdpi/string_encodings:bit_string_test                      (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                     (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                  (cached) PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner           (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                      (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner               (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test            (cached) PASSED in 0.2s
//p4_pdpi/testing:mock_p4_runtime_server_test                   (cached) PASSED in 0.4s
//p4_pdpi/utils:annotation_parser_test                          (cached) PASSED in 0.2s
//p4_pdpi/utils:ir_test                                         (cached) PASSED in 0.3s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.4s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.4s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.0s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.3s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s

Executed 14 out of 31 tests: 31 tests pass.
INFO: Build completed successfully, 15 total actions
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4rt_app/...
INFO: Analyzed 102 targets (0 packages loaded, 0 targets configured).
INFO: Found 66 targets and 36 test targets...
INFO: Elapsed time: 0.391s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//p4rt_app/event_monitoring:app_state_db_port_table_event_test  (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test     (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test      (cached) PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                        (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test            (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                   (cached) PASSED in 0.4s
//p4rt_app/p4runtime:packetio_helpers_test                      (cached) PASSED in 0.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test              (cached) PASSED in 0.4s
//p4rt_app/sonic:app_db_manager_test                            (cached) PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test              (cached) PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                             (cached) PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                             (cached) PASSED in 0.3s
//p4rt_app/sonic:response_handler_test                          (cached) PASSED in 0.4s
//p4rt_app/sonic:state_verification_test                        (cached) PASSED in 0.3s
//p4rt_app/sonic:vrf_entry_translation_test                     (cached) PASSED in 0.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test              (cached) PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                 (cached) PASSED in 1.2s
//p4rt_app/tests:action_set_test                                (cached) PASSED in 0.7s
//p4rt_app/tests:api_access_test                                (cached) PASSED in 0.7s
//p4rt_app/tests:arbitration_test                               (cached) PASSED in 0.7s
//p4rt_app/tests:fixed_l3_tables_test                           (cached) PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test                (cached) PASSED in 3.1s
//p4rt_app/tests:grpc_behavior_test                             (cached) PASSED in 5.0s
//p4rt_app/tests:p4_constraints_test                            (cached) PASSED in 0.1s
//p4rt_app/tests:p4_constraints_test_runner                     (cached) PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                               (cached) PASSED in 1.2s
//p4rt_app/tests:packetio_test                                  (cached) PASSED in 3.2s
//p4rt_app/tests:port_name_and_id_test                          (cached) PASSED in 0.8s
//p4rt_app/tests:response_path_test                             (cached) PASSED in 2.2s
//p4rt_app/tests:role_test                                      (cached) PASSED in 0.8s
//p4rt_app/tests:state_verification_test                        (cached) PASSED in 1.0s
//p4rt_app/tests/lib:app_db_entry_builder_test                  (cached) PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                        (cached) PASSED in 0.0s
//p4rt_app/utils:table_utility_test                             (cached) PASSED in 0.4s

Executed 0 out of 36 tests: 36 tests pass.
INFO: Build completed successfully, 1 total action
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ 
