### PR TITLE
Factor out the read path code from p4runtime_impl.cc

### DIFF
--- a/p4rt_app/p4runtime/BUILD.bazel
+++ b/p4rt_app/p4runtime/BUILD.bazel
@@ -129,6 +129,7 @@ cc_library(
     deps = [
         ":ir_translation",
         ":p4info_verification",
+        ":p4runtime_read",
         ":packetio_helpers",
         ":sdn_controller_manager",
         "//gutil:io",
@@ -181,6 +182,29 @@ cc_library(
         ":p4runtime_impl",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
         "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "p4runtime_read",
+    srcs = ["p4runtime_read.cc"],
+    hdrs = ["p4runtime_read.h"],
+    deps = [
+        ":ir_translation",
+        "//gutil:status",
+        "//gutil:table_entry_key",
+        "//p4_pdpi:ir_cc_proto",
+        "//p4rt_app/sonic:app_db_manager",
+        "//p4rt_app/sonic:redis_connections",
+        "//p4rt_app/utils:table_utility",
+        "@boost//:bimap",
+        "@boost//:graph",
+        "@com_github_google_glog//:glog",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
     ],
 )
 

--- a/p4rt_app/p4runtime/p4runtime_read.cc
+++ b/p4rt_app/p4runtime/p4runtime_read.cc
@@ -1,0 +1,142 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "p4rt_app/p4runtime/p4runtime_read.h"
+
+#include <string>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "boost/bimap.hpp"
+#include "glog/logging.h"
+#include "gutil/status.h"
+#include "gutil/table_entry_key.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4rt_app/p4runtime/ir_translation.h"
+#include "p4rt_app/sonic/app_db_manager.h"
+#include "p4rt_app/sonic/redis_connections.h"
+#include "p4rt_app/utils/table_utility.h"
+
+namespace p4rt_app {
+namespace {
+
+absl::Status SupportedTableEntryRequest(const p4::v1::TableEntry& table_entry) {
+  if (table_entry.table_id() != 0 || !table_entry.match().empty() ||
+      table_entry.priority() != 0 || !table_entry.metadata().empty() ||
+      table_entry.has_action() || table_entry.is_default_action() != false) {
+    return gutil::UnimplementedErrorBuilder()
+           << "Read request for table entry: "
+           << table_entry.ShortDebugString();
+  }
+  return absl::OkStatus();
+}
+
+absl::Status AppendAclCounterData(
+    p4::v1::TableEntry& pi_table_entry, const pdpi::IrP4Info& ir_p4_info,
+    bool translate_port_ids,
+    const boost::bimap<std::string, std::string>& port_translation_map,
+    sonic::P4rtTable& p4rt_table) {
+  ASSIGN_OR_RETURN(
+      pdpi::IrTableEntry ir_table_entry,
+      TranslatePiTableEntryForOrchAgent(
+          pi_table_entry, ir_p4_info, translate_port_ids, port_translation_map,
+          /*translate_key_only=*/false));
+
+  RETURN_IF_ERROR(sonic::AppendCounterDataForTableEntry(
+      ir_table_entry, p4rt_table, ir_p4_info));
+  if (ir_table_entry.has_counter_data()) {
+    *pi_table_entry.mutable_counter_data() = ir_table_entry.counter_data();
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status AppendTableEntryReads(
+    p4::v1::ReadResponse& response, const p4::v1::TableEntry& cached_entry,
+    const std::string& role_name, const pdpi::IrP4Info& ir_p4_info,
+    bool translate_port_ids,
+    const boost::bimap<std::string, std::string>& port_translation_map,
+    sonic::P4rtTable& p4rt_table) {
+  // Fetch the table defintion since it will inform how we process the read
+  // request.
+  auto table_def = ir_p4_info.tables_by_id().find(cached_entry.table_id());
+  if (table_def == ir_p4_info.tables_by_id().end()) {
+    return gutil::InternalErrorBuilder() << absl::StreamFormat(
+               "Could not find table ID %u when checking role access. Did an "
+               "IR translation fail somewhere?",
+               cached_entry.table_id());
+  }
+
+  // Multiple roles can be connected to a switch so we need to ensure the
+  // reader has access to the table. Otherwise, we just ignore reporting it.
+  if (!role_name.empty() && table_def->second.role() != role_name) {
+    VLOG(2) << absl::StreamFormat(
+        "Role '%s' is not allowed access to table '%s'.", role_name,
+        table_def->second.preamble().name());
+    return absl::OkStatus();
+  }
+
+  // Update the response to include the table entry.
+  p4::v1::TableEntry* response_entry =
+      response.add_entities()->mutable_table_entry();
+  *response_entry = cached_entry;
+
+  // For ACL tables we need to check for counter/meter data, and append it as
+  // needed.
+  ASSIGN_OR_RETURN(table::Type table_type, GetTableType(table_def->second),
+                   _ << "Could not determine table type for table '"
+                     << table_def->second.preamble().name() << "'.");
+  if (table_type == table::Type::kAcl) {
+    RETURN_IF_ERROR(AppendAclCounterData(*response_entry, ir_p4_info,
+                                         translate_port_ids,
+                                         port_translation_map, p4rt_table));
+  }
+
+  return absl::OkStatus();
+}
+
+}  // namespace
+
+absl::StatusOr<p4::v1::ReadResponse> ReadAllTableEntries(
+    const p4::v1::ReadRequest& request, const pdpi::IrP4Info& ir_p4_info,
+    const absl::flat_hash_map<gutil::TableEntryKey, p4::v1::TableEntry>&
+        table_entry_cache,
+    bool translate_port_ids,
+    const boost::bimap<std::string, std::string>& port_translation_map,
+    sonic::P4rtTable& p4rt_table) {
+  p4::v1::ReadResponse response;
+  for (const auto& entity : request.entities()) {
+    VLOG(1) << "Read request: " << entity.ShortDebugString();
+    switch (entity.entity_case()) {
+      case p4::v1::Entity::kTableEntry: {
+        RETURN_IF_ERROR(SupportedTableEntryRequest(entity.table_entry()));
+        for (const auto& [_, entry] : table_entry_cache) {
+          RETURN_IF_ERROR(AppendTableEntryReads(
+              response, entry, request.role(), ir_p4_info, translate_port_ids,
+              port_translation_map, p4rt_table));
+        }
+        break;
+      }
+      default:
+        return gutil::UnimplementedErrorBuilder()
+               << "Read has not been implemented for: "
+               << entity.ShortDebugString();
+    }
+  }
+  return response;
+}
+
+}  // namespace p4rt_app

--- a/p4rt_app/p4runtime/p4runtime_read.h
+++ b/p4rt_app/p4runtime/p4runtime_read.h
@@ -1,0 +1,41 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef PINS_P4RT_APP_P4RUNTIME_P4RUNTIME_READ_H_
+#define PINS_P4RT_APP_P4RUNTIME_P4RUNTIME_READ_H_
+
+#include <string>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/statusor.h"
+#include "boost/bimap.hpp"
+#include "gutil/table_entry_key.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4rt_app/sonic/redis_connections.h"
+
+namespace p4rt_app {
+
+// Reads all table entries from a cache. For each ACL entry we also fetch
+// counter data from CounterDb.
+absl::StatusOr<p4::v1::ReadResponse> ReadAllTableEntries(
+    const p4::v1::ReadRequest& request, const pdpi::IrP4Info& ir_p4_info,
+    const absl::flat_hash_map<gutil::TableEntryKey, p4::v1::TableEntry>&
+        table_entry_cache,
+    bool translate_port_ids,
+    const boost::bimap<std::string, std::string>& port_translation_map,
+    sonic::P4rtTable& p4rt_table);
+
+}  // namespace p4rt_app
+
+#endif  // PINS_P4RT_APP_P4RUNTIME_P4RUNTIME_READ_H_


### PR DESCRIPTION
### Build Results:
divya@1ce2fff47237:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 271 targets (0 packages loaded, 0 targets configured).
INFO: Found 271 targets...
...
INFO: Elapsed time: 318.048s, Critical Path: 149.70s
INFO: 203 processes: 94 internal, 109 linux-sandbox.
INFO: Build completed successfully, 203 total actions

### Test Results:
divya@1ce2fff47237:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Analyzed 271 targets (0 packages loaded, 0 targets configured).
INFO: Found 172 targets and 99 test targets...
INFO: Elapsed time: 29.591s, Critical Path: 5.20s
INFO: 30 processes: 1 internal, 13 linux-sandbox, 16 local.
INFO: Build completed successfully, 30 total actions
//gutil:collections_test                                        (cached) PASSED in 0.7s
//gutil:io_test                                                 (cached) PASSED in 0.8s
//gutil:proto_matchers_test                                     (cached) PASSED in 1.0s
//gutil:proto_test                                              (cached) PASSED in 0.8s
//gutil:status_matchers_test                                    (cached) PASSED in 0.7s
//gutil:table_entry_key_test                                    (cached) PASSED in 0.4s
//gutil:testing_test                                            (cached) PASSED in 0.8s
//p4_fuzzer:fuzz_util_test                                      (cached) PASSED in 1.2s
//p4_fuzzer:switch_state_test                                   (cached) PASSED in 1.3s
//p4_fuzzer:table_entry_key_test                                (cached) PASSED in 0.5s
//p4_pdpi:ir_tools_test                                         (cached) PASSED in 1.3s
//p4_pdpi:p4_runtime_matchers_test                              (cached) PASSED in 0.8s
//p4_pdpi:sequencing_util_test                                  (cached) PASSED in 0.4s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test         (cached) PASSED in 1.0s
//p4_pdpi/netaddr:ipv6_address_test                             (cached) PASSED in 1.1s
//p4_pdpi/netaddr:mac_address_test                              (cached) PASSED in 0.9s
//p4_pdpi/packetlib:packetlib_fuzzer_test                       (cached) PASSED in 22.5s
//p4_pdpi/packetlib:packetlib_matchers_test                     (cached) PASSED in 0.8s
//p4_pdpi/packetlib:packetlib_test                              (cached) PASSED in 0.4s
//p4_pdpi/packetlib:packetlib_test_runner                       (cached) PASSED in 0.4s
//p4_pdpi/packetlib:packetlib_unit_test                         (cached) PASSED in 2.2s
//p4_pdpi/string_encodings:bit_string_test                      (cached) PASSED in 0.6s
//p4_pdpi/string_encodings:byte_string_test                     (cached) PASSED in 1.5s
//p4_pdpi/string_encodings:decimal_string_test                  (cached) PASSED in 0.7s
//p4_pdpi/string_encodings:decimal_string_test_runner           (cached) PASSED in 0.5s
//p4_pdpi/string_encodings:hex_string_test                      (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test_runner               (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:readable_byte_string_test            (cached) PASSED in 0.6s
//p4_pdpi/testing:helper_function_test                          (cached) PASSED in 0.9s
//p4_pdpi/testing:info_test                                     (cached) PASSED in 0.2s
//p4_pdpi/testing:info_test_runner                              (cached) PASSED in 2.0s
//p4_pdpi/testing:main_pd_test                                  (cached) PASSED in 0.3s
//p4_pdpi/testing:mock_p4_runtime_server_test                   (cached) PASSED in 1.3s
//p4_pdpi/testing:packet_io_test                                (cached) PASSED in 0.4s
//p4_pdpi/testing:packet_io_test_runner                         (cached) PASSED in 0.5s
//p4_pdpi/testing:rpc_test                                      (cached) PASSED in 0.6s
//p4_pdpi/testing:rpc_test_runner                               (cached) PASSED in 0.4s
//p4_pdpi/testing:sequencing_test                               (cached) PASSED in 0.3s
//p4_pdpi/testing:sequencing_test_runner                        (cached) PASSED in 0.6s
//p4_pdpi/testing:sequencing_util_test                          (cached) PASSED in 0.3s
//p4_pdpi/testing:sequencing_util_test_runner                   (cached) PASSED in 0.6s
//p4_pdpi/testing:table_entry_gunit_test                        (cached) PASSED in 0.7s
//p4_pdpi/testing:table_entry_test                              (cached) PASSED in 0.5s
//p4_pdpi/testing:table_entry_test_runner                       (cached) PASSED in 0.4s
//p4_pdpi/utils:annotation_parser_test                          (cached) PASSED in 0.7s
//p4_pdpi/utils:ir_test                                         (cached) PASSED in 1.2s
//p4rt_app/p4runtime:p4info_verification_schema_test            (cached) PASSED in 1.2s
//p4rt_app/p4runtime:p4info_verification_test                   (cached) PASSED in 1.0s
//p4rt_app/sonic:app_db_acl_def_table_manager_test              (cached) PASSED in 1.2s
//p4rt_app/sonic:app_db_manager_test                            (cached) PASSED in 1.6s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test              (cached) PASSED in 1.6s
//p4rt_app/sonic:hashing_test                                   (cached) PASSED in 0.9s
//p4rt_app/sonic:packetio_impl_test                             (cached) PASSED in 0.8s
//p4rt_app/sonic:packetio_port_test                             (cached) PASSED in 1.2s
//p4rt_app/sonic:response_handler_test                          (cached) PASSED in 1.1s
//p4rt_app/sonic:vrf_entry_translation_test                     (cached) PASSED in 1.2s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test              (cached) PASSED in 0.3s
//p4rt_app/tests/lib:app_db_entry_builder_test                  (cached) PASSED in 0.2s
//p4rt_app/utils:event_data_tracker_test                        (cached) PASSED in 0.1s
//p4rt_app/utils:table_utility_test                             (cached) PASSED in 1.6s
//sai_p4/instantiations/google:clos_stage_test                  (cached) PASSED in 0.6s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test (cached) PASSED in 0.2s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test (cached) PASSED in 0.1s
//sai_p4/instantiations/google:sai_p4info_fetcher_test          (cached) PASSED in 1.3s
//sai_p4/instantiations/google:sai_p4info_test                  (cached) PASSED in 1.7s
//sai_p4/instantiations/google:sai_pd_proto_test                (cached) PASSED in 0.2s
//sai_p4/instantiations/google:sai_pd_util_test                 (cached) PASSED in 0.7s
//sai_p4/instantiations/google:union_p4info_up_to_date_test     (cached) PASSED in 0.4s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test       (cached) PASSED in 0.2s
//sai_p4/tools:p4info_tools_test                                (cached) PASSED in 1.1s
//gutil:version_test                                                     PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.8s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 1.0s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.6s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.6s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.5s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.8s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.3s
//p4rt_app/tests:acl_table_test                                          PASSED in 0.9s
//p4rt_app/tests:action_set_test                                         PASSED in 0.6s
//p4rt_app/tests:api_access_test                                         PASSED in 0.6s
//p4rt_app/tests:arbitration_test                                        PASSED in 0.7s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 0.5s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 1.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 2.6s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.1s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.9s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.1s
//p4rt_app/tests:p4_programs_test                                        PASSED in 0.9s
//p4rt_app/tests:packetio_test                                           PASSED in 3.0s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 1.5s
//p4rt_app/tests:response_path_test                                      PASSED in 1.7s
//p4rt_app/tests:role_test                                               PASSED in 0.7s
//p4rt_app/tests:state_verification_test                                 PASSED in 0.8s
//p4rt_app/tests:vrf_table_test                                          PASSED in 0.9s

Executed 29 out of 99 tests: 99 tests pass.
INFO: Build completed successfully, 30 total actions

### Keyword check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.