### PR TITLE
Initial import of p4-symbolic - bmv2

### DIFF
--- a/p4_symbolic/bmv2/expected/basic.pb.txt
+++ b/p4_symbolic/bmv2/expected/basic.pb.txt
@@ -1,0 +1,1066 @@
+header_types {
+  name: "scalars_0"
+}
+header_types {
+  name: "standard_metadata"
+  id: 1
+  fields {
+    values {
+      string_value: "ingress_port"
+    }
+    values {
+      number_value: 9
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_spec"
+    }
+    values {
+      number_value: 9
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_port"
+    }
+    values {
+      number_value: 9
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "instance_type"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "packet_length"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "enq_timestamp"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "enq_qdepth"
+    }
+    values {
+      number_value: 19
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "deq_timedelta"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "deq_qdepth"
+    }
+    values {
+      number_value: 19
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "ingress_global_timestamp"
+    }
+    values {
+      number_value: 48
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_global_timestamp"
+    }
+    values {
+      number_value: 48
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "mcast_grp"
+    }
+    values {
+      number_value: 16
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_rid"
+    }
+    values {
+      number_value: 16
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "checksum_error"
+    }
+    values {
+      number_value: 1
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "parser_error"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "priority"
+    }
+    values {
+      number_value: 3
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "_padding"
+    }
+    values {
+      number_value: 3
+    }
+    values {
+      bool_value: false
+    }
+  }
+}
+header_types {
+  name: "ethernet_t"
+  id: 2
+  fields {
+    values {
+      string_value: "dstAddr"
+    }
+    values {
+      number_value: 48
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "srcAddr"
+    }
+    values {
+      number_value: 48
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "etherType"
+    }
+    values {
+      number_value: 16
+    }
+    values {
+      bool_value: false
+    }
+  }
+}
+header_types {
+  name: "ipv4_t"
+  id: 3
+  fields {
+    values {
+      string_value: "version"
+    }
+    values {
+      number_value: 4
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "ihl"
+    }
+    values {
+      number_value: 4
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "diffserv"
+    }
+    values {
+      number_value: 8
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "totalLen"
+    }
+    values {
+      number_value: 16
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "identification"
+    }
+    values {
+      number_value: 16
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "flags"
+    }
+    values {
+      number_value: 3
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "fragOffset"
+    }
+    values {
+      number_value: 13
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "ttl"
+    }
+    values {
+      number_value: 8
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "protocol"
+    }
+    values {
+      number_value: 8
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "hdrChecksum"
+    }
+    values {
+      number_value: 16
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "srcAddr"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "dstAddr"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+}
+headers {
+  name: "scalars"
+  header_type: "scalars_0"
+  metadata: true
+}
+headers {
+  id: 1
+  name: "standard_metadata"
+  header_type: "standard_metadata"
+  metadata: true
+}
+headers {
+  id: 2
+  name: "ethernet"
+  header_type: "ethernet_t"
+}
+headers {
+  id: 3
+  name: "ipv4"
+  header_type: "ipv4_t"
+}
+parsers {
+  name: "parser"
+  init_state: "start"
+  parse_states {
+    name: "start"
+    transitions {
+      value: "0x0800"
+      type: hexstr
+      next_state: "parse_ipv4"
+    }
+    transitions {
+    }
+  }
+  parse_states {
+    name: "parse_ipv4"
+    id: 1
+    transitions {
+    }
+  }
+}
+deparsers {
+  name: "deparser"
+  source_info {
+    line: 172
+    column: 8
+    source_fragment: "MyDeparser"
+  }
+}
+actions {
+  name: "NoAction"
+}
+actions {
+  name: "MyIngress.drop"
+  id: 1
+  primitives {
+    fields {
+      key: "op"
+      value {
+        string_value: "mark_to_drop"
+      }
+    }
+    fields {
+      key: "parameters"
+      value {
+        list_value {
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "header"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  string_value: "standard_metadata"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    fields {
+      key: "source_info"
+      value {
+        struct_value {
+          fields {
+            key: "column"
+            value {
+              number_value: 8
+            }
+          }
+          fields {
+            key: "filename"
+            value {
+              string_value: ""
+            }
+          }
+          fields {
+            key: "line"
+            value {
+              number_value: 104
+            }
+          }
+          fields {
+            key: "source_fragment"
+            value {
+              string_value: "mark_to_drop(standard_metadata)"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+actions {
+  name: "MyIngress.ipv4_forward"
+  id: 2
+  runtime_data {
+    name: "dstAddr"
+    bitwidth: 48
+  }
+  runtime_data {
+    name: "port"
+    bitwidth: 9
+  }
+  primitives {
+    fields {
+      key: "op"
+      value {
+        string_value: "assign"
+      }
+    }
+    fields {
+      key: "parameters"
+      value {
+        list_value {
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "field"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  list_value {
+                    values {
+                      string_value: "standard_metadata"
+                    }
+                    values {
+                      string_value: "egress_spec"
+                    }
+                  }
+                }
+              }
+            }
+          }
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "runtime_data"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  number_value: 1
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    fields {
+      key: "source_info"
+      value {
+        struct_value {
+          fields {
+            key: "column"
+            value {
+              number_value: 8
+            }
+          }
+          fields {
+            key: "filename"
+            value {
+              string_value: ""
+            }
+          }
+          fields {
+            key: "line"
+            value {
+              number_value: 108
+            }
+          }
+          fields {
+            key: "source_fragment"
+            value {
+              string_value: "standard_metadata.egress_spec = port"
+            }
+          }
+        }
+      }
+    }
+  }
+  primitives {
+    fields {
+      key: "op"
+      value {
+        string_value: "assign"
+      }
+    }
+    fields {
+      key: "parameters"
+      value {
+        list_value {
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "field"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  list_value {
+                    values {
+                      string_value: "ethernet"
+                    }
+                    values {
+                      string_value: "srcAddr"
+                    }
+                  }
+                }
+              }
+            }
+          }
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "field"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  list_value {
+                    values {
+                      string_value: "ethernet"
+                    }
+                    values {
+                      string_value: "dstAddr"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    fields {
+      key: "source_info"
+      value {
+        struct_value {
+          fields {
+            key: "column"
+            value {
+              number_value: 8
+            }
+          }
+          fields {
+            key: "filename"
+            value {
+              string_value: ""
+            }
+          }
+          fields {
+            key: "line"
+            value {
+              number_value: 109
+            }
+          }
+          fields {
+            key: "source_fragment"
+            value {
+              string_value: "hdr.ethernet.srcAddr = hdr.ethernet.dstAddr"
+            }
+          }
+        }
+      }
+    }
+  }
+  primitives {
+    fields {
+      key: "op"
+      value {
+        string_value: "assign"
+      }
+    }
+    fields {
+      key: "parameters"
+      value {
+        list_value {
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "field"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  list_value {
+                    values {
+                      string_value: "ethernet"
+                    }
+                    values {
+                      string_value: "dstAddr"
+                    }
+                  }
+                }
+              }
+            }
+          }
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "runtime_data"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  number_value: 0
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    fields {
+      key: "source_info"
+      value {
+        struct_value {
+          fields {
+            key: "column"
+            value {
+              number_value: 8
+            }
+          }
+          fields {
+            key: "filename"
+            value {
+              string_value: ""
+            }
+          }
+          fields {
+            key: "line"
+            value {
+              number_value: 110
+            }
+          }
+          fields {
+            key: "source_fragment"
+            value {
+              string_value: "hdr.ethernet.dstAddr = dstAddr"
+            }
+          }
+        }
+      }
+    }
+  }
+  primitives {
+    fields {
+      key: "op"
+      value {
+        string_value: "assign"
+      }
+    }
+    fields {
+      key: "parameters"
+      value {
+        list_value {
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "field"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  list_value {
+                    values {
+                      string_value: "ipv4"
+                    }
+                    values {
+                      string_value: "ttl"
+                    }
+                  }
+                }
+              }
+            }
+          }
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "expression"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  struct_value {
+                    fields {
+                      key: "type"
+                      value {
+                        string_value: "expression"
+                      }
+                    }
+                    fields {
+                      key: "value"
+                      value {
+                        struct_value {
+                          fields {
+                            key: "left"
+                            value {
+                              struct_value {
+                                fields {
+                                  key: "type"
+                                  value {
+                                    string_value: "expression"
+                                  }
+                                }
+                                fields {
+                                  key: "value"
+                                  value {
+                                    struct_value {
+                                      fields {
+                                        key: "left"
+                                        value {
+                                          struct_value {
+                                            fields {
+                                              key: "type"
+                                              value {
+                                                string_value: "field"
+                                              }
+                                            }
+                                            fields {
+                                              key: "value"
+                                              value {
+                                                list_value {
+                                                  values {
+                                                    string_value: "ipv4"
+                                                  }
+                                                  values {
+                                                    string_value: "ttl"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                      fields {
+                                        key: "op"
+                                        value {
+                                          string_value: "+"
+                                        }
+                                      }
+                                      fields {
+                                        key: "right"
+                                        value {
+                                          struct_value {
+                                            fields {
+                                              key: "type"
+                                              value {
+                                                string_value: "hexstr"
+                                              }
+                                            }
+                                            fields {
+                                              key: "value"
+                                              value {
+                                                string_value: "0xff"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                          fields {
+                            key: "op"
+                            value {
+                              string_value: "&"
+                            }
+                          }
+                          fields {
+                            key: "right"
+                            value {
+                              struct_value {
+                                fields {
+                                  key: "type"
+                                  value {
+                                    string_value: "hexstr"
+                                  }
+                                }
+                                fields {
+                                  key: "value"
+                                  value {
+                                    string_value: "0xff"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    fields {
+      key: "source_info"
+      value {
+        struct_value {
+          fields {
+            key: "column"
+            value {
+              number_value: 8
+            }
+          }
+          fields {
+            key: "filename"
+            value {
+              string_value: ""
+            }
+          }
+          fields {
+            key: "line"
+            value {
+              number_value: 111
+            }
+          }
+          fields {
+            key: "source_fragment"
+            value {
+              string_value: "hdr.ipv4.ttl = hdr.ipv4.ttl - 1"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+pipelines {
+  name: "ingress"
+  source_info {
+    line: 100
+    column: 8
+    source_fragment: "MyIngress"
+  }
+  init_table: "node_2"
+  tables {
+    name: "MyIngress.ipv4_lpm"
+    source_info {
+      line: 114
+      column: 10
+      source_fragment: "ipv4_lpm"
+    }
+    key {
+      match_type: lpm
+      name: "hdr.ipv4.dstAddr"
+      target: "ipv4"
+      target: "dstAddr"
+    }
+    match_type: lpm
+    max_size: 1024
+    action_ids: 2
+    action_ids: 1
+    action_ids: 0
+    actions: "MyIngress.ipv4_forward"
+    actions: "MyIngress.drop"
+    actions: "NoAction"
+    default_entry {
+      action_id: 1
+    }
+    next_tables {
+      key: "MyIngress.drop"
+      value: ""
+    }
+    next_tables {
+      key: "MyIngress.ipv4_forward"
+      value: ""
+    }
+    next_tables {
+      key: "NoAction"
+      value: ""
+    }
+  }
+  conditionals {
+    name: "node_2"
+    expression {
+      fields {
+        key: "type"
+        value {
+          string_value: "expression"
+        }
+      }
+      fields {
+        key: "value"
+        value {
+          struct_value {
+            fields {
+              key: "left"
+              value {
+                null_value: NULL_VALUE
+              }
+            }
+            fields {
+              key: "op"
+              value {
+                string_value: "d2b"
+              }
+            }
+            fields {
+              key: "right"
+              value {
+                struct_value {
+                  fields {
+                    key: "type"
+                    value {
+                      string_value: "field"
+                    }
+                  }
+                  fields {
+                    key: "value"
+                    value {
+                      list_value {
+                        values {
+                          string_value: "ipv4"
+                        }
+                        values {
+                          string_value: "$valid$"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    true_next: "MyIngress.ipv4_lpm"
+  }
+}
+pipelines {
+  name: "egress"
+  id: 1
+  source_info {
+    line: 138
+    column: 8
+    source_fragment: "MyEgress"
+  }
+}

--- a/p4_symbolic/bmv2/expected/hardcoded.pb.txt
+++ b/p4_symbolic/bmv2/expected/hardcoded.pb.txt
@@ -1,0 +1,524 @@
+header_types {
+  name: "scalars_0"
+}
+header_types {
+  name: "standard_metadata"
+  id: 1
+  fields {
+    values {
+      string_value: "ingress_port"
+    }
+    values {
+      number_value: 9
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_spec"
+    }
+    values {
+      number_value: 9
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_port"
+    }
+    values {
+      number_value: 9
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "instance_type"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "packet_length"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "enq_timestamp"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "enq_qdepth"
+    }
+    values {
+      number_value: 19
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "deq_timedelta"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "deq_qdepth"
+    }
+    values {
+      number_value: 19
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "ingress_global_timestamp"
+    }
+    values {
+      number_value: 48
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_global_timestamp"
+    }
+    values {
+      number_value: 48
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "mcast_grp"
+    }
+    values {
+      number_value: 16
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_rid"
+    }
+    values {
+      number_value: 16
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "checksum_error"
+    }
+    values {
+      number_value: 1
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "parser_error"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "priority"
+    }
+    values {
+      number_value: 3
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "_padding"
+    }
+    values {
+      number_value: 3
+    }
+    values {
+      bool_value: false
+    }
+  }
+}
+headers {
+  name: "scalars"
+  header_type: "scalars_0"
+  metadata: true
+}
+headers {
+  id: 1
+  name: "standard_metadata"
+  header_type: "standard_metadata"
+  metadata: true
+}
+parsers {
+  name: "parser"
+  init_state: "start"
+  parse_states {
+    name: "start"
+    transitions {
+    }
+  }
+}
+deparsers {
+  name: "deparser"
+  source_info {
+    line: 45
+    column: 8
+    source_fragment: "UselessDeparser"
+  }
+}
+actions {
+  name: "hardcoded55"
+  primitives {
+    fields {
+      key: "op"
+      value {
+        string_value: "assign"
+      }
+    }
+    fields {
+      key: "parameters"
+      value {
+        list_value {
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "field"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  list_value {
+                    values {
+                      string_value: "standard_metadata"
+                    }
+                    values {
+                      string_value: "egress_spec"
+                    }
+                  }
+                }
+              }
+            }
+          }
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "hexstr"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  string_value: "0x0001"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    fields {
+      key: "source_info"
+      value {
+        struct_value {
+          fields {
+            key: "column"
+            value {
+              number_value: 12
+            }
+          }
+          fields {
+            key: "filename"
+            value {
+              string_value: ""
+            }
+          }
+          fields {
+            key: "line"
+            value {
+              number_value: 55
+            }
+          }
+          fields {
+            key: "source_fragment"
+            value {
+              string_value: "standard_metadata.egress_spec = 1"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+actions {
+  name: "hardcoded57"
+  id: 1
+  primitives {
+    fields {
+      key: "op"
+      value {
+        string_value: "assign"
+      }
+    }
+    fields {
+      key: "parameters"
+      value {
+        list_value {
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "field"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  list_value {
+                    values {
+                      string_value: "standard_metadata"
+                    }
+                    values {
+                      string_value: "egress_spec"
+                    }
+                  }
+                }
+              }
+            }
+          }
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "hexstr"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  string_value: "0x0000"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    fields {
+      key: "source_info"
+      value {
+        struct_value {
+          fields {
+            key: "column"
+            value {
+              number_value: 12
+            }
+          }
+          fields {
+            key: "filename"
+            value {
+              string_value: ""
+            }
+          }
+          fields {
+            key: "line"
+            value {
+              number_value: 57
+            }
+          }
+          fields {
+            key: "source_fragment"
+            value {
+              string_value: "standard_metadata.egress_spec = 0"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+pipelines {
+  name: "ingress"
+  source_info {
+    line: 50
+    column: 8
+    source_fragment: "MyIngress"
+  }
+  init_table: "node_2"
+  tables {
+    name: "tbl_hardcoded55"
+    source_info {
+      line: 55
+      column: 42
+      source_fragment: "="
+    }
+    max_size: 1024
+    action_ids: 0
+    actions: "hardcoded55"
+    default_entry {
+    }
+    next_tables {
+      key: "hardcoded55"
+      value: ""
+    }
+  }
+  tables {
+    name: "tbl_hardcoded57"
+    id: 1
+    source_info {
+      line: 57
+      column: 42
+      source_fragment: "="
+    }
+    max_size: 1024
+    action_ids: 1
+    actions: "hardcoded57"
+    default_entry {
+      action_id: 1
+    }
+    next_tables {
+      key: "hardcoded57"
+      value: ""
+    }
+  }
+  conditionals {
+    name: "node_2"
+    expression {
+      fields {
+        key: "type"
+        value {
+          string_value: "expression"
+        }
+      }
+      fields {
+        key: "value"
+        value {
+          struct_value {
+            fields {
+              key: "left"
+              value {
+                struct_value {
+                  fields {
+                    key: "type"
+                    value {
+                      string_value: "field"
+                    }
+                  }
+                  fields {
+                    key: "value"
+                    value {
+                      list_value {
+                        values {
+                          string_value: "standard_metadata"
+                        }
+                        values {
+                          string_value: "ingress_port"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            fields {
+              key: "op"
+              value {
+                string_value: "=="
+              }
+            }
+            fields {
+              key: "right"
+              value {
+                struct_value {
+                  fields {
+                    key: "type"
+                    value {
+                      string_value: "hexstr"
+                    }
+                  }
+                  fields {
+                    key: "value"
+                    value {
+                      string_value: "0x0000"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    true_next: "tbl_hardcoded55"
+    false_next: "tbl_hardcoded57"
+  }
+}
+pipelines {
+  name: "egress"
+  id: 1
+  source_info {
+    line: 35
+    column: 8
+    source_fragment: "UselessEgress"
+  }
+}

--- a/p4_symbolic/bmv2/expected/reflector.pb.txt
+++ b/p4_symbolic/bmv2/expected/reflector.pb.txt
@@ -1,0 +1,352 @@
+header_types {
+  name: "scalars_0"
+}
+header_types {
+  name: "standard_metadata"
+  id: 1
+  fields {
+    values {
+      string_value: "ingress_port"
+    }
+    values {
+      number_value: 9
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_spec"
+    }
+    values {
+      number_value: 9
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_port"
+    }
+    values {
+      number_value: 9
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "instance_type"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "packet_length"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "enq_timestamp"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "enq_qdepth"
+    }
+    values {
+      number_value: 19
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "deq_timedelta"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "deq_qdepth"
+    }
+    values {
+      number_value: 19
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "ingress_global_timestamp"
+    }
+    values {
+      number_value: 48
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_global_timestamp"
+    }
+    values {
+      number_value: 48
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "mcast_grp"
+    }
+    values {
+      number_value: 16
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_rid"
+    }
+    values {
+      number_value: 16
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "checksum_error"
+    }
+    values {
+      number_value: 1
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "parser_error"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "priority"
+    }
+    values {
+      number_value: 3
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "_padding"
+    }
+    values {
+      number_value: 3
+    }
+    values {
+      bool_value: false
+    }
+  }
+}
+headers {
+  name: "scalars"
+  header_type: "scalars_0"
+  metadata: true
+}
+headers {
+  id: 1
+  name: "standard_metadata"
+  header_type: "standard_metadata"
+  metadata: true
+}
+parsers {
+  name: "parser"
+  init_state: "start"
+  parse_states {
+    name: "start"
+    transitions {
+    }
+  }
+}
+deparsers {
+  name: "deparser"
+  source_info {
+    line: 45
+    column: 8
+    source_fragment: "UselessDeparser"
+  }
+}
+actions {
+  name: "reflector54"
+  primitives {
+    fields {
+      key: "op"
+      value {
+        string_value: "assign"
+      }
+    }
+    fields {
+      key: "parameters"
+      value {
+        list_value {
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "field"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  list_value {
+                    values {
+                      string_value: "standard_metadata"
+                    }
+                    values {
+                      string_value: "egress_spec"
+                    }
+                  }
+                }
+              }
+            }
+          }
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "field"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  list_value {
+                    values {
+                      string_value: "standard_metadata"
+                    }
+                    values {
+                      string_value: "ingress_port"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    fields {
+      key: "source_info"
+      value {
+        struct_value {
+          fields {
+            key: "column"
+            value {
+              number_value: 8
+            }
+          }
+          fields {
+            key: "filename"
+            value {
+              string_value: ""
+            }
+          }
+          fields {
+            key: "line"
+            value {
+              number_value: 54
+            }
+          }
+          fields {
+            key: "source_fragment"
+            value {
+              string_value: "standard_metadata.egress_spec = standard_metadata.ingress_port"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+pipelines {
+  name: "ingress"
+  source_info {
+    line: 50
+    column: 8
+    source_fragment: "MyIngress"
+  }
+  init_table: "tbl_reflector54"
+  tables {
+    name: "tbl_reflector54"
+    source_info {
+      line: 54
+      column: 38
+      source_fragment: "="
+    }
+    max_size: 1024
+    action_ids: 0
+    actions: "reflector54"
+    default_entry {
+    }
+    next_tables {
+      key: "reflector54"
+      value: ""
+    }
+  }
+}
+pipelines {
+  name: "egress"
+  id: 1
+  source_info {
+    line: 35
+    column: 8
+    source_fragment: "UselessEgress"
+  }
+}

--- a/p4_symbolic/bmv2/expected/table.pb.txt
+++ b/p4_symbolic/bmv2/expected/table.pb.txt
@@ -1,0 +1,364 @@
+header_types {
+  name: "scalars_0"
+}
+header_types {
+  name: "standard_metadata"
+  id: 1
+  fields {
+    values {
+      string_value: "ingress_port"
+    }
+    values {
+      number_value: 9
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_spec"
+    }
+    values {
+      number_value: 9
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_port"
+    }
+    values {
+      number_value: 9
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "instance_type"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "packet_length"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "enq_timestamp"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "enq_qdepth"
+    }
+    values {
+      number_value: 19
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "deq_timedelta"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "deq_qdepth"
+    }
+    values {
+      number_value: 19
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "ingress_global_timestamp"
+    }
+    values {
+      number_value: 48
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_global_timestamp"
+    }
+    values {
+      number_value: 48
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "mcast_grp"
+    }
+    values {
+      number_value: 16
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "egress_rid"
+    }
+    values {
+      number_value: 16
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "checksum_error"
+    }
+    values {
+      number_value: 1
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "parser_error"
+    }
+    values {
+      number_value: 32
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "priority"
+    }
+    values {
+      number_value: 3
+    }
+    values {
+      bool_value: false
+    }
+  }
+  fields {
+    values {
+      string_value: "_padding"
+    }
+    values {
+      number_value: 3
+    }
+    values {
+      bool_value: false
+    }
+  }
+}
+headers {
+  name: "scalars"
+  header_type: "scalars_0"
+  metadata: true
+}
+headers {
+  id: 1
+  name: "standard_metadata"
+  header_type: "standard_metadata"
+  metadata: true
+}
+parsers {
+  name: "parser"
+  init_state: "start"
+  parse_states {
+    name: "start"
+    transitions {
+    }
+  }
+}
+deparsers {
+  name: "deparser"
+  source_info {
+    line: 45
+    column: 8
+    source_fragment: "UselessDeparser"
+  }
+}
+actions {
+  name: "NoAction"
+}
+actions {
+  name: "MyIngress.set_egress_spec"
+  id: 1
+  runtime_data {
+    name: "port"
+    bitwidth: 9
+  }
+  primitives {
+    fields {
+      key: "op"
+      value {
+        string_value: "assign"
+      }
+    }
+    fields {
+      key: "parameters"
+      value {
+        list_value {
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "field"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  list_value {
+                    values {
+                      string_value: "standard_metadata"
+                    }
+                    values {
+                      string_value: "egress_spec"
+                    }
+                  }
+                }
+              }
+            }
+          }
+          values {
+            struct_value {
+              fields {
+                key: "type"
+                value {
+                  string_value: "runtime_data"
+                }
+              }
+              fields {
+                key: "value"
+                value {
+                  number_value: 0
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    fields {
+      key: "source_info"
+      value {
+        struct_value {
+          fields {
+            key: "column"
+            value {
+              number_value: 8
+            }
+          }
+          fields {
+            key: "filename"
+            value {
+              string_value: ""
+            }
+          }
+          fields {
+            key: "line"
+            value {
+              number_value: 56
+            }
+          }
+          fields {
+            key: "source_fragment"
+            value {
+              string_value: "standard_metadata.egress_spec = port"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+pipelines {
+  name: "ingress"
+  source_info {
+    line: 50
+    column: 8
+    source_fragment: "MyIngress"
+  }
+  init_table: "MyIngress.ports_exact"
+  tables {
+    name: "MyIngress.ports_exact"
+    source_info {
+      line: 60
+      column: 10
+      source_fragment: "ports_exact"
+    }
+    key {
+      name: "standard_metadata.ingress_port"
+      target: "standard_metadata"
+      target: "ingress_port"
+    }
+    max_size: 1024
+    action_ids: 1
+    action_ids: 0
+    actions: "MyIngress.set_egress_spec"
+    actions: "NoAction"
+    default_entry {
+    }
+    next_tables {
+      key: "MyIngress.set_egress_spec"
+      value: ""
+    }
+    next_tables {
+      key: "NoAction"
+      value: ""
+    }
+  }
+}
+pipelines {
+  name: "egress"
+  id: 1
+  source_info {
+    line: 35
+    column: 8
+    source_fragment: "UselessEgress"
+  }
+}


### PR DESCRIPTION
**Build and Test:**
rkavitha@148ad99dcce3:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 266 targets (0 packages loaded, 0 targets configured).
INFO: Found 266 targets...
INFO: Elapsed time: 0.497s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
rkavitha@148ad99dcce3:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Analyzed 266 targets (0 packages loaded, 0 targets configured).
INFO: Found 170 targets and 96 test targets...
INFO: Elapsed time: 0.540s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//gutil:collections_test                                        (cached) PASSED in 1.3s
//gutil:io_test                                                 (cached) PASSED in 1.1s
//gutil:proto_matchers_test                                     (cached) PASSED in 1.6s
//gutil:proto_test                                              (cached) PASSED in 1.2s
//gutil:status_matchers_test                                    (cached) PASSED in 0.8s
//gutil:table_entry_key_test                                    (cached) PASSED in 0.4s
//gutil:testing_test                                            (cached) PASSED in 0.8s
//gutil:version_test                                            (cached) PASSED in 0.9s
//p4_fuzzer:fuzz_util_test                                      (cached) PASSED in 3.0s
//p4_fuzzer:switch_state_test                                   (cached) PASSED in 1.1s
//p4_fuzzer:table_entry_key_test                                (cached) PASSED in 0.7s
//p4_pdpi:ir_tools_test                                         (cached) PASSED in 1.6s
//p4_pdpi:p4_runtime_matchers_test                              (cached) PASSED in 1.8s
//p4_pdpi:sequencing_util_test                                  (cached) PASSED in 1.4s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test         (cached) PASSED in 1.1s
//p4_pdpi/netaddr:ipv6_address_test                             (cached) PASSED in 1.1s
//p4_pdpi/netaddr:mac_address_test                              (cached) PASSED in 0.9s
//p4_pdpi/packetlib:packetlib_fuzzer_test                       (cached) PASSED in 20.0s
//p4_pdpi/packetlib:packetlib_matchers_test                     (cached) PASSED in 0.8s
//p4_pdpi/packetlib:packetlib_test                              (cached) PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_test_runner                       (cached) PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_unit_test                         (cached) PASSED in 3.2s
//p4_pdpi/string_encodings:bit_string_test                      (cached) PASSED in 1.2s
//p4_pdpi/string_encodings:byte_string_test                     (cached) PASSED in 0.8s
//p4_pdpi/string_encodings:decimal_string_test                  (cached) PASSED in 3.6s
//p4_pdpi/string_encodings:decimal_string_test_runner           (cached) PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                      (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test_runner               (cached) PASSED in 0.6s
//p4_pdpi/string_encodings:readable_byte_string_test            (cached) PASSED in 1.2s
//p4_pdpi/testing:helper_function_test                          (cached) PASSED in 1.6s
//p4_pdpi/testing:info_test                                     (cached) PASSED in 0.6s
//p4_pdpi/testing:info_test_runner                              (cached) PASSED in 0.6s
//p4_pdpi/testing:main_pd_test                                  (cached) PASSED in 0.7s
//p4_pdpi/testing:mock_p4_runtime_server_test                   (cached) PASSED in 1.8s
//p4_pdpi/testing:packet_io_test                                (cached) PASSED in 0.4s
//p4_pdpi/testing:packet_io_test_runner                         (cached) PASSED in 0.3s
//p4_pdpi/testing:rpc_test                                      (cached) PASSED in 0.6s
//p4_pdpi/testing:rpc_test_runner                               (cached) PASSED in 0.3s
//p4_pdpi/testing:sequencing_test                               (cached) PASSED in 2.1s
//p4_pdpi/testing:sequencing_test_runner                        (cached) PASSED in 1.0s
//p4_pdpi/testing:sequencing_util_test                          (cached) PASSED in 2.3s
//p4_pdpi/testing:sequencing_util_test_runner                   (cached) PASSED in 0.2s
//p4_pdpi/testing:table_entry_gunit_test                        (cached) PASSED in 1.7s
//p4_pdpi/testing:table_entry_test                              (cached) PASSED in 0.8s
//p4_pdpi/testing:table_entry_test_runner                       (cached) PASSED in 0.3s
//p4_pdpi/utils:annotation_parser_test                          (cached) PASSED in 0.9s
//p4_pdpi/utils:ir_test                                         (cached) PASSED in 1.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test  (cached) PASSED in 1.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test (cached) PASSED in 2.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test (cached) PASSED in 2.0s
//p4rt_app/event_monitoring:config_db_port_table_event_test     (cached) PASSED in 2.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test         (cached) PASSED in 2.3s
//p4rt_app/event_monitoring:state_verification_events_test      (cached) PASSED in 2.4s
//p4rt_app/p4runtime:ir_translation_test                        (cached) PASSED in 2.5s
//p4rt_app/p4runtime:p4info_verification_schema_test            (cached) PASSED in 1.9s
//p4rt_app/p4runtime:p4info_verification_test                   (cached) PASSED in 2.1s
//p4rt_app/p4runtime:packetio_helpers_test                      (cached) PASSED in 2.2s
//p4rt_app/sonic:app_db_acl_def_table_manager_test              (cached) PASSED in 1.8s
//p4rt_app/sonic:app_db_manager_test                            (cached) PASSED in 2.3s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test              (cached) PASSED in 4.1s
//p4rt_app/sonic:hashing_test                                   (cached) PASSED in 1.9s
//p4rt_app/sonic:packetio_impl_test                             (cached) PASSED in 1.7s
//p4rt_app/sonic:packetio_port_test                             (cached) PASSED in 1.2s
//p4rt_app/sonic:response_handler_test                          (cached) PASSED in 1.7s
//p4rt_app/sonic:state_verification_test                        (cached) PASSED in 1.3s
//p4rt_app/sonic:vrf_entry_translation_test                     (cached) PASSED in 2.0s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test              (cached) PASSED in 0.4s
//p4rt_app/tests:acl_table_test                                 (cached) PASSED in 1.4s
//p4rt_app/tests:action_set_test                                (cached) PASSED in 0.9s
//p4rt_app/tests:api_access_test                                (cached) PASSED in 1.1s
//p4rt_app/tests:arbitration_test                               (cached) PASSED in 1.5s
//p4rt_app/tests:debug_data_dump_test                           (cached) PASSED in 0.8s
//p4rt_app/tests:fixed_l3_tables_test                           (cached) PASSED in 3.4s
//p4rt_app/tests:forwarding_pipeline_config_test                (cached) PASSED in 5.3s
//p4rt_app/tests:grpc_behavior_test                             (cached) PASSED in 5.2s
//p4rt_app/tests:p4_constraints_test                            (cached) PASSED in 1.2s
//p4rt_app/tests:p4_constraints_test_runner                     (cached) PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                               (cached) PASSED in 1.4s
//p4rt_app/tests:packetio_test                                  (cached) PASSED in 3.9s
//p4rt_app/tests:port_name_and_id_test                          (cached) PASSED in 3.0s
//p4rt_app/tests:response_path_test                             (cached) PASSED in 3.6s
//p4rt_app/tests:role_test                                      (cached) PASSED in 1.0s
//p4rt_app/tests:state_verification_test                        (cached) PASSED in 1.7s
//p4rt_app/tests/lib:app_db_entry_builder_test                  (cached) PASSED in 0.5s
//p4rt_app/utils:event_data_tracker_test                        (cached) PASSED in 0.2s
//p4rt_app/utils:table_utility_test                             (cached) PASSED in 1.8s
//sai_p4/instantiations/google:clos_stage_test                  (cached) PASSED in 0.9s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test (cached) PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test (cached) PASSED in 0.1s
//sai_p4/instantiations/google:sai_p4info_fetcher_test          (cached) PASSED in 1.5s
//sai_p4/instantiations/google:sai_p4info_test                  (cached) PASSED in 2.1s
//sai_p4/instantiations/google:sai_pd_proto_test                (cached) PASSED in 0.2s
//sai_p4/instantiations/google:sai_pd_util_test                 (cached) PASSED in 1.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test     (cached) PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test       (cached) PASSED in 0.3s
//sai_p4/tools:p4info_tools_test                                (cached) PASSED in 2.1s

Executed 0 out of 96 tests: 96 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeoutINFO: Build completed successfully, 1 total action

**Keyword Check:**
rkavitha@eonms3vm12:~/Google/May-21/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/Google/tools/keyword_checks.sh .
Keyword check Passed.
