### PR TITLE
[PDPI] Fix roundtrip bugs in color counter translation.

### DIFF
--- a/p4_pdpi/testing/testdata/table_entry.expected
+++ b/p4_pdpi/testing/testdata/table_entry.expected
@@ -4978,12 +4978,6 @@ counter_data {
   packet_count: 789
 }
 meter_counter_data {
-  green {
-  }
-  yellow {
-  }
-  red {
-  }
 }
 
 --- PI:
@@ -5011,51 +5005,8 @@ counter_data {
   packet_count: 789
 }
 meter_counter_data {
-  green {
-  }
-  yellow {
-  }
-  red {
-  }
 }
 
-TEST FAILED (DO NOT SUBMIT)
-TEST NAME: table entry with meter counter data but no color counters
-FAILURE REASON: Reverse translation from IR to PD resulted in a different PD.
-
-Differences: added: count_and_meter_table_entry.meter_counter_data.green: { }
-added: count_and_meter_table_entry.meter_counter_data.yellow: { }
-added: count_and_meter_table_entry.meter_counter_data.red: { }
-
-PD (after reverse translation):
-count_and_meter_table_entry {
-  match {
-    ipv4 {
-      value: "16.36.50.0"
-      prefix_length: 24
-    }
-  }
-  action {
-    count_and_meter {
-    }
-  }
-  meter_config {
-    bytes_per_second: 123
-    burst_bytes: 345
-  }
-  counter_data {
-    byte_count: 567
-    packet_count: 789
-  }
-  meter_counter_data {
-    green {
-    }
-    yellow {
-    }
-    red {
-    }
-  }
-}
 
 =========================================================================
 table entry with meter counter data but missing some colors
@@ -5122,8 +5073,6 @@ meter_counter_data {
     byte_count: 568
     packet_count: 790
   }
-  yellow {
-  }
   red {
     byte_count: 570
     packet_count: 792
@@ -5159,53 +5108,12 @@ meter_counter_data {
     byte_count: 568
     packet_count: 790
   }
-  yellow {
-  }
   red {
     byte_count: 570
     packet_count: 792
   }
 }
 
-TEST FAILED (DO NOT SUBMIT)
-TEST NAME: table entry with meter counter data but missing some colors
-FAILURE REASON: Reverse translation from IR to PD resulted in a different PD.
-
-Differences: added: count_and_meter_table_entry.meter_counter_data.yellow: { }
-
-PD (after reverse translation):
-count_and_meter_table_entry {
-  match {
-    ipv4 {
-      value: "16.36.50.0"
-      prefix_length: 24
-    }
-  }
-  action {
-    count_and_meter {
-    }
-  }
-  meter_config {
-    bytes_per_second: 123
-    burst_bytes: 345
-  }
-  counter_data {
-    byte_count: 567
-    packet_count: 789
-  }
-  meter_counter_data {
-    green {
-      byte_count: 568
-      packet_count: 790
-    }
-    yellow {
-    }
-    red {
-      byte_count: 570
-      packet_count: 792
-    }
-  }
-}
 
 =========================================================================
 missing matches with key_only=true


### PR DESCRIPTION
### PR Description :
[PDPI] Fix roundtrip bugs in color counter translation.

### Keyword Check
bibhuprasad@eonms7vm1:~/Sonic_04_29_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/Google/tools/keyword_checks.sh .
Keyword check Passed.

### Build Results :
bibhuprasad@26c7ccef2fda:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 266 targets (0 packages loaded, 0 targets configured).
INFO: Found 266 targets...
INFO: Elapsed time: 0.712s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### UT Results :
bibhuprasad@26c7ccef2fda:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Analyzed 266 targets (0 packages loaded, 0 targets configured).
INFO: Found 170 targets and 96 test targets...
INFO: Elapsed time: 1.993s, Critical Path: 0.54s
INFO: 14 processes: 18 linux-sandbox.
INFO: Build completed successfully, 14 total actions
//gutil:collections_test                                        (cached) PASSED in 0.3s
//gutil:io_test                                                 (cached) PASSED in 0.3s
//gutil:proto_matchers_test                                     (cached) PASSED in 0.3s
//gutil:proto_test                                              (cached) PASSED in 0.2s
//gutil:status_matchers_test                                    (cached) PASSED in 0.2s
//gutil:table_entry_key_test                                    (cached) PASSED in 0.1s
//gutil:testing_test                                            (cached) PASSED in 0.3s
//gutil:version_test                                            (cached) PASSED in 0.3s
//p4_pdpi:ir_tools_test                                         (cached) PASSED in 0.4s
//p4_pdpi:p4_runtime_matchers_test                              (cached) PASSED in 0.6s
//p4_pdpi:sequencing_util_test                                  (cached) PASSED in 0.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test         (cached) PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                             (cached) PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                              (cached) PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                       (cached) PASSED in 15.4s
//p4_pdpi/packetlib:packetlib_matchers_test                     (cached) PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test                              (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                       (cached) PASSED in 0.0s
//p4_pdpi/packetlib:packetlib_unit_test                         (cached) PASSED in 0.9s
//p4_pdpi/string_encodings:bit_string_test                      (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                     (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                  (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test_runner           (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                      (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner               (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test            (cached) PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                          (cached) PASSED in 0.3s
//p4_pdpi/testing:info_test                                     (cached) PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                              (cached) PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                  (cached) PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                   (cached) PASSED in 0.8s
//p4_pdpi/testing:packet_io_test                                (cached) PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                         (cached) PASSED in 0.0s
//p4_pdpi/testing:rpc_test                                      (cached) PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                        (cached) PASSED in 0.0s
//p4_pdpi/testing:sequencing_util_test                          (cached) PASSED in 0.0s
//p4_pdpi/testing:sequencing_util_test_runner                   (cached) PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                        (cached) PASSED in 0.3s
//p4_pdpi/testing:table_entry_test                              (cached) PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                          (cached) PASSED in 0.2s
//p4_pdpi/utils:ir_test                                         (cached) PASSED in 0.3s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test  (cached) PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test     (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:debug_data_dump_events_test         (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test      (cached) PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                        (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test            (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                   (cached) PASSED in 0.4s
//p4rt_app/p4runtime:packetio_helpers_test                      (cached) PASSED in 0.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test              (cached) PASSED in 0.4s
//p4rt_app/sonic:app_db_manager_test                            (cached) PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test              (cached) PASSED in 0.4s
//p4rt_app/sonic:hashing_test                                   (cached) PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                             (cached) PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                             (cached) PASSED in 0.3s
//p4rt_app/sonic:response_handler_test                          (cached) PASSED in 0.6s
//p4rt_app/sonic:state_verification_test                        (cached) PASSED in 0.2s
//p4rt_app/sonic:vrf_entry_translation_test                     (cached) PASSED in 0.5s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test              (cached) PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                 (cached) PASSED in 0.9s
//p4rt_app/tests:action_set_test                                (cached) PASSED in 0.6s
//p4rt_app/tests:api_access_test                                (cached) PASSED in 0.6s
//p4rt_app/tests:arbitration_test                               (cached) PASSED in 0.7s
//p4rt_app/tests:debug_data_dump_test                           (cached) PASSED in 0.5s
//p4rt_app/tests:fixed_l3_tables_test                           (cached) PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test                (cached) PASSED in 3.6s
//p4rt_app/tests:grpc_behavior_test                             (cached) PASSED in 5.0s
//p4rt_app/tests:p4_constraints_test                            (cached) PASSED in 0.1s
//p4rt_app/tests:p4_constraints_test_runner                     (cached) PASSED in 0.1s
//p4rt_app/tests:p4_programs_test                               (cached) PASSED in 1.2s
//p4rt_app/tests:packetio_test                                  (cached) PASSED in 3.3s
//p4rt_app/tests:port_name_and_id_test                          (cached) PASSED in 2.4s
//p4rt_app/tests:response_path_test                             (cached) PASSED in 2.3s
//p4rt_app/tests:role_test                                      (cached) PASSED in 0.7s
//p4rt_app/tests:state_verification_test                        (cached) PASSED in 0.9s
//p4rt_app/tests/lib:app_db_entry_builder_test                  (cached) PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                        (cached) PASSED in 0.0s
//p4rt_app/utils:table_utility_test                             (cached) PASSED in 0.4s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.4s
//p4_fuzzer:switch_state_test                                            PASSED in 0.3s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.2s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.3s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.5s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.2s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.3s

Executed 13 out of 96 tests: 96 tests pass.
INFO: Build completed successfully, 14 total actions
bibhuprasad@26c7ccef2fda:/sonic/src/sonic-p4rt/sonic-pins$ 