### PR TITLE
PR8 - Added p4_fuzzer, a library for fuzzing P4Runtime requests.

### DIFF
--- a/p4_fuzzer/BUILD.bazel
+++ b/p4_fuzzer/BUILD.bazel
@@ -7,6 +7,20 @@ package(
     licenses = ["notice"],
 )
 
+proto_library(
+    name = "fuzzer_proto",
+    srcs = ["fuzzer.proto"],
+    deps = [
+        "//p4_pdpi:ir_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "fuzzer_cc_proto",
+    deps = [":fuzzer_proto"],
+)
+
 cc_library(
     name = "p4_programs/sai-p4-google/ids",
     hdrs = ["p4_programs/sai-p4-google/ids.h"],

--- a/p4_fuzzer/BUILD.bazel
+++ b/p4_fuzzer/BUILD.bazel
@@ -97,6 +97,33 @@ cc_library(
 )
 
 cc_library(
+    name = "oracle_util",
+    srcs = [
+        "oracle_util.cc",
+    ],
+    hdrs = ["oracle_util.h"],
+    deps = [
+        ":fuzzer_cc_proto",
+        ":switch_state",
+        ":table_entry_key",
+        "//gutil:status",
+        "//p4_pdpi:ir",
+        "//p4_pdpi:pd",
+        "@com_github_google_glog//:glog",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/random",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:optional",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_library(
     name = "p4_programs/sai-p4-google/ids",
     hdrs = ["p4_programs/sai-p4-google/ids.h"],
 )

--- a/p4_fuzzer/BUILD.bazel
+++ b/p4_fuzzer/BUILD.bazel
@@ -84,6 +84,54 @@ cc_test(
 )
 
 cc_library(
+    name = "mutation_and_fuzz_util",
+    srcs = [
+        "fuzz_util.cc",
+        "mutation.cc",
+    ],
+    hdrs = [
+        "fuzz_util.h",
+        "mutation.h",
+    ],
+    deps = [
+        ":annotation_util",
+        ":fuzzer_cc_proto",
+        ":switch_state",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/base:endian",
+        "@com_google_absl//absl/random",
+        "@com_google_absl//absl/strings",
+        # TODO: This target is not visible in google3.
+        # "//third_party/libprotobuf_mutator:libprotobuf_mutator_internals",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "//gutil:collections",
+        "//gutil:status",
+        "//p4_pdpi:ir",
+        "//p4_pdpi:pd",
+        "//p4_pdpi/utils:ir",
+    ],
+)
+
+cc_test(
+    name = "fuzz_util_test",
+    srcs = [
+        "fuzz_util_test.cc",
+    ],
+    data = ["acl_table_test.p4info.pb.txt"],
+    deps = [
+        ":fuzzer_cc_proto",
+        ":mutation_and_fuzz_util",
+        "//gutil:proto",
+        "//p4_pdpi:ir",
+        "//p4_pdpi:pd",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "annotation_util",
     srcs = ["annotation_util.cc"],
     hdrs = ["annotation_util.h"],

--- a/p4_fuzzer/BUILD.bazel
+++ b/p4_fuzzer/BUILD.bazel
@@ -22,6 +22,44 @@ cc_proto_library(
 )
 
 cc_library(
+    name = "table_entry_key",
+    srcs = ["table_entry_key.cc"],
+    hdrs = ["table_entry_key.h"],
+    deps = [
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/hash",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_test(
+    name = "table_entry_key_test",
+    srcs = [
+        "table_entry_key.cc",
+        "table_entry_key_test.cc",
+    ],
+    deps = [
+        ":table_entry_key",
+        "@com_google_absl//absl/hash:hash_testing",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_library(
+    name = "annotation_util",
+    srcs = ["annotation_util.cc"],
+    hdrs = ["annotation_util.h"],
+    deps = [
+        ":fuzzer_cc_proto",
+        "//p4_pdpi:ir",
+        "//p4_pdpi/utils:ir",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+    ],
+)
+
+cc_library(
     name = "p4_programs/sai-p4-google/ids",
     hdrs = ["p4_programs/sai-p4-google/ids.h"],
 )

--- a/p4_fuzzer/BUILD.bazel
+++ b/p4_fuzzer/BUILD.bazel
@@ -7,6 +7,11 @@ package(
     licenses = ["notice"],
 )
 
+cc_library(
+    name = "p4_programs/sai-p4-google/ids",
+    hdrs = ["p4_programs/sai-p4-google/ids.h"],
+)
+
 p4_library(
     name = "single_table_single_entry",
     src = "p4_programs/single_table_single_entry.p4",
@@ -23,5 +28,19 @@ p4_library(
     name = "constraints_not_equals",
     src = "p4_programs/constraints_not_equals.p4",
     p4info_out = "constraints_not_equals.p4info.pb.txt",
+)
+
+p4_library(
+    name = "acl_table_test",
+    src = "p4_programs/acl_table_test.p4",
+    p4info_out = "acl_table_test.p4info.pb.txt",
+    deps = [
+        "p4_programs/sai-p4-google/acl_actions.p4",
+        "p4_programs/sai-p4-google/acl_set_vrf.p4",
+        "p4_programs/sai-p4-google/headers.p4",
+        "p4_programs/sai-p4-google/ids.h",
+        "p4_programs/sai-p4-google/metadata.p4",
+        "p4_programs/sai-p4-google/resource_limits.p4",
+    ],
 )
 

--- a/p4_fuzzer/BUILD.bazel
+++ b/p4_fuzzer/BUILD.bazel
@@ -58,3 +58,10 @@ p4_library(
     ],
 )
 
+p4_library(
+    name = "sai_main",
+    src = "p4_programs/sai-p4-google/sai_main.p4",
+    p4info_out = "sai_main_info.pb.txt",
+    deps = glob(["p4_programs/sai-p4-google/*"]),
+)
+

--- a/p4_fuzzer/BUILD.bazel
+++ b/p4_fuzzer/BUILD.bazel
@@ -22,6 +22,43 @@ cc_proto_library(
 )
 
 cc_library(
+    name = "switch_state",
+    srcs = ["switch_state.cc"],
+    hdrs = ["switch_state.h"],
+    deps = [
+        ":table_entry_key",
+        "//gutil:collections",
+        "//gutil:status",
+        "//p4_pdpi:ir",
+        "//p4_pdpi:ir_cc_proto",
+        "//p4_pdpi:pd",
+        "@com_github_google_glog//:glog",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:node_hash_map",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:optional",
+    ],
+)
+
+cc_test(
+    name = "switch_state_test",
+    srcs = ["switch_state_test.cc"],
+    deps = [
+        ":switch_state",
+        "//p4_pdpi:ir",
+        "//p4_pdpi:pd",
+        "@com_github_google_glog//:glog",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "table_entry_key",
     srcs = ["table_entry_key.cc"],
     hdrs = ["table_entry_key.h"],

--- a/p4_fuzzer/annotation_util.cc
+++ b/p4_fuzzer/annotation_util.cc
@@ -1,0 +1,60 @@
+#include "p4_fuzzer/annotation_util.h"
+
+namespace p4_fuzzer {
+
+AnnotatedTableEntry GetAnnotatedTableEntry(
+    const pdpi::IrP4Info& ir_p4_info, const p4::v1::TableEntry& entry,
+    const std::vector<Mutation> mutations) {
+  AnnotatedTableEntry debug_entry;
+  *debug_entry.mutable_pi() = entry;
+
+  auto status_or_ir = pdpi::PiTableEntryToIr(ir_p4_info, entry);
+
+  if (!status_or_ir.ok()) {
+    debug_entry.set_error(status_or_ir.status().ToString());
+  } else {
+    *debug_entry.mutable_ir() = status_or_ir.value();
+  }
+
+  for (auto mutation : mutations) {
+    debug_entry.add_mutations(mutation);
+  }
+
+  return debug_entry;
+}
+
+AnnotatedUpdate GetAnnotatedUpdate(const pdpi::IrP4Info& ir_p4_info,
+                                   const p4::v1::Update& pi_update,
+                                   const std::vector<Mutation> mutations) {
+  AnnotatedUpdate update;
+  *update.mutable_pi() = pi_update;
+
+  auto status_or_ir = pdpi::PiUpdateToIr(ir_p4_info, pi_update);
+
+  if (!status_or_ir.ok()) {
+    update.set_error(status_or_ir.status().ToString());
+  } else {
+    *update.mutable_ir() = status_or_ir.value();
+  }
+
+  for (auto mutation : mutations) {
+    update.add_mutations(mutation);
+  }
+
+  return update;
+}
+
+p4::v1::WriteRequest RemoveAnnotations(const AnnotatedWriteRequest& request) {
+  p4::v1::WriteRequest base_request;
+
+  base_request.set_device_id(request.device_id());
+  *base_request.mutable_election_id() = request.election_id();
+
+  for (const auto& update : request.updates()) {
+    *base_request.add_updates() = update.pi();
+  }
+
+  return base_request;
+}
+
+}  // namespace p4_fuzzer

--- a/p4_fuzzer/annotation_util.h
+++ b/p4_fuzzer/annotation_util.h
@@ -1,0 +1,27 @@
+#ifndef P4_FUZZER_ANNOTATION_UTIL_H_
+#define P4_FUZZER_ANNOTATION_UTIL_H_
+
+#include "p4/config/v1/p4info.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_fuzzer/fuzzer.pb.h"
+#include "p4_pdpi/ir.h"
+#include "p4_pdpi/utils/ir.h"
+
+namespace p4_fuzzer {
+
+// Returns an AnnotatedTableEntry.
+AnnotatedTableEntry GetAnnotatedTableEntry(
+    const pdpi::IrP4Info& ir_p4_info, const p4::v1::TableEntry& entry,
+    const std::vector<Mutation> mutations);
+
+// Returns an AnnotatedUpdate.
+AnnotatedUpdate GetAnnotatedUpdate(const pdpi::IrP4Info& ir_p4_info,
+                                   const p4::v1::Update& pi_update,
+                                   const std::vector<Mutation> mutations);
+
+// Creates a P4Runtime WriteRequest from an AnnotatedWriteRequest.
+p4::v1::WriteRequest RemoveAnnotations(const AnnotatedWriteRequest& request);
+
+}  // namespace p4_fuzzer
+
+#endif  // P4_FUZZER_ANNOTATION_UTIL_H_

--- a/p4_fuzzer/fuzz_util.cc
+++ b/p4_fuzzer/fuzz_util.cc
@@ -1,0 +1,523 @@
+#include "p4_fuzzer/fuzz_util.h"
+
+#include "absl/algorithm/container.h"
+#include "absl/base/casts.h"
+#include "absl/base/internal/endian.h"
+#include "gutil/collections.h"
+#include "p4_fuzzer/annotation_util.h"
+#include "p4_fuzzer/mutation.h"
+#include "p4_pdpi/pd.h"
+#include "p4_pdpi/utils/ir.h"
+
+namespace p4_fuzzer {
+
+using ::absl::gntohll;
+
+using ::absl::Uniform;
+using ::p4::v1::Action;
+using ::p4::v1::FieldMatch;
+using ::p4::v1::TableEntry;
+using ::p4::v1::Update;
+
+constexpr int kBitsInByte = 8;
+
+// The probability that another entry is added to an update. 0.98 has been
+// empirically determined to lead to big enough updates so that the test runs
+// fast, but also sometimes generates small updates, which increases coverage.
+constexpr float kAddUpdateProbability = 0.98;
+// The probability of inserting an entry (in contrast to removing one).
+// The probability of inserting a entry is larger than the probability of
+// removing one, which means that eventually the switch fills up. 0.8 is a nice
+// number because it causes the switch to fill up quickly, but there is still a
+// good chance to get a couple of deletes in a row.
+constexpr float kInsertProbability = 0.8;
+// Upper bound of the number of actions in an ActionProfileActionSet for tables
+// that support one-shot action selector programming.
+constexpr uint32_t kActionProfileActionSetMax = 16;
+// The probability of performing a mutation on a given table entry.
+constexpr float kMutateUpdateProbability = 0.1;
+// The probability of using a wildcard for a ternary or lpm match field.
+constexpr float kFieldMatchWildcardProbability = 0.1;
+
+namespace {
+
+inline int DivideRoundedUp(const unsigned int n, const unsigned int d) {
+  if (n == 0 || d == 0) {
+    return 0;
+  }
+
+  return (n - 1) / d + 1;
+}
+
+p4::v1::ActionProfileAction FuzzActionProfileAction(
+    absl::BitGen* gen, const pdpi::IrP4Info& ir_p4_info,
+    const pdpi::IrTableDefinition& ir_table_info) {
+  p4::v1::ActionProfileAction action;
+
+  *action.mutable_action() =
+      FuzzAction(gen, ChooseNonDefaultActionRef(gen, ir_table_info).action());
+
+  action.set_weight(Uniform<int32_t>(*gen, 1, kActionProfileActionMaxWeight));
+
+  // TODO: set the watch port field by uniformly selecting from a set
+  // of valid watch ports.
+
+  return action;
+}
+
+// Returns the table ids of tables that use one shot action selector
+// programming.
+std::vector<uint32_t> GetOneShotTableIds(const pdpi::IrP4Info& ir_p4_info) {
+  std::vector<uint32_t> table_ids;
+
+  for (auto& [id, table] : ir_p4_info.tables_by_id()) {
+    if (table.uses_oneshot()) {
+      table_ids.push_back(id);
+    }
+  }
+
+  return table_ids;
+}
+
+// Returns the table ids of tables that contain at least one exact match field.
+std::vector<uint32_t> GetMandatoryMatchTableIds(
+    const pdpi::IrP4Info& ir_p4_info) {
+  std::vector<uint32_t> table_ids;
+
+  for (auto& [id, table] : ir_p4_info.tables_by_id()) {
+    for (auto& [match_id, match] : table.match_fields_by_id()) {
+      if (match.match_field().match_type() ==
+          p4::config::v1::MatchField::EXACT) {
+        table_ids.push_back(id);
+        break;
+      }
+    }
+  }
+
+  return table_ids;
+}
+
+// Randomly generates an update type.
+Update::Type FuzzUpdateType(absl::BitGen* gen, const SwitchState& state) {
+  if (state.AllTablesEmpty()) {
+    // Insert if there are no entries to delete.
+    return Update::INSERT;
+  } else {
+    // If both insert and delete are possible, choose one randomly.
+    if (absl::Bernoulli(*gen, kInsertProbability)) {
+      return Update::INSERT;
+    } else {
+      return Update::DELETE;
+    }
+  }
+}
+
+// Randomly generates the table id of a non-empty table.
+int FuzzNonEmptyTableId(absl::BitGen* gen, const SwitchState& switch_state) {
+  CHECK(!switch_state.AllTablesEmpty())
+      << "state: " << switch_state.SwitchStateSummary();
+  int table_id;
+  do {
+    table_id = FuzzTableId(gen, switch_state);
+  } while (switch_state.IsTableEmpty(table_id));
+  return table_id;
+}
+
+// Randomly changes the table_entry, without affecting the key fields.
+void FuzzNonKeyFields(absl::BitGen* gen, TableEntry* table_entry) {
+  // With some probability, don't modify the element at all.
+  if (absl::Bernoulli(*gen, 0.5)) return;
+
+  // TODO: can't remove action at the moment, because IsWellformedUpdate
+  // will think the update is no longer well-formed.
+  if (absl::Bernoulli(*gen, 0.5)) {
+    table_entry->clear_controller_metadata();
+  }
+  // TODO: also add/modify non-key fields.
+}
+
+// Randomly generates an INSERT or DELETE update. The update may be mutated (see
+// go/p4-fuzzer-design for mutation types).
+AnnotatedUpdate FuzzUpdate(absl::BitGen* gen, const pdpi::IrP4Info& ir_p4_info,
+                           const SwitchState& switch_state) {
+  std::vector<uint32_t> table_ids = switch_state.AllTableIds();
+  CHECK_GT(table_ids.size(), 0)
+      << "Cannot generate updates for program with no tables";
+
+  Mutation mutation;
+  bool do_mutate = false;
+
+  if (absl::Bernoulli(*gen, kMutateUpdateProbability)) {
+    do_mutate = true;
+    mutation = FuzzMutation(gen);
+    switch (mutation) {
+      case Mutation::INVALID_ACTION_SELECTOR_WEIGHT:
+        table_ids = GetOneShotTableIds(ir_p4_info);
+        if (table_ids.empty()) {
+          // Retry mutating the update.
+          return FuzzUpdate(gen, ir_p4_info, switch_state);
+        }
+
+        break;
+
+      case Mutation::MISSING_MANDATORY_MATCH_FIELD:
+        table_ids = GetMandatoryMatchTableIds(ir_p4_info);
+        if (table_ids.empty()) {
+          // Retry mutating the update.
+          return FuzzUpdate(gen, ir_p4_info, switch_state);
+        }
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  Update::Type type = FuzzUpdateType(gen, switch_state);
+  Update update;
+  update.set_type(type);
+
+  switch (type) {
+    case Update::INSERT: {
+      const int table_id = UniformFromVector(gen, table_ids);
+
+      // This might (with low probability) generate an entry that already
+      // exists leading to a duplicate insert. This is fine, this update is just
+      // rendered invalid and the oracle incorporates this in its prediction of
+      // switch behavior.
+      p4::v1::TableEntry table_entry =
+          FuzzValidTableEntry(gen, ir_p4_info, table_id);
+
+      *update.mutable_entity()->mutable_table_entry() = table_entry;
+
+      break;
+    }
+    case Update::DELETE: {
+      const int table_id = FuzzNonEmptyTableId(gen, switch_state);
+      // Within a single call of FuzzWriteRequest, this might delete the same
+      // entry multiple times.  This is fine, all but one of the deletes are
+      // just invalid (and it is the oracle's job to know what the switch is
+      // supposed to do with this).
+      TableEntry table_entry =
+          UniformFromVector(gen, switch_state.GetTableEntries(table_id));
+      FuzzNonKeyFields(gen, &table_entry);
+      *update.mutable_entity()->mutable_table_entry() = table_entry;
+      break;
+    }
+    default:
+      LOG(FATAL) << "Unsupported update type " << type;
+  }
+
+  if (do_mutate) {
+    if (!MutateUpdate(gen, &update, ir_p4_info, switch_state, mutation).ok()) {
+      // Retry mutating the update.
+      return FuzzUpdate(gen, ir_p4_info, switch_state);
+    }
+
+    return GetAnnotatedUpdate(ir_p4_info, update, /* mutations = */ {mutation});
+  }
+
+  return GetAnnotatedUpdate(ir_p4_info, update, /* mutations = */ {});
+}
+
+}  // namespace
+
+// Randomly generates a table id.
+int FuzzTableId(absl::BitGen* gen, const SwitchState& switch_state) {
+  return UniformFromVector(gen, switch_state.AllTableIds());
+}
+
+Mutation FuzzMutation(absl::BitGen* gen) {
+  std::vector<int> valid_indexes;
+
+  for (int i = Mutation_MIN; i <= Mutation_MAX; ++i) {
+    if (Mutation_IsValid(i)) {
+      valid_indexes.push_back(i);
+    }
+  }
+
+  return static_cast<Mutation>(
+      valid_indexes[Uniform<int>(*gen, 0, valid_indexes.size())]);
+}
+
+pdpi::IrActionReference ChooseNonDefaultActionRef(
+    absl::BitGen* gen, const pdpi::IrTableDefinition& ir_table_info) {
+  std::vector<pdpi::IrActionReference> refs;
+
+  for (const auto& action_ref : ir_table_info.entry_actions()) {
+    refs.push_back(action_ref);
+  }
+
+  return refs[absl::Uniform(*gen, 0u, refs.size())];
+}
+
+std::string SetUnusedBitsToZero(int used_bits, std::string data) {
+  const int bytes = data.size();
+  const int used_bytes = DivideRoundedUp(used_bits, kBitsInByte);
+  const int unused_bytes = bytes - used_bytes;
+  const int overhanging_bits = used_bits % kBitsInByte;
+
+  CHECK_GE(used_bits, 0) << "data: '" << data << "'";
+  CHECK_GE(bytes * kBitsInByte, used_bits) << "data: '" << data << "'";
+
+  // Zero the completely unused bytes.
+  for (int i = 0; i < unused_bytes; ++i) data[i] = 0;
+
+  // Zero the remaining unused bits.
+  if (overhanging_bits != 0) {
+    const int padding_mask = (1 << overhanging_bits) - 1;
+    data[unused_bytes] &= padding_mask;
+  }
+  return data;
+}
+
+uint64_t BitsToUint64(const std::string& data) {
+  CHECK_EQ(data.size(), sizeof(uint64_t)) << "Data: " << data;
+  return gntohll(reinterpret_cast<const uint64_t&>(data[0]));
+}
+
+std::string FuzzBits(absl::BitGen* gen, int bits, int bytes) {
+  std::string data(bytes, 0);
+  for (int i = 0; i < bytes; ++i)
+    data[i] = absl::implicit_cast<char>(Uniform<uint8_t>(*gen));
+
+  return SetUnusedBitsToZero(bits, std::move(data));
+}
+
+std::string FuzzBits(absl::BitGen* gen, int bits) {
+  return FuzzBits(gen, bits, DivideRoundedUp(bits, kBitsInByte));
+}
+
+uint64_t FuzzUint64(absl::BitGen* gen, int bits) {
+  return BitsToUint64(FuzzBits(gen, bits, sizeof(uint64_t)));
+}
+
+p4::v1::FieldMatch FuzzTernaryFieldMatch(absl::BitGen* gen, int bits) {
+  std::string mask = FuzzBits(gen, bits);
+  std::string value = FuzzBits(gen, bits);
+
+  // If a mask bit is 0, the corresponding value bit also has to be 0.
+  value = pdpi::Intersection(value, mask).value();
+
+  p4::v1::FieldMatch match;
+
+  // If the mask is 0 (then the value must also be 0), so clear the field,
+  // as demanded by P4Runtime.
+  // If the value is 0, but the mask is not, then just set the fields normally.
+  if (!pdpi::IsAllZeros(mask)) {
+    match.mutable_ternary()->set_mask(mask);
+    match.mutable_ternary()->set_value(value);
+  }
+
+  return match;
+}
+
+p4::v1::FieldMatch FuzzLpmFieldMatch(absl::BitGen* gen, int bits) {
+  // Since /8, /16, /24, and /32 are common, we want to bias the fuzzer to
+  // generate more of them.
+  std::vector<int> likely_bits;
+  for (int i = kBitsInByte; i <= bits; i += kBitsInByte) {
+    likely_bits.push_back(i);
+  }
+
+  int prefix_len;
+  if (bits >= kBitsInByte && absl::Bernoulli(*gen, 0.5)) {
+    prefix_len = UniformFromVector(gen, likely_bits);
+  } else {
+    prefix_len = absl::Uniform(*gen, 0, bits + 1);
+  }
+
+  p4::v1::FieldMatch match;
+  match.mutable_lpm()->set_prefix_len(prefix_len);
+  match.mutable_lpm()->set_value(FuzzBits(gen, prefix_len));
+  return match;
+}
+
+p4::v1::FieldMatch FuzzExactFieldMatch(absl::BitGen* gen, int bits) {
+  p4::v1::FieldMatch match;
+  // Note that exact messages have to be provided, even if the value is 0.
+  match.mutable_exact()->set_value(FuzzBits(gen, bits));
+  return match;
+}
+
+p4::v1::FieldMatch FuzzExactFieldMatch(absl::BitGen* gen, int bits, int bytes) {
+  p4::v1::FieldMatch match;
+  // Note that exact messages have to be provided, even if the value is 0.
+  match.mutable_exact()->set_value(FuzzBits(gen, bits, bytes));
+  return match;
+}
+
+p4::v1::FieldMatch FuzzFieldMatch(
+    absl::BitGen* gen,
+    const pdpi::IrMatchFieldDefinition& ir_match_field_info) {
+  const p4::config::v1::MatchField& match_field_info =
+      ir_match_field_info.match_field();
+
+  p4::v1::FieldMatch match_field;
+  switch (match_field_info.match_type()) {
+    case p4::config::v1::MatchField::TERNARY:
+      match_field = FuzzTernaryFieldMatch(gen, match_field_info.bitwidth());
+      break;
+    case p4::config::v1::MatchField::LPM:
+      match_field = FuzzLpmFieldMatch(gen, match_field_info.bitwidth());
+      break;
+    case p4::config::v1::MatchField::EXACT:
+      match_field = FuzzExactFieldMatch(gen, match_field_info.bitwidth());
+      break;
+    default:
+      LOG(FATAL) << "Unsupported match: " << match_field_info.DebugString();
+  }
+  match_field.set_field_id(match_field_info.id());
+  return match_field;
+}
+
+p4::v1::Action FuzzAction(absl::BitGen* gen,
+                          const pdpi::IrActionDefinition& ir_action_info) {
+  p4::v1::Action action;
+  action.set_action_id(ir_action_info.preamble().id());
+
+  for (auto& [id, ir_param] : ir_action_info.params_by_id()) {
+    p4::v1::Action::Param* param = action.add_params();
+    param->set_param_id(id);
+    param->set_value(FuzzBits(gen, ir_param.param().bitwidth()));
+  }
+
+  return action;
+}
+
+p4::v1::ActionProfileActionSet FuzzActionProfileActionSet(
+    absl::BitGen* gen, const pdpi::IrP4Info& ir_p4_info,
+    const pdpi::IrTableDefinition& ir_table_info) {
+  p4::v1::ActionProfileActionSet action_set;
+
+  auto number_of_actions =
+      Uniform<int32_t>(*gen, 0, kActionProfileActionSetMax);
+
+  for (auto i = 0; i < number_of_actions; i++) {
+    *action_set.add_action_profile_actions() =
+        FuzzActionProfileAction(gen, ir_p4_info, ir_table_info);
+  }
+
+  return action_set;
+}
+
+p4::v1::FieldMatch MakeIPv4EthTypeMatch(
+    const p4::config::v1::MatchField& match_field_info) {
+  p4::v1::FieldMatch match;
+  match.set_field_id(match_field_info.id());
+  // Exact match on IPv4 ETH TYPE
+  match.mutable_ternary()->set_mask(std::string("\xff\xff", 2));
+  match.mutable_ternary()->set_value(std::string("\x08\x00", 2));
+  return match;
+}
+
+void EnforceTableConstraints(absl::BitGen* gen,
+                             const pdpi::IrP4Info& ir_p4_info,
+                             const pdpi::IrTableDefinition& ir_table_info,
+                             TableEntry* table_entry) {
+  // TODO: implement program independent version of this function.
+}
+
+TableEntry FuzzValidTableEntry(absl::BitGen* gen,
+                               const pdpi::IrP4Info& ir_p4_info,
+                               const pdpi::IrTableDefinition& ir_table_info) {
+  TableEntry table_entry;
+  table_entry.set_table_id(ir_table_info.preamble().id());
+
+  // Generate the matches.
+  for (auto& [key, match_field_info] : ir_table_info.match_fields_by_id()) {
+    // Skip deprecated fields
+    bool deprecated =
+        absl::c_any_of(match_field_info.match_field().annotations(),
+                       [](const std::string annotation) {
+                         return absl::StartsWith(annotation, "@deprecated(");
+                       });
+    if (deprecated) continue;
+
+    // If the field can have wildcards, this may generate a wildcard match.
+    // That's illegal according to P4RT spec, because wilcards must be
+    // represented as the absence of that match.
+    if (match_field_info.match_field().match_type() ==
+            p4::config::v1::MatchField::TERNARY ||
+        (match_field_info.match_field().match_type() ==
+             p4::config::v1::MatchField::LPM &&
+         absl::Bernoulli(*gen, kFieldMatchWildcardProbability))) {
+      continue;
+    }
+
+    *table_entry.add_match() = FuzzFieldMatch(gen, match_field_info);
+  }
+
+  EnforceTableConstraints(gen, ir_p4_info, ir_table_info, &table_entry);
+
+  // Generate the action.
+  if (!ir_table_info.uses_oneshot()) {
+    // Normal table, so choose a non-default action.
+    *table_entry.mutable_action()->mutable_action() =
+        FuzzAction(gen, ChooseNonDefaultActionRef(gen, ir_table_info).action());
+  } else {
+    *table_entry.mutable_action()->mutable_action_profile_action_set() =
+        FuzzActionProfileActionSet(gen, ir_p4_info, ir_table_info);
+  }
+
+  // Set cookie and priority.
+  table_entry.set_controller_metadata(FuzzUint64(gen, /*bits=*/64));
+  for (const auto& match : table_entry.match()) {
+    if (match.has_ternary()) {
+      table_entry.set_priority(FuzzUint64(gen, /*bits=*/16));
+      break;
+    }
+  }
+
+  // TODO: Fuzz default actions.
+  // TODO: Fuzz meters and counters.
+  return table_entry;
+}
+
+TableEntry FuzzValidTableEntry(absl::BitGen* gen,
+                               const pdpi::IrP4Info& ir_p4_info,
+                               const uint32_t table_id) {
+  TableEntry entry;
+  return FuzzValidTableEntry(
+      gen, ir_p4_info, gutil::FindOrDie(ir_p4_info.tables_by_id(), table_id));
+}
+
+std::vector<AnnotatedTableEntry> ValidForwardingEntries(
+    absl::BitGen* gen, const pdpi::IrP4Info& ir_p4_info,
+    const int num_entries) {
+  std::vector<AnnotatedTableEntry> entries;
+  SwitchState state(ir_p4_info);
+
+  for (int i = 0; i < num_entries; ++i) {
+    p4::v1::TableEntry entry;
+
+    do {
+      entry = FuzzValidTableEntry(gen, ir_p4_info, FuzzTableId(gen, state));
+    } while (state.GetTableEntry(entry) != absl::nullopt);
+
+    p4::v1::Update update;
+    update.set_type(p4::v1::Update::INSERT);
+    *update.mutable_entity()->mutable_table_entry() = entry;
+
+    state.ApplyUpdate(update);
+
+    entries.push_back(
+        GetAnnotatedTableEntry(ir_p4_info, entry, /*mutations = */ {}));
+  }
+
+  return entries;
+}
+
+AnnotatedWriteRequest FuzzWriteRequest(absl::BitGen* gen,
+                                       const pdpi::IrP4Info& ir_p4_info,
+                                       const SwitchState& switch_state) {
+  AnnotatedWriteRequest request;
+
+  while (absl::Bernoulli(*gen, kAddUpdateProbability)) {
+    *request.add_updates() = FuzzUpdate(gen, ir_p4_info, switch_state);
+  }
+
+  return request;
+}
+
+}  // namespace p4_fuzzer

--- a/p4_fuzzer/fuzz_util.h
+++ b/p4_fuzzer/fuzz_util.h
@@ -1,0 +1,148 @@
+// The `FuzzFoo` functions in this file are all of the form:
+//
+//     Foo foo = FuzzFoo(gen, context)
+//
+// Each of these functions randomly generates a valid value of type `Foo`.
+// The goal is that these functions are also complete, in the sense that every
+// valid value of `Foo` has a non-zero (though possibly extremely small)
+// propability of being returned from the `FuzzFoo` function. Whenever this is
+// violated, there should be a TODO with an associated bug.
+//
+// The meaning of "valid" depends on the type Foo, and often some context
+// parameters. Read each function's documentation to understand validity.
+
+#ifndef P4_FUZZER_FUZZ_UTIL_H_
+#define P4_FUZZER_FUZZ_UTIL_H_
+
+#include <string>
+#include <vector>
+
+#include "absl/random/random.h"
+#include "absl/strings/match.h"
+#include "glog/logging.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_fuzzer/fuzzer.pb.h"
+#include "p4_fuzzer/switch_state.h"
+#include "p4_pdpi/ir.h"
+
+namespace p4_fuzzer {
+
+// Upper bound on the weight of each ActionProfileAction in an
+// ActionProfileActionSet for tables that support one-shot action selector
+// programming.
+constexpr int32_t kActionProfileActionMaxWeight = 100;
+
+template <typename T>
+const T& UniformFromVector(absl::BitGen* gen, const std::vector<T>& vec) {
+  CHECK(!vec.empty());
+  int index = absl::Uniform<int>(*gen, /*lo=*/0, /*hi=*/vec.size());
+  return vec[index];
+}
+
+// Takes a string `data` that represents a number in network byte
+// order (big-endian), and masks off all but the least significant `used_bits`
+// bits.
+//
+// For example, given a 3 byte string, that represents the 10 bit number 1000
+// (binary 1111101000):
+//
+//                      1                   2
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3
+// +---------------+---------------+---------------+
+// |0 0 0 0 0 0 0 0|0 0 0 0 0 0 1 1|1 1 1 0 1 0 0 0|
+// +---------------+---------------+---------------+
+// |          padding          |
+//
+// and a `used_bits` value of 7, the function will generate this string:
+//
+//                      1                   2
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3
+// +---------------+---------------+---------------+
+// |0 0 0 0 0 0 0 0|0 0 0 0 0 0 0 0|0 1 1 0 1 0 0 0|
+// +---------------+---------------+---------------+
+// |          padding                |
+//
+// The numbers above the string indicate each bit's index in the string.
+std::string SetUnusedBitsToZero(int used_bits, std::string data);
+
+// Takes an 8 byte string that represents a number in network byte order, and
+// turns it into a uint64 in host byte order. Dies if the string is not 8 byte.
+uint64_t BitsToUint64(const std::string& data);
+
+// Returns a mutation type uniformly randomly chosen from the enum in
+// fuzzer.proto.
+Mutation FuzzMutation(absl::BitGen* gen);
+
+// Returns a randomly generated `bits` long number in network byte order, stored
+// in a `bytes` long string. Unused bits are set to 0.
+std::string FuzzBits(absl::BitGen* gen, int bits, int bytes);
+
+// Just like above, but the returned string is just long enough to hold the
+// randomly generated number.
+std::string FuzzBits(absl::BitGen* gen, int bits);
+
+// Generates a `bits` long uint64 in host byte order.
+uint64_t FuzzUint64(absl::BitGen* gen, int bits);
+
+// Randomly generates a ternary field match with a bitwidth of `bits`.
+// Does not set the match field id. See "9.1.1. Match Format" in the P4Runtime
+// specification for details about which FieldMatch values are valid.
+p4::v1::FieldMatch FuzzTernaryFieldMatch(absl::BitGen* gen, int bits);
+
+// Randomly generates a field match that conforms to the given
+// match field info. See "9.1.1. Match Format" in the P4Runtime
+// specification for details about which FieldMatch values are valid.
+p4::v1::FieldMatch FuzzFieldMatch(
+    absl::BitGen* gen, const pdpi::IrMatchFieldDefinition& ir_match_field_info);
+
+// Randomly generates an action that conforms to the given `ir_action_info`.
+// See "9.1.2. Action Specification"  in the P4Runtime specification for details
+// about which Action values are valid.
+p4::v1::Action FuzzAction(absl::BitGen* gen,
+                          const pdpi::IrActionDefinition& ir_action_info);
+
+// Randomly generates an ActionProfileActionSet that conforms to the given
+// `ir_table_info` and `ir_p4_info` for tables that support one-shot
+// action selector programming. Refer to section "9.2.3. One Shot Action
+// Selector Programming" in the P4Runtime specification for details on
+// ActionProfileActionSets.
+p4::v1::ActionProfileActionSet FuzzActionProfileActionSet(
+    absl::BitGen* gen, const pdpi::IrP4Info& ir_p4_info,
+    const pdpi::IrTableDefinition& ir_table_info);
+
+// Randomly chooses an id that belongs to a table in the switch.
+int FuzzTableId(absl::BitGen* gen, const SwitchState& switch_state);
+
+// Randomly generates a table entry that conforms to the given table info.
+// The p4 info is used to lookup action references. See go/p4-fuzzer-design for
+// details about which TableEntry values are valid.
+p4::v1::TableEntry FuzzValidTableEntry(
+    absl::BitGen* gen, const pdpi::IrP4Info& ir_p4_info,
+    const pdpi::IrTableDefinition& ir_table_info);
+
+// Randomly generates a table entry that conforms to the table info in the
+// p4 info with the given table id. See go/p4-fuzzer-design for details about
+// which TableEntry values are valid.
+p4::v1::TableEntry FuzzValidTableEntry(absl::BitGen* gen,
+                                       const pdpi::IrP4Info& p4_info,
+                                       const uint32_t table_id);
+
+// Randomly generates a set of valid table entries that, when installed in order
+// to an empty switch state, all install correctly.
+std::vector<AnnotatedTableEntry> ValidForwardingEntries(
+    absl::BitGen* gen, const pdpi::IrP4Info& ir_p4_info, const int num_entries);
+
+// Randomly generates a set of updates, both valid and invalid.
+AnnotatedWriteRequest FuzzWriteRequest(absl::BitGen* gen,
+                                       const pdpi::IrP4Info& ir_p4_info,
+                                       const SwitchState& switch_state);
+
+// Takes a P4 Runtime table and returns randomly chosen action ref from the
+// action refs that are not in default only scope.
+pdpi::IrActionReference ChooseNonDefaultActionRef(
+    absl::BitGen* gen, const pdpi::IrTableDefinition& ir_table_info);
+
+}  // namespace p4_fuzzer
+
+#endif  // P4_FUZZER_FUZZ_UTIL_H_

--- a/p4_fuzzer/fuzz_util_test.cc
+++ b/p4_fuzzer/fuzz_util_test.cc
@@ -1,0 +1,107 @@
+#include "p4_fuzzer/fuzz_util.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "gutil/proto.h"
+#include "p4_fuzzer/fuzzer.pb.h"
+#include "p4_fuzzer/mutation.h"
+#include "p4_pdpi/ir.h"
+#include "p4_pdpi/pd.h"
+
+namespace p4_fuzzer {
+namespace {
+
+TEST(FuzzUtilTest, SetUnusedBitsToZeroInThreeBytes) {
+  std::string data("\xff\xff\xff", 3);
+  EXPECT_EQ(SetUnusedBitsToZero(24, data), std::string("\xff\xff\xff", 3));
+  EXPECT_EQ(SetUnusedBitsToZero(23, data), std::string("\x7f\xff\xff", 3));
+  EXPECT_EQ(SetUnusedBitsToZero(22, data), std::string("\x3f\xff\xff", 3));
+  EXPECT_EQ(SetUnusedBitsToZero(21, data), std::string("\x1f\xff\xff", 3));
+  EXPECT_EQ(SetUnusedBitsToZero(20, data), std::string("\x0f\xff\xff", 3));
+  EXPECT_EQ(SetUnusedBitsToZero(16, data), std::string("\x00\xff\xff", 3));
+  EXPECT_EQ(SetUnusedBitsToZero(15, data), std::string("\x00\x7f\xff", 3));
+  EXPECT_EQ(SetUnusedBitsToZero(14, data), std::string("\x00\x3f\xff", 3));
+  EXPECT_EQ(SetUnusedBitsToZero(13, data), std::string("\x00\x1f\xff", 3));
+  EXPECT_EQ(SetUnusedBitsToZero(12, data), std::string("\x00\x0f\xff", 3));
+  EXPECT_EQ(SetUnusedBitsToZero(3, data), std::string("\x00\x00\x07", 3));
+  EXPECT_EQ(SetUnusedBitsToZero(2, data), std::string("\x00\x00\x03", 3));
+  EXPECT_EQ(SetUnusedBitsToZero(1, data), std::string("\x00\x00\x01", 3));
+  EXPECT_EQ(SetUnusedBitsToZero(0, data), std::string("\x00\x00\x00", 3));
+}
+
+TEST(FuzzUtilTest, SetUnusedBitsToZeroInNineBytes) {
+  std::string data("\xff\xff\xff\xff\xff\xff\xff\xff\xff", 9);
+  EXPECT_EQ(SetUnusedBitsToZero(72, data),
+            std::string("\xff\xff\xff\xff\xff\xff\xff\xff\xff", 9));
+  EXPECT_EQ(SetUnusedBitsToZero(71, data),
+            std::string("\x7f\xff\xff\xff\xff\xff\xff\xff\xff", 9));
+  EXPECT_EQ(SetUnusedBitsToZero(65, data),
+            std::string("\x01\xff\xff\xff\xff\xff\xff\xff\xff", 9));
+  EXPECT_EQ(SetUnusedBitsToZero(64, data),
+            std::string("\x00\xff\xff\xff\xff\xff\xff\xff\xff", 9));
+  EXPECT_EQ(SetUnusedBitsToZero(63, data),
+            std::string("\x00\x7f\xff\xff\xff\xff\xff\xff\xff", 9));
+  EXPECT_EQ(SetUnusedBitsToZero(33, data),
+            std::string("\x00\x00\x00\x00\x01\xff\xff\xff\xff", 9));
+  EXPECT_EQ(SetUnusedBitsToZero(32, data),
+            std::string("\x00\x00\x00\x00\x00\xff\xff\xff\xff", 9));
+  EXPECT_EQ(SetUnusedBitsToZero(31, data),
+            std::string("\x00\x00\x00\x00\x00\x7f\xff\xff\xff", 9));
+  EXPECT_EQ(SetUnusedBitsToZero(9, data),
+            std::string("\x00\x00\x00\x00\x00\x00\x00\x01\xff", 9));
+  EXPECT_EQ(SetUnusedBitsToZero(8, data),
+            std::string("\x00\x00\x00\x00\x00\x00\x00\x00\xff", 9));
+  EXPECT_EQ(SetUnusedBitsToZero(7, data),
+            std::string("\x00\x00\x00\x00\x00\x00\x00\x00\x7f", 9));
+  EXPECT_EQ(SetUnusedBitsToZero(0, data),
+            std::string("\x00\x00\x00\x00\x00\x00\x00\x00\x00", 9));
+}
+
+TEST(FuzzUtilTest, BitsToUint64) {
+  EXPECT_EQ(BitsToUint64(std::string("\0\0\0\0\0\0\0\x63", 8)), 0x63);
+  EXPECT_EQ(BitsToUint64(std::string("\0\0\0\0\0\0\x30\x63", 8)), 0x3063);
+  EXPECT_EQ(BitsToUint64(std::string("\x01\x02\x03\x04\x05\x06\x07\x08", 8)),
+            0x0102030405060708);
+}
+
+TEST(FuzzUtilTest, FuzzBitsStringSize) {
+  struct TestCase {
+    int bits;
+    int bytes;
+  } test_cases[] = {{1, 1},  {5, 1},  {7, 1},  {8, 1},    {9, 2},
+                    {10, 2}, {16, 2}, {17, 3}, {128, 16}, {129, 17}};
+
+  absl::BitGen gen;
+  for (auto test_case : test_cases) {
+    std::string data = FuzzBits(&gen, test_case.bits);
+    EXPECT_EQ(data.size(), test_case.bytes)
+        << "bits: " << test_case.bits << " data: '" << data << "'";
+  }
+}
+
+TEST(FuzzUtilTest, FuzzBitsStringPaddingWorks) {
+  absl::BitGen gen;
+  for (int i = 0; i < 100; ++i) {
+    std::string data = FuzzBits(&gen, /*bits=*/3);
+    ASSERT_EQ(data.size(), 1);
+    EXPECT_EQ(data[0] & 0xf8, 0);
+  }
+}
+
+TEST(FuzzUtilTest, FuzzUint64SmallInRange) {
+  absl::BitGen gen;
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_LE(FuzzUint64(&gen, /*bits=*/1), 1);
+  }
+}
+
+TEST(FuzzUtilTest, FuzzUint64LargeInRange) {
+  absl::BitGen gen;
+  for (int i = 0; i < 10000; ++i) {
+    EXPECT_LT(FuzzUint64(&gen, /*bits=*/10), 1024);
+  }
+}
+
+}  // namespace
+}  // namespace p4_fuzzer

--- a/p4_fuzzer/fuzzer.proto
+++ b/p4_fuzzer/fuzzer.proto
@@ -1,0 +1,122 @@
+syntax = "proto3";
+
+package p4_fuzzer;
+
+import "p4/v1/p4runtime.proto";
+import "p4_pdpi/ir.proto";
+
+// The types of mutations p4-fuzzer can perform on a given table entry.
+enum Mutation {
+  // Change a valid table identifier in a table entry to one that does
+  // not exist in the P4Info file associated with the P4 program.
+  INVALID_TABLE_ID = 0;
+
+  // Works the same way as INVALID_TABLE_ID but acts on action
+  // identifiers.
+  INVALID_ACTION_ID = 1;
+
+  // Works the same way as INVALID_TABLE_ID but acts on match field
+  // identifiers.
+  INVALID_MATCH_FIELD_ID = 2;
+
+  // Removes a mandatory match field from a table entry.
+  MISSING_MANDATORY_MATCH_FIELD = 3;
+
+  // Duplicates a match field in a table entry.
+  DUPLICATE_MATCH_FIELD = 4;
+
+  // Picks table entry fields and changes their value to randomly generated ones
+  // of the same type.
+  INVALID_GENERIC = 5;
+
+  // Changes a table entry with an ActionProfileActionSet (intended for tables
+  // that implement one-shot action selector programming) to a table that
+  // expects a single action and vice versa.
+  INVALID_TABLE_IMPLEMENTATION = 6;
+
+  // Picks an action_profile_action and sets its weight to zero.
+  INVALID_ACTION_SELECTOR_WEIGHT = 7;
+
+  // Attempts to insert a table entry that is a duplicate of an already inserted
+  // table entry.
+  DUPLICATE_INSERT = 8;
+
+  // Attempts to delete a table entry that does not exist in the switch.
+  NONEXISTING_DELETE = 9;
+}
+
+// Human readable version of a (fuzzed) table entry. Contains the original
+// P4Runtime table entry (pi) and either a more readable program
+// dependent version of the table entry translated using p4-pdpi or an error
+// message if translation was attempted and failed.
+message AnnotatedTableEntry {
+  // The P4 runtime spec table entry (program independent representation).
+  p4.v1.TableEntry pi = 1;
+
+  oneof pd {
+    // An error message in case a conversion from the program independent
+    // version of the table entry (pi) to the program dependent version (ir)
+    // failed.
+    string error = 2;
+
+    // The PDPI program dependent representation of a table entry.
+    pdpi.IrTableEntry ir = 3;
+  }
+
+  repeated Mutation mutations = 4;
+}
+
+// Like AnnotatedTableEntry, but for updates instead.
+message AnnotatedUpdate {
+  p4.v1.Update pi = 1;
+
+  oneof pd {
+    string error = 2;
+
+    pdpi.IrUpdate ir = 3;
+  }
+
+  repeated Mutation mutations = 4;
+}
+
+// Like AnnotatedTableEntry, but for write requests.
+message AnnotatedWriteRequest {
+  uint64 device_id = 1;
+  p4.v1.Uint128 election_id = 2;
+  repeated AnnotatedUpdate updates = 3;
+}
+
+// Logs fuzzed requests (both correct and incorrect) along with their responses.
+// This is primarily intended for debugging and analysis.
+message Request {
+  // 0-based batch number
+  int64 batch_id = 1;
+
+  // Unix timestamp for the request, in milliseconds.
+  int64 timestamp_request = 2;
+
+  // Unix timestamp for the response, in milliseconds.
+  int64 timestamp_response = 3;
+
+  // The P4 write request (program independent representation)
+  p4.v1.WriteRequest pi = 4;
+
+  // TODO: add a program dependent representation after understanding
+  // p4-pdpi. Reserving field 5 for now.
+  reserved 5;
+
+  // TODO: add an open-source Status proto message. Reserving field 6
+  // for now.
+  reserved 6;
+
+  // List of errors, according to fuzzing oracle
+  repeated string errors = 7;
+
+  // The number of updates sent by the fuzzer prior to the current request.
+  // Helpful for tracking fuzzer progress.
+  int64 num_prior_updates = 8;
+}
+
+message Requests {
+  repeated Request requests = 1;
+}

--- a/p4_fuzzer/mutation.cc
+++ b/p4_fuzzer/mutation.cc
@@ -1,0 +1,316 @@
+#include "p4_fuzzer/mutation.h"
+
+// #include "third_party/libprotobuf_mutator/src/mutator.h"
+#include "absl/algorithm/container.h"
+#include "gutil/collections.h"
+#include "p4_fuzzer/fuzz_util.h"
+
+namespace p4_fuzzer {
+
+using ::absl::BitGen;
+using ::absl::Uniform;
+using ::p4::v1::TableEntry;
+
+namespace {
+
+// Returns a uniformly random ID that is not from a given list.
+uint32_t UniformNotFromList(BitGen* gen, const std::vector<uint32_t>& list) {
+  uint32_t choice;
+
+  do {
+    choice = Uniform<uint32_t>(*gen);
+  } while (absl::c_find(list, choice) != list.end());
+
+  return choice;
+}
+
+// Returns the list of all table IDs in the underlying P4 program.
+const std::vector<uint32_t> AllTableIds(const pdpi::IrP4Info& ir_p4_info) {
+  std::vector<uint32_t> table_ids;
+
+  for (auto& [table_id, table_def] : ir_p4_info.tables_by_id()) {
+    table_ids.push_back(table_id);
+  }
+
+  return table_ids;
+}
+
+// Returns the list of all action IDs in the underlying P4 program.
+const std::vector<uint32_t> AllActionIds(const pdpi::IrP4Info& ir_p4_info) {
+  std::vector<uint32_t> action_ids;
+
+  for (auto& [action_id, action_def] : ir_p4_info.actions_by_id()) {
+    action_ids.push_back(action_id);
+  }
+
+  return action_ids;
+}
+
+// Returns the list of all match field IDs in the underlying P4 program for
+// table with id table_id.
+const std::vector<uint32_t> AllMatchFieldIds(const pdpi::IrP4Info& ir_p4_info,
+                                             const uint32_t table_id) {
+  std::vector<uint32_t> match_ids;
+
+  for (auto& [match_id, match_def] :
+       gutil::FindOrDie(ir_p4_info.tables_by_id(), table_id)
+           .match_fields_by_id()) {
+    match_ids.push_back(match_id);
+  }
+
+  return match_ids;
+}
+
+// Max size hint for lib protobuf mutator's Mutate function.
+const int32_t kProtobufMutatorMaxByteSize = 200;
+
+}  // namespace
+
+void MutateInvalidGeneric(TableEntry* entry) {
+  // TODO: mutator is not a visible class in google3.
+  // static protobuf_mutator::Mutator mutator;
+  // mutator.Mutate(entry, kProtobufMutatorMaxByteSize);
+}
+
+absl::Status MutateInvalidMatchFieldId(BitGen* gen, TableEntry* entry,
+                                       const pdpi::IrP4Info& ir_p4_info) {
+  if (entry->match_size() == 0) {
+    return absl::InvalidArgumentError("TableEntry has no match fields to fuzz");
+  }
+
+  auto table_ids = AllTableIds(ir_p4_info);
+
+  if (absl::c_find(table_ids, entry->table_id()) == table_ids.end()) {
+    return absl::InvalidArgumentError(
+        "Cannot fuzz matches on invalid table id (it was probably fuzzed)");
+  }
+
+  int match_to_fuzz = Uniform<int>(*gen, 0, entry->match_size());
+  entry->mutable_match(match_to_fuzz)
+      ->set_field_id(UniformNotFromList(
+          gen, AllMatchFieldIds(ir_p4_info, entry->table_id())));
+
+  return absl::OkStatus();
+}
+
+absl::Status MutateMissingMandatoryMatchField(BitGen* gen, TableEntry* entry) {
+  std::vector<int> mandatory_matches;
+
+  int i = 0;
+  for (const auto& match : entry->match()) {
+    if (match.field_match_type_case() == p4::v1::FieldMatch::kExact) {
+      mandatory_matches.push_back(i);
+    }
+
+    ++i;
+  }
+
+  if (mandatory_matches.empty()) {
+    return absl::InvalidArgumentError(
+        "Table entry has no mandatory match fields to remove");
+  }
+
+  entry->mutable_match()->erase(
+      entry->mutable_match()->begin() +
+      mandatory_matches[Uniform<int>(*gen, 0, mandatory_matches.size())]);
+
+  return absl::OkStatus();
+}
+
+absl::Status MutateDuplicateMatchField(BitGen* gen, TableEntry* entry) {
+  if (entry->match_size() == 0) {
+    return absl::InvalidArgumentError(
+        "TableEntry has no match fields to duplicate");
+  }
+
+  *entry->add_match() =
+      entry->match(Uniform<int>(*gen, 0, entry->match_size()));
+
+  return absl::OkStatus();
+}
+
+void MutateInvalidTableId(BitGen* gen, TableEntry* entry,
+                          const pdpi::IrP4Info& ir_p4_info) {
+  entry->set_table_id(UniformNotFromList(gen, AllTableIds(ir_p4_info)));
+}
+
+void MutateInvalidActionId(BitGen* gen, TableEntry* entry,
+                           const pdpi::IrP4Info& ir_p4_info) {
+  auto action = entry->mutable_action();
+
+  switch (action->type_case()) {
+    case p4::v1::TableAction::kAction:
+      action->mutable_action()->set_action_id(
+          UniformNotFromList(gen, AllActionIds(ir_p4_info)));
+      break;
+    case p4::v1::TableAction::kActionProfileActionSet: {
+      auto* action_set = action->mutable_action_profile_action_set();
+      const int num_actions = action_set->action_profile_actions_size();
+      if (num_actions == 0) return;
+      const int action_to_fuzz = Uniform<int>(*gen, 0, num_actions);
+      auto* action_profile_action =
+          action_set->mutable_action_profile_actions(action_to_fuzz);
+      action_profile_action->mutable_action()->set_action_id(
+          UniformNotFromList(gen, AllActionIds(ir_p4_info)));
+    }
+
+    break;
+    default:
+      LOG(FATAL) << "Only single action table entries or table entries that "
+                    "use one one shot action selector programming supported.";
+  }
+}
+
+absl::Status MutateInvalidTableImplementation(
+    BitGen* gen, TableEntry* entry, const pdpi::IrP4Info& ir_p4_info) {
+  auto table_ids = AllTableIds(ir_p4_info);
+
+  if (absl::c_find(table_ids, entry->table_id()) == table_ids.end()) {
+    return absl::InvalidArgumentError(
+        "Cannot fuzz matches on invalid table id (it was probably fuzzed)");
+  }
+
+  pdpi::IrTableDefinition ir_table_info =
+      gutil::FindOrDie(ir_p4_info.tables_by_id(), entry->table_id());
+
+  switch (entry->action().type_case()) {
+    case p4::v1::TableAction::kActionProfileActionSet: {
+      *entry->mutable_action()->mutable_action() = FuzzAction(
+          gen, ChooseNonDefaultActionRef(gen, ir_table_info).action());
+      break;
+    }
+
+    case p4::v1::TableAction::kAction: {
+      *entry->mutable_action()->mutable_action_profile_action_set() =
+          FuzzActionProfileActionSet(gen, ir_p4_info, ir_table_info);
+      break;
+    }
+
+    default:
+      return absl::InvalidArgumentError(
+          "Only single action tables or one shot action selector programming "
+          "tables supported.");
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status MutateInvalidActionSelectorWeight(
+    BitGen* gen, p4::v1::TableEntry* entry, const pdpi::IrP4Info& ir_p4_info) {
+  auto action = entry->mutable_action();
+
+  if (action->type_case() != p4::v1::TableAction::kActionProfileActionSet) {
+    return absl::InvalidArgumentError(
+        "INVALID_ACTION_SELECTOR_WEIGHT mutation only works on tables that use "
+        "one shot action selector programming.");
+  }
+
+  auto action_set = action->mutable_action_profile_action_set();
+
+  if (action_set->action_profile_actions_size() == 0) {
+    return absl::OkStatus();
+  }
+
+  int action_to_fuzz =
+      Uniform<int>(*gen, 0, action_set->action_profile_actions_size());
+  auto action_profile_action =
+      action_set->mutable_action_profile_actions(action_to_fuzz);
+
+  if (absl::Bernoulli(*gen, 0.5)) {
+    action_profile_action->set_weight(0);
+  } else {
+    action_profile_action->set_weight(
+        absl::Uniform<int32_t>(*gen, -1 * kActionProfileActionMaxWeight, 0));
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status MutateDuplicateInsert(absl::BitGen* gen, p4::v1::Update* update,
+                                   const pdpi::IrP4Info& ir_p4_info,
+                                   const SwitchState& switch_state) {
+  std::vector<TableEntry> entries;
+
+  for (auto id : switch_state.AllTableIds()) {
+    std::vector<TableEntry> entries_from_table =
+        switch_state.GetTableEntries(id);
+    entries.insert(entries.end(), entries_from_table.begin(),
+                   entries_from_table.end());
+  }
+
+  if (entries.empty()) {
+    return absl::InvalidArgumentError(
+        "Cannot do a duplicate insert when there are no installed entries");
+  }
+
+  update->set_type(p4::v1::Update::INSERT);
+  *update->mutable_entity()->mutable_table_entry() =
+      UniformFromVector(gen, entries);
+
+  return absl::OkStatus();
+}
+
+absl::Status MutateNonexistingDelete(absl::BitGen* gen, p4::v1::Update* update,
+                                     const pdpi::IrP4Info& ir_p4_info,
+                                     const SwitchState& switch_state) {
+  const int table_id = FuzzTableId(gen, switch_state);
+
+  p4::v1::TableEntry entry = FuzzValidTableEntry(gen, ir_p4_info, table_id);
+  if (switch_state.GetTableEntry(entry) != absl::nullopt) {
+    return absl::InternalError("Generated entry that exists in switch");
+  }
+
+  *update->mutable_entity()->mutable_table_entry() = entry;
+  update->set_type(p4::v1::Update::DELETE);
+
+  return absl::OkStatus();
+}
+
+absl::Status MutateUpdate(BitGen* gen, p4::v1::Update* update,
+                          const pdpi::IrP4Info& ir_p4_info,
+                          const SwitchState& switch_state,
+                          const Mutation& mutation) {
+  TableEntry* entry = update->mutable_entity()->mutable_table_entry();
+
+  switch (mutation) {
+    case Mutation::INVALID_TABLE_ID:
+      MutateInvalidTableId(gen, entry, ir_p4_info);
+      return absl::OkStatus();
+
+    case Mutation::INVALID_ACTION_ID:
+      MutateInvalidActionId(gen, entry, ir_p4_info);
+      return absl::OkStatus();
+
+    case Mutation::INVALID_MATCH_FIELD_ID:
+      return MutateInvalidMatchFieldId(gen, entry, ir_p4_info);
+
+    case Mutation::MISSING_MANDATORY_MATCH_FIELD:
+      return MutateMissingMandatoryMatchField(gen, entry);
+
+    case Mutation::DUPLICATE_MATCH_FIELD:
+      return MutateDuplicateMatchField(gen, entry);
+
+    case Mutation::INVALID_GENERIC:
+      MutateInvalidGeneric(entry);
+      return absl::OkStatus();
+
+    case Mutation::INVALID_TABLE_IMPLEMENTATION:
+      return MutateInvalidTableImplementation(gen, entry, ir_p4_info);
+
+    case Mutation::INVALID_ACTION_SELECTOR_WEIGHT:
+      return MutateInvalidActionSelectorWeight(gen, entry, ir_p4_info);
+
+    case Mutation::DUPLICATE_INSERT:
+      return MutateDuplicateInsert(gen, update, ir_p4_info, switch_state);
+
+    case Mutation::NONEXISTING_DELETE:
+      return MutateNonexistingDelete(gen, update, ir_p4_info, switch_state);
+
+    default:
+      LOG(FATAL) << "Unsupported mutation type";
+  }
+
+  return absl::InternalError("Control flow should have never reached here.");
+}
+
+}  // namespace p4_fuzzer

--- a/p4_fuzzer/mutation.h
+++ b/p4_fuzzer/mutation.h
@@ -1,0 +1,78 @@
+#ifndef P4_FUZZER_MUTATION_H_
+#define P4_FUZZER_MUTATION_H_
+
+#include "absl/random/random.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_fuzzer/fuzzer.pb.h"
+#include "p4_fuzzer/switch_state.h"
+
+namespace p4_fuzzer {
+
+// TODO: implement.
+// Takes a valid table entry with N fields, picks fields and changes their value
+// to randomly generated ones of the same type. This does not *need* to result
+// in an invalid table entry but *may* result in one.
+// void MutateInvalidGeneric(p4::v1::TableEntry* entry);
+
+// Sets the table id of the table entry to a value that does no belong to any
+// table in the P4 program.
+void MutateInvalidTableId(absl::BitGen* gen, p4::v1::TableEntry* entry,
+                          const pdpi::IrP4Info& ir_p4_info);
+
+// Sets the action id of the table entry to a value that does not belong to
+// any action in the P4 program.
+void MutateInvalidActionId(absl::BitGen* gen, p4::v1::TableEntry* entry,
+                           const pdpi::IrP4Info& ir_p4_info);
+
+// Sets the id of one of the match fields in the table entry to a value that
+// does no belong to any table in the P4 program. Returns an error if the table
+// entry contains no match fields.
+absl::Status MutateInvalidMatchFieldId(absl::BitGen* gen,
+                                       p4::v1::TableEntry* entry,
+                                       const pdpi::IrP4Info& ir_p4_info);
+
+// Changes the number of match fields sent via a table entry to an invalid
+// smaller value e.g 4 fields sent for a table that matches on 3.
+absl::Status MutateMissingMandatoryMatchField(absl::BitGen* gen,
+                                              p4::v1::TableEntry* entry);
+
+// Adds a duplicate for an already existing match field e.g two copies of match
+// field id 3.
+absl::Status MutateDuplicateMatchField(absl::BitGen* gen,
+                                       p4::v1::TableEntry* entry);
+
+// Changes a table entry with an ActionProfileActionSet (intended for tables
+// that implement one-shot action selector programming) to a table that
+// expects a single action and vice versa.
+absl::Status MutateInvalidTableImplementation(absl::BitGen* gen,
+                                              p4::v1::TableEntry* entry,
+                                              const pdpi::IrP4Info& ir_p4_info);
+
+// This picks an action_profile_action and sets its weight to a non-positive
+// integer. This is only intended for tables that support one-shot action
+// selector programming.
+absl::Status MutateInvalidActionSelectorWeight(
+    absl::BitGen* gen, p4::v1::TableEntry* entry,
+    const pdpi::IrP4Info& ir_p4_info);
+
+// This randomly selects an already inserted table entry from the switch state
+// and sets the value of TableEntry* entry to that of the already inserted
+// entry.
+absl::Status MutateDuplicateInsert(absl::BitGen* gen, p4::v1::Update* update,
+                                   const pdpi::IrP4Info& ir_p4_info,
+                                   const SwitchState& switch_state);
+
+// This attempts to delete a table entry that does not exist in the switch.
+absl::Status MutateNonexistingDelete(absl::BitGen* gen, p4::v1::Update* update,
+                                     const pdpi::IrP4Info& ir_p4_info,
+                                     const SwitchState& switch_state);
+
+// Applied a given mutation to the update.
+absl::Status MutateUpdate(absl::BitGen* gen, p4::v1::Update* update,
+                          const pdpi::IrP4Info& ir_p4_info,
+                          const SwitchState& switch_state,
+                          const Mutation& mutation);
+}  // namespace p4_fuzzer
+
+#endif /* P4_FUZZER_MUTATION_H_ */

--- a/p4_fuzzer/oracle_util.cc
+++ b/p4_fuzzer/oracle_util.cc
@@ -1,0 +1,281 @@
+#include "p4_fuzzer/oracle_util.h"
+
+#include <algorithm>
+#include <numeric>
+
+#include "absl/algorithm/container.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/status.h"
+#include "absl/types/optional.h"
+#include "gutil/status.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4_fuzzer/switch_state.h"
+#include "p4_fuzzer/table_entry_key.h"
+#include "p4_pdpi/ir.h"
+
+namespace p4_fuzzer {
+
+using absl::StatusCode;
+using ::p4::v1::Error;
+using ::p4::v1::TableEntry;
+using ::p4::v1::Update;
+using ::p4::v1::WriteRequest;
+
+absl::Status IsWellformedUpdate(const pdpi::IrP4Info& ir_p4_info,
+                                const Update& update) {
+  // Check by converting to PD
+  TableEntry table_entry = update.entity().table_entry();
+
+  ASSIGN_OR_RETURN(pdpi::IrTableEntry ir_entry,
+                   pdpi::PiTableEntryToIr(ir_p4_info, table_entry));
+
+  // TODO: check table constraints.
+  return absl::OkStatus();
+}
+
+absl::Status UpdateOracle(const pdpi::IrP4Info& ir_p4_info,
+                          const Update& update, const Error& status,
+                          const SwitchState& state) {
+  StatusCode code = static_cast<StatusCode>(status.canonical_code());
+  absl::Status invalid_reason = IsWellformedUpdate(ir_p4_info, update);
+  if (!invalid_reason.ok()) {
+    if (code != StatusCode::kInvalidArgument) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Invalid entries must be rejected with StatusCode::kInvalidArgument. "
+          "Reason the entry is invalid: ",
+          invalid_reason.message()));
+    }
+  } else {
+    const TableEntry& table_entry = update.entity().table_entry();
+    const absl::optional<TableEntry>& previous =
+        state.GetTableEntry(table_entry);
+    bool exists = previous.has_value();
+    switch (update.type()) {
+      case p4::v1::Update::DELETE:
+        if (exists) {
+          if (code != StatusCode::kOk) {
+            return absl::InvalidArgumentError(
+                "Deleting an existing entry must succeed.");
+          }
+        } else {
+          if (code != StatusCode::kNotFound) {
+            return absl::InvalidArgumentError(
+                "Deleting a non-existing entry must fail with "
+                "StatusCode::kNotFound.");
+          }
+        }
+        break;
+      case p4::v1::Update::INSERT:
+        if (exists) {
+          if (code != StatusCode::kAlreadyExists) {
+            return absl::InvalidArgumentError(
+                "Inserting an existing entry must fail with "
+                "tatusCode::kAlreadyExists.");
+          }
+        } else {
+          if (code == StatusCode::kResourceExhausted) {
+            if (!state.IsTableFull(table_entry.table_id())) {
+              return absl::InvalidArgumentError(
+                  "Inserting an entry into a table that is not full must "
+                  "succeed.");
+            }
+          } else {
+            if (code != StatusCode::kOk) {
+              return absl::InvalidArgumentError(
+                  "Inserting a non-existing entry must succeed.");
+            }
+          }
+        }
+        break;
+      default:
+        // TODO: Support MODIFY here once b/126750297 has been fixed.
+        CHECK(false) << "Update type not supported: " << update.type();
+    }
+  }
+  return absl::OkStatus();
+}
+
+// Verify if a sequence of updates with their associated statuses is valid in a
+// given switch state.  Returns nullopt if everything is valid, and a
+// description of why this sequence is not valid otherwise.
+absl::optional<std::string> SequenceOfUpdatesOracle(
+    const pdpi::IrP4Info& ir_p4_info,
+    const std::vector<IndexUpdateStatus>& updates,
+    const SwitchState& initial_state) {
+  std::vector<absl::Status> oracle_failures;
+
+  // Create a copy of the state.
+  SwitchState state = initial_state;
+
+  // Go through all updates and check if the status makes sense in the current
+  // state.
+  std::string error = "";
+  for (int i = 0; i < updates.size(); i++) {
+    int index = updates[i].index;
+    const Update& update = updates[i].update;
+    const Error& status = updates[i].status;
+
+    const auto& update_oracle_result =
+        UpdateOracle(ir_p4_info, update, status, state);
+    if (!update_oracle_result.ok()) {
+      error += absl::StrCat(
+          "\n- ", "The update with id=", index,
+          " was not processed correctly by the switch. The problem was: ",
+          update_oracle_result.message());
+    }
+
+    // Update the state
+    if (status.canonical_code() == 0) {
+      state.ApplyUpdate(update);
+    }
+  }
+
+  if (error.empty()) return absl::nullopt;
+  return error.substr(1);
+}
+
+// See go/p4-fuzzing for more info on the design.
+absl::optional<std::vector<std::string>> WriteRequestOracle(
+    const pdpi::IrP4Info& ir_p4_info, const WriteRequest& request,
+    const absl::Span<const Error>& statuses, const SwitchState& state) {
+  // For now, we only support checking requests with table entries.
+  CHECK(absl::c_all_of(request.updates(), [](const Update& update) {
+    return update.entity().has_table_entry();
+  }));
+
+  std::vector<std::string> problems;
+
+  // Match updates with status codes.
+  CHECK_EQ(request.updates_size(), statuses.size());
+  std::vector<IndexUpdateStatus> updates;
+  for (int i = 0; i < request.updates().size(); i++) {
+    const Update& update = request.updates(i);
+    const Error& status = statuses[i];
+    updates.push_back({i, update, status});
+  }
+
+  // Group by flow key.
+  absl::flat_hash_map<TableEntryKey, std::vector<IndexUpdateStatus>>
+      flowkey_to_updates;
+  for (const auto& update : updates) {
+    // Filter out any resource exhausted errors.
+    StatusCode code = static_cast<StatusCode>(update.status.canonical_code());
+    if (code == StatusCode::kResourceExhausted) continue;
+
+    flowkey_to_updates[TableEntryKey(update.update.entity().table_entry())]
+        .push_back(update);
+  }
+
+  // Check each flow key individually.
+  for (auto& [key, updates] : flowkey_to_updates) {
+    // Go over all possible permutations to handle the updates for this key.
+    std::string first_failure = "";
+    bool found_legal_permutation = false;
+    do {
+      absl::optional<std::string> res = absl::nullopt;
+      // Optimization: If there is just a single update, we don't need to invoke
+      // SequenceOfUpdatesOracle and can avoid the state copy.
+      if (updates.size() == 1) {
+        const auto& update_oracle_result = UpdateOracle(
+            ir_p4_info, updates[0].update, updates[0].status, state);
+        if (!update_oracle_result.ok()) {
+          res = absl::StrCat(
+              "The update with id=", updates[0].index,
+              " was not processed correctly by the switch. The problem was: ",
+              update_oracle_result.message());
+        }
+      } else {
+        res = SequenceOfUpdatesOracle(ir_p4_info, updates, state);
+      }
+
+      if (!res.has_value()) {
+        found_legal_permutation = true;
+        break;
+      } else if (first_failure.empty()) {
+        first_failure = res.value();
+      }
+    } while (absl::c_next_permutation(
+        updates, [](const IndexUpdateStatus& a, const IndexUpdateStatus& b) {
+          return a.index < b.index;
+        }));
+
+    // Report error if all permutations are invalid.
+    if (!found_legal_permutation) {
+      int n = updates.size();
+      std::string explanation;
+      if (n == 1) {
+        explanation = absl::StrCat("Flow #", updates[0].index,
+                                   " was not handeled correctly. Flow:", "\n\n",
+                                   updates[0].update.DebugString(), "\n\n",
+                                   "Response by switch:", "\n\n",
+                                   updates[0].status.DebugString(), "\n\n",
+                                   "Problems:", "\n\n", first_failure);
+      } else {
+        explanation =
+            absl::StrCat("A group of ", n,
+                         " flows were not handled correctly.  All flows have "
+                         "the same flow key.",
+                         "\n\n", "The actual flows are:");
+        for (const auto& update : updates) {
+          explanation += absl::StrCat("\n\n", "Flow #", update.index, ":", "\n",
+                                      update.update.DebugString());
+          explanation += absl::StrCat("\n\n", "Response by switch:", "\n",
+                                      update.status.DebugString());
+        }
+        explanation += absl::StrCat(
+            "\n\n",
+            "These group of flows can be processed in any order, but no "
+            "permutation was found to be legal.  If they were processed in "
+            "order, then these were the problems:",
+            "\n", first_failure);
+      }
+
+      problems.push_back(explanation);
+    }
+  }
+
+  // Check resource errors.  First, count number of successful inserts per
+  // table.
+  absl::flat_hash_map<int, int> table_id_to_num_inserts;
+  for (const auto& update : updates) {
+    StatusCode code = static_cast<StatusCode>(update.status.canonical_code());
+    const auto& p4update = update.update;
+
+    // Not successful, skip.
+    if (code != StatusCode::kOk) continue;
+
+    // Not an insert, skip.
+    if (p4update.type() != p4::v1::Update::INSERT) continue;
+
+    auto table_id = p4update.entity().table_entry().table_id();
+    table_id_to_num_inserts[table_id] += 1;
+  }
+  // Then, assume all inserts happen first, and check if resource exhaustion is
+  // okay.
+  for (const auto& update : updates) {
+    StatusCode code = static_cast<StatusCode>(update.status.canonical_code());
+    const auto& p4update = update.update;
+    auto table_id = p4update.entity().table_entry().table_id();
+    if (code != StatusCode::kResourceExhausted) continue;
+
+    int num_inserts = table_id_to_num_inserts[table_id];
+    if (state.CanAccommodateInserts(table_id, num_inserts + 1)) {
+      std::string explanation = absl::StrCat(
+          "Flow #", update.index, " was not handeled correctly. Flow:", "\n\n",
+          update.update.DebugString(), "\n\n", "Response by switch:", "\n\n",
+          update.status.DebugString(), "\n\n",
+          "The switch rejected the flow with RESOURCE_EXHAUSTED, but the "
+          "table ",
+          table_id, " is not full yet.  There are ",
+          state.GetNumTableEntries(table_id),
+          " entries in the table before the batch, and ", num_inserts,
+          " inserts in this same batch were successful.");
+      problems.push_back(explanation);
+    }
+  }
+
+  if (problems.empty()) return absl::nullopt;
+  return problems;
+}
+
+}  // namespace p4_fuzzer

--- a/p4_fuzzer/oracle_util.h
+++ b/p4_fuzzer/oracle_util.h
@@ -1,0 +1,54 @@
+// Utility functions to determine if the switch is behaving correctly.  The main
+// function takes a WriteRequest and a list of statuses, and returns whether
+// that behavior is allowed by the switch according to the P4/P4RT
+// specification.
+
+#ifndef P4_FUZZER_ORACLE_UTIL_H_
+#define P4_FUZZER_ORACLE_UTIL_H_
+
+#include <string>
+#include <vector>
+
+#include "absl/types/span.h"
+#include "gutil/status.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_fuzzer/switch_state.h"
+
+namespace p4_fuzzer {
+
+// An update and it's corresponding status.
+struct UpdateStatus {
+  p4::v1::Update update;
+  p4::v1::Error status;
+};
+
+// An update with an index and it's corresponding status.
+struct IndexUpdateStatus {
+  int index;
+  p4::v1::Update update;
+  p4::v1::Error status;
+};
+
+// Is the given update well-formed according to the P4RT specification (e.g.,
+// not missing a field)?
+absl::Status IsWellformedUpdate(const pdpi::IrP4Info& ir_p4_info,
+                                const p4::v1::Update& update);
+
+// Is `status` a correct way to respond to the given update, when the switch is
+// the given state?
+absl::Status UpdateOracle(const pdpi::IrP4Info& ir_p4_info,
+                          const p4::v1::Update& update,
+                          const p4::v1::Error& status,
+                          const SwitchState& state);
+
+// Takes a batch and checks whether the way the switch responded is legal.  For
+// now, batches are processed in sequence.  Returns nullopt if everything is
+// valid, and a list of problems otherwise.
+absl::optional<std::vector<std::string>> WriteRequestOracle(
+    const pdpi::IrP4Info& ir_p4_info, const p4::v1::WriteRequest& request,
+    const absl::Span<const ::p4::v1::Error>& statuses,
+    const SwitchState& state);
+
+}  // namespace p4_fuzzer
+
+#endif  // P4_FUZZER_ORACLE_UTIL_H_

--- a/p4_fuzzer/oracle_util_test.cc
+++ b/p4_fuzzer/oracle_util_test.cc
@@ -1,0 +1,307 @@
+#include "p4_fuzzer/oracle_util.h"
+
+#include <utility>
+
+#include "absl/status/status.h"
+#include "devtools/build/runtime/get_runfiles_dir.h"
+#include "file/base/helpers.h"
+#include "file/base/options.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status.h"
+#include "net/google::protobuf/contrib/parse_proto/parse_text_proto.h"
+#include "platforms/networking/orion/core/sfe/sfe.pb.h"
+#include "util/task/canonical_errors.h"
+
+namespace switchstack {
+namespace testing {
+namespace hercules {
+namespace {
+
+using ::absl::StatusCode;
+using ::google::protobuf::contrib::parse_proto::ParseTextProtoOrDie;
+using ::orion::core::sfe::P4Entity;
+using ::orion::core::sfe::P4Update;
+using ::orion::p4::test::PdToPiUpdate;
+using ::p4::v1::Update;
+using ::p4::v1::WriteRequest;
+using ::testing::Not;
+using ::testing::status::IsOk;
+
+constexpr char kDecapFlow[] = R"(
+type: INSERT
+entity {
+  flow_entry {
+    priority: 900
+    table_entry {
+      decap_table_entry {
+        match {
+          hdr_ethernet_ether_type {
+            mask: 0xffff
+            value: 2048
+          }
+          hdr_ipv4_base_src_addr {
+            mask: 4294967295
+            value: 1869573999
+          }
+          hdr_ipv4_base_dst_addr {
+            mask: 4294967295
+            value: 170408329
+          }
+        }
+        action {
+          ip_decap {
+          }
+        }
+      }
+    }
+  }
+}
+)";
+
+util::Status CheckWellformed(P4Update pd) {
+  ASSIGN_OR_RETURN(Update pi, PdToPiUpdate(pd));
+  return IsWellformedUpdate(pi);
+}
+
+TEST(OracleUtilTest, IsWellformedUpdate) {
+  // Starting with PD because it's easier to read and write.
+  P4Update pd = ParseTextProtoOrDie(kDecapFlow);
+
+  // Regular update is fine
+  EXPECT_OK(CheckWellformed(pd));
+
+  // Wrong eth type (but still matching on IPv4 fields)
+  pd.mutable_entity()
+      ->mutable_flow_entry()
+      ->mutable_table_entry()
+      ->mutable_decap_table_entry()
+      ->mutable_match()
+      ->mutable_hdr_ethernet_ether_type()
+      ->set_value(1234);
+  EXPECT_THAT(CheckWellformed(pd), Not(IsOk()));
+
+  // Missing eth_type (but still matching on IPv4 fields)
+  pd.mutable_entity()
+      ->mutable_flow_entry()
+      ->mutable_table_entry()
+      ->mutable_decap_table_entry()
+      ->mutable_match()
+      ->clear_hdr_ethernet_ether_type();
+  EXPECT_THAT(CheckWellformed(pd), Not(IsOk()));
+}
+
+TEST(OracleUtilTest, IsWellformedLackOfPriority) {
+  P4Update pd = ParseTextProtoOrDie(R"(
+    type: INSERT
+    entity {
+      flow_entry {
+        priority: 0
+        cookie: 9223372036855300096
+        table_entry {
+          punt_table_entry {
+            match {
+              hdr_ethernet_ether_type { mask: 65535 value: 34525 }
+              hdr_ipv6_base_dst_addr {
+                mask: "\377\377\377\377\377\377\377\377\000\000\000\000\000\000\000\000"
+                value: "&\007\370\260\321\001P\004\000\000\000\000\000\000\000\000"
+              }
+            }
+            action { set_queue_and_send_to_cpu { queue_id: 2 } }
+          }
+        }
+        meter_config { cir: 28672 cburst: 57344 pir: 28672 pburst: 57344 }
+      }
+    }
+  )");
+
+  // Priority cannot be 0 if there are ternary matches
+  EXPECT_THAT(CheckWellformed(pd), Not(IsOk()));
+}
+
+constexpr char kVrfClassifierFlow[] = R"(
+flow_entry {
+  priority: 1134
+  cookie: 9223372036854841344
+  table_entry {
+    vrf_classifier_table_entry {
+      match {
+        hdr_ethernet_ether_type {
+          mask: 65535
+          value: 2048
+        }
+        standard_metadata_ingress_port {
+          mask: 4294967295
+          value: 1025
+        }
+      }
+      action {
+        set_vrf {
+          vrf_id: 117
+        }
+      }
+    }
+  }
+}
+)";
+
+SwitchState EmptyState() { return {}; }
+
+// Add a flow to a state.
+void AddFlow(const P4Entity& flow, SwitchState* state) {
+  P4Update update;
+  update.set_type(orion::core::sfe::P4Update::INSERT);
+  *update.mutable_entity() = flow;
+  CHECK_OK(state->ApplyUpdate(PdToPiUpdate(update).value()));
+}
+
+// Get a VRF classifier flow (n can be varied to get different flows).
+P4Entity GetVrfClassifierFlow(int n) {
+  P4Entity flow = ParseTextProtoOrDie(kVrfClassifierFlow);
+  flow.mutable_flow_entry()
+      ->mutable_table_entry()
+      ->mutable_vrf_classifier_table_entry()
+      ->mutable_match()
+      ->mutable_hdr_ethernet_ether_type()
+      ->set_value(n);
+  return flow;
+}
+
+// An update and it's corresponding status.
+struct PdUpdateStatus {
+  P4Update update;
+  StatusCode status;
+};
+
+// Checks whether the update+state combo is plausible or not
+util::Status Check(const std::vector<PdUpdateStatus>& updates,
+                   const SwitchState& state, bool valid) {
+  WriteRequest request;
+  std::vector<::p4::v1::Error> statuses;
+  for (const auto& update : updates) {
+    ASSIGN_OR_RETURN(Update pi, PdToPiUpdate(update.update));
+    *request.add_updates() = pi;
+    ::p4::v1::Error status;
+    status.set_canonical_code(static_cast<int32>(update.status));
+    statuses.push_back(status);
+  }
+  absl::optional<std::vector<std::string>> oracle =
+      WriteRequestOracle(request, statuses, state);
+  if (valid) {
+    if (oracle.has_value()) {
+      std::string explanation = absl::StrCat(
+          "Expected the write request and statuses to be a valid combination, "
+          "but they are not.",
+          "\n", "errors reported:");
+      for (const auto& error : oracle.value()) {
+        explanation += absl::StrCat("\n", error);
+      }
+      return util::InvalidArgumentError(explanation);
+    }
+  } else {
+    if (!oracle.has_value()) {
+      return util::InvalidArgumentError(
+          "Expected the write request and statuses to not be a valid "
+          "combination, "
+          "but they are according to the oracle.");
+    }
+  }
+  return util::OkStatus();
+}
+
+PdUpdateStatus MakeInsert(const P4Entity& entity, StatusCode status) {
+  P4Update update;
+  update.set_type(orion::core::sfe::P4Update::INSERT);
+  *update.mutable_entity() = entity;
+  return {update, status};
+}
+
+PdUpdateStatus MakeDelete(const P4Entity& entity, StatusCode status) {
+  P4Update update;
+  update.set_type(orion::core::sfe::P4Update::DELETE);
+  *update.mutable_entity() = entity;
+  return {update, status};
+}
+
+TEST(OracleUtilTest, BatchInsertDelete) {
+  P4Entity flow = ParseTextProtoOrDie(kVrfClassifierFlow);
+
+  // Insert/delete is fine in either order.
+  EXPECT_OK(Check(
+      {MakeInsert(flow, StatusCode::kOk), MakeDelete(flow, StatusCode::kOk)},
+      EmptyState(), /*valid=*/true));
+  EXPECT_OK(Check(
+      {MakeDelete(flow, StatusCode::kOk), MakeInsert(flow, StatusCode::kOk)},
+      EmptyState(), /*valid=*/true));
+
+  // It is also fine for the delete to fail (in either order).
+  EXPECT_OK(Check({MakeDelete(flow, StatusCode::kNotFound),
+                   MakeInsert(flow, StatusCode::kOk)},
+                  EmptyState(), /*valid=*/true));
+  EXPECT_OK(Check({MakeInsert(flow, StatusCode::kOk),
+                   MakeDelete(flow, StatusCode::kNotFound)},
+                  EmptyState(), /*valid=*/true));
+}
+
+TEST(OracleUtilTest, BatchDoubleInsert) {
+  P4Entity flow = ParseTextProtoOrDie(kVrfClassifierFlow);
+
+  // Double insert is not okay.
+  EXPECT_OK(Check(
+      {MakeInsert(flow, StatusCode::kOk), MakeInsert(flow, StatusCode::kOk)},
+      EmptyState(), /*valid=*/false));
+
+  // If one is rejected, it's fine.
+  EXPECT_OK(Check({MakeInsert(flow, StatusCode::kAlreadyExists),
+                   MakeInsert(flow, StatusCode::kOk)},
+                  EmptyState(), /*valid=*/true));
+  EXPECT_OK(Check({MakeInsert(flow, StatusCode::kOk),
+                   MakeInsert(flow, StatusCode::kAlreadyExists)},
+                  EmptyState(), /*valid=*/true));
+}
+
+TEST(OracleUtilTest, BatchResources) {
+  // Create a state that's full.
+  SwitchState full;
+  for (int i = 1; i <= 512; i++) {
+    AddFlow(GetVrfClassifierFlow(i), &full);
+  }
+
+  P4Entity new_flow = GetVrfClassifierFlow(513);
+
+  // Inserting into full table is okay.
+  EXPECT_OK(
+      Check({MakeInsert(new_flow, StatusCode::kOk)}, full, /*valid=*/true));
+
+  // Resource exhasted is okay too.
+  EXPECT_OK(Check({MakeInsert(new_flow, StatusCode::kResourceExhausted)}, full,
+                  /*valid=*/true));
+}
+
+TEST(OracleUtilTest, BatchResourcesAlmostFull) {
+  // Create a state that's almost full (1 entry remaining).
+  SwitchState almost_full;
+  for (int i = 1; i <= 511; i++) {
+    AddFlow(GetVrfClassifierFlow(i), &almost_full);
+  }
+
+  P4Entity new_flow1 = GetVrfClassifierFlow(513);
+  P4Entity new_flow2 = GetVrfClassifierFlow(514);
+
+  // Resource exhasted is not okay.
+  EXPECT_OK(Check({MakeInsert(new_flow1, StatusCode::kResourceExhausted)},
+                  almost_full, /*valid=*/false));
+
+  // Inserting two flows, one of them can fail.
+  EXPECT_OK(Check({MakeInsert(new_flow1, StatusCode::kOk),
+                   MakeInsert(new_flow2, StatusCode::kResourceExhausted)},
+                  almost_full, /*valid=*/true));
+  EXPECT_OK(Check({MakeInsert(new_flow1, StatusCode::kResourceExhausted),
+                   MakeInsert(new_flow2, StatusCode::kOk)},
+                  almost_full, /*valid=*/true));
+}
+
+}  // namespace
+}  // namespace hercules
+}  // namespace testing
+}  // namespace switchstack

--- a/p4_fuzzer/p4_programs/acl_table_test.p4
+++ b/p4_fuzzer/p4_programs/acl_table_test.p4
@@ -1,0 +1,72 @@
+/* -*- P4_16 -*- */
+#include <core.p4>
+#include <v1model.p4>
+#include "sai-p4-google/acl_set_vrf.p4"
+
+// -- Headers.
+header hdr_fuzz_t {
+    bit<8> fuzz_field_1;
+}
+
+struct metadata {
+}
+
+
+// -- Parsers.
+parser MyParser(packet_in packet,
+                out headers_t hdr,
+                inout local_metadata_t meta,
+                inout standard_metadata_t standard_metadata) {
+
+    state start {
+        transition accept;
+    }
+}
+
+
+// -- Checksum verification.
+control MyVerifyChecksum(inout headers_t hdr, inout local_metadata_t meta) {
+    apply {  }
+}
+
+
+// -- Ingress processing.
+control MyIngress(inout headers_t hdr,
+                  inout local_metadata_t meta,
+                  inout standard_metadata_t standard_metadata) {
+  apply {
+    acl_set_vrf.apply(hdr, meta, standard_metadata);
+ }
+}
+
+// -- Egress processing.
+control MyEgress(inout headers_t hdr,
+                 inout local_metadata_t meta,
+                 inout standard_metadata_t standard_metadata) {
+    apply {  }
+}
+
+// -- Checksum computation.
+control MyComputeChecksum(inout headers_t hdr, inout local_metadata_t meta) {
+     apply {
+
+    }
+}
+
+
+// -- Deparser.
+control MyDeparser(packet_out packet, in headers_t hdr) {
+    apply {
+    }
+}
+
+// -- Switch.
+// Switch architecture.
+V1Switch(
+MyParser(),
+MyVerifyChecksum(),
+MyIngress(),
+MyEgress(),
+MyComputeChecksum(),
+MyDeparser()
+) main;

--- a/p4_fuzzer/p4_programs/sai-p4-google/acl_actions.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/acl_actions.p4
@@ -1,0 +1,23 @@
+#ifndef SAI_ACL_ACTIONS_P4_
+#define SAI_ACL_ACTIONS_P4_
+
+#include "v1model.p4"
+
+// User defined ACL tables can use the actions from this file.
+
+// Copy the packet to the CPU. The original packet proceeds unmodified.
+@id(ACL_COPY_ACTION_ID)
+@sai_action(SAI_PACKET_ACTION_COPY)
+action copy(inout standard_metadata_t standard_metadata) {
+  clone(CloneType.I2E, COPY_TO_CPU_SESSION_ID);
+}
+
+// Copy the packet to the CPU. The original packet is dropped.
+@id(ACL_TRAP_ACTION_ID)
+@sai_action(SAI_PACKET_ACTION_TRAP)
+action trap(inout standard_metadata_t standard_metadata) {
+  copy(standard_metadata);
+  mark_to_drop(standard_metadata);
+}
+
+#endif  // SAI_ACL_ACTIONS_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/acl_punt.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/acl_punt.p4
@@ -1,0 +1,49 @@
+#ifndef SAI_ACL_PUNT_P4_
+#define SAI_ACL_PUNT_P4_
+
+#include "v1model.p4"
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+#include "resource_limits.p4"
+#include "acl_actions.p4"
+
+control acl_punt(inout headers_t headers,
+                 inout local_metadata_t local_metadata,
+                 inout standard_metadata_t standard_metadata) {
+
+  @proto_package("sai")
+  @id(ACL_PUNT_TABLE_ID)
+  @sai_acl(INGRESS)
+  table sai_punt_table {
+    key = {
+      headers.ethernet.ether_type : ternary @name("ether_type") @id(1)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE);
+      headers.ethernet.dst_addr : ternary @name("ether_dst") @id(2)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_DST_MAC) @format(MAC_ADDRESS);
+      headers.ipv6.dst_addr : ternary @name("ipv6_dst") @id(3)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6) @format(IPV6_ADDRESS);
+      headers.ipv6.next_header : ternary @name("ipv6_next_header") @id(4)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_IPV6_NEXT_HEADER);
+      headers.ipv6.hop_limit : ternary @name("ttl") @id(5)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_TTL);
+      headers.icmp.type : ternary @name("icmp_type") @id(6)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_ICMP_TYPE);
+      local_metadata.l4_dst_port : ternary @name("l4_dst_port") @id(7)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_L4_DST_PORT);
+    }
+    actions = {
+      @proto_id(1) copy(standard_metadata);
+      @proto_id(2) trap(standard_metadata);
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    size = PUNT_TABLE_SIZE;
+  }
+
+  apply {
+    sai_punt_table.apply();
+  }
+}  // control acl_punt
+
+#endif  // SAI_ACL_PUNT_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/acl_set_vrf.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/acl_set_vrf.p4
@@ -1,0 +1,48 @@
+#ifndef SAI_ACL_SET_VRF_P4_
+#define SAI_ACL_SET_VRF_P4_
+
+#include "v1model.p4"
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+#include "resource_limits.p4"
+#include "acl_actions.p4"
+
+control acl_set_vrf(inout headers_t headers,
+                    inout local_metadata_t local_metadata,
+                    inout standard_metadata_t standard_metadata) {
+
+  @id(ACL_SET_VRF_SET_VRF_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD)
+  action set_vrf(@sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_SET_VRF)
+                 @id(1) vrf_id_t vrf_id) {
+    local_metadata.vrf_id = vrf_id;
+  }
+
+  @proto_package("sai")
+  @id(ACL_SET_VRF_TABLE_ID)
+  @sai_acl(PREINGRESS)
+  @entry_constraint("ether_type == 0x86DD")
+  table set_vrf_table {
+    key = {
+      headers.ethernet.ether_type : exact @name("ether_type") @id(1)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE);
+      headers.ipv6.dst_addr : ternary @name("ipv6_dst") @id(2)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6) @format(IPV6_ADDRESS);
+      headers.ipv6.dscp : ternary @name("dscp") @id(3)
+          @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_DSCP);
+    }
+    actions = {
+      @proto_id(1) set_vrf;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    size = SET_VRF_TABLE_SIZE;
+  }
+
+  apply {
+    set_vrf_table.apply();
+  }
+}  // control acl_set_vrf
+
+#endif  // SAI_ACL_SET_VRF_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/headers.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/headers.p4
@@ -1,0 +1,119 @@
+#ifndef SAI_HEADERS_P4_
+#define SAI_HEADERS_P4_
+
+#define ETHERTYPE_IPV4  0x0800
+#define ETHERTYPE_IPV6  0x86dd
+#define ETHERTYPE_ARP   0x0806
+#define ETHERTYPE_LLDP  0x88CC
+
+#define IP_PROTOCOL_TCP    0x06
+#define IP_PROTOCOL_UDP    0x11
+#define IP_PROTOCOL_ICMP   0x01
+#define IP_PROTOCOL_ICMPV6 0x3a
+
+typedef bit<48> ethernet_addr_t;
+typedef bit<32> ipv4_addr_t;
+typedef bit<128> ipv6_addr_t;
+typedef bit<32> portid_t;
+
+// -- Protocol headers ---------------------------------------------------------
+
+header ethernet_t {
+  ethernet_addr_t dst_addr;
+  ethernet_addr_t src_addr;
+  bit<16> ether_type;
+}
+
+header ipv4_t {
+  bit<4> version;
+  bit<4> ihl;
+  bit<6> dscp;  // The 6 most significant bits of the diff_serv field.
+  bit<2> ecn;   // The 2 least significant bits of the diff_serv field.
+  bit<16> total_len;
+  bit<16> identification;
+  bit<3> flags;
+  bit<13> frag_offset;
+  bit<8> ttl;
+  bit<8> protocol;
+  bit<16> header_checksum;
+  ipv4_addr_t src_addr;
+  ipv4_addr_t dst_addr;
+}
+
+header ipv6_t {
+  bit<4> version;
+  bit<6> dscp;  // The 6 most significant bits of the traffic_class field.
+  bit<2> ecn;   // The 2 least significant bits of the traffic_class field.
+  bit<20> flow_label;
+  bit<16> payload_length;
+  bit<8> next_header;
+  bit<8> hop_limit;
+  ipv6_addr_t src_addr;
+  ipv6_addr_t dst_addr;
+}
+
+header udp_t {
+  bit<16> src_port;
+  bit<16> dst_port;
+  bit<16> hdr_length;
+  bit<16> checksum;
+}
+
+header tcp_t {
+  bit<16> src_port;
+  bit<16> dst_port;
+  bit<32> seq_no;
+  bit<32> ack_no;
+  bit<4> data_offset;
+  bit<4> res;
+  bit<8> flags;
+  bit<16> window;
+  bit<16> checksum;
+  bit<16> urgent_ptr;
+}
+
+header icmp_t {
+  bit<8> type;
+  bit<8> code;
+  bit<16> checksum;
+}
+
+header arp_t {
+  bit<16> hw_type;
+  bit<16> proto_type;
+  bit<8> hw_addr_len;
+  bit<8> proto_addr_len;
+  bit<16> opcode;
+  bit<48> sender_hw_addr;
+  bit<32> sender_proto_addr;
+  bit<48> target_hw_addr;
+  bit<32> target_proto_addr;
+}
+
+// -- Packet IO headers --------------------------------------------------------
+
+@controller_header("packet_in")
+header packet_in_header_t {
+  // The port the packet ingressed on.
+  @id(1)
+  portid_t ingress_port;
+  // The initial intended egress port decided for the packet by the pipeline.
+  @id(2)
+  portid_t target_egress_port;
+}
+
+@controller_header("packet_out")
+header packet_out_header_t {
+  // The port this packet should egress out of.
+  @id(1)
+  portid_t egress_port;
+  // Should the packet be submitted to the ingress pipeline instead of being
+  // sent directly?
+  @id(2)
+  bit<1> submit_to_ingress;
+  // BMV2 backend requires headers to be multiple of 8-bits.
+  @id(3)
+  bit<7> unused_pad;
+}
+
+#endif  // SAI_HEADERS_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/ids.h
+++ b/p4_fuzzer/p4_programs/sai-p4-google/ids.h
@@ -1,0 +1,56 @@
+// Rename this for the open source version.
+#ifndef P4_SAI_IDS_H_
+#define P4_SAI_IDS_H_
+
+// All declarations (tables, actions, action profiles, meters, counters) have a
+// stable ID. This list will evolve as new declarations are added. IDs cannot be
+// reused. If a declaration is removed, its ID macro is kept and marked reserved
+// to avoid the ID being reused.
+//
+// The IDs are classified using the 8 most significant bits to be compatible
+// with "6.3. ID Allocation for P4Info Objects" in the P4Runtime specification.
+
+// IDs of fixed SAI tables (8 most significant bits = 0x02).
+#define ROUTING_NEIGHBOR_TABLE_ID 0x02000040          // 33554496
+#define ROUTING_ROUTER_INTERFACE_TABLE_ID 0x02000041  // 33554497
+#define ROUTING_NEXTHOP_TABLE_ID 0x02000042           // 33554498
+#define ROUTING_WCMP_GROUP_TABLE_ID 0x02000043        // 33554499
+#define ROUTING_IPV4_TABLE_ID 0x02000044              // 33554500
+#define ROUTING_IPV6_TABLE_ID 0x02000045              // 33554501
+
+// IDs of ACL tables (8 most significant bits = 0x02).
+// Since these IDs are user defined, they need to be separate from the fixed SAI
+// table ID space. We achieve this by starting the IDs at 0x100.
+#define ACL_PUNT_TABLE_ID 0x02000100     // 33554688
+#define ACL_SET_VRF_TABLE_ID 0x02000101  // 33554689
+
+// IDs of fixed SAI actions (8 most significant bits = 0x01).
+#define ROUTING_SET_DST_MAC_ACTION_ID 0x01000001           // 16777217
+#define ROUTING_SET_PORT_AND_SRC_MAC_ACTION_ID 0x01000002  // 16777218
+#define ROUTING_SET_NEXTHOP_ACTION_ID 0x01000003           // 16777219
+#define ROUTING_SET_WCMP_GROUP_ID_ACTION_ID 0x01000004     // 16777220
+#define ROUTING_SET_NEXTHOP_ID_ACTION_ID 0x01000005        // 16777221
+#define ROUTING_DROP_ACTION_ID 0x01000006                  // 16777222
+#define ACL_COPY_ACTION_ID 0x01000007                      // 16777223
+#define ACL_TRAP_ACTION_ID 0x01000008                      // 16777224
+
+// IDs of ACL actions (8 most significant bits = 0x01).
+// Since these IDs are user defined, they need to be separate from the fixed SAI
+// actions ID space. We achieve this by starting the IDs at 0x100.
+#define ACL_SET_VRF_SET_VRF_ACTION_ID 0x01000100  // 16777472
+
+// The COPY_TO_CPU_SESSION_ID must be programmed in the target using P4Runtime:
+//
+// type: INSERT
+// entity {
+//   packet_replication_engine_entry {
+//     clone_session_entry {
+//       session_id: COPY_TO_CPU_SESSION_ID
+//       replicas { egress_port: 0xfffffffd } # to CPU
+//     }
+//   }
+// }
+//
+#define COPY_TO_CPU_SESSION_ID 1024
+
+#endif  // P4_SAI_IDS_H_

--- a/p4_fuzzer/p4_programs/sai-p4-google/ipv4_checksum.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/ipv4_checksum.p4
@@ -1,0 +1,37 @@
+#ifndef SAI_IPV4_CHECKSUM_H_
+#define SAI_IPV4_CHECKSUM_H_
+
+#include "headers.p4"
+#include "metadata.p4"
+
+// IPv6 does not have a checksum, so this code is only for IPv4.
+
+control verify_ipv4_checksum(inout headers_t headers,
+                             inout local_metadata_t local_metadata) {
+  apply {
+    verify_checksum(headers.ipv4.isValid(),
+      {headers.ipv4.version, headers.ipv4.ihl,
+       headers.ipv4.dscp, headers.ipv4.ecn, headers.ipv4.total_len,
+       headers.ipv4.identification, headers.ipv4.flags,
+       headers.ipv4.frag_offset, headers.ipv4.ttl,
+       headers.ipv4.protocol, headers.ipv4.src_addr,
+       headers.ipv4.dst_addr}, headers.ipv4.header_checksum,
+       HashAlgorithm.csum16);
+  }
+}  // control verify_ipv4_checksum
+
+control compute_ipv4_checksum(inout headers_t headers,
+                              inout local_metadata_t local_metadata) {
+  apply {
+    update_checksum(headers.ipv4.isValid(),
+      {headers.ipv4.version, headers.ipv4.ihl,
+       headers.ipv4.dscp, headers.ipv4.ecn, headers.ipv4.total_len,
+       headers.ipv4.identification, headers.ipv4.flags,
+       headers.ipv4.frag_offset, headers.ipv4.ttl,
+       headers.ipv4.protocol, headers.ipv4.src_addr,
+       headers.ipv4.dst_addr}, headers.ipv4.header_checksum,
+       HashAlgorithm.csum16);
+  }
+}  // control compute_ipv4_checksum
+
+#endif  // SAI_IPV4_CHECKSUM_H_

--- a/p4_fuzzer/p4_programs/sai-p4-google/metadata.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/metadata.p4
@@ -1,0 +1,42 @@
+#ifndef SAI_METADATA_P4_
+#define SAI_METADATA_P4_
+
+#include "headers.p4"
+#include "resource_limits.p4"
+
+@p4runtime_translation("", 32)
+type bit<MAX_NEXTHOPS_LOG2> nexthop_id_t;
+
+@p4runtime_translation("", 32)
+type bit<MAX_WCMP_GROUPS_LOG2> wcmp_group_id_t;
+
+@p4runtime_translation("", 32)
+type bit<MAX_VRFS_LOG2> vrf_id_t;
+
+@p4runtime_translation("", 32)
+type bit<MAX_ROUTER_INTERFACES_LOG2> router_interface_id_t;
+
+@p4runtime_translation("", 32)
+type bit<MAX_NEIGHBORS_LOG2> neighbor_id_t;
+
+@p4runtime_translation("", 32)
+type bit<MAX_PORTS_LOG2> port_id_t;
+
+struct headers_t {
+  ethernet_t ethernet;
+  ipv4_t ipv4;
+  ipv6_t ipv6;
+  icmp_t icmp;
+  tcp_t tcp;
+  udp_t udp;
+  arp_t arp;
+}
+
+// Local metadata for each packet being processed.
+struct local_metadata_t {
+  vrf_id_t vrf_id;
+  bit<16> l4_src_port;
+  bit<16> l4_dst_port;
+}
+
+#endif  // SAI_METADATA_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/parser.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/parser.p4
@@ -1,0 +1,84 @@
+#ifndef SAI_PARSER_P4_
+#define SAI_PARSER_P4_
+
+#include "v1model.p4"
+#include "headers.p4"
+#include "metadata.p4"
+
+parser packet_parser(packet_in packet, out headers_t headers,
+                     inout local_metadata_t local_metadata,
+                     inout standard_metadata_t standard_metadata) {
+  state start {
+    transition parse_ethernet;
+  }
+
+  state parse_ethernet {
+    packet.extract(headers.ethernet);
+    transition select(headers.ethernet.ether_type) {
+      ETHERTYPE_IPV4: parse_ipv4;
+      ETHERTYPE_IPV6: parse_ipv6;
+      ETHERTYPE_ARP:  parse_arp;
+      _:              accept;
+    }
+  }
+
+  state parse_ipv4 {
+    packet.extract(headers.ipv4);
+    transition select(headers.ipv4.protocol) {
+      IP_PROTOCOL_ICMP: parse_icmp;
+      IP_PROTOCOL_TCP:  parse_tcp;
+      IP_PROTOCOL_UDP:  parse_udp;
+      _:                accept;
+    }
+  }
+
+  state parse_ipv6 {
+    packet.extract(headers.ipv6);
+    transition select(headers.ipv6.next_header) {
+      IP_PROTOCOL_ICMPV6: parse_icmp;
+      IP_PROTOCOL_TCP:    parse_tcp;
+      IP_PROTOCOL_UDP:    parse_udp;
+      _:                  accept;
+    }
+  }
+
+  state parse_tcp {
+    packet.extract(headers.tcp);
+    // Normalize TCP port metadata to common port metadata.
+    local_metadata.l4_src_port = headers.tcp.src_port;
+    local_metadata.l4_dst_port = headers.tcp.dst_port;
+    transition accept;
+  }
+
+  state parse_udp {
+    packet.extract(headers.udp);
+    // Normalize UDP port metadata to common port metadata.
+    local_metadata.l4_src_port = headers.udp.src_port;
+    local_metadata.l4_dst_port = headers.udp.dst_port;
+    transition accept;
+  }
+
+  state parse_icmp {
+    packet.extract(headers.icmp);
+    transition accept;
+  }
+
+  state parse_arp {
+    packet.extract(headers.arp);
+    transition accept;
+  }
+}  // parser packet_parser
+
+control packet_deparser(packet_out packet, in headers_t headers) {
+  apply {
+    packet.emit(headers.ethernet);
+    packet.emit(headers.ipv4);
+    packet.emit(headers.ipv6);
+    packet.emit(headers.arp);
+    packet.emit(headers.icmp);
+    packet.emit(headers.tcp);
+    packet.emit(headers.udp);
+  }
+}  // control packet_deparser
+
+#endif  // SAI_PARSER_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/punt_acl.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/punt_acl.p4
@@ -1,0 +1,47 @@
+#ifndef SAI_PUNT_ACL_P4_
+#define SAI_PUNT_ACL_P4_
+
+#include "v1model.p4"
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+#include "resource_limits.p4"
+#include "acl_actions.p4"
+
+control punt_acl(inout headers_t headers,
+                 inout local_metadata_t local_metadata,
+                 inout standard_metadata_t standard_metadata) {
+
+  @proto_package("punt")
+  @id(PUNT_ACL_TABLE_ID)
+  @sai_acl(INGRESS)
+  table punt_table {
+    key = {
+      headers.ethernet.ether_type : ternary @name("ether_type")
+          @proto_tag(1) @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE);
+      headers.ethernet.dst_addr : ternary @name("ether_dst")
+          @proto_tag(2) @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_DST_MAC);
+      headers.ipv6.dst_addr : ternary @name("ipv6_dst")
+          @proto_tag(3) @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6);
+      headers.ipv6.next_header : ternary @name("ipv6_next_header")
+          @proto_tag(4) @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_IPV6_NEXT_HEADER);
+      headers.ipv6.hop_limit : ternary @name("ttl")
+          @proto_tag(5) @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_TTL);
+      headers.icmp.type : ternary @name("icmp_type")
+          @proto_tag(6) @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_ICMP_TYPE);
+      local_metadata.l4_dst_port : ternary @name("l4_dst_port")
+          @proto_tag(7) @sai_field(SAI_ACL_ENTRY_ATTR_FIELD_L4_DST_PORT);
+    }
+    actions = {
+      @proto_tag(1) copy(standard_metadata);
+      @proto_tag(2) trap(standard_metadata);
+    }
+    size = PUNT_TABLE_SIZE;
+  }
+
+  apply {
+    punt_table.apply();
+  }
+}  // control punt_acl
+
+#endif  // SAI_PUNT_ACL_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/resource_limits.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/resource_limits.p4
@@ -1,0 +1,30 @@
+#ifndef SAI_RESOURCE_LIMITS_P4_
+#define SAI_RESOURCE_LIMITS_P4_
+
+#define MAX_PORTS_LOG2 9
+
+#define MAX_VRFS_LOG2 10
+
+#define MAX_NEXTHOPS 1024
+#define MAX_NEXTHOPS_LOG2 10
+
+#define MAX_NEIGHBORS 1024
+#define MAX_NEIGHBORS_LOG2 10
+
+#define MAX_ROUTER_INTERFACES 1024
+#define MAX_ROUTER_INTERFACES_LOG2 10
+
+// The maximum number of wcmp groups.
+#define MAX_WCMP_GROUPS 4096
+#define MAX_WCMP_GROUPS_LOG2 12
+
+// The maximum sum of weights across all wcmp groups.
+#define MAX_WCMP_GROUPS_SUM_OF_WEIGHTS 65536
+
+// The maximum sum of weights for each wcmp group.
+#define MAX_WCMP_GROUP_SUM_OF_WEIGHTS_LOG2 7
+
+#define PUNT_TABLE_SIZE 128
+#define SET_VRF_TABLE_SIZE 256
+
+#endif  // SAI_RESOURCE_LIMITS_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/routing.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/routing.p4
@@ -1,0 +1,251 @@
+#ifndef SAI_ROUTING_P4_
+#define SAI_ROUTING_P4_
+
+#include "v1model.p4"
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+#include "resource_limits.p4"
+
+// This control block models the L3 routing pipeline.
+//
+// +-------+   +-------+ wcmp  +---------+       +-----------+
+// |  lpm  |-->| group |------>| nexthop |----+->| router    |--> egress_port
+// |       |   |       |------>|         |-+  |  | interface |--> src_mac
+// +-------+   +-------+       +---------+ |  |  +-----------+
+//   |   |                         ^       |  |  +-----------+
+//   |   |                         |       |  +->| neighbor  |
+//   V   +-------------------------+       +---->|           |--> dst_mac
+//  drop                                         +-----------+
+//
+// The pipeline first performs a longest prefix match on the packet's
+// destination IP address. The action associated with the match then either
+// drops the packet, points to a nexthop, or points to a wcmp group which uses a
+// hash of the packet to choose from a set of nexthops. The nexthop points to a
+// router interface, which determines the packet's src_mac and the egress_port
+// to forward the packet to. The nexthop also points to a neighbor which,
+// together with the router_interface, determines the packet's dst_mac.
+control routing(inout headers_t headers,
+                inout local_metadata_t local_metadata,
+                inout standard_metadata_t standard_metadata) {
+  // Wcmp group id, only valid if `wcmp_group_id_valid` is true.
+  bool wcmp_group_id_valid = false;
+  wcmp_group_id_t wcmp_group_id_value;
+
+  // Nexthop id, only valid if `nexthop_id_valid` is true.
+  bool nexthop_id_valid = false;
+  nexthop_id_t nexthop_id_value;
+
+  // Router interface id, only valid if `router_interface_id_valid` is true.
+  bool router_interface_id_valid = false;
+  router_interface_id_t router_interface_id_value;
+
+  // Neighbor id, only valid if `neighbor_id_valid` is true.
+  bool neighbor_id_valid = false;
+  neighbor_id_t neighbor_id_value;
+
+  const bit<1> HASH_BASE_CRC16 = 1w0;
+  const bit<14> HASH_MAX_CRC16 = 14w1024;
+  bit<MAX_WCMP_GROUP_SUM_OF_WEIGHTS_LOG2> wcmp_selector_input = 0;
+
+  // Sets SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS.
+  @id(ROUTING_SET_DST_MAC_ACTION_ID)
+  action set_dst_mac(@id(1) @format(MAC_ADDRESS) ethernet_addr_t dst_mac) {
+    headers.ethernet.dst_addr = dst_mac;
+  }
+
+  @proto_package("sai")
+  @id(ROUTING_NEIGHBOR_TABLE_ID)
+  table neighbor_table {
+    key = {
+      // Sets rif_id in sai_neighbor_entry_t.
+      router_interface_id_value : exact @id(1)
+                                        @name("router_interface_id");
+      // Sets ip_address in sai_neighbor_entry_t.
+      neighbor_id_value : exact @id(2) @name("neighbor_id");
+    }
+    actions = {
+      @proto_id(1) set_dst_mac;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+  }
+
+  // Sets SAI_ROUTER_INTERFACE_ATTR_TYPE to SAI_ROUTER_INTERFACE_TYPE_PORT, and
+  // SAI_ROUTER_INTERFACE_ATTR_PORT_ID, and
+  // SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS.
+  @id(ROUTING_SET_PORT_AND_SRC_MAC_ACTION_ID)
+  action set_port_and_src_mac(@id(1) port_id_t port_id,
+                              @id(2) @format(MAC_ADDRESS)
+                              ethernet_addr_t src_mac) {
+    // Cast is necessary, because v1model does not define port using `type`.
+    standard_metadata.egress_spec = (bit<MAX_PORTS_LOG2>)port_id;
+    headers.ethernet.src_addr = src_mac;
+  }
+
+  @proto_package("sai")
+  @id(ROUTING_ROUTER_INTERFACE_TABLE_ID)
+  table router_interface_table {
+    key = {
+      router_interface_id_value : exact @id(1)
+                                        @name("router_interface_id");
+    }
+    actions = {
+      @proto_id(1) set_port_and_src_mac;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+  }
+
+  // Sets SAI_NEXT_HOP_ATTR_TYPE to SAI_NEXT_HOP_TYPE_IP, and
+  // SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID, and SAI_NEXT_HOP_ATTR_IP.
+  //
+  // This action can only refer to `router_interface_id`s and `neighbor_id`s
+  // that are programmed in the `router_interface_table` and `neighbor_table`.
+  @id(ROUTING_SET_NEXTHOP_ACTION_ID)
+  action set_nexthop(@id(1) router_interface_id_t router_interface_id,
+                     @id(2) neighbor_id_t neighbor_id) {
+    router_interface_id_valid = true;
+    router_interface_id_value = router_interface_id;
+    neighbor_id_valid = true;
+    neighbor_id_value = neighbor_id;
+  }
+
+  @proto_package("sai")
+  @id(ROUTING_NEXTHOP_TABLE_ID)
+  table nexthop_table {
+    key = {
+      nexthop_id_value : exact @id(1) @name("nexthop_id");
+    }
+    actions = {
+      @proto_id(1) set_nexthop;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+  }
+
+  // When called from a route, sets SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION to
+  // SAI_PACKET_ACTION_FORWARD, and SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID to a
+  // SAI_OBJECT_TYPE_NEXT_HOP.
+  //
+  // When called from a group, sets SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID.
+  //
+  // This action can only refer to `nexthop_id`s that are programmed in the
+  // `nexthop_table`.
+  @id(ROUTING_SET_NEXTHOP_ID_ACTION_ID)
+  action set_nexthop_id(@id(1) nexthop_id_t nexthop_id) {
+    nexthop_id_valid = true;
+    nexthop_id_value = nexthop_id;
+  }
+
+  action_selector(HashAlgorithm.identity,
+                  MAX_WCMP_GROUPS_SUM_OF_WEIGHTS,
+                  MAX_WCMP_GROUP_SUM_OF_WEIGHTS_LOG2) wcmp_group_selector;
+
+  @proto_package("sai")
+  @id(ROUTING_WCMP_GROUP_TABLE_ID)
+  @weight_proto_id(1)
+  @oneshot()
+  @weight_proto_tag(2)  // Sets SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT.
+  table wcmp_group_table {
+    key = {
+      wcmp_group_id_value : exact @id(1) @name("wcmp_group_id");
+      wcmp_selector_input : selector;
+    }
+    actions = {
+      @proto_id(1) set_nexthop_id;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    implementation = wcmp_group_selector;
+  }
+
+  // Sets SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION to SAI_PACKET_ACTION_DROP.
+  @id(ROUTING_DROP_ACTION_ID)
+  action drop() {
+    mark_to_drop(standard_metadata);
+  }
+
+  // Sets SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION to SAI_PACKET_ACTION_FORWARD, and
+  // SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID to a SAI_OBJECT_TYPE_NEXT_HOP_GROUP.
+  //
+  // This action can only refer to `wcmp_group_id`s that are programmed in the
+  // `wcmp_group_table`.
+  @id(ROUTING_SET_WCMP_GROUP_ID_ACTION_ID)
+  action set_wcmp_group_id(@id(1) wcmp_group_id_t wcmp_group_id) {
+    wcmp_group_id_valid = true;
+    wcmp_group_id_value = wcmp_group_id;
+  }
+
+  @proto_package("sai")
+  @id(ROUTING_IPV4_TABLE_ID)
+  table ipv4_table {
+    key = {
+      // Sets vr_id in sai_route_entry_t.
+      local_metadata.vrf_id : exact @id(1) @name("vrf_id");
+      // Sets destination in sai_route_entry_t to an IPv4 prefix.
+      headers.ipv4.dst_addr : lpm @format(IPV4_ADDRESS) @id(2)
+                                  @name("ipv4_dst");
+    }
+    actions = {
+      @proto_id(1) drop;
+      @proto_id(2) set_nexthop_id;
+      @proto_id(3) set_wcmp_group_id;
+    }
+    const default_action = drop;
+  }
+
+  @proto_package("sai")
+  @id(ROUTING_IPV6_TABLE_ID)
+  table ipv6_table {
+    key = {
+      // Sets vr_id in sai_route_entry_t.
+      local_metadata.vrf_id : exact @id(1) @name("vrf_id");
+      // Sets destination in sai_route_entry_t to an IPv6 prefix.
+      headers.ipv6.dst_addr : lpm @format(IPV6_ADDRESS) @id(2)
+                                  @name("ipv6_dst");
+    }
+    actions = {
+      @proto_id(1) drop;
+      @proto_id(2) set_nexthop_id;
+      @proto_id(3) set_wcmp_group_id;
+    }
+    const default_action = drop;
+  }
+
+  apply {
+    if (headers.ipv4.isValid()) {
+      hash(wcmp_selector_input, HashAlgorithm.crc16, HASH_BASE_CRC16, {
+           headers.ipv4.dst_addr, headers.ipv4.src_addr,
+           local_metadata.l4_src_port, local_metadata.l4_dst_port},
+           HASH_MAX_CRC16);
+      ipv4_table.apply();
+    } else if (headers.ipv6.isValid()) {
+      hash(wcmp_selector_input, HashAlgorithm.crc16, HASH_BASE_CRC16, {
+           headers.ipv6.dst_addr, headers.ipv6.src_addr,
+           headers.ipv6.flow_label[15:0], local_metadata.l4_src_port,
+           local_metadata.l4_dst_port}, HASH_MAX_CRC16);
+      ipv6_table.apply();
+    }
+
+    // The lpm tables may not set a valid `wcmp_group_id`, e.g. they may drop.
+    if (wcmp_group_id_valid) {
+      wcmp_group_table.apply();
+    }
+
+    // The lpm tables may not set a valid `nexthop_id`, e.g. they may drop.
+    // The `wcmp_group_table` should always set a valid `nexthop_id`.
+    if (nexthop_id_valid) {
+      nexthop_table.apply();
+
+      // The `nexthop_table` should always set a valid
+      // `router_interface_id` and `neighbor_id`.
+      if (router_interface_id_valid && neighbor_id_valid) {
+        router_interface_table.apply();
+        neighbor_table.apply();
+      }
+    }
+  }
+}  // control l3_fwd
+
+#endif  // SAI_L3_FWD_P4_

--- a/p4_fuzzer/p4_programs/sai-p4-google/sai_main.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/sai_main.p4
@@ -1,0 +1,29 @@
+#include "v1model.p4"
+#include "headers.p4"
+#include "metadata.p4"
+#include "parser.p4"
+#include "routing.p4"
+#include "ipv4_checksum.p4"
+#include "ttl.p4"
+#include "acl_punt.p4"
+#include "acl_set_vrf.p4"
+
+control ingress(inout headers_t headers,
+                inout local_metadata_t local_metadata,
+                inout standard_metadata_t standard_metadata) {
+  apply {
+    acl_set_vrf.apply(headers, local_metadata, standard_metadata);
+    routing.apply(headers, local_metadata, standard_metadata);
+    acl_punt.apply(headers, local_metadata, standard_metadata);
+    ttl.apply(headers, standard_metadata);
+  }
+}  // control ingress
+
+control egress(inout headers_t headers,
+               inout local_metadata_t local_metadata,
+               inout standard_metadata_t standard_metadata) {
+  apply {}
+}  // control egress
+
+V1Switch(packet_parser(), verify_ipv4_checksum(), ingress(), egress(),
+         compute_ipv4_checksum(), packet_deparser()) main;

--- a/p4_fuzzer/p4_programs/sai-p4-google/ttl.p4
+++ b/p4_fuzzer/p4_programs/sai-p4-google/ttl.p4
@@ -1,0 +1,29 @@
+#ifndef SAI_TTL_P4_
+#define SAI_TTL_P4_
+
+#include "v1model.p4"
+#include "headers.p4"
+#include "metadata.p4"
+
+control ttl(inout headers_t headers,
+            inout standard_metadata_t standard_metadata) {
+  apply {
+    if (headers.ipv4.isValid()) {
+      if (headers.ipv4.ttl <= 1) {
+        mark_to_drop(standard_metadata);
+      } else {
+        headers.ipv4.ttl = headers.ipv4.ttl - 1;
+      }
+    }
+
+    if (headers.ipv6.isValid()) {
+      if (headers.ipv6.hop_limit <= 1) {
+        mark_to_drop(standard_metadata);
+      } else {
+        headers.ipv6.hop_limit = headers.ipv6.hop_limit - 1;
+      }
+    }
+  }
+}  // control ttl
+
+#endif  // SAI_TTL_P4_

--- a/p4_fuzzer/switch_state.cc
+++ b/p4_fuzzer/switch_state.cc
@@ -1,0 +1,141 @@
+#include "p4_fuzzer/switch_state.h"
+
+#include <algorithm>
+#include <iterator>
+#include <set>
+
+#include "absl/algorithm/container.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "glog/logging.h"
+#include "gutil/collections.h"
+
+namespace p4_fuzzer {
+
+using ::absl::StrAppend;
+using ::absl::StrCat;
+using ::absl::StrFormat;
+using ::gutil::FindOrDie;
+using ::p4::v1::TableEntry;
+using ::p4::v1::Update;
+using ::pdpi::IrP4Info;
+
+namespace {
+
+std::string GetTableName(const IrP4Info& info, const uint32_t table_id) {
+  return FindOrDie(info.tables_by_id(), table_id).preamble().name();
+}
+
+}  // namespace
+
+SwitchState::SwitchState(IrP4Info ir_p4info) : ir_p4info_(ir_p4info) {
+  for (auto& [table_id, table] : ir_p4info_.tables_by_id()) {
+    tables_[table_id] = TableEntries();
+  }
+}
+
+bool SwitchState::AllTablesEmpty() const {
+  for (auto table_id : AllTableIds()) {
+    if (!IsTableEmpty(table_id)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool SwitchState::IsTableFull(const uint32_t table_id) const {
+  return !CanAccommodateInserts(table_id, 1);
+}
+
+int64_t SwitchState::GetNumTableEntries(const uint32_t table_id) const {
+  return FindOrDie(tables_, table_id).size();
+}
+
+const std::vector<uint32_t> SwitchState::AllTableIds() const {
+  std::vector<uint32_t> table_ids;
+
+  for (auto& [key, table] : ir_p4info_.tables_by_id()) {
+    table_ids.push_back(key);
+  }
+
+  return table_ids;
+}
+
+bool SwitchState::CanAccommodateInserts(const uint32_t table_id,
+                                        const int n) const {
+  return (FindOrDie(ir_p4info_.tables_by_id(), table_id).size() -
+          GetNumTableEntries(table_id)) >= n;
+}
+
+bool SwitchState::IsTableEmpty(const uint32_t table_id) const {
+  return FindOrDie(tables_, table_id).empty();
+}
+
+std::vector<TableEntry> SwitchState::GetTableEntries(
+    const uint32_t table_id) const {
+  std::vector<TableEntry> result;
+
+  for (const auto& [key, entry] : FindOrDie(tables_, table_id)) {
+    result.push_back(entry);
+  }
+
+  return result;
+}
+
+absl::optional<TableEntry> SwitchState::GetTableEntry(TableEntry entry) const {
+  auto table = FindOrDie(tables_, entry.table_id());
+
+  if (auto table_iter = table.find(TableEntryKey(entry));
+      table_iter != table.end()) {
+    auto [table_key, table_entry] = *table_iter;
+    return table_entry;
+  }
+
+  return absl::nullopt;
+}
+
+void SwitchState::ApplyUpdate(const Update& update) {
+  const int table_id = update.entity().table_entry().table_id();
+
+  auto& table = FindOrDie(tables_, table_id);
+
+  TableEntry table_entry = update.entity().table_entry();
+
+  switch (update.type()) {
+    case Update::INSERT: {
+      auto [iter, not_present] =
+          table.insert(/*value=*/{TableEntryKey(table_entry), table_entry});
+
+      CHECK(not_present)
+          << "Cannot install the same table entry multiple times. Update: "
+          << update.DebugString();
+      break;
+    }
+
+    case Update::DELETE:
+      CHECK_EQ(tables_[table_id].erase(TableEntryKey(table_entry)), 1)
+          << "Cannot erase non-existent table entries. Update: "
+          << update.DebugString();
+      break;
+    default:
+      LOG(FATAL) << "Update of unsupported type: " << update.DebugString();
+  }
+}
+
+std::string SwitchState::SwitchStateSummary() const {
+  if (tables_.empty()) return std::string("EmptyState()");
+  std::string res = "";
+  int total = 0;
+  for (const auto& [table_id, table] : tables_) {
+    total += table.size();
+
+    StrAppend(&res, "\n  ", absl::StrFormat("% 10d", table.size()), " ",
+              GetTableName(ir_p4info_, table_id));
+  }
+
+  return StrCat("State(", "\n  ", StrFormat("% 10d", total),
+                " total number of flows", res, "\n", ")");
+}
+
+}  // namespace p4_fuzzer

--- a/p4_fuzzer/switch_state.h
+++ b/p4_fuzzer/switch_state.h
@@ -1,0 +1,86 @@
+#ifndef P4_FUZZER_SWITCH_STATE_H_
+#define P4_FUZZER_SWITCH_STATE_H_
+
+#include <cstdio>
+#include <string>
+#include <unordered_map>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/node_hash_map.h"
+#include "absl/status/status.h"
+#include "absl/types/optional.h"
+#include "glog/logging.h"
+#include "gutil/status.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_fuzzer/table_entry_key.h"
+#include "p4_pdpi/ir.pb.h"
+
+namespace p4_fuzzer {
+
+// Only a subset of the fields of TableEntry are used for equality in P4Runtime
+// (as part of the class TableEntryKey). We use an instance of TableEntryKey
+// generated from a TableEntry as the key in an absl::node_hash_map.
+// Therefore, the class SwitchState must preserve the invariant that:
+//   forall t1, t2. table_[t1] = t2  ==> t1 = TableEntryKey(t2)
+//   TableEntryKey() here is the constructor for the class TableEntryKey.
+using TableEntries = absl::node_hash_map<TableEntryKey, p4::v1::TableEntry>;
+
+// Tracks the state of a switch, with methods to apply updates or query the
+// current state. The class assumes all calls are valid (e.g table_ids must all
+// exist). Crashes if that is not the case.
+class SwitchState {
+ public:
+  // SwitchState needs to know the (PDPI internal representation of the) P4Info
+  // of the P4 program P4 fuzzer is fuzzing in order to implement its functions
+  // in a program independent manner.
+  SwitchState(pdpi::IrP4Info ir_p4info);
+
+  // Returns true if the table is at its resource limit. This means that there
+  // is no guarantee that any further entry will fit into this table. Whether
+  // or not a table is full, may depend on the entries in other tables as well.
+  bool IsTableFull(const uint32_t table_id) const;
+
+  // Checks whether the given set of table entries is empty.
+  bool AllTablesEmpty() const;
+
+  // Returns true if the table is empty.
+  bool IsTableEmpty(const uint32_t table_id) const;
+
+  // Returns true iff the given table can accommodate at least n more entries.
+  bool CanAccommodateInserts(const uint32_t table_id, const int n) const;
+
+  // Returns all table entries in a given table.
+  std::vector<p4::v1::TableEntry> GetTableEntries(
+      const uint32_t table_id) const;
+
+  // Returns the number of table entries in a given table.
+  int64_t GetNumTableEntries(const uint32_t table_id) const;
+
+  // Returns the current state of a table entry (or nullopt if it is not
+  // present).  Only the uniquely identifying fields of entry are considered.
+  absl::optional<p4::v1::TableEntry> GetTableEntry(
+      p4::v1::TableEntry entry) const;
+
+  // Returns the list of all non-const table IDs in the underlying P4 program.
+  const std::vector<uint32_t> AllTableIds() const;
+
+  // Applies the given update to the given table entries. Assumes that all
+  // updates can actually be applied successfully e.g for INSERT, an entry
+  // cannot already be present, and crashed otherwise. Updates are applied in
+  // the order given.
+  void ApplyUpdate(const p4::v1::Update& update);
+
+  // Returns a summary of the state.
+  std::string SwitchStateSummary() const;
+
+ private:
+  // A map from table ids to the entries they store.
+  absl::flat_hash_map<int, TableEntries> tables_;
+
+  pdpi::IrP4Info ir_p4info_;
+};
+
+}  // namespace p4_fuzzer
+
+#endif  // P4_FUZZER_SWITCH_STATE_H_

--- a/p4_fuzzer/switch_state_test.cc
+++ b/p4_fuzzer/switch_state_test.cc
@@ -1,0 +1,105 @@
+#include "p4_fuzzer/switch_state.h"
+
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+#include "p4_pdpi/ir.h"
+
+namespace p4_fuzzer {
+namespace {
+
+using ::p4::config::v1::P4Info;
+using ::p4::config::v1::Preamble;
+using ::p4::config::v1::Table;
+using ::p4::v1::TableEntry;
+using ::p4::v1::Update;
+using ::pdpi::CreateIrP4Info;
+using ::pdpi::IrP4Info;
+
+TEST(SwitchStateTest, TableEmptyTrivial) {
+  IrP4Info info;
+  SwitchState state(info);
+
+  EXPECT_TRUE(state.AllTablesEmpty());
+}
+
+TEST(SwitchStateTest, TableEmptyFromP4Info) {
+  P4Info info;
+  Table* ptable = info.add_tables();
+  ptable->mutable_preamble()->set_id(42);
+
+  IrP4Info ir_info = CreateIrP4Info(info).value();
+
+  SwitchState state(ir_info);
+  EXPECT_TRUE(state.AllTablesEmpty());
+}
+
+TEST(SwitchStateTest, RuleInsert) {
+  P4Info info;
+  Table* ptable = info.add_tables();
+  Preamble* preamble = ptable->mutable_preamble();
+  preamble->set_id(42);
+  preamble->set_alias("Spam");
+
+  ptable = info.add_tables();
+  preamble = ptable->mutable_preamble();
+  preamble->set_id(43);
+  preamble->set_alias("Eggs");
+
+  IrP4Info ir_info = CreateIrP4Info(info).value();
+
+  SwitchState state(ir_info);
+
+  Update update;
+  update.set_type(Update::INSERT);
+
+  TableEntry* entry = update.mutable_entity()->mutable_table_entry();
+  entry->set_table_id(42);
+
+  state.ApplyUpdate(update);
+
+  EXPECT_FALSE(state.AllTablesEmpty());
+  EXPECT_FALSE(state.IsTableEmpty(42));
+  EXPECT_TRUE(state.IsTableEmpty(43));
+
+  EXPECT_EQ(state.GetNumTableEntries(42), 1);
+  EXPECT_EQ(state.GetNumTableEntries(43), 0);
+
+  EXPECT_EQ(state.GetTableEntries(42).size(), 1);
+  EXPECT_EQ(state.GetTableEntries(43).size(), 0);
+}
+
+TEST(SwitchStateTest, RuleDelete) {
+  P4Info info;
+  Table* ptable = info.add_tables();
+  Preamble* preamble = ptable->mutable_preamble();
+  preamble->set_id(42);
+  preamble->set_alias("Spam");
+
+  ptable = info.add_tables();
+  preamble = ptable->mutable_preamble();
+  preamble->set_id(43);
+  preamble->set_alias("Eggs");
+
+  IrP4Info ir_info = CreateIrP4Info(info).value();
+
+  SwitchState state(ir_info);
+
+  Update update;
+  update.set_type(Update::INSERT);
+
+  TableEntry* entry = update.mutable_entity()->mutable_table_entry();
+  entry->set_table_id(42);
+
+  state.ApplyUpdate(update);
+
+  update.set_type(Update::DELETE);
+  state.ApplyUpdate(update);
+
+  EXPECT_TRUE(state.AllTablesEmpty());
+
+  EXPECT_EQ(state.GetNumTableEntries(42), 0);
+  EXPECT_EQ(state.GetTableEntries(42).size(), 0);
+}
+
+}  // namespace
+}  // namespace p4_fuzzer

--- a/p4_fuzzer/table_entry_key.cc
+++ b/p4_fuzzer/table_entry_key.cc
@@ -1,0 +1,32 @@
+#include "p4_fuzzer/table_entry_key.h"
+
+#include <algorithm>
+
+#include "google/protobuf/util/message_differencer.h"
+
+namespace p4_fuzzer {
+
+using ::google::protobuf::util::MessageDifferencer;
+using ::p4::v1::FieldMatch;
+using ::p4::v1::TableEntry;
+
+TableEntryKey::TableEntryKey(const p4::v1::TableEntry& entry) {
+  table_id_ = entry.table_id();
+  priority_ = entry.priority();
+
+  auto match = entry.match();
+  matches_ = std::vector<FieldMatch>(match.begin(), match.end());
+  // Sort matches by field to ensure consistent keys.
+  std::sort(matches_.begin(), matches_.end(),
+            [](const FieldMatch& a, const FieldMatch& b) {
+              return a.field_id() < b.field_id();
+            });
+}
+
+bool TableEntryKey::operator==(const TableEntryKey& other) const {
+  return (table_id_ == other.table_id_) && (priority_ == other.priority_) &&
+         std::equal(matches_.begin(), matches_.end(), other.matches_.begin(),
+                    MessageDifferencer::Equals);
+}
+
+}  // namespace p4_fuzzer

--- a/p4_fuzzer/table_entry_key.h
+++ b/p4_fuzzer/table_entry_key.h
@@ -1,0 +1,47 @@
+#ifndef P4_FUZZER_TABLE_ENTRY_KEY_H_
+#define P4_FUZZER_TABLE_ENTRY_KEY_H_
+
+#include <vector>
+
+#include "absl/hash/hash.h"
+#include "p4/v1/p4runtime.pb.h"
+
+namespace p4_fuzzer {
+
+class TableEntryKey {
+ public:
+  TableEntryKey(const p4::v1::TableEntry& entry);
+
+  template <typename H>
+  friend H AbslHashValue(H h, const TableEntryKey& key);
+
+  bool operator==(const TableEntryKey& other) const;
+
+ private:
+  uint32_t table_id_;
+  int32_t priority_;
+  std::vector<p4::v1::FieldMatch> matches_;
+};
+
+template <typename H>
+H AbslHashValue(H h, const TableEntryKey& key) {
+  h = H::combine(std::move(h), key.table_id_, key.priority_);
+
+  for (auto field : key.matches_) {
+    // Since protobufs yield a default value for an unset field and since {
+    // exact, ternary, lpm, range, optional } are all part of the oneof
+    // directive (i,e only one of them will be set at a given time), we can get
+    // a correct hash by combining all fields without checking which one is set.
+    h = H::combine(std::move(h), field.field_id(), field.exact().value(),
+                   field.ternary().value(), field.ternary().mask(),
+                   field.lpm().value(), field.lpm().prefix_len(),
+                   field.range().low(), field.range().high(),
+                   field.optional().value());
+  }
+
+  return h;
+}
+
+}  // namespace p4_fuzzer
+
+#endif  // P4_FUZZER_TABLE_ENTRY_KEY_H_

--- a/p4_fuzzer/table_entry_key_test.cc
+++ b/p4_fuzzer/table_entry_key_test.cc
@@ -1,0 +1,69 @@
+#include "p4_fuzzer/table_entry_key.h"
+
+#include "absl/hash/hash_testing.h"
+#include "gtest/gtest.h"
+
+namespace p4_fuzzer {
+namespace {
+
+using ::p4::v1::FieldMatch;
+using ::p4::v1::TableEntry;
+
+TEST(TableEntryKeyTest, TrivialEquality) {
+  TableEntry entry;
+  TableEntryKey key_a(entry);
+  TableEntryKey key_b(entry);
+
+  EXPECT_EQ(key_a, key_b);
+}
+
+TEST(TableEntryKeyTest, DiscardOtherValues) {
+  TableEntry entry;
+  entry.set_table_id(42);
+  entry.set_idle_timeout_ns(7);
+
+  TableEntry entry2;
+  entry2.set_table_id(42);
+  entry2.set_idle_timeout_ns(8);
+
+  TableEntryKey key_a(entry);
+  TableEntryKey key_b(entry2);
+
+  EXPECT_EQ(key_a, key_b);
+
+  TableEntry entry3;
+  entry3.set_table_id(42);
+
+  TableEntryKey key_c(entry3);
+
+  EXPECT_EQ(key_a, key_c);
+}
+
+TEST(TableEntryKeyTest, Hashing) {
+  TableEntry entry;
+  entry.set_table_id(42);
+  entry.set_idle_timeout_ns(7);
+
+  TableEntryKey key_a(entry);
+
+  entry.set_idle_timeout_ns(8);
+  TableEntryKey key_b(entry);
+
+  entry.set_priority(100);
+
+  TableEntryKey key_c(entry);
+
+  FieldMatch* field = entry.add_match();
+  field->set_field_id(43);
+
+  TableEntryKey key_d(entry);
+
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
+      /*values = */ {key_a, key_b, key_c}));
+
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
+      /*values = */ {key_a, key_b, key_c}));
+}
+
+}  // namespace
+}  // namespace p4_fuzzer


### PR DESCRIPTION
### Build Results:

divya@e6d72d01c011:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 248 targets (156 packages loaded, 14520 targets configured).
INFO: Found 248 targets...
INFO: From Compiling p4_fuzzer/fuzz_util.cc:
p4_fuzzer/fuzz_util.cc: In function 'void p4_fuzzer::{anonymous}::FuzzNonKeyFields(absl::lts_20230802::BitGen*, p4::v1::TableEntry*)':
p4_fuzzer/fuzz_util.cc:134:44: warning: 'void p4::v1::TableEntry::clear_controller_metadata()' is deprecated [-Wdeprecated-declarations]
  134 |     table_entry->clear_controller_metadata();
      |                                            ^
In file included from ./p4_fuzzer/fuzz_util.h:24,
                 from p4_fuzzer/fuzz_util.cc:1:
bazel-out/k8-fastbuild/bin/external/com_github_p4lang_p4runtime/p4/v1/p4runtime.pb.h:13951:13: note: declared here
13951 | inline void TableEntry::clear_controller_metadata() {
      |             ^~~~~~~~~~
p4_fuzzer/fuzz_util.cc: In function 'p4::v1::TableEntry p4_fuzzer::FuzzValidTableEntry(absl::lts_20230802::BitGen*, const pdpi::IrP4Info&, const pdpi::IrTableDefinition&)':
p4_fuzzer/fuzz_util.cc:464:67: warning: 'void p4::v1::TableEntry::set_controller_metadata(uint64_t)' is deprecated [-Wdeprecated-declarations]
  464 |   table_entry.set_controller_metadata(FuzzUint64(gen, /*bits=*/64));
      |                                                                   ^
In file included from ./p4_fuzzer/fuzz_util.h:24,
                 from p4_fuzzer/fuzz_util.cc:1:
bazel-out/k8-fastbuild/bin/external/com_github_p4lang_p4runtime/p4/v1/p4runtime.pb.h:13965:13: note: declared here
13965 | inline void TableEntry::set_controller_metadata(uint64_t value) {
      |             ^~~~~~~~~~
In file included from ./p4_fuzzer/fuzz_util.h:22,
                 from p4_fuzzer/fuzz_util.cc:1:
bazel-out/k8-fastbuild/bin/external/com_github_google_glog/_virtual_includes/glog/glog/logging.h: In instantiation of 'std::string* google::Check_GTImpl(const T1&, const T2&, const char*) [with T1 = long unsigned int; T2 = int; std::string = std::__cxx11::basic_string<char>]':
p4_fuzzer/fuzz_util.cc:144:3:   required from here
bazel-out/k8-fastbuild/bin/external/com_github_google_glog/_virtual_includes/glog/glog/logging.h:724:32: warning: comparison of integer expressions of different signedness: 'const long unsigned int' and 'const int' [-Wsign-compare]
  724 | DEFINE_CHECK_OP_IMPL(Check_GT, > )
      |                                ^
bazel-out/k8-fastbuild/bin/external/com_github_google_glog/_virtual_includes/glog/glog/logging.h:148:53: note: in definition of macro 'GOOGLE_PREDICT_TRUE'
  148 | #define GOOGLE_PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
      |                                                     ^
bazel-out/k8-fastbuild/bin/external/com_github_google_glog/_virtual_includes/glog/glog/logging.h:724:1: note: in expansion of macro 'DEFINE_CHECK_OP_IMPL'
  724 | DEFINE_CHECK_OP_IMPL(Check_GT, > )
      | ^~~~~~~~~~~~~~~~~~~~
INFO: Elapsed time: 31.287s, Critical Path: 5.87s
INFO: 15 processes: 9 internal, 6 linux-sandbox.
INFO: Build completed successfully, 15 total actions

### Test Results:

divya@e6d72d01c011:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Analyzed 248 targets (0 packages loaded, 0 targets configured).
INFO: Found 162 targets and 86 test targets...
INFO: Elapsed time: 1.176s, Critical Path: 0.61s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions
//gutil:collections_test                                        (cached) PASSED in 0.5s
//gutil:io_test                                                 (cached) PASSED in 0.2s
//gutil:proto_matchers_test                                     (cached) PASSED in 0.3s
//gutil:proto_test                                              (cached) PASSED in 0.2s
//gutil:status_matchers_test                                    (cached) PASSED in 0.2s
//gutil:table_entry_key_test                                    (cached) PASSED in 0.0s
//p4_fuzzer:switch_state_test                                   (cached) PASSED in 0.3s
//p4_fuzzer:table_entry_key_test                                (cached) PASSED in 0.0s
//p4_pdpi:ir_tools_test                                         (cached) PASSED in 0.4s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test         (cached) PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                             (cached) PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                              (cached) PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                       (cached) PASSED in 15.3s
//p4_pdpi/packetlib:packetlib_test                              (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                       (cached) PASSED in 0.0s
//p4_pdpi/packetlib:packetlib_unit_test                         (cached) PASSED in 1.2s
//p4_pdpi/string_encodings:bit_string_test                      (cached) PASSED in 0.3s
//p4_pdpi/string_encodings:byte_string_test                     (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                  (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test_runner           (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                      (cached) PASSED in 0.8s
//p4_pdpi/string_encodings:hex_string_test_runner               (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test            (cached) PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                          (cached) PASSED in 0.4s
//p4_pdpi/testing:info_test                                     (cached) PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                              (cached) PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                  (cached) PASSED in 0.6s
//p4_pdpi/testing:mock_p4_runtime_server_test                   (cached) PASSED in 0.4s
//p4_pdpi/testing:packet_io_test                                (cached) PASSED in 0.3s
//p4_pdpi/testing:packet_io_test_runner                         (cached) PASSED in 0.0s
//p4_pdpi/testing:rpc_test                                      (cached) PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                               (cached) PASSED in 0.0s
//p4_pdpi/testing:sequencing_test                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                        (cached) PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                        (cached) PASSED in 0.4s
//p4_pdpi/testing:table_entry_test                              (cached) PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                          (cached) PASSED in 0.2s
//p4_pdpi/utils:ir_test                                         (cached) PASSED in 0.3s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test  (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test (cached) PASSED in 0.7s
//p4rt_app/event_monitoring:config_db_port_table_event_test     (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test      (cached) PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                        (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test            (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                   (cached) PASSED in 0.7s
//p4rt_app/p4runtime:packetio_helpers_test                      (cached) PASSED in 0.7s
//p4rt_app/sonic:app_db_acl_def_table_manager_test              (cached) PASSED in 0.4s
//p4rt_app/sonic:app_db_manager_test                            (cached) PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test              (cached) PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                             (cached) PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                             (cached) PASSED in 0.3s
//p4rt_app/sonic:response_handler_test                          (cached) PASSED in 0.4s
//p4rt_app/sonic:state_verification_test                        (cached) PASSED in 0.3s
//p4rt_app/sonic:vrf_entry_translation_test                     (cached) PASSED in 0.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test              (cached) PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                 (cached) PASSED in 0.8s
//p4rt_app/tests:action_set_test                                (cached) PASSED in 0.6s
//p4rt_app/tests:api_access_test                                (cached) PASSED in 0.5s
//p4rt_app/tests:arbitration_test                               (cached) PASSED in 0.6s
//p4rt_app/tests:fixed_l3_tables_test                           (cached) PASSED in 1.6s
//p4rt_app/tests:forwarding_pipeline_config_test                (cached) PASSED in 2.1s
//p4rt_app/tests:grpc_behavior_test                             (cached) PASSED in 5.0s
//p4rt_app/tests:p4_constraints_test                            (cached) PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                     (cached) PASSED in 0.1s
//p4rt_app/tests:p4_programs_test                               (cached) PASSED in 0.8s
//p4rt_app/tests:packetio_test                                  (cached) PASSED in 2.9s
//p4rt_app/tests:port_name_and_id_test                          (cached) PASSED in 0.7s
//p4rt_app/tests:response_path_test                             (cached) PASSED in 1.3s
//p4rt_app/tests:role_test                                      (cached) PASSED in 0.6s
//p4rt_app/tests:state_verification_test                        (cached) PASSED in 0.8s
//p4rt_app/tests/lib:app_db_entry_builder_test                  (cached) PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                        (cached) PASSED in 0.0s
//p4rt_app/utils:table_utility_test                             (cached) PASSED in 0.4s
//sai_p4/instantiations/google:clos_stage_test                  (cached) PASSED in 0.2s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test (cached) PASSED in 0.2s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test (cached) PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test          (cached) PASSED in 0.3s
//sai_p4/instantiations/google:sai_p4info_test                  (cached) PASSED in 0.4s
//sai_p4/instantiations/google:sai_pd_proto_test                (cached) PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                 (cached) PASSED in 0.2s
//sai_p4/instantiations/google:union_p4info_up_to_date_test     (cached) PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test       (cached) PASSED in 0.0s
//sai_p4/tools:p4info_tools_test                                (cached) PASSED in 0.3s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s

Executed 1 out of 86 tests: 86 tests pass.
INFO: Build completed successfully, 2 total actions
divya@e6d72d01c011:/sonic/src/sonic-p4rt/sonic-pins$ 