### PR TITLE
[P4 Reachability analysis] Creates a helper function to create ReferredTableEntries for an entry that refers to other entries.

### DIFF
--- a/p4_pdpi/BUILD.bazel
+++ b/p4_pdpi/BUILD.bazel
@@ -19,9 +19,16 @@ package(
 
 cc_library(
     name = "sequencing_util",
+    srcs = ["sequencing_util.cc"],
     hdrs = ["sequencing_util.h"],
     deps = [
+        ":ir_cc_proto",
+        "//gutil:collections",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
         "@com_google_absl//absl/container:btree",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
     ],

--- a/p4_pdpi/sequencing_util.cc
+++ b/p4_pdpi/sequencing_util.cc
@@ -1,0 +1,167 @@
+#include "p4_pdpi/sequencing_util.h"
+
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "gutil/collections.h"
+#include "gutil/status.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/ir.pb.h"
+
+namespace pdpi {
+namespace {
+
+// Returns the match field value for `field_match` as string if `field_match`'s
+// field_match_type is exact or optional. Returns InvalidArgument for other
+// field_match_type.
+absl::StatusOr<std::string> GetExactOrOptionalMatchFieldValue(
+    const ::p4::v1::FieldMatch& field_match) {
+  switch (field_match.field_match_type_case()) {
+    case ::p4::v1::FieldMatch::kExact:
+      return field_match.exact().value();
+    case ::p4::v1::FieldMatch::kOptional:
+      return field_match.optional().value();
+    default:
+      return absl::InvalidArgumentError(
+          absl::StrCat("cannot extract value from field match type: ",
+                       field_match.field_match_type_case()));
+  }
+}
+
+// Returns a vector of ReferredTableEntries that `table_entry`'s match fields
+// refer to.
+absl::StatusOr<std::vector<ReferredTableEntry>>
+EntriesReferredToByTableEntryMatchFields(
+    const ::p4::v1::TableEntry& table_entry, const IrP4Info& info) {
+  ASSIGN_OR_RETURN(
+      const IrTableDefinition* ir_table_definition,
+      gutil::FindPtrOrStatus(info.tables_by_id(), table_entry.table_id()));
+  absl::flat_hash_map<std::string, ReferredTableEntry> referred_table_entries;
+
+  // Iterate through match fields of `table_entry` and incrementally build
+  // ReferredTableEntries that `table_entry` can refer to.
+  // At the end of the iteration, each value in the k/v pair represents a table
+  // and its match fields that `table_entry` refers to.
+  for (const p4::v1::FieldMatch& field_match : table_entry.match()) {
+    ASSIGN_OR_RETURN(
+        const auto* match_field_definition,
+        gutil::FindPtrOrStatus(ir_table_definition->match_fields_by_id(),
+                               field_match.field_id()));
+    // Ignore other match field type since only Exact or Optional are used to
+    // refer to entries.
+    if (!field_match.has_exact() && !field_match.has_optional()) continue;
+    ASSIGN_OR_RETURN(std::string value,
+                     GetExactOrOptionalMatchFieldValue(field_match));
+    for (const auto& ir_reference : match_field_definition->references()) {
+      referred_table_entries[ir_reference.table()].table = ir_reference.table();
+      referred_table_entries[ir_reference.table()].referred_fields.insert(
+          {ir_reference.match_field(), value});
+    }
+  }
+
+  // Extract accumulated table entries into a vector to return.
+  std::vector<ReferredTableEntry> referred_table_entries_vector;
+  for (auto& [table_name, referred_table_entry] : referred_table_entries) {
+    referred_table_entries_vector.push_back(std::move(referred_table_entry));
+  }
+  return referred_table_entries_vector;
+}
+
+// Returns a vector of ReferredTableEntry that `action_params` refers to.
+absl::StatusOr<std::vector<ReferredTableEntry>> EntriesReferredToByActionParams(
+    absl::Span<const p4::v1::Action_Param* const> action_params,
+    const IrActionDefinition& ir_action_definition, const IrP4Info& info) {
+  absl::flat_hash_map<std::string, ReferredTableEntry> referred_table_entries;
+  for (const p4::v1::Action_Param* const param : action_params) {
+    ASSIGN_OR_RETURN(
+        const auto* param_definition,
+        gutil::FindPtrOrStatus(ir_action_definition.params_by_id(),
+                               param->param_id()),
+        _ << "Failed to extract action definition when creating entries "
+             "referred by action: Action param with ID "
+          << param->param_id() << " does not exist.");
+    for (const auto& ir_reference : param_definition->references()) {
+      referred_table_entries[ir_reference.table()].table = ir_reference.table();
+      referred_table_entries[ir_reference.table()].referred_fields.insert(
+          {ir_reference.match_field(), param->value()});
+    }
+  }
+
+  // Extract accumulated table entries into a vector to return.
+  std::vector<ReferredTableEntry> referred_table_entries_vector;
+  for (auto& [table_name, referred_table_entry] : referred_table_entries) {
+    referred_table_entries_vector.push_back(std::move(referred_table_entry));
+  }
+  return referred_table_entries_vector;
+}
+
+// Returns a vector of `ReferredTableEntry`s that `action` refers to based on
+// its action parameters' values and `info` reference fields for the given
+// action.
+absl::StatusOr<std::vector<ReferredTableEntry>> EntriesReferredToByAction(
+    const ::p4::v1::TableAction& action, const IrP4Info& info) {
+  switch (action.type_case()) {
+    case p4::v1::TableAction::kAction: {
+      ASSIGN_OR_RETURN(
+          const IrActionDefinition* ir_action_definition,
+          gutil::FindPtrOrStatus(info.actions_by_id(),
+                                 action.action().action_id()),
+          _ << "Failed to extract action definition when creating entries "
+               "referred by action: Action with ID "
+            << action.action().action_id() << " does not exist in IrP4Info.");
+      return EntriesReferredToByActionParams(action.action().params(),
+                                             *ir_action_definition, info);
+    }
+    case p4::v1::TableAction::kActionProfileActionSet: {
+      std::vector<ReferredTableEntry> referred_table_entries_vector;
+      for (const auto& action :
+           action.action_profile_action_set().action_profile_actions()) {
+        ASSIGN_OR_RETURN(
+            const IrActionDefinition* ir_action_definition,
+            gutil::FindPtrOrStatus(info.actions_by_id(),
+                                   action.action().action_id()),
+            _ << "Failed to extract action definition when creating entries "
+                 "referred by action: Action with ID "
+              << action.action().action_id() << " does not exist in IrP4Info.");
+
+        ASSIGN_OR_RETURN(
+            std::vector<ReferredTableEntry> referred_entries_by_action,
+            EntriesReferredToByActionParams(action.action().params(),
+                                            *ir_action_definition, info));
+        for (auto& referred_table_entry : referred_entries_by_action) {
+          referred_table_entries_vector.push_back(
+              std::move(referred_table_entry));
+        }
+      }
+      return referred_table_entries_vector;
+    }
+    default:
+      return absl::UnimplementedError(absl::StrCat(
+          "Sequencing can only handle action and action profile set, but got:",
+          action.type_case()));
+  }
+}
+
+}  // namespace
+
+absl::StatusOr<std::vector<ReferredTableEntry>> EntriesReferredToByTableEntry(
+    const ::p4::v1::TableEntry& table_entry, const IrP4Info& ir_p4info) {
+  ASSIGN_OR_RETURN(
+      std::vector<ReferredTableEntry> referred_table_entries_by_match_fields,
+      EntriesReferredToByTableEntryMatchFields(table_entry, ir_p4info));
+  ASSIGN_OR_RETURN(
+      std::vector<ReferredTableEntry> referred_table_entries_by_actions,
+      EntriesReferredToByAction(table_entry.action(), ir_p4info));
+  referred_table_entries_by_match_fields.insert(
+      referred_table_entries_by_match_fields.end(),
+      std::make_move_iterator(referred_table_entries_by_actions.begin()),
+      std::make_move_iterator(referred_table_entries_by_actions.end()));
+  return referred_table_entries_by_match_fields;
+}
+
+}  // namespace pdpi

--- a/p4_pdpi/sequencing_util.h
+++ b/p4_pdpi/sequencing_util.h
@@ -2,10 +2,14 @@
 #define PINS_INFRA_P4_PDPI_SEQUENCING_UTIL_H_
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "absl/container/btree_set.h"
+#include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/ir.pb.h"
 
 // TODO rename this file to reachability_util.h once reachability
 // analysis replaces p4 sequencing.
@@ -26,6 +30,7 @@ struct ReferredField {
     return match_field_name < rhs.match_field_name ||
            (match_field_name == rhs.match_field_name && value < rhs.value);
   }
+
   // The hash is a concatenation of match field name and match field value.
   // See https://abseil.io/docs/cpp/guides/hash for details about making a
   // struct hashable.
@@ -35,7 +40,7 @@ struct ReferredField {
   }
   template <typename Sink>
   friend void AbslStringify(Sink& sink, const ReferredField& referred_field) {
-    absl::Format(&sink, "ReferredField{ match_field_name: %s,field_value: %s}",
+    absl::Format(&sink, "ReferredField{match_field_name: %s,field_value: %s}",
                  referred_field.match_field_name, referred_field.value);
   }
 };
@@ -74,10 +79,19 @@ struct ReferredTableEntry {
   friend void AbslStringify(Sink& sink, const ReferredTableEntry& table_entry) {
     absl::Format(
         &sink,
-        "ReferredTableEntry{ table_name: %s, match_fields and values: [%s]}",
-        table_entry.table, absl::StrJoin(table_entry.referred_fields, ","));
+        "ReferredTableEntry{table_name: %s, match_fields and values: [%s]}",
+        table_entry.table, absl::StrJoin(table_entry.referred_fields, ", "));
   }
 };
+
+// Returns a vector of ReferredTableEntries that `table_entry` refers to.
+// What table entries `table_entry` refers to depends on `ir_p4info`'s reference
+// fields for the match fields and actions plus the value of the match fields
+// and actions.
+// This function assumes each `table_entry` can at most refer to 1
+// table entry for each table type.
+absl::StatusOr<std::vector<ReferredTableEntry>> EntriesReferredToByTableEntry(
+    const p4::v1::TableEntry& table_entry, const IrP4Info& ir_p4info);
 
 }  // namespace pdpi
 

--- a/p4_pdpi/testing/BUILD.bazel
+++ b/p4_pdpi/testing/BUILD.bazel
@@ -181,6 +181,31 @@ cmd_diff_test(
     ],
 )
 
+cc_test(
+    name = "sequencing_util_test_runner",
+    srcs = ["sequencing_util_test_runner.cc"],
+    linkstatic = True,
+    deps = [
+        ":main_p4_pd_cc_proto",
+        ":test_helper",
+        ":test_p4info_cc",
+        "//gutil:proto",
+        "//gutil:testing",
+        "//p4_pdpi:pd",
+        "//p4_pdpi:sequencing_util",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cmd_diff_test(
+    name = "sequencing_util_test",
+    actual_cmd = "$(execpath :sequencing_util_test_runner) ",
+    expected = "//p4_pdpi/testing/testdata:sequencing_util.expected",
+    tools = [":sequencing_util_test_runner"],
+)
+
 # go/golden-test-with-coverage
 cc_test(
     name = "info_test_runner",

--- a/p4_pdpi/testing/sequencing_util_test_runner.cc
+++ b/p4_pdpi/testing/sequencing_util_test_runner.cc
@@ -1,0 +1,116 @@
+
+#include <iostream>
+#include <string>
+
+#include "absl/algorithm/container.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "gutil/proto.h"
+#include "gutil/testing.h"
+#include "p4_pdpi/pd.h"
+#include "p4_pdpi/sequencing_util.h"
+#include "p4_pdpi/testing/main_p4_pd.pb.h"
+#include "p4_pdpi/testing/test_helper.h"
+#include "p4_pdpi/testing/test_p4info.h"
+
+constexpr absl::string_view kInputBanner =
+    "-- INPUT "
+    "-----------------------------------------------------------------------\n";
+const absl::string_view kOutputBanner =
+    "-- OUTPUT "
+    "---------------------------------------------------------------------\n";
+
+// Runs golden file test for EntriesReferredToByTableEntry function.
+void EntriesReferredToByTableEntryTest(absl::string_view test_name,
+                                       absl::string_view pd_string) {
+  std::cout << TestHeader(absl::StrCat("EntriesReferredToByTableEntryTest: ",
+                                       test_name))
+            << std::endl;
+
+  pdpi::TableEntry pd_entry =
+      gutil::ParseProtoOrDie<pdpi::TableEntry>(pd_string);
+
+  const auto pi_table_entry =
+      pdpi::PdTableEntryToPi(pdpi::GetTestIrP4Info(), pd_entry);
+  CHECK(pi_table_entry.ok());  // Crash ok
+
+  std::cout << kInputBanner << "-- PD table entry --\n";
+  std::cout << gutil::PrintTextProto(pd_entry) << std::endl;
+
+  auto referred_table_entries = pdpi::EntriesReferredToByTableEntry(
+      *pi_table_entry, pdpi::GetTestIrP4Info());
+  CHECK(referred_table_entries.ok());  // Crash ok
+
+  // Since ReferredTableEntry has less than operator, we can sort and maintain
+  // golden file stability.
+  absl::c_sort(*referred_table_entries);
+  std::cout << kOutputBanner << "-- ReferredTableEntries --\n";
+  if (referred_table_entries->empty()) {
+    std::cout << "<empty>\n";
+  }
+  for (const auto& entry : *referred_table_entries) {
+    std::cout << absl::StrCat(entry) << std::endl;
+  }
+  std::cout << std::endl;
+}
+
+int main(int argc, char** argv) {
+  EntriesReferredToByTableEntryTest(
+      "Referring to using an entry with 1 match field",
+      R"pb(
+        referring_by_match_field_table_entry {
+          match { referring_id_1: "key-a" }
+          action { do_thing_4 {} }
+          priority: 32
+        }
+      )pb");
+
+  EntriesReferredToByTableEntryTest(
+      "Referring to an entry using with 2 match fields",
+      R"pb(
+        referring_by_match_field_table_entry {
+          match {
+            referring_id_1: "key-x"
+            referring_id_2 { value: "0x223" }
+          }
+          action { do_thing_4 {} }
+          priority: 32
+        }
+      )pb");
+  EntriesReferredToByTableEntryTest(
+      "Referring to an entry using with 1 action param",
+      R"pb(
+        referring_by_action_table_entry {
+          match { val: "0x012" }
+          action {
+            referring_to_one_match_field_action {
+              referring_id_1: "key-a",
+            }
+          }
+        }
+      )pb");
+  EntriesReferredToByTableEntryTest(
+      "Referring to an entry using with 2 action params",
+      R"pb(
+        referring_by_action_table_entry {
+          match { val: "0x012" }
+          action {
+            referring_to_two_match_fields_action {
+              referring_id_1: "key-xy",
+              referring_id_2: "0x033"
+            }
+          }
+        }
+      )pb");
+  EntriesReferredToByTableEntryTest(
+      "Entry that doesn't refer to other entry will not generate "
+      "ReferredTableEntry",
+      R"pb(
+        two_match_fields_table_entry {
+          match { id_1: "key-b", id_2: "0x024" }
+          action { do_thing_4 {} }
+        }
+      )pb");
+
+  return 0;
+}

--- a/p4_pdpi/testing/testdata/sequencing_util.expected
+++ b/p4_pdpi/testing/testdata/sequencing_util.expected
@@ -1,0 +1,104 @@
+=========================================================================
+EntriesReferredToByTableEntryTest: Referring to using an entry with 1 match field
+=========================================================================
+-- INPUT -----------------------------------------------------------------------
+-- PD table entry --
+referring_by_match_field_table_entry {
+  match {
+    referring_id_1: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+  priority: 32
+}
+
+-- OUTPUT ---------------------------------------------------------------------
+-- ReferredTableEntries --
+ReferredTableEntry{table_name: two_match_fields_table, match_fields and values: [ReferredField{match_field_name: id_1,field_value: key-a}]}
+
+=========================================================================
+EntriesReferredToByTableEntryTest: Referring to an entry using with 2 match fields
+=========================================================================
+-- INPUT -----------------------------------------------------------------------
+-- PD table entry --
+referring_by_match_field_table_entry {
+  match {
+    referring_id_1: "key-x"
+    referring_id_2 {
+      value: "0x223"
+    }
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+  priority: 32
+}
+
+-- OUTPUT ---------------------------------------------------------------------
+-- ReferredTableEntries --
+ReferredTableEntry{table_name: two_match_fields_table, match_fields and values: [ReferredField{match_field_name: id_1,field_value: key-x}, ReferredField{match_field_name: id_2,field_value: #}]}
+
+=========================================================================
+EntriesReferredToByTableEntryTest: Referring to an entry using with 1 action param
+=========================================================================
+-- INPUT -----------------------------------------------------------------------
+-- PD table entry --
+referring_by_action_table_entry {
+  match {
+    val: "0x012"
+  }
+  action {
+    referring_to_one_match_field_action {
+      referring_id_1: "key-a"
+    }
+  }
+}
+
+-- OUTPUT ---------------------------------------------------------------------
+-- ReferredTableEntries --
+ReferredTableEntry{table_name: one_match_field_table, match_fields and values: [ReferredField{match_field_name: id,field_value: key-a}]}
+ReferredTableEntry{table_name: two_match_fields_table, match_fields and values: [ReferredField{match_field_name: id_1,field_value: key-a}]}
+
+=========================================================================
+EntriesReferredToByTableEntryTest: Referring to an entry using with 2 action params
+=========================================================================
+-- INPUT -----------------------------------------------------------------------
+-- PD table entry --
+referring_by_action_table_entry {
+  match {
+    val: "0x012"
+  }
+  action {
+    referring_to_two_match_fields_action {
+      referring_id_1: "key-xy"
+      referring_id_2: "0x033"
+    }
+  }
+}
+
+-- OUTPUT ---------------------------------------------------------------------
+-- ReferredTableEntries --
+ReferredTableEntry{table_name: two_match_fields_table, match_fields and values: [ReferredField{match_field_name: id_1,field_value: key-xy}, ReferredField{match_field_name: id_2,field_value: 3}]}
+
+=========================================================================
+EntriesReferredToByTableEntryTest: Entry that doesn't refer to other entry will not generate ReferredTableEntry
+=========================================================================
+-- INPUT -----------------------------------------------------------------------
+-- PD table entry --
+two_match_fields_table_entry {
+  match {
+    id_1: "key-b"
+    id_2: "0x024"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+-- OUTPUT ---------------------------------------------------------------------
+-- ReferredTableEntries --
+<empty>


### PR DESCRIPTION
### PR Description :
[P4 Reachability analysis] Creates a helper function to create ReferredTableEntries for an entry that refers to other entries.

### Build Results :
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 245 targets (3 packages loaded, 196 targets configured).
INFO: Found 245 targets...
INFO: Elapsed time: 16.425s, Critical Path: 9.45s
INFO: 20 processes: 13 internal, 7 linux-sandbox.
INFO: Build completed successfully, 20 total actions

### UT Results :
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4_pdpi/...
INFO: Analyzed 80 targets (0 packages loaded, 0 targets configured).
INFO: Found 46 targets and 34 test targets...
INFO: Elapsed time: 1.518s, Critical Path: 0.55s
INFO: 4 processes: 5 linux-sandbox.
INFO: Build completed successfully, 4 total actions
//p4_pdpi:ir_tools_test                                         (cached) PASSED in 0.7s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test         (cached) PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                             (cached) PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                              (cached) PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                       (cached) PASSED in 15.7s
//p4_pdpi/packetlib:packetlib_test                              (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                         (cached) PASSED in 1.7s
//p4_pdpi/string_encodings:bit_string_test                      (cached) PASSED in 0.4s
//p4_pdpi/string_encodings:byte_string_test                     (cached) PASSED in 0.7s
//p4_pdpi/string_encodings:decimal_string_test                  (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test_runner           (cached) PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                      (cached) PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner               (cached) PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test            (cached) PASSED in 0.3s
//p4_pdpi/testing:helper_function_test                          (cached) PASSED in 0.3s
//p4_pdpi/testing:info_test                                     (cached) PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                              (cached) PASSED in 0.0s
//p4_pdpi/testing:main_pd_test                                  (cached) PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                   (cached) PASSED in 0.3s
//p4_pdpi/testing:packet_io_test                                (cached) PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                         (cached) PASSED in 0.0s
//p4_pdpi/testing:rpc_test                                      (cached) PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                               (cached) PASSED in 0.5s
//p4_pdpi/testing:sequencing_test                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                        (cached) PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                        (cached) PASSED in 0.4s
//p4_pdpi/testing:table_entry_test                              (cached) PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                          (cached) PASSED in 0.4s
//p4_pdpi/utils:ir_test                                         (cached) PASSED in 0.3s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.5s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.2s

Executed 3 out of 34 tests: 34 tests pass.
INFO: Build completed successfully, 4 total actions
bibhuprasad@eaba4ee0062c:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4rt_app/...
INFO: Analyzed 106 targets (0 packages loaded, 0 targets configured).
INFO: Found 68 targets and 38 test targets...
INFO: Elapsed time: 0.798s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//p4rt_app/event_monitoring:app_state_db_port_table_event_test  (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test (cached) PASSED in 0.6s
//p4rt_app/event_monitoring:config_db_port_table_event_test     (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:debug_data_dump_events_test         (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test      (cached) PASSED in 0.7s
//p4rt_app/p4runtime:ir_translation_test                        (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test            (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                   (cached) PASSED in 0.4s
//p4rt_app/p4runtime:packetio_helpers_test                      (cached) PASSED in 0.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test              (cached) PASSED in 0.4s
//p4rt_app/sonic:app_db_manager_test                            (cached) PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test              (cached) PASSED in 0.4s
//p4rt_app/sonic:hashing_test                                   (cached) PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                             (cached) PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                             (cached) PASSED in 0.3s
//p4rt_app/sonic:response_handler_test                          (cached) PASSED in 0.3s
//p4rt_app/sonic:state_verification_test                        (cached) PASSED in 0.5s
//p4rt_app/sonic:vrf_entry_translation_test                     (cached) PASSED in 0.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test              (cached) PASSED in 0.2s
//p4rt_app/tests:acl_table_test                                 (cached) PASSED in 0.9s
//p4rt_app/tests:action_set_test                                (cached) PASSED in 0.7s
//p4rt_app/tests:api_access_test                                (cached) PASSED in 0.6s
//p4rt_app/tests:arbitration_test                               (cached) PASSED in 0.7s
//p4rt_app/tests:fixed_l3_tables_test                           (cached) PASSED in 2.4s
//p4rt_app/tests:forwarding_pipeline_config_test                (cached) PASSED in 3.7s
//p4rt_app/tests:grpc_behavior_test                             (cached) PASSED in 5.0s
//p4rt_app/tests:p4_constraints_test                            (cached) PASSED in 0.1s
//p4rt_app/tests:p4_constraints_test_runner                     (cached) PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                               (cached) PASSED in 1.2s
//p4rt_app/tests:packetio_test                                  (cached) PASSED in 3.3s
//p4rt_app/tests:port_name_and_id_test                          (cached) PASSED in 0.8s
//p4rt_app/tests:response_path_test                             (cached) PASSED in 2.7s
//p4rt_app/tests:role_test                                      (cached) PASSED in 0.7s
//p4rt_app/tests:state_verification_test                        (cached) PASSED in 1.0s
//p4rt_app/tests/lib:app_db_entry_builder_test                  (cached) PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                        (cached) PASSED in 0.1s
//p4rt_app/utils:table_utility_test                             (cached) PASSED in 0.8s

Executed 0 out of 38 tests: 38 tests pass.
INFO: Build completed successfully, 1 total action
