### PR TITLE
PR4 - Added p4_fuzzer, a library for fuzzing P4Runtime requests.

### DIFF
--- a/p4_fuzzer/BUILD.bazel
+++ b/p4_fuzzer/BUILD.bazel
@@ -7,6 +7,20 @@ package(
     licenses = ["notice"],
 )
 
+proto_library(
+    name = "fuzzer_proto",
+    srcs = ["fuzzer.proto"],
+    deps = [
+        "//p4_pdpi:ir_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "fuzzer_cc_proto",
+    deps = [":fuzzer_proto"],
+)
+
 cc_library(
     name = "p4_programs/sai-p4-google/ids",
     hdrs = ["p4_programs/sai-p4-google/ids.h"],

--- a/p4_fuzzer/BUILD.bazel
+++ b/p4_fuzzer/BUILD.bazel
@@ -7,6 +7,11 @@ package(
     licenses = ["notice"],
 )
 
+cc_library(
+    name = "p4_programs/sai-p4-google/ids",
+    hdrs = ["p4_programs/sai-p4-google/ids.h"],
+)
+
 p4_library(
     name = "single_table_single_entry",
     src = "p4_programs/single_table_single_entry.p4",
@@ -23,5 +28,19 @@ p4_library(
     name = "constraints_not_equals",
     src = "p4_programs/constraints_not_equals.p4",
     p4info_out = "constraints_not_equals.p4info.pb.txt",
+)
+
+p4_library(
+    name = "acl_table_test",
+    src = "p4_programs/acl_table_test.p4",
+    p4info_out = "acl_table_test.p4info.pb.txt",
+    deps = [
+        "p4_programs/sai-p4-google/acl_actions.p4",
+        "p4_programs/sai-p4-google/acl_set_vrf.p4",
+        "p4_programs/sai-p4-google/headers.p4",
+        "p4_programs/sai-p4-google/ids.h",
+        "p4_programs/sai-p4-google/metadata.p4",
+        "p4_programs/sai-p4-google/resource_limits.p4",
+    ],
 )
 

--- a/p4_fuzzer/BUILD.bazel
+++ b/p4_fuzzer/BUILD.bazel
@@ -58,3 +58,10 @@ p4_library(
     ],
 )
 
+p4_library(
+    name = "sai_main",
+    src = "p4_programs/sai-p4-google/sai_main.p4",
+    p4info_out = "sai_main_info.pb.txt",
+    deps = glob(["p4_programs/sai-p4-google/*"]),
+)
+

--- a/p4_fuzzer/fuzzer.proto
+++ b/p4_fuzzer/fuzzer.proto
@@ -1,0 +1,122 @@
+syntax = "proto3";
+
+package p4_fuzzer;
+
+import "p4/v1/p4runtime.proto";
+import "p4_pdpi/ir.proto";
+
+// The types of mutations p4-fuzzer can perform on a given table entry.
+enum Mutation {
+  // Change a valid table identifier in a table entry to one that does
+  // not exist in the P4Info file associated with the P4 program.
+  INVALID_TABLE_ID = 0;
+
+  // Works the same way as INVALID_TABLE_ID but acts on action
+  // identifiers.
+  INVALID_ACTION_ID = 1;
+
+  // Works the same way as INVALID_TABLE_ID but acts on match field
+  // identifiers.
+  INVALID_MATCH_FIELD_ID = 2;
+
+  // Removes a mandatory match field from a table entry.
+  MISSING_MANDATORY_MATCH_FIELD = 3;
+
+  // Duplicates a match field in a table entry.
+  DUPLICATE_MATCH_FIELD = 4;
+
+  // Picks table entry fields and changes their value to randomly generated ones
+  // of the same type.
+  INVALID_GENERIC = 5;
+
+  // Changes a table entry with an ActionProfileActionSet (intended for tables
+  // that implement one-shot action selector programming) to a table that
+  // expects a single action and vice versa.
+  INVALID_TABLE_IMPLEMENTATION = 6;
+
+  // Picks an action_profile_action and sets its weight to zero.
+  INVALID_ACTION_SELECTOR_WEIGHT = 7;
+
+  // Attempts to insert a table entry that is a duplicate of an already inserted
+  // table entry.
+  DUPLICATE_INSERT = 8;
+
+  // Attempts to delete a table entry that does not exist in the switch.
+  NONEXISTING_DELETE = 9;
+}
+
+// Human readable version of a (fuzzed) table entry. Contains the original
+// P4Runtime table entry (pi) and either a more readable program
+// dependent version of the table entry translated using p4-pdpi or an error
+// message if translation was attempted and failed.
+message AnnotatedTableEntry {
+  // The P4 runtime spec table entry (program independent representation).
+  p4.v1.TableEntry pi = 1;
+
+  oneof pd {
+    // An error message in case a conversion from the program independent
+    // version of the table entry (pi) to the program dependent version (ir)
+    // failed.
+    string error = 2;
+
+    // The PDPI program dependent representation of a table entry.
+    pdpi.IrTableEntry ir = 3;
+  }
+
+  repeated Mutation mutations = 4;
+}
+
+// Like AnnotatedTableEntry, but for updates instead.
+message AnnotatedUpdate {
+  p4.v1.Update pi = 1;
+
+  oneof pd {
+    string error = 2;
+
+    pdpi.IrUpdate ir = 3;
+  }
+
+  repeated Mutation mutations = 4;
+}
+
+// Like AnnotatedTableEntry, but for write requests.
+message AnnotatedWriteRequest {
+  uint64 device_id = 1;
+  p4.v1.Uint128 election_id = 2;
+  repeated AnnotatedUpdate updates = 3;
+}
+
+// Logs fuzzed requests (both correct and incorrect) along with their responses.
+// This is primarily intended for debugging and analysis.
+message Request {
+  // 0-based batch number
+  int64 batch_id = 1;
+
+  // Unix timestamp for the request, in milliseconds.
+  int64 timestamp_request = 2;
+
+  // Unix timestamp for the response, in milliseconds.
+  int64 timestamp_response = 3;
+
+  // The P4 write request (program independent representation)
+  p4.v1.WriteRequest pi = 4;
+
+  // TODO: add a program dependent representation after understanding
+  // p4-pdpi. Reserving field 5 for now.
+  reserved 5;
+
+  // TODO: add an open-source Status proto message. Reserving field 6
+  // for now.
+  reserved 6;
+
+  // List of errors, according to fuzzing oracle
+  repeated string errors = 7;
+
+  // The number of updates sent by the fuzzer prior to the current request.
+  // Helpful for tracking fuzzer progress.
+  int64 num_prior_updates = 8;
+}
+
+message Requests {
+  repeated Request requests = 1;
+}

--- a/p4_fuzzer/p4_programs/acl_table_test.p4
+++ b/p4_fuzzer/p4_programs/acl_table_test.p4
@@ -1,0 +1,72 @@
+/* -*- P4_16 -*- */
+#include <core.p4>
+#include <v1model.p4>
+#include "sai-p4-google/acl_set_vrf.p4"
+
+// -- Headers.
+header hdr_fuzz_t {
+    bit<8> fuzz_field_1;
+}
+
+struct metadata {
+}
+
+
+// -- Parsers.
+parser MyParser(packet_in packet,
+                out headers_t hdr,
+                inout local_metadata_t meta,
+                inout standard_metadata_t standard_metadata) {
+
+    state start {
+        transition accept;
+    }
+}
+
+
+// -- Checksum verification.
+control MyVerifyChecksum(inout headers_t hdr, inout local_metadata_t meta) {
+    apply {  }
+}
+
+
+// -- Ingress processing.
+control MyIngress(inout headers_t hdr,
+                  inout local_metadata_t meta,
+                  inout standard_metadata_t standard_metadata) {
+  apply {
+    acl_set_vrf.apply(hdr, meta, standard_metadata);
+ }
+}
+
+// -- Egress processing.
+control MyEgress(inout headers_t hdr,
+                 inout local_metadata_t meta,
+                 inout standard_metadata_t standard_metadata) {
+    apply {  }
+}
+
+// -- Checksum computation.
+control MyComputeChecksum(inout headers_t hdr, inout local_metadata_t meta) {
+     apply {
+
+    }
+}
+
+
+// -- Deparser.
+control MyDeparser(packet_out packet, in headers_t hdr) {
+    apply {
+    }
+}
+
+// -- Switch.
+// Switch architecture.
+V1Switch(
+MyParser(),
+MyVerifyChecksum(),
+MyIngress(),
+MyEgress(),
+MyComputeChecksum(),
+MyDeparser()
+) main;

--- a/p4_fuzzer/p4_programs/sai-p4-google/acl_actions.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/acl_actions.p4
@@ -1,0 +1,23 @@
+#ifndef SAI_ACL_ACTIONS_P4_
+#define SAI_ACL_ACTIONS_P4_
+
+#include "v1model.p4"
+
+// User defined ACL tables can use the actions from this file.
+
+// Copy the packet to the CPU. The original packet proceeds unmodified.
+@id(ACL_COPY_ACTION_ID)
+@sai_action(SAI_PACKET_ACTION_COPY)
+action copy(inout standard_metadata_t standard_metadata) {
+  clone(CloneType.I2E, COPY_TO_CPU_SESSION_ID);
+}
+
+// Copy the packet to the CPU. The original packet is dropped.
+@id(ACL_TRAP_ACTION_ID)
+@sai_action(SAI_PACKET_ACTION_TRAP)
+action trap(inout standard_metadata_t standard_metadata) {
+  copy(standard_metadata);
+  mark_to_drop(standard_metadata);
+}
+
+#endif  // SAI_ACL_ACTIONS_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/acl_punt.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/acl_punt.p4
@@ -1,0 +1,49 @@
+#ifndef SAI_ACL_PUNT_P4_
+#define SAI_ACL_PUNT_P4_
+
+#include "v1model.p4"
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+#include "resource_limits.p4"
+#include "acl_actions.p4"
+
+control acl_punt(inout headers_t headers,
+                 inout local_metadata_t local_metadata,
+                 inout standard_metadata_t standard_metadata) {
+
+  @proto_package("sai")
+  @id(ACL_PUNT_TABLE_ID)
+  @sai_acl(INGRESS)
+  table sai_punt_table {
+    key = {
+      headers.ethernet.ether_type : ternary @name("ether_type") @id(1)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE);
+      headers.ethernet.dst_addr : ternary @name("ether_dst") @id(2)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_DST_MAC) @format(MAC_ADDRESS);
+      headers.ipv6.dst_addr : ternary @name("ipv6_dst") @id(3)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6) @format(IPV6_ADDRESS);
+      headers.ipv6.next_header : ternary @name("ipv6_next_header") @id(4)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_IPV6_NEXT_HEADER);
+      headers.ipv6.hop_limit : ternary @name("ttl") @id(5)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_TTL);
+      headers.icmp.type : ternary @name("icmp_type") @id(6)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_ICMP_TYPE);
+      local_metadata.l4_dst_port : ternary @name("l4_dst_port") @id(7)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_L4_DST_PORT);
+    }
+    actions = {
+      @proto_id(1) copy(standard_metadata);
+      @proto_id(2) trap(standard_metadata);
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    size = PUNT_TABLE_SIZE;
+  }
+
+  apply {
+    sai_punt_table.apply();
+  }
+}  // control acl_punt
+
+#endif  // SAI_ACL_PUNT_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/acl_set_vrf.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/acl_set_vrf.p4
@@ -1,0 +1,48 @@
+#ifndef SAI_ACL_SET_VRF_P4_
+#define SAI_ACL_SET_VRF_P4_
+
+#include "v1model.p4"
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+#include "resource_limits.p4"
+#include "acl_actions.p4"
+
+control acl_set_vrf(inout headers_t headers,
+                    inout local_metadata_t local_metadata,
+                    inout standard_metadata_t standard_metadata) {
+
+  @id(ACL_SET_VRF_SET_VRF_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD)
+  action set_vrf(@sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_SET_VRF)
+                 @id(1) vrf_id_t vrf_id) {
+    local_metadata.vrf_id = vrf_id;
+  }
+
+  @proto_package("sai")
+  @id(ACL_SET_VRF_TABLE_ID)
+  @sai_acl(PREINGRESS)
+  @entry_constraint("ether_type == 0x86DD")
+  table set_vrf_table {
+    key = {
+      headers.ethernet.ether_type : exact @name("ether_type") @id(1)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE);
+      headers.ipv6.dst_addr : ternary @name("ipv6_dst") @id(2)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6) @format(IPV6_ADDRESS);
+      headers.ipv6.dscp : ternary @name("dscp") @id(3)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_DSCP);
+    }
+    actions = {
+      @proto_id(1) set_vrf;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    size = SET_VRF_TABLE_SIZE;
+  }
+
+  apply {
+    set_vrf_table.apply();
+  }
+}  // control acl_set_vrf
+
+#endif  // SAI_ACL_SET_VRF_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/headers.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/headers.p4
@@ -1,0 +1,119 @@
+#ifndef SAI_HEADERS_P4_
+#define SAI_HEADERS_P4_
+
+#define ETHERTYPE_IPV4  0x0800
+#define ETHERTYPE_IPV6  0x86dd
+#define ETHERTYPE_ARP   0x0806
+#define ETHERTYPE_LLDP  0x88CC
+
+#define IP_PROTOCOL_TCP    0x06
+#define IP_PROTOCOL_UDP    0x11
+#define IP_PROTOCOL_ICMP   0x01
+#define IP_PROTOCOL_ICMPV6 0x3a
+
+typedef bit<48> ethernet_addr_t;
+typedef bit<32> ipv4_addr_t;
+typedef bit<128> ipv6_addr_t;
+typedef bit<32> portid_t;
+
+// -- Protocol headers ---------------------------------------------------------
+
+header ethernet_t {
+  ethernet_addr_t dst_addr;
+  ethernet_addr_t src_addr;
+  bit<16> ether_type;
+}
+
+header ipv4_t {
+  bit<4> version;
+  bit<4> ihl;
+  bit<6> dscp;  // The 6 most significant bits of the diff_serv field.
+  bit<2> ecn;   // The 2 least significant bits of the diff_serv field.
+  bit<16> total_len;
+  bit<16> identification;
+  bit<3> flags;
+  bit<13> frag_offset;
+  bit<8> ttl;
+  bit<8> protocol;
+  bit<16> header_checksum;
+  ipv4_addr_t src_addr;
+  ipv4_addr_t dst_addr;
+}
+
+header ipv6_t {
+  bit<4> version;
+  bit<6> dscp;  // The 6 most significant bits of the traffic_class field.
+  bit<2> ecn;   // The 2 least significant bits of the traffic_class field.
+  bit<20> flow_label;
+  bit<16> payload_length;
+  bit<8> next_header;
+  bit<8> hop_limit;
+  ipv6_addr_t src_addr;
+  ipv6_addr_t dst_addr;
+}
+
+header udp_t {
+  bit<16> src_port;
+  bit<16> dst_port;
+  bit<16> hdr_length;
+  bit<16> checksum;
+}
+
+header tcp_t {
+  bit<16> src_port;
+  bit<16> dst_port;
+  bit<32> seq_no;
+  bit<32> ack_no;
+  bit<4> data_offset;
+  bit<4> res;
+  bit<8> flags;
+  bit<16> window;
+  bit<16> checksum;
+  bit<16> urgent_ptr;
+}
+
+header icmp_t {
+  bit<8> type;
+  bit<8> code;
+  bit<16> checksum;
+}
+
+header arp_t {
+  bit<16> hw_type;
+  bit<16> proto_type;
+  bit<8> hw_addr_len;
+  bit<8> proto_addr_len;
+  bit<16> opcode;
+  bit<48> sender_hw_addr;
+  bit<32> sender_proto_addr;
+  bit<48> target_hw_addr;
+  bit<32> target_proto_addr;
+}
+
+// -- Packet IO headers --------------------------------------------------------
+
+@controller_header("packet_in")
+header packet_in_header_t {
+  // The port the packet ingressed on.
+  @id(1)
+  portid_t ingress_port;
+  // The initial intended egress port decided for the packet by the pipeline.
+  @id(2)
+  portid_t target_egress_port;
+}
+
+@controller_header("packet_out")
+header packet_out_header_t {
+  // The port this packet should egress out of.
+  @id(1)
+  portid_t egress_port;
+  // Should the packet be submitted to the ingress pipeline instead of being
+  // sent directly?
+  @id(2)
+  bit<1> submit_to_ingress;
+  // BMV2 backend requires headers to be multiple of 8-bits.
+  @id(3)
+  bit<7> unused_pad;
+}
+
+#endif  // SAI_HEADERS_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/ids.h
+++ b/p4_fuzzer/p4_programs/sai-p4-google/ids.h
@@ -1,0 +1,56 @@
+// Rename this for the open source version.
+#ifndef P4_SAI_IDS_H_
+#define P4_SAI_IDS_H_
+
+// All declarations (tables, actions, action profiles, meters, counters) have a
+// stable ID. This list will evolve as new declarations are added. IDs cannot be
+// reused. If a declaration is removed, its ID macro is kept and marked reserved
+// to avoid the ID being reused.
+//
+// The IDs are classified using the 8 most significant bits to be compatible
+// with "6.3. ID Allocation for P4Info Objects" in the P4Runtime specification.
+
+// IDs of fixed SAI tables (8 most significant bits = 0x02).
+#define ROUTING_NEIGHBOR_TABLE_ID 0x02000040          // 33554496
+#define ROUTING_ROUTER_INTERFACE_TABLE_ID 0x02000041  // 33554497
+#define ROUTING_NEXTHOP_TABLE_ID 0x02000042           // 33554498
+#define ROUTING_WCMP_GROUP_TABLE_ID 0x02000043        // 33554499
+#define ROUTING_IPV4_TABLE_ID 0x02000044              // 33554500
+#define ROUTING_IPV6_TABLE_ID 0x02000045              // 33554501
+
+// IDs of ACL tables (8 most significant bits = 0x02).
+// Since these IDs are user defined, they need to be separate from the fixed SAI
+// table ID space. We achieve this by starting the IDs at 0x100.
+#define ACL_PUNT_TABLE_ID 0x02000100     // 33554688
+#define ACL_SET_VRF_TABLE_ID 0x02000101  // 33554689
+
+// IDs of fixed SAI actions (8 most significant bits = 0x01).
+#define ROUTING_SET_DST_MAC_ACTION_ID 0x01000001           // 16777217
+#define ROUTING_SET_PORT_AND_SRC_MAC_ACTION_ID 0x01000002  // 16777218
+#define ROUTING_SET_NEXTHOP_ACTION_ID 0x01000003           // 16777219
+#define ROUTING_SET_WCMP_GROUP_ID_ACTION_ID 0x01000004     // 16777220
+#define ROUTING_SET_NEXTHOP_ID_ACTION_ID 0x01000005        // 16777221
+#define ROUTING_DROP_ACTION_ID 0x01000006                  // 16777222
+#define ACL_COPY_ACTION_ID 0x01000007                      // 16777223
+#define ACL_TRAP_ACTION_ID 0x01000008                      // 16777224
+
+// IDs of ACL actions (8 most significant bits = 0x01).
+// Since these IDs are user defined, they need to be separate from the fixed SAI
+// actions ID space. We achieve this by starting the IDs at 0x100.
+#define ACL_SET_VRF_SET_VRF_ACTION_ID 0x01000100  // 16777472
+
+// The COPY_TO_CPU_SESSION_ID must be programmed in the target using P4Runtime:
+//
+// type: INSERT
+// entity {
+//   packet_replication_engine_entry {
+//     clone_session_entry {
+//       session_id: COPY_TO_CPU_SESSION_ID
+//       replicas { egress_port: 0xfffffffd } # to CPU
+//     }
+//   }
+// }
+//
+#define COPY_TO_CPU_SESSION_ID 1024
+
+#endif  // P4_SAI_IDS_H_

--- a/p4_fuzzer/p4_programs/sai-p4-google/ipv4_checksum.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/ipv4_checksum.p4
@@ -1,0 +1,37 @@
+#ifndef SAI_IPV4_CHECKSUM_H_
+#define SAI_IPV4_CHECKSUM_H_
+
+#include "headers.p4"
+#include "metadata.p4"
+
+// IPv6 does not have a checksum, so this code is only for IPv4.
+
+control verify_ipv4_checksum(inout headers_t headers,
+                             inout local_metadata_t local_metadata) {
+  apply {
+    verify_checksum(headers.ipv4.isValid(),
+      {headers.ipv4.version, headers.ipv4.ihl,
+       headers.ipv4.dscp, headers.ipv4.ecn, headers.ipv4.total_len,
+       headers.ipv4.identification, headers.ipv4.flags,
+       headers.ipv4.frag_offset, headers.ipv4.ttl,
+       headers.ipv4.protocol, headers.ipv4.src_addr,
+       headers.ipv4.dst_addr}, headers.ipv4.header_checksum,
+       HashAlgorithm.csum16);
+  }
+}  // control verify_ipv4_checksum
+
+control compute_ipv4_checksum(inout headers_t headers,
+                              inout local_metadata_t local_metadata) {
+  apply {
+    update_checksum(headers.ipv4.isValid(),
+      {headers.ipv4.version, headers.ipv4.ihl,
+       headers.ipv4.dscp, headers.ipv4.ecn, headers.ipv4.total_len,
+       headers.ipv4.identification, headers.ipv4.flags,
+       headers.ipv4.frag_offset, headers.ipv4.ttl,
+       headers.ipv4.protocol, headers.ipv4.src_addr,
+       headers.ipv4.dst_addr}, headers.ipv4.header_checksum,
+       HashAlgorithm.csum16);
+  }
+}  // control compute_ipv4_checksum
+
+#endif  // SAI_IPV4_CHECKSUM_H_

--- a/p4_fuzzer/p4_programs/sai-p4-google/metadata.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/metadata.p4
@@ -1,0 +1,42 @@
+#ifndef SAI_METADATA_P4_
+#define SAI_METADATA_P4_
+
+#include "headers.p4"
+#include "resource_limits.p4"
+
+@p4runtime_translation("", 32)
+type bit<MAX_NEXTHOPS_LOG2> nexthop_id_t;
+
+@p4runtime_translation("", 32)
+type bit<MAX_WCMP_GROUPS_LOG2> wcmp_group_id_t;
+
+@p4runtime_translation("", 32)
+type bit<MAX_VRFS_LOG2> vrf_id_t;
+
+@p4runtime_translation("", 32)
+type bit<MAX_ROUTER_INTERFACES_LOG2> router_interface_id_t;
+
+@p4runtime_translation("", 32)
+type bit<MAX_NEIGHBORS_LOG2> neighbor_id_t;
+
+@p4runtime_translation("", 32)
+type bit<MAX_PORTS_LOG2> port_id_t;
+
+struct headers_t {
+  ethernet_t ethernet;
+  ipv4_t ipv4;
+  ipv6_t ipv6;
+  icmp_t icmp;
+  tcp_t tcp;
+  udp_t udp;
+  arp_t arp;
+}
+
+// Local metadata for each packet being processed.
+struct local_metadata_t {
+  vrf_id_t vrf_id;
+  bit<16> l4_src_port;
+  bit<16> l4_dst_port;
+}
+
+#endif  // SAI_METADATA_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/parser.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/parser.p4
@@ -1,0 +1,84 @@
+#ifndef SAI_PARSER_P4_
+#define SAI_PARSER_P4_
+
+#include "v1model.p4"
+#include "headers.p4"
+#include "metadata.p4"
+
+parser packet_parser(packet_in packet, out headers_t headers,
+                     inout local_metadata_t local_metadata,
+                     inout standard_metadata_t standard_metadata) {
+  state start {
+    transition parse_ethernet;
+  }
+
+  state parse_ethernet {
+    packet.extract(headers.ethernet);
+    transition select(headers.ethernet.ether_type) {
+      ETHERTYPE_IPV4: parse_ipv4;
+      ETHERTYPE_IPV6: parse_ipv6;
+      ETHERTYPE_ARP:  parse_arp;
+      _:              accept;
+    }
+  }
+
+  state parse_ipv4 {
+    packet.extract(headers.ipv4);
+    transition select(headers.ipv4.protocol) {
+      IP_PROTOCOL_ICMP: parse_icmp;
+      IP_PROTOCOL_TCP:  parse_tcp;
+      IP_PROTOCOL_UDP:  parse_udp;
+      _:                accept;
+    }
+  }
+
+  state parse_ipv6 {
+    packet.extract(headers.ipv6);
+    transition select(headers.ipv6.next_header) {
+      IP_PROTOCOL_ICMPV6: parse_icmp;
+      IP_PROTOCOL_TCP:    parse_tcp;
+      IP_PROTOCOL_UDP:    parse_udp;
+      _:                  accept;
+    }
+  }
+
+  state parse_tcp {
+    packet.extract(headers.tcp);
+    // Normalize TCP port metadata to common port metadata.
+    local_metadata.l4_src_port = headers.tcp.src_port;
+    local_metadata.l4_dst_port = headers.tcp.dst_port;
+    transition accept;
+  }
+
+  state parse_udp {
+    packet.extract(headers.udp);
+    // Normalize UDP port metadata to common port metadata.
+    local_metadata.l4_src_port = headers.udp.src_port;
+    local_metadata.l4_dst_port = headers.udp.dst_port;
+    transition accept;
+  }
+
+  state parse_icmp {
+    packet.extract(headers.icmp);
+    transition accept;
+  }
+
+  state parse_arp {
+    packet.extract(headers.arp);
+    transition accept;
+  }
+}  // parser packet_parser
+
+control packet_deparser(packet_out packet, in headers_t headers) {
+  apply {
+    packet.emit(headers.ethernet);
+    packet.emit(headers.ipv4);
+    packet.emit(headers.ipv6);
+    packet.emit(headers.arp);
+    packet.emit(headers.icmp);
+    packet.emit(headers.tcp);
+    packet.emit(headers.udp);
+  }
+}  // control packet_deparser
+
+#endif  // SAI_PARSER_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/punt_acl.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/punt_acl.p4
@@ -1,0 +1,47 @@
+#ifndef SAI_PUNT_ACL_P4_
+#define SAI_PUNT_ACL_P4_
+
+#include "v1model.p4"
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+#include "resource_limits.p4"
+#include "acl_actions.p4"
+
+control punt_acl(inout headers_t headers,
+                 inout local_metadata_t local_metadata,
+                 inout standard_metadata_t standard_metadata) {
+
+  @proto_package("punt")
+  @id(PUNT_ACL_TABLE_ID)
+  @sai_acl(INGRESS)
+  table punt_table {
+    key = {
+      headers.ethernet.ether_type : ternary @name("ether_type")
+          @proto_tag(1) @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE);
+      headers.ethernet.dst_addr : ternary @name("ether_dst")
+          @proto_tag(2) @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_DST_MAC);
+      headers.ipv6.dst_addr : ternary @name("ipv6_dst")
+          @proto_tag(3) @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6);
+      headers.ipv6.next_header : ternary @name("ipv6_next_header")
+          @proto_tag(4) @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_IPV6_NEXT_HEADER);
+      headers.ipv6.hop_limit : ternary @name("ttl")
+          @proto_tag(5) @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_TTL);
+      headers.icmp.type : ternary @name("icmp_type")
+          @proto_tag(6) @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_ICMP_TYPE);
+      local_metadata.l4_dst_port : ternary @name("l4_dst_port")
+          @proto_tag(7) @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_L4_DST_PORT);
+    }
+    actions = {
+      @proto_tag(1) copy(standard_metadata);
+      @proto_tag(2) trap(standard_metadata);
+    }
+    size = PUNT_TABLE_SIZE;
+  }
+
+  apply {
+    punt_table.apply();
+  }
+}  // control punt_acl
+
+#endif  // SAI_PUNT_ACL_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/resource_limits.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/resource_limits.p4
@@ -1,0 +1,30 @@
+#ifndef SAI_RESOURCE_LIMITS_P4_
+#define SAI_RESOURCE_LIMITS_P4_
+
+#define MAX_PORTS_LOG2 9
+
+#define MAX_VRFS_LOG2 10
+
+#define MAX_NEXTHOPS 1024
+#define MAX_NEXTHOPS_LOG2 10
+
+#define MAX_NEIGHBORS 1024
+#define MAX_NEIGHBORS_LOG2 10
+
+#define MAX_ROUTER_INTERFACES 1024
+#define MAX_ROUTER_INTERFACES_LOG2 10
+
+// The maximum number of wcmp groups.
+#define MAX_WCMP_GROUPS 4096
+#define MAX_WCMP_GROUPS_LOG2 12
+
+// The maximum sum of weights across all wcmp groups.
+#define MAX_WCMP_GROUPS_SUM_OF_WEIGHTS 65536
+
+// The maximum sum of weights for each wcmp group.
+#define MAX_WCMP_GROUP_SUM_OF_WEIGHTS_LOG2 7
+
+#define PUNT_TABLE_SIZE 128
+#define SET_VRF_TABLE_SIZE 256
+
+#endif  // SAI_RESOURCE_LIMITS_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/routing.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/routing.p4
@@ -1,0 +1,251 @@
+#ifndef SAI_ROUTING_P4_
+#define SAI_ROUTING_P4_
+
+#include "v1model.p4"
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+#include "resource_limits.p4"
+
+// This control block models the L3 routing pipeline.
+//
+// +-------+   +-------+ wcmp  +---------+       +-----------+
+// |  lpm  |-->| group |------>| nexthop |----+->| router    |--> egress_port
+// |       |   |       |------>|         |-+  |  | interface |--> src_mac
+// +-------+   +-------+       +---------+ |  |  +-----------+
+//   |   |                         ^       |  |  +-----------+
+//   |   |                         |       |  +->| neighbor  |
+//   V   +-------------------------+       +---->|           |--> dst_mac
+//  drop                                         +-----------+
+//
+// The pipeline first performs a longest prefix match on the packet's
+// destination IP address. The action associated with the match then either
+// drops the packet, points to a nexthop, or points to a wcmp group which uses a
+// hash of the packet to choose from a set of nexthops. The nexthop points to a
+// router interface, which determines the packet's src_mac and the egress_port
+// to forward the packet to. The nexthop also points to a neighbor which,
+// together with the router_interface, determines the packet's dst_mac.
+control routing(inout headers_t headers,
+                inout local_metadata_t local_metadata,
+                inout standard_metadata_t standard_metadata) {
+  // Wcmp group id, only valid if `wcmp_group_id_valid` is true.
+  bool wcmp_group_id_valid = false;
+  wcmp_group_id_t wcmp_group_id_value;
+
+  // Nexthop id, only valid if `nexthop_id_valid` is true.
+  bool nexthop_id_valid = false;
+  nexthop_id_t nexthop_id_value;
+
+  // Router interface id, only valid if `router_interface_id_valid` is true.
+  bool router_interface_id_valid = false;
+  router_interface_id_t router_interface_id_value;
+
+  // Neighbor id, only valid if `neighbor_id_valid` is true.
+  bool neighbor_id_valid = false;
+  neighbor_id_t neighbor_id_value;
+
+  const bit<1> HASH_BASE_CRC16 = 1w0;
+  const bit<14> HASH_MAX_CRC16 = 14w1024;
+  bit<MAX_WCMP_GROUP_SUM_OF_WEIGHTS_LOG2> wcmp_selector_input = 0;
+
+  // Sets SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS.
+  @id(ROUTING_SET_DST_MAC_ACTION_ID)
+  action set_dst_mac(@id(1) @format(MAC_ADDRESS) ethernet_addr_t dst_mac) {
+    headers.ethernet.dst_addr = dst_mac;
+  }
+
+  @proto_package("sai")
+  @id(ROUTING_NEIGHBOR_TABLE_ID)
+  table neighbor_table {
+    key = {
+      // Sets rif_id in sai_neighbor_entry_t.
+      router_interface_id_value : exact @id(1)
+                                        @name("router_interface_id");
+      // Sets ip_address in sai_neighbor_entry_t.
+      neighbor_id_value : exact @id(2) @name("neighbor_id");
+    }
+    actions = {
+      @proto_id(1) set_dst_mac;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+  }
+
+  // Sets SAI_ROUTER_INTERFACE_ATTR_TYPE to SAI_ROUTER_INTERFACE_TYPE_PORT, and
+  // SAI_ROUTER_INTERFACE_ATTR_PORT_ID, and
+  // SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS.
+  @id(ROUTING_SET_PORT_AND_SRC_MAC_ACTION_ID)
+  action set_port_and_src_mac(@id(1) port_id_t port_id,
+                              @id(2) @format(MAC_ADDRESS)
+                              ethernet_addr_t src_mac) {
+    // Cast is necessary, because v1model does not define port using `type`.
+    standard_metadata.egress_spec = (bit<MAX_PORTS_LOG2>)port_id;
+    headers.ethernet.src_addr = src_mac;
+  }
+
+  @proto_package("sai")
+  @id(ROUTING_ROUTER_INTERFACE_TABLE_ID)
+  table router_interface_table {
+    key = {
+      router_interface_id_value : exact @id(1)
+                                        @name("router_interface_id");
+    }
+    actions = {
+      @proto_id(1) set_port_and_src_mac;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+  }
+
+  // Sets SAI_NEXT_HOP_ATTR_TYPE to SAI_NEXT_HOP_TYPE_IP, and
+  // SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID, and SAI_NEXT_HOP_ATTR_IP.
+  //
+  // This action can only refer to `router_interface_id`s and `neighbor_id`s
+  // that are programmed in the `router_interface_table` and `neighbor_table`.
+  @id(ROUTING_SET_NEXTHOP_ACTION_ID)
+  action set_nexthop(@id(1) router_interface_id_t router_interface_id,
+                     @id(2) neighbor_id_t neighbor_id) {
+    router_interface_id_valid = true;
+    router_interface_id_value = router_interface_id;
+    neighbor_id_valid = true;
+    neighbor_id_value = neighbor_id;
+  }
+
+  @proto_package("sai")
+  @id(ROUTING_NEXTHOP_TABLE_ID)
+  table nexthop_table {
+    key = {
+      nexthop_id_value : exact @id(1) @name("nexthop_id");
+    }
+    actions = {
+      @proto_id(1) set_nexthop;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+  }
+
+  // When called from a route, sets SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION to
+  // SAI_PACKET_ACTION_FORWARD, and SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID to a
+  // SAI_OBJECT_TYPE_NEXT_HOP.
+  //
+  // When called from a group, sets SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID.
+  //
+  // This action can only refer to `nexthop_id`s that are programmed in the
+  // `nexthop_table`.
+  @id(ROUTING_SET_NEXTHOP_ID_ACTION_ID)
+  action set_nexthop_id(@id(1) nexthop_id_t nexthop_id) {
+    nexthop_id_valid = true;
+    nexthop_id_value = nexthop_id;
+  }
+
+  action_selector(HashAlgorithm.identity,
+                  MAX_WCMP_GROUPS_SUM_OF_WEIGHTS,
+                  MAX_WCMP_GROUP_SUM_OF_WEIGHTS_LOG2) wcmp_group_selector;
+
+  @proto_package("sai")
+  @id(ROUTING_WCMP_GROUP_TABLE_ID)
+  @weight_proto_id(1)
+  @oneshot()
+  @weight_proto_tag(2)  // Sets SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT.
+  table wcmp_group_table {
+    key = {
+      wcmp_group_id_value : exact @id(1) @name("wcmp_group_id");
+      wcmp_selector_input : selector;
+    }
+    actions = {
+      @proto_id(1) set_nexthop_id;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    implementation = wcmp_group_selector;
+  }
+
+  // Sets SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION to SAI_PACKET_ACTION_DROP.
+  @id(ROUTING_DROP_ACTION_ID)
+  action drop() {
+    mark_to_drop(standard_metadata);
+  }
+
+  // Sets SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION to SAI_PACKET_ACTION_FORWARD, and
+  // SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID to a SAI_OBJECT_TYPE_NEXT_HOP_GROUP.
+  //
+  // This action can only refer to `wcmp_group_id`s that are programmed in the
+  // `wcmp_group_table`.
+  @id(ROUTING_SET_WCMP_GROUP_ID_ACTION_ID)
+  action set_wcmp_group_id(@id(1) wcmp_group_id_t wcmp_group_id) {
+    wcmp_group_id_valid = true;
+    wcmp_group_id_value = wcmp_group_id;
+  }
+
+  @proto_package("sai")
+  @id(ROUTING_IPV4_TABLE_ID)
+  table ipv4_table {
+    key = {
+      // Sets vr_id in sai_route_entry_t.
+      local_metadata.vrf_id : exact @id(1) @name("vrf_id");
+      // Sets destination in sai_route_entry_t to an IPv4 prefix.
+      headers.ipv4.dst_addr : lpm @format(IPV4_ADDRESS) @id(2)
+                                  @name("ipv4_dst");
+    }
+    actions = {
+      @proto_id(1) drop;
+      @proto_id(2) set_nexthop_id;
+      @proto_id(3) set_wcmp_group_id;
+    }
+    const default_action = drop;
+  }
+
+  @proto_package("sai")
+  @id(ROUTING_IPV6_TABLE_ID)
+  table ipv6_table {
+    key = {
+      // Sets vr_id in sai_route_entry_t.
+      local_metadata.vrf_id : exact @id(1) @name("vrf_id");
+      // Sets destination in sai_route_entry_t to an IPv6 prefix.
+      headers.ipv6.dst_addr : lpm @format(IPV6_ADDRESS) @id(2)
+                                  @name("ipv6_dst");
+    }
+    actions = {
+      @proto_id(1) drop;
+      @proto_id(2) set_nexthop_id;
+      @proto_id(3) set_wcmp_group_id;
+    }
+    const default_action = drop;
+  }
+
+  apply {
+    if (headers.ipv4.isValid()) {
+      hash(wcmp_selector_input, HashAlgorithm.crc16, HASH_BASE_CRC16, {
+           headers.ipv4.dst_addr, headers.ipv4.src_addr,
+           local_metadata.l4_src_port, local_metadata.l4_dst_port},
+           HASH_MAX_CRC16);
+      ipv4_table.apply();
+    } else if (headers.ipv6.isValid()) {
+      hash(wcmp_selector_input, HashAlgorithm.crc16, HASH_BASE_CRC16, {
+           headers.ipv6.dst_addr, headers.ipv6.src_addr,
+           headers.ipv6.flow_label[15:0], local_metadata.l4_src_port,
+           local_metadata.l4_dst_port}, HASH_MAX_CRC16);
+      ipv6_table.apply();
+    }
+
+    // The lpm tables may not set a valid `wcmp_group_id`, e.g. they may drop.
+    if (wcmp_group_id_valid) {
+      wcmp_group_table.apply();
+    }
+
+    // The lpm tables may not set a valid `nexthop_id`, e.g. they may drop.
+    // The `wcmp_group_table` should always set a valid `nexthop_id`.
+    if (nexthop_id_valid) {
+      nexthop_table.apply();
+
+      // The `nexthop_table` should always set a valid
+      // `router_interface_id` and `neighbor_id`.
+      if (router_interface_id_valid && neighbor_id_valid) {
+        router_interface_table.apply();
+        neighbor_table.apply();
+      }
+    }
+  }
+}  // control l3_fwd
+
+#endif  // SAI_L3_FWD_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/sai_main.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/sai_main.p4
@@ -1,0 +1,29 @@
+#include "v1model.p4"
+#include "headers.p4"
+#include "metadata.p4"
+#include "parser.p4"
+#include "routing.p4"
+#include "ipv4_checksum.p4"
+#include "ttl.p4"
+#include "acl_punt.p4"
+#include "acl_set_vrf.p4"
+
+control ingress(inout headers_t headers,
+                inout local_metadata_t local_metadata,
+                inout standard_metadata_t standard_metadata) {
+  apply {
+    acl_set_vrf.apply(headers, local_metadata, standard_metadata);
+    routing.apply(headers, local_metadata, standard_metadata);
+    acl_punt.apply(headers, local_metadata, standard_metadata);
+    ttl.apply(headers, standard_metadata);
+  }
+}  // control ingress
+
+control egress(inout headers_t headers,
+               inout local_metadata_t local_metadata,
+               inout standard_metadata_t standard_metadata) {
+  apply {}
+}  // control egress
+
+V1Switch(packet_parser(), verify_ipv4_checksum(), ingress(), egress(),
+         compute_ipv4_checksum(), packet_deparser()) main;

--- a/p4_fuzzer/p4_programs/sai-p4-google/ttl.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/ttl.p4
@@ -1,0 +1,29 @@
+#ifndef SAI_TTL_P4_
+#define SAI_TTL_P4_
+
+#include "v1model.p4"
+#include "headers.p4"
+#include "metadata.p4"
+
+control ttl(inout headers_t headers,
+            inout standard_metadata_t standard_metadata) {
+  apply {
+    if (headers.ipv4.isValid()) {
+      if (headers.ipv4.ttl <= 1) {
+        mark_to_drop(standard_metadata);
+      } else {
+        headers.ipv4.ttl = headers.ipv4.ttl - 1;
+      }
+    }
+
+    if (headers.ipv6.isValid()) {
+      if (headers.ipv6.hop_limit <= 1) {
+        mark_to_drop(standard_metadata);
+      } else {
+        headers.ipv6.hop_limit = headers.ipv6.hop_limit - 1;
+      }
+    }
+  }
+}  // control ttl
+
+#endif  // SAI_TTL_P4_


### PR DESCRIPTION
### Build Results:

divya@e6d72d01c011:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 240 targets (0 packages loaded, 0 targets configured).
INFO: Found 240 targets...
INFO: Elapsed time: 0.246s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
divya@e6d72d01c011:/sonic/src/sonic-p4rt/sonic-pins$ 

### Test Results:

divya@e6d72d01c011:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Analyzed 240 targets (1 packages loaded, 53 targets configured).
INFO: Found 157 targets and 83 test targets...
INFO: Elapsed time: 40.382s, Critical Path: 15.36s
INFO: 84 processes: 91 linux-sandbox, 14 local.
INFO: Build completed successfully, 84 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.2s
//gutil:proto_matchers_test                                              PASSED in 0.3s
//gutil:proto_test                                                       PASSED in 0.2s
//gutil:status_matchers_test                                             PASSED in 0.2s
//gutil:table_entry_key_test                                             PASSED in 0.0s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.4s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 15.3s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.0s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.2s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.3s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.8s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.4s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.6s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.4s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.3s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.0s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.0s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.4s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.2s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.3s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.7s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.7s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.7s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.4s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.3s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.4s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.3s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 0.8s
//p4rt_app/tests:action_set_test                                         PASSED in 0.6s
//p4rt_app/tests:api_access_test                                         PASSED in 0.5s
//p4rt_app/tests:arbitration_test                                        PASSED in 0.6s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 1.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 2.1s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.0s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.1s
//p4rt_app/tests:p4_programs_test                                        PASSED in 0.8s
//p4rt_app/tests:packetio_test                                           PASSED in 2.9s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 0.7s
//p4rt_app/tests:response_path_test                                      PASSED in 1.3s
//p4rt_app/tests:role_test                                               PASSED in 0.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 0.8s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.4s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.2s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.2s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.3s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.4s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.2s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.3s

Executed 83 out of 83 tests: 83 tests pass.
INFO: Build completed successfully, 84 total actions