### PR TITLE
[IrP4Info] Extend table/action/match definitions with is_unsupported field.

### DIFF
--- a/p4_pdpi/ir.proto
+++ b/p4_pdpi/ir.proto
@@ -60,6 +60,10 @@ message IrMatchFieldDefinition {
   Format format = 2;
   // Optional. The set of references.
   repeated IrMatchFieldReference references = 3;
+  // True if match field has @unsupported annotation, otherwise false. Indicates
+  // that the match field is not (yet) supported by the target.
+  // See go/unblocking-sai-p4 for more details.
+  bool is_unsupported = 14;
 }
 
 // Describes a meter.
@@ -109,7 +113,11 @@ message IrTableDefinition {
   IrActionDefinition const_default_action = 11;
   // Optional. P4Runtime role of this table.
   string role = 12;
-  // Next: 14
+  // True if table has @unsupported annotation, otherwise false. Indicates that
+  // the table is not (yet) supported by the target.
+  // See go/unblocking-sai-p4 for more details.
+  bool is_unsupported = 14;
+  // Next: 15
 }
 
 // Describes a reference to an action (from a table).
@@ -140,6 +148,10 @@ message IrActionDefinition {
   map<uint32, IrActionParamDefinition> params_by_id = 2;
   // Required. Maps parameter names to parameters.
   map<string, IrActionParamDefinition> params_by_name = 3;
+  // True if action has @unsupported annotation, otherwise false. Indicates that
+  // the action is not (yet) supported by the target.
+  // See go/unblocking-sai-p4 for more details.
+  bool is_unsupported = 4;
 }
 
 // Describes an action profile definition.

--- a/p4_pdpi/testing/testdata/info.expected
+++ b/p4_pdpi/testing/testdata/info.expected
@@ -1770,6 +1770,7 @@ tables_by_id {
           bitwidth: 1
           match_type: TERNARY
         }
+        is_unsupported: true
       }
     }
     match_fields_by_id {
@@ -1887,6 +1888,7 @@ tables_by_id {
           bitwidth: 1
           match_type: TERNARY
         }
+        is_unsupported: true
       }
     }
     entry_actions {
@@ -1955,6 +1957,7 @@ tables_by_id {
           alias: "unsupported_action"
           annotations: "@unsupported"
         }
+        is_unsupported: true
       }
       proto_id: 2
     }
@@ -2870,6 +2873,7 @@ tables_by_id {
         annotations: "@noWarn(\"unused\")"
       }
     }
+    is_unsupported: true
   }
 }
 tables_by_id {
@@ -6039,6 +6043,7 @@ tables_by_name {
           bitwidth: 1
           match_type: TERNARY
         }
+        is_unsupported: true
       }
     }
     match_fields_by_id {
@@ -6156,6 +6161,7 @@ tables_by_name {
           bitwidth: 1
           match_type: TERNARY
         }
+        is_unsupported: true
       }
     }
     entry_actions {
@@ -6224,6 +6230,7 @@ tables_by_name {
           alias: "unsupported_action"
           annotations: "@unsupported"
         }
+        is_unsupported: true
       }
       proto_id: 2
     }
@@ -6443,6 +6450,7 @@ tables_by_name {
         annotations: "@noWarn(\"unused\")"
       }
     }
+    is_unsupported: true
   }
 }
 tables_by_name {
@@ -7054,6 +7062,7 @@ actions_by_id {
       alias: "unsupported_action"
       annotations: "@unsupported"
     }
+    is_unsupported: true
   }
 }
 actions_by_id {
@@ -7651,6 +7660,7 @@ actions_by_name {
       alias: "unsupported_action"
       annotations: "@unsupported"
     }
+    is_unsupported: true
   }
 }
 packet_in_metadata_by_id {

--- a/p4_pdpi/utils/ir.cc
+++ b/p4_pdpi/utils/ir.cc
@@ -533,13 +533,6 @@ std::string MetadataName(absl::string_view metadata_name) {
   return absl::StrCat("Metadata '", metadata_name, "'");
 }
 
-bool IsElementUnsupported(
-    const google::protobuf::RepeatedPtrField<std::string> &annotations) {
-  return absl::c_any_of(annotations, [](absl::string_view annotation) {
-    return annotation == "@unsupported";
-  });
-}
-
 bool IsElementDeprecated(
     const google::protobuf::RepeatedPtrField<std::string> &annotations) {
   return absl::c_any_of(annotations, [](absl::string_view annotation) {

--- a/p4_pdpi/utils/ir.h
+++ b/p4_pdpi/utils/ir.h
@@ -156,10 +156,6 @@ std::string ParamName(absl::string_view param_name);
 // Returns a "Metadata <packet_name>" string.
 std::string MetadataName(absl::string_view metadata_name);
 
-// Checks for an "@unsupported" annotation in the argument.
-bool IsElementUnsupported(
-    const google::protobuf::RepeatedPtrField<std::string> &annotations);
-
 // Checks for an "@deprecated" annotation in the argument.
 bool IsElementDeprecated(
     const google::protobuf::RepeatedPtrField<std::string> &annotations);

--- a/p4_pdpi/utils/ir_test.cc
+++ b/p4_pdpi/utils/ir_test.cc
@@ -369,22 +369,6 @@ INSTANTIATE_TEST_SUITE_P(PerBitwidth, Ipv6BitwidthTest,
                          testing::Values(63, 64, 65, 128),
                          testing::PrintToStringParamName());
 
-TEST(AnnotationTests, IsElementUnsupportedTest) {
-  std::vector<std::string> annotations_with_unsupported = {
-      "@irrelevant", "@unsupported", "@irrelevant2"};
-  EXPECT_TRUE(
-      IsElementUnsupported(google::protobuf::RepeatedPtrField<std::string>(
-          annotations_with_unsupported.begin(),
-          annotations_with_unsupported.end())));
-
-  std::vector<std::string> annotations_without_unsupported = {
-      "@irrelevant", "@deprecated", "@irrelevant2"};
-  EXPECT_FALSE(
-      IsElementUnsupported(google::protobuf::RepeatedPtrField<std::string>(
-          annotations_without_unsupported.begin(),
-          annotations_without_unsupported.end())));
-}
-
 TEST(AnnotationTests, IsElementDeprecatedTest) {
   std::vector<std::string> annotations_with_deprecated = {
       "@irrelevant", "@deprecated", "@irrelevant2"};


### PR DESCRIPTION
PR Description :
[IrP4Info] Extend table/action/match definitions with is_unsupported field.

Build Results :
bibhuprasad@26c7ccef2fda:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 257 targets (0 packages loaded, 0 targets configured).
INFO: Found 257 targets...
INFO: Elapsed time: 308.953s, Critical Path: 30.87s
INFO: 216 processes: 14 internal, 202 linux-sandbox.
INFO: Build completed successfully, 216 total actions
bibhuprasad@26c7ccef2fda:/sonic/src/sonic-p4rt/sonic-pins$ 

UT Results :
bibhuprasad@26c7ccef2fda:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4_pdpi/...
INFO: Analyzed 84 targets (0 packages loaded, 0 targets configured).
INFO: Found 48 targets and 36 test targets...
INFO: Elapsed time: 1.753s, Critical Path: 0.37s
INFO: 18 processes: 29 linux-sandbox.
INFO: Build completed successfully, 18 total actions
//p4_pdpi:p4_runtime_matchers_test                              (cached) PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test         (cached) PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                             (cached) PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                              (cached) PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                       (cached) PASSED in 15.4s
//p4_pdpi/packetlib:packetlib_matchers_test                     (cached) PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test                              (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                       (cached) PASSED in 0.0s
//p4_pdpi/packetlib:packetlib_unit_test                         (cached) PASSED in 0.9s
//p4_pdpi/string_encodings:bit_string_test                      (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                     (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                  (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test_runner           (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                      (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner               (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test            (cached) PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                  (cached) PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                   (cached) PASSED in 0.8s
//p4_pdpi/utils:annotation_parser_test                          (cached) PASSED in 0.2s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.3s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.3s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.3s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.0s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.0s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.4s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.3s

Executed 17 out of 36 tests: 36 tests pass.
INFO: Build completed successfully, 18 total actions
bibhuprasad@26c7ccef2fda:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS p4rt_app/...
INFO: Analyzed 107 targets (0 packages loaded, 0 targets configured).
INFO: Found 68 targets and 39 test targets...
INFO: Elapsed time: 31.327s, Critical Path: 5.13s
INFO: 36 processes: 1 internal, 20 linux-sandbox, 15 local.
INFO: Build completed successfully, 36 total actions
//p4rt_app/sonic:state_verification_test                        (cached) PASSED in 0.2s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test              (cached) PASSED in 0.1s
//p4rt_app/tests/lib:app_db_entry_builder_test                  (cached) PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                        (cached) PASSED in 0.0s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.5s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.4s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.4s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.4s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.3s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.3s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.4s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.0s
//p4rt_app/tests:action_set_test                                         PASSED in 0.7s
//p4rt_app/tests:api_access_test                                         PASSED in 0.6s
//p4rt_app/tests:arbitration_test                                        PASSED in 0.7s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 0.6s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.8s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 4.2s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.1s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.0s
//p4rt_app/tests:packetio_test                                           PASSED in 3.2s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.2s
//p4rt_app/tests:response_path_test                                      PASSED in 2.5s
//p4rt_app/tests:role_test                                               PASSED in 0.7s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.3s

Executed 35 out of 39 tests: 39 tests pass.
INFO: Build completed successfully, 36 total actions
bibhuprasad@26c7ccef2fda:/sonic/src/sonic-p4rt/sonic-pins$