### PR TITLE
[SAI P4] Add packet-in padding for BMv2 only. Model PacketIn in SAI P4 [pdpi][p4] Add annotation to ignore padding in pd and ir. Annotation only, implementation in follow up cl. [pdpi][p4] Add boolean field to metadata definition to denote whether metadata is PI only and zero-valued. [sai-p4] Use conditional on table hit/miss.

### DIFF
--- a/p4_pdpi/ir.proto
+++ b/p4_pdpi/ir.proto
@@ -167,6 +167,10 @@ message IrPacketIoMetadataDefinition {
   // Required, the format of this parameter as deduced from the parameter type
   // and annotations.
   Format format = 2;
+  // True if metadata field has @padding (go/pdpi-padding) annotation present,
+  // otherwise false. Indicates that metadata is excluded from IR and PD proto,
+  // and zero-valued in PI proto.
+  bool is_padding = 3;
 }
 
 // Describes an entire P4 program.

--- a/p4_pdpi/pdgenlib.cc
+++ b/p4_pdpi/pdgenlib.cc
@@ -371,6 +371,8 @@ StatusOr<std::string> GetPacketIoMessage(const IrP4Info& info) {
   absl::StrAppend(&result, "  bytes payload = 1;\n\n");
   absl::StrAppend(&result, "  message Metadata {\n");
   for (const auto& [name, meta] : Ordered(info.packet_in_metadata_by_name())) {
+    // Skip PI-only padding.
+    if (meta.is_padding()) continue;
     ASSIGN_OR_RETURN(
         const std::string meta_name,
         P4NameToProtobufFieldName(meta.metadata().name(), kP4MetaField));
@@ -387,6 +389,8 @@ StatusOr<std::string> GetPacketIoMessage(const IrP4Info& info) {
   absl::StrAppend(&result, "  bytes payload = 1;\n\n");
   absl::StrAppend(&result, "  message Metadata {\n");
   for (const auto& [name, meta] : Ordered(info.packet_out_metadata_by_name())) {
+    // Skip PI-only padding.
+    if (meta.is_padding()) continue;
     ASSIGN_OR_RETURN(
         const std::string meta_name,
         P4NameToProtobufFieldName(meta.metadata().name(), kP4MetaField));

--- a/p4_pdpi/testing/table_entry_test_runner.cc
+++ b/p4_pdpi/testing/table_entry_test_runner.cc
@@ -43,7 +43,7 @@ static void RunPiTableEntryTest(const pdpi::IrP4Info& info,
 static void RunIrTableEntryTest(const pdpi::IrP4Info& info,
                                 const std::string& test_name,
                                 const pdpi::IrTableEntry& ir) {
-  RunGenericIrTest<pdpi::IrTableEntry, p4::v1::TableEntry>(
+  RunGenericIrToPiTest<pdpi::IrTableEntry, p4::v1::TableEntry>(
       info, test_name, ir,
       [](const pdpi::IrP4Info& info, const pdpi::IrTableEntry& ir) {
         return IrTableEntryToPi(info, ir, false);

--- a/p4_pdpi/testing/test_helper.h
+++ b/p4_pdpi/testing/test_helper.h
@@ -90,10 +90,9 @@ void RunGenericPiTest(
 
 // Runs a generic test starting from an invalid IR and checks that it cannot be
 // translated to PI. If you want to test valid IR, instead write a
-// generic PD test. IR to PD is not tested, since only PI to PD is supported for
-// converting to PD.
+// generic PD test.
 template <typename IR, typename PI>
-void RunGenericIrTest(
+void RunGenericIrToPiTest(
     const pdpi::IrP4Info& info, const std::string& test_name, const IR& ir,
     const std::function<absl::StatusOr<PI>(const pdpi::IrP4Info&, const IR&)>&
         ir_to_pi) {

--- a/p4_pdpi/testing/testdata/info.expected
+++ b/p4_pdpi/testing/testdata/info.expected
@@ -1210,6 +1210,12 @@ controller_packet_metadata {
       name: "string_id_t"
     }
   }
+  metadata {
+    id: 3
+    name: "unused_padding"
+    annotations: "@padding"
+    bitwidth: 3
+  }
 }
 controller_packet_metadata {
   preamble {
@@ -1229,6 +1235,12 @@ controller_packet_metadata {
     id: 2
     name: "submit_to_ingress"
     bitwidth: 1
+  }
+  metadata {
+    id: 3
+    name: "unused_padding"
+    annotations: "@padding"
+    bitwidth: 6
   }
 }
 type_info {
@@ -7686,6 +7698,18 @@ packet_in_metadata_by_id {
     format: STRING
   }
 }
+packet_in_metadata_by_id {
+  key: 3
+  value {
+    metadata {
+      id: 3
+      name: "unused_padding"
+      annotations: "@padding"
+      bitwidth: 3
+    }
+    is_padding: true
+  }
+}
 packet_in_metadata_by_name {
   key: "ingress_port"
   value {
@@ -7707,6 +7731,18 @@ packet_in_metadata_by_name {
       }
     }
     format: STRING
+  }
+}
+packet_in_metadata_by_name {
+  key: "unused_padding"
+  value {
+    metadata {
+      id: 3
+      name: "unused_padding"
+      annotations: "@padding"
+      bitwidth: 3
+    }
+    is_padding: true
   }
 }
 packet_out_metadata_by_id {
@@ -7732,6 +7768,18 @@ packet_out_metadata_by_id {
     }
   }
 }
+packet_out_metadata_by_id {
+  key: 3
+  value {
+    metadata {
+      id: 3
+      name: "unused_padding"
+      annotations: "@padding"
+      bitwidth: 6
+    }
+    is_padding: true
+  }
+}
 packet_out_metadata_by_name {
   key: "egress_port"
   value {
@@ -7753,6 +7801,18 @@ packet_out_metadata_by_name {
       name: "submit_to_ingress"
       bitwidth: 1
     }
+  }
+}
+packet_out_metadata_by_name {
+  key: "unused_padding"
+  value {
+    metadata {
+      id: 3
+      name: "unused_padding"
+      annotations: "@padding"
+      bitwidth: 6
+    }
+    is_padding: true
   }
 }
 references {

--- a/p4_pdpi/testing/testdata/main.p4
+++ b/p4_pdpi/testing/testdata/main.p4
@@ -32,6 +32,10 @@ header packet_in_header_t {
   // The initial intended egress port decided for the packet by the pipeline.
   @id(2)
   string_id_t target_egress_port;
+  // Unused padding to test @padding annotation.
+  @id(3)
+  @padding
+  bit<3> unused_padding;
 }
 
 @controller_header("packet_out")
@@ -43,6 +47,10 @@ header packet_out_header_t {
   // sent directly?
   @id(2)
   bit<1> submit_to_ingress;
+  // Unused padding to test @padding annotation.
+  @id(3)
+  @padding
+  bit<6> unused_padding;
 }
 
 // Note: proto_tag annotations are only necessary until PD supports the @id annotation, which will be preferred.

--- a/p4_pdpi/testing/testdata/packet_io.expected
+++ b/p4_pdpi/testing/testdata/packet_io.expected
@@ -12,11 +12,35 @@ metadata {
   metadata_id: 1
   value: "4"
 }
+metadata {
+  metadata_id: 2
+  value: "#"
+}
+metadata {
+  metadata_id: 3
+  value: "\000"
+}
 
 --- PI is invalid/unsupported:
-INVALID_ARGUMENT: 'packet-in' message is invalid for the following reasons:
-  - Duplicate metadata found with ID 1.
-  - Metadata 'target_egress_port' with id 2 is missing.
+INVALID_ARGUMENT: 'packet-in' message is invalid: Duplicate metadata found with ID 1.
+
+=========================================================================
+PacketIn test: missing metadata
+=========================================================================
+
+--- PI (Input):
+payload: "1"
+metadata {
+  metadata_id: 1
+  value: "4"
+}
+metadata {
+  metadata_id: 3
+  value: "\000"
+}
+
+--- PI is invalid/unsupported:
+INVALID_ARGUMENT: 'packet-in' message is invalid: Metadata 'target_egress_port' with id 2 is missing.
 
 =========================================================================
 PacketIn test: extra metadata
@@ -34,14 +58,18 @@ metadata {
 }
 metadata {
   metadata_id: 3
+  value: "\000"
+}
+metadata {
+  metadata_id: 4
   value: "\0224"
 }
 
 --- PI is invalid/unsupported:
-INVALID_ARGUMENT: 'packet-in' message is invalid:  Metadata with ID 3 not defined.
+INVALID_ARGUMENT: 'packet-in' message is invalid:  Metadata with ID 4 not defined.
 
 =========================================================================
-PacketIn test: missing metadata
+PacketIn test: padding metadata is non-zero
 =========================================================================
 
 --- PI (Input):
@@ -50,9 +78,73 @@ metadata {
   metadata_id: 1
   value: "4"
 }
+metadata {
+  metadata_id: 2
+  value: "#"
+}
+metadata {
+  metadata_id: 3
+  value: "\022"
+}
 
 --- PI is invalid/unsupported:
-INVALID_ARGUMENT: 'packet-in' message is invalid: Metadata 'target_egress_port' with id 2 is missing.
+INVALID_ARGUMENT: 'packet-in' message is invalid:  Metadata with ID 3 has @padding annotation, so bytestring must be all zeros.
+
+=========================================================================
+PacketIn test: padding metadata present in IR during IR->PI
+=========================================================================
+
+--- IR (Input):
+payload: "1"
+metadata {
+  name: "ingress_port"
+  value {
+    hex_str: "0x034"
+  }
+}
+metadata {
+  name: "target_egress_port"
+  value {
+    str: "eth-1/2/3"
+  }
+}
+metadata {
+  name: "unused_padding"
+  value {
+    hex_str: "0x0"
+  }
+}
+
+--- IR (converting to PI) is invalid/unsupported:
+INVALID_ARGUMENT: 'packet-in' message is invalid: Metadata 'unused_padding' with id 3 has @padding annotation so it must be omitted in IR representation.
+
+=========================================================================
+PacketIn test: padding metadata present in IR during IR->PD
+=========================================================================
+
+--- IR (Input):
+payload: "1"
+metadata {
+  name: "ingress_port"
+  value {
+    hex_str: "0x034"
+  }
+}
+metadata {
+  name: "target_egress_port"
+  value {
+    str: "eth-1/2/3"
+  }
+}
+metadata {
+  name: "unused_padding"
+  value {
+    hex_str: "0x0"
+  }
+}
+
+--- IR (converting to PD) is invalid/unsupported:
+INVALID_ARGUMENT: 'packet-in' message is invalid: Metadata with name 'unused_padding' has @padding annotation and so it must be omitted in IR representation.
 
 =========================================================================
 PacketIn test: ok
@@ -89,6 +181,10 @@ metadata {
 metadata {
   metadata_id: 2
   value: "eth-1/2/3"
+}
+metadata {
+  metadata_id: 3
+  value: "\000"
 }
 
 
@@ -128,6 +224,10 @@ metadata {
   metadata_id: 2
   value: "\00423"
 }
+metadata {
+  metadata_id: 3
+  value: "\000"
+}
 
 
 =========================================================================
@@ -144,11 +244,17 @@ metadata {
   metadata_id: 1
   value: "\001"
 }
+metadata {
+  metadata_id: 2
+  value: "\001"
+}
+metadata {
+  metadata_id: 3
+  value: "\000"
+}
 
 --- PI is invalid/unsupported:
-INVALID_ARGUMENT: 'packet-out' message is invalid for the following reasons:
-  - Duplicate metadata found with ID 1.
-  - Metadata 'submit_to_ingress' with id 2 is missing.
+INVALID_ARGUMENT: 'packet-out' message is invalid: Duplicate metadata found with ID 1.
 
 =========================================================================
 PacketOut test: missing metadata
@@ -159,6 +265,10 @@ payload: "1"
 metadata {
   metadata_id: 1
   value: "\001"
+}
+metadata {
+  metadata_id: 3
+  value: "\000"
 }
 
 --- PI is invalid/unsupported:
@@ -180,11 +290,93 @@ metadata {
 }
 metadata {
   metadata_id: 3
+  value: "\000"
+}
+metadata {
+  metadata_id: 4
   value: "\001"
 }
 
 --- PI is invalid/unsupported:
-INVALID_ARGUMENT: 'packet-out' message is invalid:  Metadata with ID 3 not defined.
+INVALID_ARGUMENT: 'packet-out' message is invalid:  Metadata with ID 4 not defined.
+
+=========================================================================
+PacketOut test: padding metadata is non-zero
+=========================================================================
+
+--- PI (Input):
+payload: "1"
+metadata {
+  metadata_id: 1
+  value: "\000"
+}
+metadata {
+  metadata_id: 2
+  value: "\001"
+}
+metadata {
+  metadata_id: 3
+  value: "\001"
+}
+
+--- PI is invalid/unsupported:
+INVALID_ARGUMENT: 'packet-out' message is invalid:  Metadata with ID 3 has @padding annotation, so bytestring must be all zeros.
+
+=========================================================================
+PacketOut test: padding metadata present in IR during IR->PI
+=========================================================================
+
+--- IR (Input):
+payload: "1"
+metadata {
+  name: "egress_port"
+  value {
+    str: "eth-1/2/3"
+  }
+}
+metadata {
+  name: "submit_to_ingress"
+  value {
+    hex_str: "0x1"
+  }
+}
+metadata {
+  name: "unused_padding"
+  value {
+    hex_str: "0x0"
+  }
+}
+
+--- IR (converting to PI) is invalid/unsupported:
+INVALID_ARGUMENT: 'packet-out' message is invalid: Metadata 'unused_padding' with id 3 has @padding annotation so it must be omitted in IR representation.
+
+=========================================================================
+PacketOut test: padding metadata present in IR during IR->PD
+=========================================================================
+
+--- IR (Input):
+payload: "1"
+metadata {
+  name: "egress_port"
+  value {
+    str: "eth-1/2/3"
+  }
+}
+metadata {
+  name: "submit_to_ingress"
+  value {
+    hex_str: "0x1"
+  }
+}
+metadata {
+  name: "unused_padding"
+  value {
+    hex_str: "0x0"
+  }
+}
+
+--- IR (converting to PD) is invalid/unsupported:
+INVALID_ARGUMENT: 'packet-out' message is invalid: Metadata with name 'unused_padding' has @padding annotation and so it must be omitted in IR representation.
 
 =========================================================================
 PacketOut test: ok
@@ -222,6 +414,10 @@ metadata {
   metadata_id: 2
   value: "\001"
 }
+metadata {
+  metadata_id: 3
+  value: "\000"
+}
 
 
 =========================================================================
@@ -257,4 +453,8 @@ metadata {
 metadata {
   metadata_id: 2
   value: "\001"
+}
+metadata {
+  metadata_id: 3
+  value: "\000"
 }

--- a/p4_pdpi/testing/testdata/rpc.expected
+++ b/p4_pdpi/testing/testdata/rpc.expected
@@ -1525,6 +1525,10 @@ packet {
     metadata_id: 2
     value: "\001"
   }
+  metadata {
+    metadata_id: 3
+    value: "\000"
+  }
 }
 
 
@@ -1625,6 +1629,10 @@ packet {
     metadata_id: 2
     value: "eth-1/2/3"
   }
+  metadata {
+    metadata_id: 3
+    value: "\000"
+  }
 }
 
 
@@ -1684,6 +1692,10 @@ error {
       metadata {
         metadata_id: 2
         value: "\001"
+      }
+      metadata {
+        metadata_id: 3
+        value: "\000"
       }
     }
   }

--- a/p4_pdpi/utils/ir.cc
+++ b/p4_pdpi/utils/ir.cc
@@ -396,6 +396,25 @@ std::string IrValueString(const IrValue &value) {
   return "";
 }
 
+absl::StatusOr<std::string> IrValueToFormattedString(const IrValue &value,
+                                                     Format format) {
+  switch (format) {
+    case Format::MAC:
+      return value.mac();
+    case Format::IPV4:
+      return value.ipv4();
+    case Format::IPV6:
+      return value.ipv6();
+    case Format::STRING:
+      return value.str();
+    case Format::HEX_STRING:
+      return value.hex_str();
+    default:
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Unexpected format: " << Format_Name(format);
+  }
+}
+
 bool IsAllZeros(const std::string &s) {
   bool has_non_zero_value = false;
   for (const auto &c : s) {

--- a/p4_pdpi/utils/ir.h
+++ b/p4_pdpi/utils/ir.h
@@ -83,6 +83,11 @@ absl::StatusOr<IrValue> ArbitraryByteStringToIrValue(Format format,
 absl::StatusOr<IrValue> FormattedStringToIrValue(const std::string &value,
                                                  Format format);
 
+// Returns a std::string based on an IrValue value and a format. The value is
+// expected to already be formatted correctly, and is just returned as is.
+absl::StatusOr<std::string> IrValueToFormattedString(const IrValue &value,
+                                                     Format format);
+
 // Returns the string contents of an IrValue for the populated format (or "" if
 // there is no data).
 std::string IrValueString(const IrValue &value);

--- a/p4rt_app/p4runtime/p4info_verification.cc
+++ b/p4rt_app/p4runtime/p4info_verification.cc
@@ -69,7 +69,7 @@ absl::Status ValidatePacketIo(const p4::config::v1::P4Info& p4info) {
         type_name { name: "port_id_t" }
       }
       metadata { id: 2 name: "submit_to_ingress" bitwidth: 1 }
-      metadata { id: 3 name: "unused_pad" bitwidth: 7 }
+      metadata { id: 3 name: "unused_pad" annotations: "@padding" bitwidth: 6 }
     }
   )pb";
 

--- a/p4rt_app/tests/packetio_test.cc
+++ b/p4rt_app/tests/packetio_test.cc
@@ -98,7 +98,6 @@ class FakePacketIoTest : public testing::Test {
     sai::PacketOut::Metadata& metadata = *packet_out.mutable_metadata();
     metadata.set_egress_port(absl::StrCat(port));
     metadata.set_submit_to_ingress(pdpi::BitsetToHexString<1>(0));
-    metadata.set_unused_pad(pdpi::BitsetToHexString<7>(0));
 
     // Assemble PacketOut request and write to stream channel.
     p4::v1::StreamMessageRequest request;
@@ -265,7 +264,6 @@ TEST_F(FakePacketIoTest, PacketOutFailForSecondary) {
   sai::PacketOut::Metadata& metadata = *packet_out.mutable_metadata();
   metadata.set_egress_port(pdpi::BitsetToHexString<9>(/*bitset=*/0));
   metadata.set_submit_to_ingress(pdpi::BitsetToHexString<1>(0));
-  metadata.set_unused_pad(pdpi::BitsetToHexString<7>(0));
 
   // Assemble PacketOut request and write to stream channel.
   p4::v1::StreamMessageRequest request;

--- a/sai_p4/fixed/BUILD.bazel
+++ b/sai_p4/fixed/BUILD.bazel
@@ -29,6 +29,7 @@ filegroup(
         "minimum_guaranteed_sizes.p4",
         "mirroring_clone.p4",
         "mirroring_encap.p4",
+	"packet_io.p4",
         "packet_rewrites.p4",
         "parser.p4",
         "roles.h",

--- a/sai_p4/fixed/ids.h
+++ b/sai_p4/fixed/ids.h
@@ -65,35 +65,24 @@
 //   packet_replication_engine_entry {
 //     clone_session_entry {
 //       session_id: COPY_TO_CPU_SESSION_ID
-//       replicas { egress_port: 0xfffffffd } # to CPU
+//       replicas {
+//        egress_port: SAI_P4_CPU_PORT
+//        instance: CLONE_REPLICA_INSTANCE_PACKET_IN
+//       }
 //     }
 //   }
 // }
 //
-#define COPY_TO_CPU_SESSION_ID 1024
+#define COPY_TO_CPU_SESSION_ID 255
 
 // --- Packet-IO ---------------------------------------------------------------
 
-// Packet-in ingress port field. Indicates which port the packet arrived at.
-// Uses @p4runtime_translation(.., string).
 #define PACKET_IN_INGRESS_PORT_ID 1
-
-// Packet-in target egress port field. Indicates the port a packet would have
-// taken if it had not gotten trapped. Uses @p4runtime_translation(.., string).
 #define PACKET_IN_TARGET_EGRESS_PORT_ID 2
+#define PACKET_IN_UNUSED_PAD_ID 3
 
-// Packet-out egress port field. Indicates the egress port for the packet-out to
-// be taken. Mutually exclusive with "submit_to_ingress". Uses
-// @p4runtime_translation(.., string).
 #define PACKET_OUT_EGRESS_PORT_ID 1
-
-// Packet-out submit_to_ingress field. Indicates that the packet should go
-// through the ingress pipeline to determine which port to take (if any).
-// Mutually exclusive with "egress_port".
 #define PACKET_OUT_SUBMIT_TO_INGRESS_ID 2
-
-// TODO: BMV2 requires the header to be multiple of 8-bits.
-// Packet-out unused padding field to align the header to 8-bit multple.
 #define PACKET_OUT_UNUSED_PAD_ID 3
 
 //--- Packet Replication Engine Instances --------------------------------------
@@ -103,6 +92,7 @@
 // replication engine (PRE) in the V1Model architecture. However, the values are
 // not defined by the P4 specification. Here we define our own values; these may
 // be changed when we adopt another architecture.
-#define CLONE_REPLICA_INSTANCE 1
+#define CLONE_REPLICA_INSTANCE_PACKET_IN 1
+#define CLONE_REPLICA_INSTANCE_MIRRORING 2
 
 #endif  // SAI_IDS_H_

--- a/sai_p4/fixed/mirroring_clone.p4
+++ b/sai_p4/fixed/mirroring_clone.p4
@@ -83,8 +83,9 @@ control mirroring_clone(inout headers_t headers,
       if (mirror_session_table.apply().hit) {
         // Map mirror port to Packet Replication Engine session.
         if (mirror_port_to_pre_session_table.apply().hit) {
-          clone_preserving_field_list(CloneType.I2E, pre_session,
-                                      (bit<8>)PreservedFieldList.CLONE_I2E);
+          clone_preserving_field_list(
+            CloneType.I2E, pre_session,
+            (bit<8>)PreservedFieldList.CLONE_I2E_MIRRORING);
         }
       }
     }

--- a/sai_p4/fixed/mirroring_encap.p4
+++ b/sai_p4/fixed/mirroring_encap.p4
@@ -11,7 +11,7 @@ control mirroring_encap(inout headers_t headers,
                         inout local_metadata_t local_metadata,
                         inout standard_metadata_t standard_metadata) {
   apply {
-    if (standard_metadata.instance_type == CLONE_REPLICA_INSTANCE) {
+    if (standard_metadata.instance_type == CLONE_REPLICA_INSTANCE_MIRRORING) {
 
       // Reference for ERSPAN Type II header construction
       // https://tools.ietf.org/html/draft-foschiano-erspan-00

--- a/sai_p4/fixed/packet_io.p4
+++ b/sai_p4/fixed/packet_io.p4
@@ -1,0 +1,46 @@
+#ifndef SAI_PACKET_IO_P4_
+#define SAI_PACKET_IO_P4_
+
+#include <v1model.p4>
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+
+// TODO: Clean up once we have better solution to handle packet-in
+// across platforms.
+control packet_in_encap(inout headers_t headers,
+                        inout local_metadata_t local_metadata,
+                        inout standard_metadata_t standard_metadata) {
+  apply {
+#if defined(PLATFORM_BMV2) || defined(PLATFORM_P4SYMBOLIC)
+    if (standard_metadata.instance_type == CLONE_REPLICA_INSTANCE_PACKET_IN) {
+      headers.packet_out_header.setInvalid();
+      headers.packet_in_header = {
+        ingress_port = (port_id_t) local_metadata.packet_in_ingress_port,
+        target_egress_port =
+          (port_id_t) local_metadata.packet_in_target_egress_port,
+        unused_pad = 0
+      };
+    }
+#endif
+  }
+}  // control populate_packet_in_header
+
+control packet_out_decap(inout headers_t headers,
+                         inout local_metadata_t local_metadata,
+                         inout standard_metadata_t standard_metadata){
+  apply {
+    if (headers.packet_out_header.isValid() &&
+        headers.packet_out_header.submit_to_ingress == 0) {
+      // Cast is necessary, because v1model does not define port using `type`.
+      standard_metadata.egress_spec =
+          (bit<PORT_BITWIDTH>) headers.packet_out_header.egress_port;
+      // Skip the rest of the ingress pipeline.
+      local_metadata.bypass_ingress = true;
+    }
+    // Set invalid as we don't need the packet out header in the output header.
+    headers.packet_out_header.setInvalid();
+  }
+}  // control packet_out_processing_ingress
+
+#endif  // SAI_PACKET_IO_P4_

--- a/sai_p4/fixed/parser.p4
+++ b/sai_p4/fixed/parser.p4
@@ -3,6 +3,7 @@
 
 #include <v1model.p4>
 #include "headers.p4"
+#include "ids.h"
 #include "metadata.p4"
 
 parser packet_parser(packet_in packet, out headers_t headers,
@@ -85,6 +86,14 @@ parser packet_parser(packet_in packet, out headers_t headers,
 
 control packet_deparser(packet_out packet, in headers_t headers) {
   apply {
+    // We always expect the packet_out_header to be invalid at the end of the
+    // pipeline, so this line has no effect on the output packet.
+    packet.emit(headers.packet_out_header);
+// TODO: Clean up once we have better solution to handle packet-in
+// across platforms.
+#if defined(PLATFORM_BMV2) || defined(PLATFORM_P4SYMBOLIC)
+    packet.emit(headers.packet_in_header);
+#endif
     packet.emit(headers.erspan_ethernet);
     packet.emit(headers.erspan_ipv4);
     packet.emit(headers.erspan_gre);

--- a/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
@@ -1161,7 +1161,8 @@ controller_packet_metadata {
   metadata {
     id: 3
     name: "unused_pad"
-    bitwidth: 7
+    annotations: "@padding"
+    bitwidth: 6
   }
 }
 type_info {

--- a/sai_p4/instantiations/google/fabric_border_router_with_s2_hash_profile.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router_with_s2_hash_profile.p4info.pb.txt
@@ -1,5 +1,6 @@
 pkg_info {
-  name: "middleblock.p4"
+  name: "fabric_border_router_with_s2_hash_profile.p4"
+  version: "1.0.0"
   arch: "v1model"
   organization: "Google"
 }
@@ -37,6 +38,14 @@ tables {
     id: 4
     name: "src_mac"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_MAC)"
+    annotations: "@format(MAC_ADDRESS)"
+    bitwidth: 48
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 9
+    name: "dst_mac"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_MAC)"
     annotations: "@format(MAC_ADDRESS)"
     bitwidth: 48
     match_type: TERNARY
@@ -84,7 +93,7 @@ tables {
   }
   const_default_action_id: 21257015
   direct_resource_ids: 318767361
-  size: 255
+  size: 254
 }
 tables {
   preamble {
@@ -184,6 +193,33 @@ tables {
 }
 tables {
   preamble {
+    id: 33554512
+    name: "ingress.routing.tunnel_table"
+    alias: "tunnel_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "tunnel_id"
+    match_type: EXACT
+    type_name {
+      name: "tunnel_id_t"
+    }
+  }
+  action_refs {
+    id: 16777235
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 512
+}
+tables {
+  preamble {
     id: 33554498
     name: "ingress.routing.nexthop_table"
     alias: "nexthop_table"
@@ -200,6 +236,10 @@ tables {
   action_refs {
     id: 16777219
     annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 16777234
+    annotations: "@proto_id(2)"
   }
   action_refs {
     id: 16777236
@@ -301,16 +341,16 @@ tables {
     annotations: "@proto_id(3)"
   }
   action_refs {
-    id: 16777231
-    annotations: "@proto_id(4)"
-  }
-  action_refs {
     id: 16777232
     annotations: "@proto_id(5)"
   }
   action_refs {
     id: 16777233
     annotations: "@proto_id(6)"
+  }
+  action_refs {
+    id: 16777237
+    annotations: "@proto_id(7)"
   }
   const_default_action_id: 16777222
   size: 32768
@@ -351,16 +391,16 @@ tables {
     annotations: "@proto_id(3)"
   }
   action_refs {
-    id: 16777231
-    annotations: "@proto_id(4)"
-  }
-  action_refs {
     id: 16777232
     annotations: "@proto_id(5)"
   }
   action_refs {
     id: 16777233
     annotations: "@proto_id(6)"
+  }
+  action_refs {
+    id: 16777237
+    annotations: "@proto_id(7)"
   }
   const_default_action_id: 16777222
   size: 4096
@@ -372,7 +412,7 @@ tables {
     alias: "acl_ingress_table"
     annotations: "@p4runtime_role(\"sdn_controller\")"
     annotations: "@sai_acl(INGRESS)"
-    annotations: "@entry_restriction(\"\n    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).\n    ether_type != 0x0800 && ether_type != 0x86dd;\n    // Only allow IP field matches for IP packets.\n    dst_ip::mask != 0 -> is_ipv4 == 1;\n    dst_ipv6::mask != 0 -> is_ipv6 == 1;\n    ttl::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ip_protocol::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    // Only allow l4_dst_port and l4_src_port matches for TCP/UDP packets.\n    l4_src_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);\n    l4_dst_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);\n\n    // Only allow arp_tpa matches for ARP packets.\n    arp_tpa::mask != 0 -> ether_type == 0x0806;\n\n    // Only allow icmp_type matches for ICMP packets\n\n\n\n    icmpv6_type::mask != 0 -> ip_protocol == 58;\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n  \")"
+    annotations: "@entry_restriction(\"\n    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).\n    ether_type != 0x0800 && ether_type != 0x86dd;\n    // Only allow IP field matches for IP packets.\n    dst_ip::mask != 0 -> is_ipv4 == 1;\n    dst_ipv6::mask != 0 -> is_ipv6 == 1;\n    ttl::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ip_protocol::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    // Only allow l4_dst_port and l4_src_port matches for TCP/UDP packets.\n    l4_src_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);\n    l4_dst_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);\n\n\n\n\n    // Only allow icmp_type matches for ICMP packets\n\n    icmp_type::mask != 0 -> ip_protocol == 1;\n\n    icmpv6_type::mask != 0 -> ip_protocol == 58;\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n  \")"
   }
   match_fields {
     id: 1
@@ -471,6 +511,13 @@ tables {
     match_type: TERNARY
   }
   match_fields {
+    id: 19
+    name: "icmp_type"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ICMP_TYPE)"
+    bitwidth: 8
+    match_type: TERNARY
+  }
+  match_fields {
     id: 14
     name: "icmpv6_type"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ICMPV6_TYPE)"
@@ -492,12 +539,20 @@ tables {
     match_type: TERNARY
   }
   match_fields {
-    id: 16
-    name: "arp_tpa"
-    annotations: "@composite_field(@ sai_udf ( base = SAI_UDF_BASE_L3 , offset = 24 , length = 2 ) , @ sai_udf ( base = SAI_UDF_BASE_L3 , offset = 26 , length = 2 ))"
-    annotations: "@format(IPV4_ADDRESS)"
-    bitwidth: 32
-    match_type: TERNARY
+    id: 17
+    name: "in_port"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT)"
+    match_type: OPTIONAL
+    type_name {
+      name: "port_id_t"
+    }
+  }
+  match_fields {
+    id: 18
+    name: "route_metadata"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ROUTE_DST_USER_META)"
+    bitwidth: 6
+    match_type: OPTIONAL
   }
   action_refs {
     id: 16777473
@@ -520,10 +575,6 @@ tables {
     annotations: "@proto_id(5)"
   }
   action_refs {
-    id: 16777625
-    annotations: "@proto_id(99)"
-  }
-  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
@@ -531,7 +582,7 @@ tables {
   const_default_action_id: 21257015
   direct_resource_ids: 318767362
   direct_resource_ids: 352321792
-  size: 128
+  size: 255
 }
 tables {
   preamble {
@@ -587,6 +638,86 @@ tables {
   const_default_action_id: 21257015
   size: 1024
 }
+tables {
+  preamble {
+    id: 33554692
+    name: "egress.acl_egress.acl_egress_table"
+    alias: "acl_egress_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+    annotations: "@sai_acl(EGRESS)"
+    annotations: "@entry_restriction(\"\n    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).\n    ether_type != 0x0800 && ether_type != 0x86dd;\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    // Only allow IP field matches for IP packets.\n    ip_protocol::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    // Only allow l4_dst_port matches for TCP/UDP packets.\n    l4_dst_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n  \")"
+  }
+  match_fields {
+    id: 1
+    name: "ether_type"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE)"
+    bitwidth: 16
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 2
+    name: "ip_protocol"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL)"
+    bitwidth: 8
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 3
+    name: "l4_dst_port"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT)"
+    bitwidth: 16
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 4
+    name: "out_port"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_OUT_PORT)"
+    match_type: OPTIONAL
+    type_name {
+      name: "port_id_t"
+    }
+  }
+  match_fields {
+    id: 5
+    name: "is_ip"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE / IP)"
+    bitwidth: 1
+    match_type: OPTIONAL
+  }
+  match_fields {
+    id: 6
+    name: "is_ipv4"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE / IPV4ANY)"
+    bitwidth: 1
+    match_type: OPTIONAL
+  }
+  match_fields {
+    id: 7
+    name: "is_ipv6"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE / IPV6ANY)"
+    bitwidth: 1
+    match_type: OPTIONAL
+  }
+  match_fields {
+    id: 8
+    name: "dscp"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_DSCP)"
+    bitwidth: 6
+    match_type: TERNARY
+  }
+  action_refs {
+    id: 16777481
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  direct_resource_ids: 318767364
+  size: 127
+}
 actions {
   preamble {
     id: 21257015
@@ -629,6 +760,76 @@ actions {
 }
 actions {
   preamble {
+    id: 17825802
+    name: "ingress.hashing.select_ecmp_hash_algorithm"
+    alias: "select_ecmp_hash_algorithm"
+    annotations: "@sai_hash_algorithm(SAI_HASH_ALGORITHM_CRC_32HI)"
+    annotations: "@sai_hash_seed(0)"
+    annotations: "@sai_hash_offset(8)"
+  }
+}
+actions {
+  preamble {
+    id: 16777227
+    name: "ingress.hashing.compute_ecmp_hash_ipv4"
+    alias: "compute_ecmp_hash_ipv4"
+    annotations: "@sai_ecmp_hash(SAI_SWITCH_ATTR_ECMP_HASH_IPV4)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_SRC_IPV4)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_DST_IPV4)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_SRC_PORT)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_DST_PORT)"
+  }
+}
+actions {
+  preamble {
+    id: 16777228
+    name: "ingress.hashing.compute_ecmp_hash_ipv6"
+    alias: "compute_ecmp_hash_ipv6"
+    annotations: "@sai_ecmp_hash(SAI_SWITCH_ATTR_ECMP_HASH_IPV6)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_SRC_IPV6)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_DST_IPV6)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_SRC_PORT)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_DST_PORT)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_IPV6_FLOW_LABEL)"
+  }
+}
+actions {
+  preamble {
+    id: 19711398
+    name: "ingress.lag_hashing_config.select_lag_hash_algorithm"
+    alias: "select_lag_hash_algorithm"
+    annotations: "@sai_hash_algorithm(SAI_HASH_ALGORITHM_CRC)"
+    annotations: "@sai_hash_seed(0)"
+    annotations: "@sai_hash_offset(7)"
+  }
+}
+actions {
+  preamble {
+    id: 16777229
+    name: "ingress.lag_hashing_config.compute_lag_hash_ipv4"
+    alias: "compute_lag_hash_ipv4"
+    annotations: "@sai_lag_hash(SAI_SWITCH_ATTR_LAG_HASH_IPV4)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_SRC_IPV4)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_DST_IPV4)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_SRC_PORT)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_DST_PORT)"
+  }
+}
+actions {
+  preamble {
+    id: 16777230
+    name: "ingress.lag_hashing_config.compute_lag_hash_ipv6"
+    alias: "compute_lag_hash_ipv6"
+    annotations: "@sai_lag_hash(SAI_SWITCH_ATTR_LAG_HASH_IPV6)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_SRC_IPV6)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_DST_IPV6)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_SRC_PORT)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_DST_PORT)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_IPV6_FLOW_LABEL)"
+  }
+}
+actions {
+  preamble {
     id: 16777217
     name: "ingress.routing.set_dst_mac"
     alias: "set_dst_mac"
@@ -658,6 +859,35 @@ actions {
     name: "src_mac"
     annotations: "@format(MAC_ADDRESS)"
     bitwidth: 48
+  }
+}
+actions {
+  preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
   }
 }
 actions {
@@ -705,6 +935,21 @@ actions {
     annotations: "@format(IPV6_ADDRESS)"
     annotations: "@refers_to(neighbor_table , neighbor_id)"
     bitwidth: 128
+  }
+}
+actions {
+  preamble {
+    id: 16777234
+    name: "ingress.routing.set_p2p_tunnel_encap_nexthop"
+    alias: "set_p2p_tunnel_encap_nexthop"
+  }
+  params {
+    id: 1
+    name: "tunnel_id"
+    annotations: "@refers_to(tunnel_table , tunnel_id)"
+    type_name {
+      name: "tunnel_id_t"
+    }
   }
 }
 actions {
@@ -793,9 +1038,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16777231
-    name: "ingress.routing.trap"
-    alias: "trap"
+    id: 16777237
+    name: "ingress.routing.set_metadata_and_drop"
+    alias: "set_metadata_and_drop"
+  }
+  params {
+    id: 1
+    name: "route_metadata"
+    bitwidth: 6
   }
 }
 actions {
@@ -821,24 +1071,6 @@ actions {
     id: 16777474
     name: "ingress.acl_ingress.acl_trap"
     alias: "acl_trap"
-    annotations: "@sai_action(SAI_PACKET_ACTION_TRAP , SAI_PACKET_COLOR_GREEN)"
-    annotations: "@sai_action(SAI_PACKET_ACTION_DROP , SAI_PACKET_COLOR_YELLOW)"
-    annotations: "@sai_action(SAI_PACKET_ACTION_DROP , SAI_PACKET_COLOR_RED)"
-  }
-  params {
-    id: 1
-    name: "qos_queue"
-    annotations: "@sai_action_param(QOS_QUEUE)"
-    type_name {
-      name: "qos_queue_t"
-    }
-  }
-}
-actions {
-  preamble {
-    id: 16777625
-    name: "ingress.acl_ingress.acl_experimental_trap"
-    alias: "acl_experimental_trap"
     annotations: "@sai_action(SAI_PACKET_ACTION_TRAP , SAI_PACKET_COLOR_GREEN)"
     annotations: "@sai_action(SAI_PACKET_ACTION_DROP , SAI_PACKET_COLOR_YELLOW)"
     annotations: "@sai_action(SAI_PACKET_ACTION_DROP , SAI_PACKET_COLOR_RED)"
@@ -947,8 +1179,8 @@ action_profiles {
   }
   table_ids: 33554499
   with_selector: true
-  size: 65536
-  max_group_size: 256
+  size: 49152
+  max_group_size: 512
 }
 direct_counters {
   preamble {
@@ -971,6 +1203,17 @@ direct_counters {
     unit: BOTH
   }
   direct_table_id: 33554688
+}
+direct_counters {
+  preamble {
+    id: 318767364
+    name: "egress.acl_egress.acl_egress_counter"
+    alias: "acl_egress_counter"
+  }
+  spec {
+    unit: BOTH
+  }
+  direct_table_id: 33554692
 }
 direct_meters {
   preamble {
@@ -1070,6 +1313,15 @@ type_info {
   }
   new_types {
     key: "router_interface_id_t"
+    value {
+      translated_type {
+        sdn_string {
+        }
+      }
+    }
+  }
+  new_types {
+    key: "tunnel_id_t"
     value {
       translated_type {
         sdn_string {

--- a/sai_p4/instantiations/google/fabric_border_router_with_s3_hash_profile.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router_with_s3_hash_profile.p4info.pb.txt
@@ -1,5 +1,6 @@
 pkg_info {
-  name: "middleblock.p4"
+  name: "fabric_border_router_with_s3_hash_profile.p4"
+  version: "1.0.0"
   arch: "v1model"
   organization: "Google"
 }
@@ -37,6 +38,14 @@ tables {
     id: 4
     name: "src_mac"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_MAC)"
+    annotations: "@format(MAC_ADDRESS)"
+    bitwidth: 48
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 9
+    name: "dst_mac"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_MAC)"
     annotations: "@format(MAC_ADDRESS)"
     bitwidth: 48
     match_type: TERNARY
@@ -84,7 +93,7 @@ tables {
   }
   const_default_action_id: 21257015
   direct_resource_ids: 318767361
-  size: 255
+  size: 254
 }
 tables {
   preamble {
@@ -184,6 +193,33 @@ tables {
 }
 tables {
   preamble {
+    id: 33554512
+    name: "ingress.routing.tunnel_table"
+    alias: "tunnel_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "tunnel_id"
+    match_type: EXACT
+    type_name {
+      name: "tunnel_id_t"
+    }
+  }
+  action_refs {
+    id: 16777235
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 512
+}
+tables {
+  preamble {
     id: 33554498
     name: "ingress.routing.nexthop_table"
     alias: "nexthop_table"
@@ -200,6 +236,10 @@ tables {
   action_refs {
     id: 16777219
     annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 16777234
+    annotations: "@proto_id(2)"
   }
   action_refs {
     id: 16777236
@@ -301,16 +341,16 @@ tables {
     annotations: "@proto_id(3)"
   }
   action_refs {
-    id: 16777231
-    annotations: "@proto_id(4)"
-  }
-  action_refs {
     id: 16777232
     annotations: "@proto_id(5)"
   }
   action_refs {
     id: 16777233
     annotations: "@proto_id(6)"
+  }
+  action_refs {
+    id: 16777237
+    annotations: "@proto_id(7)"
   }
   const_default_action_id: 16777222
   size: 32768
@@ -351,16 +391,16 @@ tables {
     annotations: "@proto_id(3)"
   }
   action_refs {
-    id: 16777231
-    annotations: "@proto_id(4)"
-  }
-  action_refs {
     id: 16777232
     annotations: "@proto_id(5)"
   }
   action_refs {
     id: 16777233
     annotations: "@proto_id(6)"
+  }
+  action_refs {
+    id: 16777237
+    annotations: "@proto_id(7)"
   }
   const_default_action_id: 16777222
   size: 4096
@@ -372,7 +412,7 @@ tables {
     alias: "acl_ingress_table"
     annotations: "@p4runtime_role(\"sdn_controller\")"
     annotations: "@sai_acl(INGRESS)"
-    annotations: "@entry_restriction(\"\n    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).\n    ether_type != 0x0800 && ether_type != 0x86dd;\n    // Only allow IP field matches for IP packets.\n    dst_ip::mask != 0 -> is_ipv4 == 1;\n    dst_ipv6::mask != 0 -> is_ipv6 == 1;\n    ttl::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ip_protocol::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    // Only allow l4_dst_port and l4_src_port matches for TCP/UDP packets.\n    l4_src_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);\n    l4_dst_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);\n\n    // Only allow arp_tpa matches for ARP packets.\n    arp_tpa::mask != 0 -> ether_type == 0x0806;\n\n    // Only allow icmp_type matches for ICMP packets\n\n\n\n    icmpv6_type::mask != 0 -> ip_protocol == 58;\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n  \")"
+    annotations: "@entry_restriction(\"\n    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).\n    ether_type != 0x0800 && ether_type != 0x86dd;\n    // Only allow IP field matches for IP packets.\n    dst_ip::mask != 0 -> is_ipv4 == 1;\n    dst_ipv6::mask != 0 -> is_ipv6 == 1;\n    ttl::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ip_protocol::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    // Only allow l4_dst_port and l4_src_port matches for TCP/UDP packets.\n    l4_src_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);\n    l4_dst_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);\n\n\n\n\n    // Only allow icmp_type matches for ICMP packets\n\n    icmp_type::mask != 0 -> ip_protocol == 1;\n\n    icmpv6_type::mask != 0 -> ip_protocol == 58;\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n  \")"
   }
   match_fields {
     id: 1
@@ -471,6 +511,13 @@ tables {
     match_type: TERNARY
   }
   match_fields {
+    id: 19
+    name: "icmp_type"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ICMP_TYPE)"
+    bitwidth: 8
+    match_type: TERNARY
+  }
+  match_fields {
     id: 14
     name: "icmpv6_type"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ICMPV6_TYPE)"
@@ -492,12 +539,20 @@ tables {
     match_type: TERNARY
   }
   match_fields {
-    id: 16
-    name: "arp_tpa"
-    annotations: "@composite_field(@ sai_udf ( base = SAI_UDF_BASE_L3 , offset = 24 , length = 2 ) , @ sai_udf ( base = SAI_UDF_BASE_L3 , offset = 26 , length = 2 ))"
-    annotations: "@format(IPV4_ADDRESS)"
-    bitwidth: 32
-    match_type: TERNARY
+    id: 17
+    name: "in_port"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT)"
+    match_type: OPTIONAL
+    type_name {
+      name: "port_id_t"
+    }
+  }
+  match_fields {
+    id: 18
+    name: "route_metadata"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ROUTE_DST_USER_META)"
+    bitwidth: 6
+    match_type: OPTIONAL
   }
   action_refs {
     id: 16777473
@@ -520,10 +575,6 @@ tables {
     annotations: "@proto_id(5)"
   }
   action_refs {
-    id: 16777625
-    annotations: "@proto_id(99)"
-  }
-  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
@@ -531,7 +582,7 @@ tables {
   const_default_action_id: 21257015
   direct_resource_ids: 318767362
   direct_resource_ids: 352321792
-  size: 128
+  size: 255
 }
 tables {
   preamble {
@@ -587,6 +638,86 @@ tables {
   const_default_action_id: 21257015
   size: 1024
 }
+tables {
+  preamble {
+    id: 33554692
+    name: "egress.acl_egress.acl_egress_table"
+    alias: "acl_egress_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+    annotations: "@sai_acl(EGRESS)"
+    annotations: "@entry_restriction(\"\n    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).\n    ether_type != 0x0800 && ether_type != 0x86dd;\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    // Only allow IP field matches for IP packets.\n    ip_protocol::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    // Only allow l4_dst_port matches for TCP/UDP packets.\n    l4_dst_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n  \")"
+  }
+  match_fields {
+    id: 1
+    name: "ether_type"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE)"
+    bitwidth: 16
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 2
+    name: "ip_protocol"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL)"
+    bitwidth: 8
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 3
+    name: "l4_dst_port"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT)"
+    bitwidth: 16
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 4
+    name: "out_port"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_OUT_PORT)"
+    match_type: OPTIONAL
+    type_name {
+      name: "port_id_t"
+    }
+  }
+  match_fields {
+    id: 5
+    name: "is_ip"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE / IP)"
+    bitwidth: 1
+    match_type: OPTIONAL
+  }
+  match_fields {
+    id: 6
+    name: "is_ipv4"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE / IPV4ANY)"
+    bitwidth: 1
+    match_type: OPTIONAL
+  }
+  match_fields {
+    id: 7
+    name: "is_ipv6"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE / IPV6ANY)"
+    bitwidth: 1
+    match_type: OPTIONAL
+  }
+  match_fields {
+    id: 8
+    name: "dscp"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_DSCP)"
+    bitwidth: 6
+    match_type: TERNARY
+  }
+  action_refs {
+    id: 16777481
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  direct_resource_ids: 318767364
+  size: 127
+}
 actions {
   preamble {
     id: 21257015
@@ -629,6 +760,76 @@ actions {
 }
 actions {
   preamble {
+    id: 17825802
+    name: "ingress.hashing.select_ecmp_hash_algorithm"
+    alias: "select_ecmp_hash_algorithm"
+    annotations: "@sai_hash_algorithm(SAI_HASH_ALGORITHM_CRC_32LO)"
+    annotations: "@sai_hash_seed(0)"
+    annotations: "@sai_hash_offset(0)"
+  }
+}
+actions {
+  preamble {
+    id: 16777227
+    name: "ingress.hashing.compute_ecmp_hash_ipv4"
+    alias: "compute_ecmp_hash_ipv4"
+    annotations: "@sai_ecmp_hash(SAI_SWITCH_ATTR_ECMP_HASH_IPV4)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_SRC_IPV4)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_DST_IPV4)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_SRC_PORT)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_DST_PORT)"
+  }
+}
+actions {
+  preamble {
+    id: 16777228
+    name: "ingress.hashing.compute_ecmp_hash_ipv6"
+    alias: "compute_ecmp_hash_ipv6"
+    annotations: "@sai_ecmp_hash(SAI_SWITCH_ATTR_ECMP_HASH_IPV6)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_SRC_IPV6)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_DST_IPV6)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_SRC_PORT)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_DST_PORT)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_IPV6_FLOW_LABEL)"
+  }
+}
+actions {
+  preamble {
+    id: 19711398
+    name: "ingress.lag_hashing_config.select_lag_hash_algorithm"
+    alias: "select_lag_hash_algorithm"
+    annotations: "@sai_hash_algorithm(SAI_HASH_ALGORITHM_CRC)"
+    annotations: "@sai_hash_seed(0)"
+    annotations: "@sai_hash_offset(7)"
+  }
+}
+actions {
+  preamble {
+    id: 16777229
+    name: "ingress.lag_hashing_config.compute_lag_hash_ipv4"
+    alias: "compute_lag_hash_ipv4"
+    annotations: "@sai_lag_hash(SAI_SWITCH_ATTR_LAG_HASH_IPV4)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_SRC_IPV4)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_DST_IPV4)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_SRC_PORT)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_DST_PORT)"
+  }
+}
+actions {
+  preamble {
+    id: 16777230
+    name: "ingress.lag_hashing_config.compute_lag_hash_ipv6"
+    alias: "compute_lag_hash_ipv6"
+    annotations: "@sai_lag_hash(SAI_SWITCH_ATTR_LAG_HASH_IPV6)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_SRC_IPV6)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_DST_IPV6)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_SRC_PORT)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_DST_PORT)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_IPV6_FLOW_LABEL)"
+  }
+}
+actions {
+  preamble {
     id: 16777217
     name: "ingress.routing.set_dst_mac"
     alias: "set_dst_mac"
@@ -658,6 +859,35 @@ actions {
     name: "src_mac"
     annotations: "@format(MAC_ADDRESS)"
     bitwidth: 48
+  }
+}
+actions {
+  preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
   }
 }
 actions {
@@ -705,6 +935,21 @@ actions {
     annotations: "@format(IPV6_ADDRESS)"
     annotations: "@refers_to(neighbor_table , neighbor_id)"
     bitwidth: 128
+  }
+}
+actions {
+  preamble {
+    id: 16777234
+    name: "ingress.routing.set_p2p_tunnel_encap_nexthop"
+    alias: "set_p2p_tunnel_encap_nexthop"
+  }
+  params {
+    id: 1
+    name: "tunnel_id"
+    annotations: "@refers_to(tunnel_table , tunnel_id)"
+    type_name {
+      name: "tunnel_id_t"
+    }
   }
 }
 actions {
@@ -793,9 +1038,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16777231
-    name: "ingress.routing.trap"
-    alias: "trap"
+    id: 16777237
+    name: "ingress.routing.set_metadata_and_drop"
+    alias: "set_metadata_and_drop"
+  }
+  params {
+    id: 1
+    name: "route_metadata"
+    bitwidth: 6
   }
 }
 actions {
@@ -821,24 +1071,6 @@ actions {
     id: 16777474
     name: "ingress.acl_ingress.acl_trap"
     alias: "acl_trap"
-    annotations: "@sai_action(SAI_PACKET_ACTION_TRAP , SAI_PACKET_COLOR_GREEN)"
-    annotations: "@sai_action(SAI_PACKET_ACTION_DROP , SAI_PACKET_COLOR_YELLOW)"
-    annotations: "@sai_action(SAI_PACKET_ACTION_DROP , SAI_PACKET_COLOR_RED)"
-  }
-  params {
-    id: 1
-    name: "qos_queue"
-    annotations: "@sai_action_param(QOS_QUEUE)"
-    type_name {
-      name: "qos_queue_t"
-    }
-  }
-}
-actions {
-  preamble {
-    id: 16777625
-    name: "ingress.acl_ingress.acl_experimental_trap"
-    alias: "acl_experimental_trap"
     annotations: "@sai_action(SAI_PACKET_ACTION_TRAP , SAI_PACKET_COLOR_GREEN)"
     annotations: "@sai_action(SAI_PACKET_ACTION_DROP , SAI_PACKET_COLOR_YELLOW)"
     annotations: "@sai_action(SAI_PACKET_ACTION_DROP , SAI_PACKET_COLOR_RED)"
@@ -947,8 +1179,8 @@ action_profiles {
   }
   table_ids: 33554499
   with_selector: true
-  size: 65536
-  max_group_size: 256
+  size: 49152
+  max_group_size: 512
 }
 direct_counters {
   preamble {
@@ -971,6 +1203,17 @@ direct_counters {
     unit: BOTH
   }
   direct_table_id: 33554688
+}
+direct_counters {
+  preamble {
+    id: 318767364
+    name: "egress.acl_egress.acl_egress_counter"
+    alias: "acl_egress_counter"
+  }
+  spec {
+    unit: BOTH
+  }
+  direct_table_id: 33554692
 }
 direct_meters {
   preamble {
@@ -1070,6 +1313,15 @@ type_info {
   }
   new_types {
     key: "router_interface_id_t"
+    value {
+      translated_type {
+        sdn_string {
+        }
+      }
+    }
+  }
+  new_types {
+    key: "tunnel_id_t"
     value {
       translated_type {
         sdn_string {

--- a/sai_p4/instantiations/google/middleblock.p4
+++ b/sai_p4/instantiations/google/middleblock.p4
@@ -10,6 +10,7 @@
 #include "../../fixed/headers.p4"
 #include "../../fixed/metadata.p4"
 #include "../../fixed/parser.p4"
+#include "../../fixed/packet_io.p4"
 #include "../../fixed/routing.p4"
 #include "../../fixed/ipv4_checksum.p4"
 #include "../../fixed/mirroring_encap.p4"
@@ -41,6 +42,7 @@ control egress(inout headers_t headers,
   apply {
     packet_rewrites.apply(headers, local_metadata, standard_metadata);
     mirroring_encap.apply(headers, local_metadata, standard_metadata);
+    packet_in_encap.apply(headers, local_metadata, standard_metadata);
   }
 }  // control egress
 

--- a/sai_p4/instantiations/google/middleblock_with_s3_ecmp_profile.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock_with_s3_ecmp_profile.p4info.pb.txt
@@ -1,7 +1,91 @@
 pkg_info {
-  name: "wbb.p4"
+  name: "middleblock_with_s3_ecmp_profile.p4"
+  version: "1.0.0"
   arch: "v1model"
   organization: "Google"
+}
+tables {
+  preamble {
+    id: 33554689
+    name: "ingress.acl_pre_ingress.acl_pre_ingress_table"
+    alias: "acl_pre_ingress_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+    annotations: "@sai_acl(PRE_INGRESS)"
+    annotations: "@entry_restriction(\"\n    // Only allow IP field matches for IP packets.\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    dst_ip::mask != 0 -> is_ipv4 == 1;\n    dst_ipv6::mask != 0 -> is_ipv6 == 1;\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n    // Reserve high priorities for switch-internal use.\n    // TODO: Remove once inband workaround is obsolete.\n    ::priority < 0x7fffffff;\n  \")"
+  }
+  match_fields {
+    id: 1
+    name: "is_ip"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE / IP)"
+    bitwidth: 1
+    match_type: OPTIONAL
+  }
+  match_fields {
+    id: 2
+    name: "is_ipv4"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE / IPV4ANY)"
+    bitwidth: 1
+    match_type: OPTIONAL
+  }
+  match_fields {
+    id: 3
+    name: "is_ipv6"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE / IPV6ANY)"
+    bitwidth: 1
+    match_type: OPTIONAL
+  }
+  match_fields {
+    id: 4
+    name: "src_mac"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_MAC)"
+    annotations: "@format(MAC_ADDRESS)"
+    bitwidth: 48
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 5
+    name: "dst_ip"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IP)"
+    annotations: "@format(IPV4_ADDRESS)"
+    bitwidth: 32
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 6
+    name: "dst_ipv6"
+    annotations: "@composite_field(@ sai_field ( SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD3 ) , @ sai_field ( SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD2 ))"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 64
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 7
+    name: "dscp"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_DSCP)"
+    bitwidth: 6
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 8
+    name: "in_port"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT)"
+    match_type: OPTIONAL
+    type_name {
+      name: "port_id_t"
+    }
+  }
+  action_refs {
+    id: 16777472
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  direct_resource_ids: 318767361
+  size: 254
 }
 tables {
   preamble {
@@ -101,6 +185,33 @@ tables {
 }
 tables {
   preamble {
+    id: 33554512
+    name: "ingress.routing.tunnel_table"
+    alias: "tunnel_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "tunnel_id"
+    match_type: EXACT
+    type_name {
+      name: "tunnel_id_t"
+    }
+  }
+  action_refs {
+    id: 16777235
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 512
+}
+tables {
+  preamble {
     id: 33554498
     name: "ingress.routing.nexthop_table"
     alias: "nexthop_table"
@@ -117,6 +228,10 @@ tables {
   action_refs {
     id: 16777219
     annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 16777234
+    annotations: "@proto_id(2)"
   }
   action_refs {
     id: 16777236
@@ -218,16 +333,16 @@ tables {
     annotations: "@proto_id(3)"
   }
   action_refs {
-    id: 16777231
-    annotations: "@proto_id(4)"
-  }
-  action_refs {
     id: 16777232
     annotations: "@proto_id(5)"
   }
   action_refs {
     id: 16777233
     annotations: "@proto_id(6)"
+  }
+  action_refs {
+    id: 16777237
+    annotations: "@proto_id(7)"
   }
   const_default_action_id: 16777222
   size: 32768
@@ -268,10 +383,6 @@ tables {
     annotations: "@proto_id(3)"
   }
   action_refs {
-    id: 16777231
-    annotations: "@proto_id(4)"
-  }
-  action_refs {
     id: 16777232
     annotations: "@proto_id(5)"
   }
@@ -279,60 +390,166 @@ tables {
     id: 16777233
     annotations: "@proto_id(6)"
   }
+  action_refs {
+    id: 16777237
+    annotations: "@proto_id(7)"
+  }
   const_default_action_id: 16777222
   size: 4096
 }
 tables {
   preamble {
-    id: 33554691
-    name: "ingress.acl_wbb_ingress.acl_wbb_ingress_table"
-    alias: "acl_wbb_ingress_table"
+    id: 33554688
+    name: "ingress.acl_ingress.acl_ingress_table"
+    alias: "acl_ingress_table"
     annotations: "@p4runtime_role(\"sdn_controller\")"
     annotations: "@sai_acl(INGRESS)"
-    annotations: "@entry_restriction(\"\n    // WBB only allows for very specific table entries:\n\n    // Traceroute (6 entries)\n    (\n      // IPv4 or IPv6\n      ((is_ipv4 == 1 && is_ipv6::mask == 0) ||\n        (is_ipv4::mask == 0 && is_ipv6 == 1)) &&\n      // TTL 0, 1, and 2\n      (ttl == 0 || ttl == 1 || ttl == 2) &&\n      ether_type::mask == 0 && outer_vlan_id::mask == 0\n    ) ||\n    // LLDP\n    (\n      ether_type == 0x88cc &&\n      is_ipv4::mask == 0 && is_ipv6::mask == 0 && ttl::mask == 0 &&\n      outer_vlan_id::mask == 0\n    ) ||\n    // ND\n    (\n    // TODO remove optional match for VLAN ID once VLAN ID is\n    // completely removed from ND flows.\n      (( outer_vlan_id::mask == 0xfff && outer_vlan_id == 0x0FA0) ||\n      outer_vlan_id::mask == 0);\n      ether_type == 0x6007;\n      is_ipv4::mask == 0;\n      is_ipv6::mask == 0;\n      ttl::mask == 0\n    )\n  \")"
+    annotations: "@entry_restriction(\"\n    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).\n    ether_type != 0x0800 && ether_type != 0x86dd;\n    // Only allow IP field matches for IP packets.\n    dst_ip::mask != 0 -> is_ipv4 == 1;\n    dst_ipv6::mask != 0 -> is_ipv6 == 1;\n    ttl::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ip_protocol::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    // Only allow l4_dst_port and l4_src_port matches for TCP/UDP packets.\n    l4_src_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);\n    l4_dst_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);\n\n    // Only allow arp_tpa matches for ARP packets.\n    arp_tpa::mask != 0 -> ether_type == 0x0806;\n\n    // Only allow icmp_type matches for ICMP packets\n\n\n\n    icmpv6_type::mask != 0 -> ip_protocol == 58;\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n  \")"
   }
   match_fields {
     id: 1
+    name: "is_ip"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE / IP)"
+    bitwidth: 1
+    match_type: OPTIONAL
+  }
+  match_fields {
+    id: 2
     name: "is_ipv4"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE / IPV4ANY)"
     bitwidth: 1
     match_type: OPTIONAL
   }
   match_fields {
-    id: 2
+    id: 3
     name: "is_ipv6"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE / IPV6ANY)"
     bitwidth: 1
     match_type: OPTIONAL
   }
   match_fields {
-    id: 3
+    id: 4
     name: "ether_type"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE)"
     bitwidth: 16
     match_type: TERNARY
   }
   match_fields {
-    id: 4
+    id: 5
+    name: "dst_mac"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_MAC)"
+    annotations: "@format(MAC_ADDRESS)"
+    bitwidth: 48
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 6
+    name: "src_ip"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_IP)"
+    annotations: "@format(IPV4_ADDRESS)"
+    bitwidth: 32
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 7
+    name: "dst_ip"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IP)"
+    annotations: "@format(IPV4_ADDRESS)"
+    bitwidth: 32
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 8
+    name: "src_ipv6"
+    annotations: "@composite_field(@ sai_field ( SAI_ACL_TABLE_ATTR_FIELD_SRC_IPV6_WORD3 ) , @ sai_field ( SAI_ACL_TABLE_ATTR_FIELD_SRC_IPV6_WORD2 ))"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 64
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 9
+    name: "dst_ipv6"
+    annotations: "@composite_field(@ sai_field ( SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD3 ) , @ sai_field ( SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD2 ))"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 64
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 10
     name: "ttl"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_TTL)"
     bitwidth: 8
     match_type: TERNARY
   }
   match_fields {
-    id: 5
-    name: "outer_vlan_id"
-    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID)"
-    bitwidth: 12
+    id: 11
+    name: "dscp"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_DSCP)"
+    bitwidth: 6
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 12
+    name: "ecn"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ECN)"
+    bitwidth: 2
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 13
+    name: "ip_protocol"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL)"
+    bitwidth: 8
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 14
+    name: "icmpv6_type"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ICMPV6_TYPE)"
+    bitwidth: 8
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 20
+    name: "l4_src_port"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_L4_SRC_PORT)"
+    bitwidth: 16
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 15
+    name: "l4_dst_port"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT)"
+    bitwidth: 16
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 16
+    name: "arp_tpa"
+    annotations: "@composite_field(@ sai_udf ( base = SAI_UDF_BASE_L3 , offset = 24 , length = 2 ) , @ sai_udf ( base = SAI_UDF_BASE_L3 , offset = 26 , length = 2 ))"
+    annotations: "@format(IPV4_ADDRESS)"
+    bitwidth: 32
     match_type: TERNARY
   }
   action_refs {
-    id: 16777479
+    id: 16777473
     annotations: "@proto_id(1)"
   }
   action_refs {
-    id: 16777480
+    id: 16777474
     annotations: "@proto_id(2)"
+  }
+  action_refs {
+    id: 16777475
+    annotations: "@proto_id(3)"
+  }
+  action_refs {
+    id: 16777476
+    annotations: "@proto_id(4)"
+  }
+  action_refs {
+    id: 16777481
+    annotations: "@proto_id(5)"
   }
   action_refs {
     id: 21257015
@@ -340,9 +557,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
-  direct_resource_ids: 318767363
-  direct_resource_ids: 352321793
-  size: 8
+  direct_resource_ids: 318767362
+  direct_resource_ids: 352321792
+  size: 255
 }
 tables {
   preamble {
@@ -408,9 +625,69 @@ actions {
 }
 actions {
   preamble {
+    id: 16777481
+    name: "acl_drop"
+    alias: "acl_drop"
+    annotations: "@sai_action(SAI_PACKET_ACTION_DROP)"
+  }
+}
+actions {
+  preamble {
+    id: 16777472
+    name: "ingress.acl_pre_ingress.set_vrf"
+    alias: "set_vrf"
+    annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD)"
+  }
+  params {
+    id: 1
+    name: "vrf_id"
+    annotations: "@sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_SET_VRF)"
+    annotations: "@refers_to(vrf_table , vrf_id)"
+    type_name {
+      name: "vrf_id_t"
+    }
+  }
+}
+actions {
+  preamble {
     id: 16777224
     name: "ingress.l3_admit.admit_to_l3"
     alias: "admit_to_l3"
+  }
+}
+actions {
+  preamble {
+    id: 17825802
+    name: "ingress.hashing.select_ecmp_hash_algorithm"
+    alias: "select_ecmp_hash_algorithm"
+    annotations: "@sai_hash_algorithm(SAI_HASH_ALGORITHM_CRC_CCITT)"
+    annotations: "@sai_hash_seed(0)"
+    annotations: "@sai_hash_offset(8)"
+  }
+}
+actions {
+  preamble {
+    id: 16777227
+    name: "ingress.hashing.compute_ecmp_hash_ipv4"
+    alias: "compute_ecmp_hash_ipv4"
+    annotations: "@sai_ecmp_hash(SAI_SWITCH_ATTR_ECMP_HASH_IPV4)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_SRC_IPV4)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_DST_IPV4)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_SRC_PORT)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_DST_PORT)"
+  }
+}
+actions {
+  preamble {
+    id: 16777228
+    name: "ingress.hashing.compute_ecmp_hash_ipv6"
+    alias: "compute_ecmp_hash_ipv6"
+    annotations: "@sai_ecmp_hash(SAI_SWITCH_ATTR_ECMP_HASH_IPV6)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_SRC_IPV6)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_DST_IPV6)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_SRC_PORT)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_L4_DST_PORT)"
+    annotations: "@sai_native_hash_field(SAI_NATIVE_HASH_FIELD_IPV6_FLOW_LABEL)"
   }
 }
 actions {
@@ -444,6 +721,35 @@ actions {
     name: "src_mac"
     annotations: "@format(MAC_ADDRESS)"
     bitwidth: 48
+  }
+}
+actions {
+  preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
   }
 }
 actions {
@@ -491,6 +797,21 @@ actions {
     annotations: "@format(IPV6_ADDRESS)"
     annotations: "@refers_to(neighbor_table , neighbor_id)"
     bitwidth: 128
+  }
+}
+actions {
+  preamble {
+    id: 16777234
+    name: "ingress.routing.set_p2p_tunnel_encap_nexthop"
+    alias: "set_p2p_tunnel_encap_nexthop"
+  }
+  params {
+    id: 1
+    name: "tunnel_id"
+    annotations: "@refers_to(tunnel_table , tunnel_id)"
+    type_name {
+      name: "tunnel_id_t"
+    }
   }
 }
 actions {
@@ -579,25 +900,77 @@ actions {
 }
 actions {
   preamble {
-    id: 16777231
-    name: "ingress.routing.trap"
-    alias: "trap"
+    id: 16777237
+    name: "ingress.routing.set_metadata_and_drop"
+    alias: "set_metadata_and_drop"
+  }
+  params {
+    id: 1
+    name: "route_metadata"
+    bitwidth: 6
   }
 }
 actions {
   preamble {
-    id: 16777479
-    name: "ingress.acl_wbb_ingress.acl_wbb_ingress_copy"
-    alias: "acl_wbb_ingress_copy"
-    annotations: "@sai_action(SAI_PACKET_ACTION_COPY)"
+    id: 16777473
+    name: "ingress.acl_ingress.acl_copy"
+    alias: "acl_copy"
+    annotations: "@sai_action(SAI_PACKET_ACTION_COPY , SAI_PACKET_COLOR_GREEN)"
+    annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_YELLOW)"
+    annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_RED)"
+  }
+  params {
+    id: 1
+    name: "qos_queue"
+    annotations: "@sai_action_param(QOS_QUEUE)"
+    type_name {
+      name: "qos_queue_t"
+    }
   }
 }
 actions {
   preamble {
-    id: 16777480
-    name: "ingress.acl_wbb_ingress.acl_wbb_ingress_trap"
-    alias: "acl_wbb_ingress_trap"
-    annotations: "@sai_action(SAI_PACKET_ACTION_TRAP)"
+    id: 16777474
+    name: "ingress.acl_ingress.acl_trap"
+    alias: "acl_trap"
+    annotations: "@sai_action(SAI_PACKET_ACTION_TRAP , SAI_PACKET_COLOR_GREEN)"
+    annotations: "@sai_action(SAI_PACKET_ACTION_DROP , SAI_PACKET_COLOR_YELLOW)"
+    annotations: "@sai_action(SAI_PACKET_ACTION_DROP , SAI_PACKET_COLOR_RED)"
+  }
+  params {
+    id: 1
+    name: "qos_queue"
+    annotations: "@sai_action_param(QOS_QUEUE)"
+    type_name {
+      name: "qos_queue_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 16777475
+    name: "ingress.acl_ingress.acl_forward"
+    alias: "acl_forward"
+    annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_GREEN)"
+    annotations: "@sai_action(SAI_PACKET_ACTION_DROP , SAI_PACKET_COLOR_YELLOW)"
+    annotations: "@sai_action(SAI_PACKET_ACTION_DROP , SAI_PACKET_COLOR_RED)"
+  }
+}
+actions {
+  preamble {
+    id: 16777476
+    name: "ingress.acl_ingress.acl_mirror"
+    alias: "acl_mirror"
+    annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD)"
+  }
+  params {
+    id: 1
+    name: "mirror_session_id"
+    annotations: "@refers_to(mirror_session_table , mirror_session_id)"
+    annotations: "@sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_INGRESS)"
+    type_name {
+      name: "mirror_session_id_t"
+    }
   }
 }
 actions {
@@ -668,30 +1041,41 @@ action_profiles {
   }
   table_ids: 33554499
   with_selector: true
-  size: 65536
-  max_group_size: 256
+  size: 49152
+  max_group_size: 512
 }
 direct_counters {
   preamble {
-    id: 318767363
-    name: "ingress.acl_wbb_ingress.acl_wbb_ingress_counter"
-    alias: "acl_wbb_ingress_counter"
+    id: 318767361
+    name: "ingress.acl_pre_ingress.acl_pre_ingress_counter"
+    alias: "acl_pre_ingress_counter"
   }
   spec {
     unit: BOTH
   }
-  direct_table_id: 33554691
+  direct_table_id: 33554689
+}
+direct_counters {
+  preamble {
+    id: 318767362
+    name: "ingress.acl_ingress.acl_ingress_counter"
+    alias: "acl_ingress_counter"
+  }
+  spec {
+    unit: BOTH
+  }
+  direct_table_id: 33554688
 }
 direct_meters {
   preamble {
-    id: 352321793
-    name: "ingress.acl_wbb_ingress.acl_wbb_ingress_meter"
-    alias: "acl_wbb_ingress_meter"
+    id: 352321792
+    name: "ingress.acl_ingress.acl_ingress_meter"
+    alias: "acl_ingress_meter"
   }
   spec {
     unit: BYTES
   }
-  direct_table_id: 33554691
+  direct_table_id: 33554688
 }
 controller_packet_metadata {
   preamble {
@@ -770,7 +1154,25 @@ type_info {
     }
   }
   new_types {
+    key: "qos_queue_t"
+    value {
+      translated_type {
+        sdn_string {
+        }
+      }
+    }
+  }
+  new_types {
     key: "router_interface_id_t"
+    value {
+      translated_type {
+        sdn_string {
+        }
+      }
+    }
+  }
+  new_types {
+    key: "tunnel_id_t"
     value {
       translated_type {
         sdn_string {

--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -554,7 +554,6 @@ message PacketOut {
   message Metadata {
     string egress_port = 1;        // Format::STRING
     string submit_to_ingress = 2;  // Format::HEX_STRING / 1 bits
-    string unused_pad = 3;         // Format::HEX_STRING / 7 bits
   }
   Metadata metadata = 2;
 }

--- a/sai_p4/instantiations/google/tests/sai_p4_bmv2_packet_io_integration_test.cc
+++ b/sai_p4/instantiations/google/tests/sai_p4_bmv2_packet_io_integration_test.cc
@@ -1,0 +1,639 @@
+#include <cassert>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "glog/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status.h"
+#include "gutil/testing.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4_pdpi/p4_runtime_session.h"
+#include "p4_pdpi/packetlib/packetlib.h"
+#include "p4_pdpi/packetlib/packetlib.pb.h"
+#include "p4_pdpi/pd.h"
+#include "p4_pdpi/string_encodings/byte_string.h"
+#include "platforms/networking/orion/p4/tests/bmv2.h"
+#include "sai_p4/fixed/ids.h"
+#include "sai_p4/instantiations/google/instantiations.h"
+#include "sai_p4/instantiations/google/sai_nonstandard_platforms.h"
+#include "sai_p4/instantiations/google/sai_p4info.h"
+#include "sai_p4/instantiations/google/sai_pd.pb.h"
+
+namespace pins {
+namespace {
+
+using ::orion::p4::test::Bmv2;
+using ::p4::v1::ForwardingPipelineConfig;
+using ::p4::v1::PacketMetadata;
+using ::p4::v1::SetForwardingPipelineConfigRequest;
+using ::p4::v1::StreamMessageResponse;
+using ::p4::v1::Update;
+using ::p4::v1::WriteRequest;
+using ::testing::ElementsAre;
+using ::testing::EqualsProto;
+using ::testing::IsEmpty;
+using ::testing::TestWithParam;
+using ::testing::status::IsOkAndHolds;
+
+using PacketStream = grpc::ClientReaderWriter<::p4::bm::PacketStreamRequest,
+                                              ::p4::bm::PacketStreamResponse>;
+
+constexpr int kBmv2PortBitwidth = 9;
+constexpr sai::NonstandardPlatform kPlatformBmv2 =
+    sai::NonstandardPlatform::kBmv2;
+enum class PuntAction { kPunt, kCopy };
+
+// Returns a set of table entries that set egress port.
+sai::TableEntries ConstructEntriesToSetEgressPort(
+    absl::string_view egress_port) {
+  sai::TableEntries sai_table_entries =
+      gutil::ParseProtoOrDie<sai::TableEntries>(
+          R"pb(
+            entries {
+              l3_admit_table_entry {
+                match {}  # Wildcard.
+                action { admit_to_l3 {} }
+                priority: 1
+              }
+            }
+            entries {
+              vrf_table_entry {
+                match { vrf_id: "vrf" }
+                action { no_action {} }
+              }
+            }
+            entries {
+              ipv4_table_entry {
+                match { vrf_id: "vrf" }
+                action { set_nexthop_id { nexthop_id: "nexthop" } }
+              }
+            }
+            entries {
+              ipv6_table_entry {
+                match { vrf_id: "vrf" }
+                action { set_nexthop_id { nexthop_id: "nexthop" } }
+              }
+            }
+            entries {
+              nexthop_table_entry {
+                match { nexthop_id: "nexthop" }
+                action {
+                  set_ip_nexthop {
+                    router_interface_id: "rif"
+                    neighbor_id: "fe80::2:2ff:fe02:202"
+                  }
+                }
+              }
+            }
+            entries {
+              acl_pre_ingress_table_entry {
+                match {}  # Wildcard.
+                action { set_vrf { vrf_id: "vrf" } }
+                priority: 1
+              }
+            }
+            entries {
+              neighbor_table_entry {
+                match {
+                  router_interface_id: "rif"
+                  neighbor_id: "fe80::2:2ff:fe02:202"
+                }
+                action { set_dst_mac { dst_mac: "02:03:04:05:06:07" } }
+              }
+            }
+          )pb");
+
+  sai::TableEntries router_interface_table_entry =
+      gutil::ParseProtoOrDie<sai::TableEntries>(
+          R"pb(entries {
+                 router_interface_table_entry {
+                   match { router_interface_id: "rif" }
+                   action {
+                     set_port_and_src_mac { src_mac: "00:01:02:03:04:05" }
+                   }
+                 }
+               }
+          )pb");
+  router_interface_table_entry.mutable_entries(0)
+      ->mutable_router_interface_table_entry()
+      ->mutable_action()
+      ->mutable_set_port_and_src_mac()
+      ->set_port(egress_port);
+
+  sai_table_entries.MergeFrom(router_interface_table_entry);
+  return sai_table_entries;
+}
+
+// Returns a set of table entries that set egress port.
+absl::StatusOr<std::vector<p4::v1::TableEntry>>
+ConstructPiEntriesToSetEgressPort(absl::string_view egress_port,
+                                  pdpi::IrP4Info& ir_p4info) {
+  return pdpi::PdTableEntriesToPi(ir_p4info,
+                                  ConstructEntriesToSetEgressPort(egress_port));
+}
+
+// Returns a set of table entries that set egress port and trap packets.
+absl::StatusOr<std::vector<p4::v1::TableEntry>>
+ConstructPiEntriesToSetEgressPortAndTrapPackets(absl::string_view egress_port,
+                                                pdpi::IrP4Info& ir_p4info,
+                                                PuntAction action) {
+  sai::TableEntries sai_table_entries =
+      gutil::ParseProtoOrDie<sai::TableEntries>(
+          R"pb(
+            entries {
+              acl_ingress_table_entry {
+                match {}     # Wildcard match
+                priority: 1  # Highest priority
+              }
+            }
+          )pb");
+  auto* acl_action = sai_table_entries.mutable_entries(0)
+                         ->mutable_acl_ingress_table_entry()
+                         ->mutable_action();
+  if (action == PuntAction::kPunt)
+    acl_action->mutable_acl_trap()->set_qos_queue("0x1");
+  else
+    acl_action->mutable_acl_copy()->set_qos_queue("0x1");
+  sai_table_entries.MergeFrom(ConstructEntriesToSetEgressPort(egress_port));
+
+  return pdpi::PdTableEntriesToPi(ir_p4info, sai_table_entries);
+}
+
+// Installs clone session entry needed for packet-in.
+absl::Status InstallP4rtCloneSessionEntry(pdpi::P4RuntimeSession& session) {
+  WriteRequest request;
+  Update& update = *request.add_updates();
+  update.set_type(Update::INSERT);
+  auto* clone_session = update.mutable_entity()
+                            ->mutable_packet_replication_engine_entry()
+                            ->mutable_clone_session_entry();
+  clone_session->set_session_id(COPY_TO_CPU_SESSION_ID);
+  auto* replica = clone_session->add_replicas();
+  replica->set_egress_port(SAI_P4_CPU_PORT);
+  replica->set_instance(CLONE_REPLICA_INSTANCE_PACKET_IN);
+
+  return pdpi::SetMetadataAndSendPiWriteRequest(&session, request);
+}
+
+using BMv2PacketIOTest = TestWithParam<sai::Instantiation>;
+
+TEST_P(BMv2PacketIOTest, ControllerReceivesPuntPacketIn) {
+  constexpr int kIngressPort = 1;
+  constexpr int kEgressPort = 42;
+
+  ForwardingPipelineConfig bmv2_config =
+      sai::GetNonstandardForwardingPipelineConfig(GetParam(), kPlatformBmv2);
+  pdpi::IrP4Info ir_p4info = sai::GetIrP4Info(GetParam());
+
+  // Create and configure BMv2.
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, Bmv2::Create({
+                                      .device_id = 1,
+                                      .cpu_port = SAI_P4_CPU_PORT,
+                                      .drop_port = SAI_P4_DROP_PORT,
+                                  }));
+  ASSERT_OK(pdpi::SetMetadataAndSetForwardingPipelineConfig(
+      &bmv2.P4RuntimeSession(),
+      SetForwardingPipelineConfigRequest::VERIFY_AND_COMMIT, bmv2_config));
+
+  // Install table enties for punting packets.
+  ASSERT_OK_AND_ASSIGN(const std::vector<p4::v1::TableEntry> kTableEntries,
+                       ConstructPiEntriesToSetEgressPortAndTrapPackets(
+                           pdpi::BitsetToP4RuntimeByteString(
+                               std::bitset<kBmv2PortBitwidth>(kEgressPort)),
+                           ir_p4info, PuntAction::kPunt));
+  ASSERT_OK(InstallPiTableEntries(&bmv2.P4RuntimeSession(), ir_p4info,
+                                  kTableEntries));
+  EXPECT_OK(InstallP4rtCloneSessionEntry(bmv2.P4RuntimeSession()));
+
+  ASSERT_OK_AND_ASSIGN(packetlib::Packet input_packet,
+                       gutil::ParseTextProto<packetlib::Packet>(R"pb(
+                         headers {
+                           ethernet_header {
+                             ethernet_destination: "02:03:04:05:06:07"
+                             ethernet_source: "00:01:02:03:04:05"
+                             ethertype: "0x0800"
+                           }
+                         }
+                         headers {
+                           ipv4_header {
+                             version: "0x4"
+                             ihl: "0x5"
+                             dscp: "0x1c"
+                             ecn: "0x0"
+                             total_length: "0x002e"
+                             identification: "0x0000"
+                             flags: "0x0"
+                             fragment_offset: "0x0000"
+                             ttl: "0x20"
+                             protocol: "0x11"
+                             checksum: "0x50fb"
+                             ipv4_source: "192.168.100.2"
+                             ipv4_destination: "192.168.100.1"
+                           }
+                         }
+                         headers {
+                           udp_header {
+                             source_port: "0x0000"
+                             destination_port: "0x0000"
+                             length: "0x001a"
+                             checksum: "0x8d24"
+                           }
+                         }
+                         payload: "Test packet."
+                       )pb"));
+  ASSERT_OK_AND_ASSIGN(absl::StatusOr<std::string> raw_input_packet,
+                       packetlib::SerializePacket(input_packet));
+
+  ASSERT_THAT(bmv2.SendPacket(pins::PacketAtPort{
+                  .port = kIngressPort,
+                  .data = *raw_input_packet,
+              }),
+              IsOkAndHolds(IsEmpty()));
+
+  // Wait for 1 second to make sure packets are fully processed by BMv2.
+  absl::SleepFor(absl::Seconds(1));
+
+  StreamMessageResponse expected_response;
+  expected_response.mutable_packet()->set_payload(*raw_input_packet);
+  // Check if the ingress port in the metadata is correct.
+  PacketMetadata* ingress_port_field =
+      expected_response.mutable_packet()->add_metadata();
+  ingress_port_field->set_metadata_id(PACKET_IN_INGRESS_PORT_ID);
+  ingress_port_field->set_value(pdpi::BitsetToP4RuntimeByteString(
+      std::bitset<kBmv2PortBitwidth>(kIngressPort)));
+  // Check if the target egress port in the metadata is correct.
+  PacketMetadata* target_egress_port_field =
+      expected_response.mutable_packet()->add_metadata();
+  target_egress_port_field->set_metadata_id(PACKET_IN_TARGET_EGRESS_PORT_ID);
+  target_egress_port_field->set_value(pdpi::BitsetToP4RuntimeByteString(
+      std::bitset<kBmv2PortBitwidth>(kEgressPort)));
+  // Padding of the packet-in header.
+  PacketMetadata* unused_pad =
+      expected_response.mutable_packet()->add_metadata();
+  unused_pad->set_metadata_id(PACKET_IN_UNUSED_PAD_ID);
+  unused_pad->set_value(pdpi::BitsetToP4RuntimeByteString(std::bitset<6>(0)));
+
+  // Check that packet is correctly punted and close the session.
+  EXPECT_THAT(bmv2.P4RuntimeSession().ReadStreamChannelResponsesAndFinish(),
+              IsOkAndHolds(ElementsAre(EqualsProto(expected_response))));
+}
+
+TEST_P(BMv2PacketIOTest, ControllerReceivesCopyPacketIn) {
+  constexpr int kIngressPort = 1;
+  constexpr int kEgressPort = 42;
+
+  ForwardingPipelineConfig bmv2_config =
+      sai::GetNonstandardForwardingPipelineConfig(GetParam(), kPlatformBmv2);
+  pdpi::IrP4Info ir_p4info = sai::GetIrP4Info(GetParam());
+
+  // Create and configure BMv2.
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, Bmv2::Create({
+                                      .device_id = 1,
+                                      .cpu_port = SAI_P4_CPU_PORT,
+                                      .drop_port = SAI_P4_DROP_PORT,
+                                  }));
+  ASSERT_OK(pdpi::SetMetadataAndSetForwardingPipelineConfig(
+      &bmv2.P4RuntimeSession(),
+      SetForwardingPipelineConfigRequest::VERIFY_AND_COMMIT, bmv2_config));
+
+  // Install table enties for punting packets.
+  ASSERT_OK_AND_ASSIGN(const std::vector<p4::v1::TableEntry> kTableEntries,
+                       ConstructPiEntriesToSetEgressPortAndTrapPackets(
+                           pdpi::BitsetToP4RuntimeByteString(
+                               std::bitset<kBmv2PortBitwidth>(kEgressPort)),
+                           ir_p4info, PuntAction::kCopy));
+  ASSERT_OK(InstallPiTableEntries(&bmv2.P4RuntimeSession(), ir_p4info,
+                                  kTableEntries));
+  EXPECT_OK(InstallP4rtCloneSessionEntry(bmv2.P4RuntimeSession()));
+
+  ASSERT_OK_AND_ASSIGN(packetlib::Packet input_packet,
+                       gutil::ParseTextProto<packetlib::Packet>(R"pb(
+                         headers {
+                           ethernet_header {
+                             ethernet_destination: "02:03:04:05:06:07"
+                             ethernet_source: "00:01:02:03:04:05"
+                             ethertype: "0x0800"
+                           }
+                         }
+                         headers {
+                           ipv4_header {
+                             version: "0x4"
+                             ihl: "0x5"
+                             dscp: "0x1c"
+                             ecn: "0x0"
+                             total_length: "0x002e"
+                             identification: "0x0000"
+                             flags: "0x0"
+                             fragment_offset: "0x0000"
+                             ttl: "0x20"
+                             protocol: "0x11"
+                             checksum: "0x50fb"
+                             ipv4_source: "192.168.100.2"
+                             ipv4_destination: "192.168.100.1"
+                           }
+                         }
+                         headers {
+                           udp_header {
+                             source_port: "0x0000"
+                             destination_port: "0x0000"
+                             length: "0x001a"
+                             checksum: "0x8d24"
+                           }
+                         }
+                         payload: "Test packet."
+                       )pb"));
+  ASSERT_OK_AND_ASSIGN(absl::StatusOr<std::string> raw_input_packet,
+                       packetlib::SerializePacket(input_packet));
+
+  // The output packet that will egress out of kEgressPort.
+  packetlib::Packet output_packet = input_packet;
+  // The ttl field of the ipv4 header will be updated by the ingress pipeline.
+  output_packet.mutable_headers(1)->mutable_ipv4_header()->set_ttl("0x1f");
+  // Update the checksum of the ipv4 header because the ttl field is changed.
+  output_packet.mutable_headers(1)->mutable_ipv4_header()->set_checksum(
+      "0x51fb");
+  ASSERT_OK_AND_ASSIGN(absl::StatusOr<std::string> raw_output_packet,
+                       packetlib::SerializePacket(output_packet));
+
+  ASSERT_THAT(bmv2.SendPacket(pins::PacketAtPort{.port = kIngressPort,
+                                                 .data = *raw_input_packet}),
+              IsOkAndHolds(ElementsAre(pins::PacketAtPort{
+                  .port = kEgressPort, .data = *raw_output_packet})));
+
+  // Wait for 1 second to make sure packets are fully processed by BMv2.
+  absl::SleepFor(absl::Seconds(1));
+
+  StreamMessageResponse expected_response;
+  expected_response.mutable_packet()->set_payload(*raw_input_packet);
+  // Check if the ingress port in the metadata is correct.
+  PacketMetadata* ingress_port_field =
+      expected_response.mutable_packet()->add_metadata();
+  ingress_port_field->set_metadata_id(PACKET_IN_INGRESS_PORT_ID);
+  ingress_port_field->set_value(pdpi::BitsetToP4RuntimeByteString(
+      std::bitset<kBmv2PortBitwidth>(kIngressPort)));
+  // Check if the target egress port in the metadata is correct.
+  PacketMetadata* target_egress_port_field =
+      expected_response.mutable_packet()->add_metadata();
+  target_egress_port_field->set_metadata_id(PACKET_IN_TARGET_EGRESS_PORT_ID);
+  target_egress_port_field->set_value(pdpi::BitsetToP4RuntimeByteString(
+      std::bitset<kBmv2PortBitwidth>(kEgressPort)));
+  // Padding of the packet-in header.
+  PacketMetadata* unused_pad =
+      expected_response.mutable_packet()->add_metadata();
+  unused_pad->set_metadata_id(PACKET_IN_UNUSED_PAD_ID);
+  unused_pad->set_value(pdpi::BitsetToP4RuntimeByteString(std::bitset<6>(0)));
+
+  // Check that packet is correctly punted and close the session.
+  EXPECT_THAT(bmv2.P4RuntimeSession().ReadStreamChannelResponsesAndFinish(),
+              IsOkAndHolds(ElementsAre(EqualsProto(expected_response))));
+}
+
+TEST_P(BMv2PacketIOTest, P4RuntimePacketOutSubmitToIngressOk) {
+  constexpr int kEgressPort = 42;
+
+  ForwardingPipelineConfig bmv2_config =
+      sai::GetNonstandardForwardingPipelineConfig(GetParam(), kPlatformBmv2);
+  pdpi::IrP4Info ir_p4info = sai::GetIrP4Info(GetParam());
+
+  // Create and configure BMv2.
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, Bmv2::Create({
+                                      .device_id = 1,
+                                      .cpu_port = SAI_P4_CPU_PORT,
+                                      .drop_port = SAI_P4_DROP_PORT,
+                                  }));
+  ASSERT_OK(pdpi::SetMetadataAndSetForwardingPipelineConfig(
+      &bmv2.P4RuntimeSession(),
+      SetForwardingPipelineConfigRequest::VERIFY_AND_COMMIT, bmv2_config));
+
+  // Install table enties for routing packets.
+  ASSERT_OK_AND_ASSIGN(const std::vector<p4::v1::TableEntry> kTableEntries,
+                       ConstructPiEntriesToSetEgressPort(
+                           pdpi::BitsetToP4RuntimeByteString(
+                               std::bitset<kBmv2PortBitwidth>(kEgressPort)),
+                           ir_p4info));
+  ASSERT_OK(InstallPiTableEntries(&bmv2.P4RuntimeSession(), ir_p4info,
+                                  kTableEntries));
+
+  ASSERT_OK_AND_ASSIGN(packetlib::Packet input_packet,
+                       gutil::ParseTextProto<packetlib::Packet>(R"pb(
+                         headers {
+                           ethernet_header {
+                             ethernet_destination: "02:03:04:05:06:07"
+                             ethernet_source: "00:01:02:03:04:05"
+                             ethertype: "0x0800"
+                           }
+                         }
+                         headers {
+                           ipv4_header {
+                             version: "0x4"
+                             ihl: "0x5"
+                             dscp: "0x1c"
+                             ecn: "0x0"
+                             total_length: "0x002e"
+                             identification: "0x0000"
+                             flags: "0x0"
+                             fragment_offset: "0x0000"
+                             ttl: "0x20"
+                             protocol: "0x11"
+                             checksum: "0x50fb"
+                             ipv4_source: "192.168.100.2"
+                             ipv4_destination: "192.168.100.1"
+                           }
+                         }
+                         headers {
+                           udp_header {
+                             source_port: "0x0000"
+                             destination_port: "0x0000"
+                             length: "0x001a"
+                             checksum: "0x8d24"
+                           }
+                         }
+                         payload: "Test packet."
+                       )pb"));
+  ASSERT_OK_AND_ASSIGN(const std::string raw_input_packet,
+                       packetlib::SerializePacket(input_packet));
+
+  // Assemble PacketOut protobuf message.
+  sai::PacketOut packet_out;
+  packet_out.set_payload(raw_input_packet);
+  sai::PacketOut::Metadata& metadata = *packet_out.mutable_metadata();
+  // Setting the `egress_port` field of the packet-out header to an arbitrary
+  // number 123, which should have no effect as we are submitting the packet to
+  // the ingress pipeline and the eventual egress port for the packet will be
+  // decided by the ingress pipeline. The `egress_port` field in the packet-out
+  // header will not be used in this case.
+  metadata.set_egress_port(
+      pdpi::BitsetToP4RuntimeByteString(std::bitset<kBmv2PortBitwidth>(123)));
+  metadata.set_submit_to_ingress(pdpi::BitsetToHexString<1>(1));
+
+  // Create packet stream before writing to the stream channel to make sure the
+  // packet stream receives the packet sent via the stream channel.
+  grpc::ClientContext context;
+  std::unique_ptr<PacketStream> packet_stream =
+      bmv2.DataplaneStub().PacketStream(&context);
+
+  // There seems to be some race conditions between the BMv2 packet stream gRPC
+  // server and p4rt session stream channel gRPC server, causing the packet
+  // stream not receiving packets sent in via the p4rt session stream channel.
+  // Wait for 1 second to reduce the flakiness.
+  // TODO: Solve BMv2 flakiness problem.
+  absl::SleepFor(absl::Seconds(1));
+
+  // Assemble PacketOut request and write to stream channel.
+  ::p4::v1::StreamMessageRequest request;
+  ASSERT_OK_AND_ASSIGN(*request.mutable_packet(),
+                       pdpi::PdPacketOutToPi(ir_p4info, packet_out));
+  ASSERT_TRUE(bmv2.P4RuntimeSession().StreamChannelWrite(request));
+
+  // Wait for 1 second to make sure packets are fully processed by BMv2.
+  absl::SleepFor(absl::Seconds(1));
+  packet_stream->WritesDone();
+
+  packetlib::Packet expected_packet = input_packet;
+  // The ttl field of the ipv4 header will be updated by the ingress pipeline.
+  expected_packet.mutable_headers(1)->mutable_ipv4_header()->set_ttl("0x1f");
+  // Update the checksum of the ipv4 header because the ttl field is changed.
+  expected_packet.mutable_headers(1)->mutable_ipv4_header()->set_checksum(
+      "0x51fb");
+
+  // Check that packet is routed correctly to the egress port.
+  ::p4::bm::PacketStreamResponse expected_response;
+  expected_response.set_port(kEgressPort);
+  expected_response.set_packet(*packetlib::SerializePacket(expected_packet));
+  expected_response.set_device_id(1);
+
+  ::p4::bm::PacketStreamResponse packet_response;
+  ASSERT_TRUE(packet_stream->Read(&packet_response));
+  EXPECT_THAT(packet_response, EqualsProto(expected_response));
+  EXPECT_FALSE(packet_stream->Read(&packet_response));
+}
+
+TEST_P(BMv2PacketIOTest, P4RuntimePacketOutSubmitToEgressOk) {
+  constexpr int kEgressPort = 42;
+
+  ForwardingPipelineConfig bmv2_config =
+      sai::GetNonstandardForwardingPipelineConfig(GetParam(), kPlatformBmv2);
+  pdpi::IrP4Info ir_p4info = sai::GetIrP4Info(GetParam());
+
+  // Create and configure BMv2.
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, Bmv2::Create({
+                                      .device_id = 1,
+                                      .cpu_port = SAI_P4_CPU_PORT,
+                                      .drop_port = SAI_P4_DROP_PORT,
+                                  }));
+  ASSERT_OK(pdpi::SetMetadataAndSetForwardingPipelineConfig(
+      &bmv2.P4RuntimeSession(),
+      SetForwardingPipelineConfigRequest::VERIFY_AND_COMMIT, bmv2_config));
+
+  // Although we gonna skip the ingress pipeline, we still install table entries
+  // here to ensure the switch is not just doing submit to ingress again. Here
+  // we set the egress port of the ingress pipeline to the drop port, so if the
+  // switch is just doing submit to ingress, packets gonna be dropped.
+  ASSERT_OK_AND_ASSIGN(
+      const std::vector<p4::v1::TableEntry> kTableEntries,
+      ConstructPiEntriesToSetEgressPort(
+          pdpi::BitsetToP4RuntimeByteString(
+              std::bitset<kBmv2PortBitwidth>(SAI_P4_DROP_PORT)),
+          ir_p4info));
+
+  ASSERT_OK(InstallPiTableEntries(&bmv2.P4RuntimeSession(), ir_p4info,
+                                  kTableEntries));
+
+  ASSERT_OK_AND_ASSIGN(packetlib::Packet input_packet,
+                       gutil::ParseTextProto<packetlib::Packet>(R"pb(
+                         headers {
+                           ethernet_header {
+                             ethernet_destination: "02:03:04:05:06:07"
+                             ethernet_source: "00:01:02:03:04:05"
+                             ethertype: "0x0800"
+                           }
+                         }
+                         headers {
+                           ipv4_header {
+                             version: "0x4"
+                             ihl: "0x5"
+                             dscp: "0x1c"
+                             ecn: "0x0"
+                             total_length: "0x002e"
+                             identification: "0x0000"
+                             flags: "0x0"
+                             fragment_offset: "0x0000"
+                             ttl: "0x20"
+                             protocol: "0x11"
+                             checksum: "0x50fb"
+                             ipv4_source: "192.168.100.2"
+                             ipv4_destination: "192.168.100.1"
+                           }
+                         }
+                         headers {
+                           udp_header {
+                             source_port: "0x0000"
+                             destination_port: "0x0000"
+                             length: "0x001a"
+                             checksum: "0x8d24"
+                           }
+                         }
+                         payload: "Test packet."
+                       )pb"));
+  ASSERT_OK_AND_ASSIGN(const std::string raw_input_packet,
+                       packetlib::SerializePacket(input_packet));
+
+  // Assemble PacketOut protobuf message.
+  sai::PacketOut packet_out;
+  packet_out.set_payload(raw_input_packet);
+  sai::PacketOut::Metadata& metadata = *packet_out.mutable_metadata();
+  // Setting the `egress_port` field of the packet-out header to `kEgressPort`
+  // and expect packet to egress on `kEgressPort`. Because we are submitting the
+  // packet to the egress pipeline and the `egress_port` field of the packet-out
+  // header should be used as the egress port of the packet in this case.
+  metadata.set_egress_port(pdpi::BitsetToP4RuntimeByteString(
+      std::bitset<kBmv2PortBitwidth>(kEgressPort)));
+  metadata.set_submit_to_ingress(pdpi::BitsetToHexString<1>(0));
+
+  // Create packet stream before writing to the stream channel to make sure the
+  // packet stream receives the packet sent via the stream channel.
+  grpc::ClientContext context;
+  std::unique_ptr<PacketStream> packet_stream =
+      bmv2.DataplaneStub().PacketStream(&context);
+
+  // There seems to be some race conditions between the BMv2 packet stream gRPC
+  // server and p4rt session stream channel gRPC server, causing the packet
+  // stream not receiving packets sent in via the p4rt session stream channel.
+  // Wait for 1 second to reduce the flakiness.
+  // TODO: Solve BMv2 flakiness problem.
+  absl::SleepFor(absl::Seconds(1));
+
+  // Assemble PacketOut request and write to stream channel.
+  ::p4::v1::StreamMessageRequest request;
+  ASSERT_OK_AND_ASSIGN(*request.mutable_packet(),
+                       pdpi::PdPacketOutToPi(ir_p4info, packet_out));
+  ASSERT_TRUE(bmv2.P4RuntimeSession().StreamChannelWrite(request));
+
+  // Wait for 1 second to make sure packets are fully processed by BMv2.
+  absl::SleepFor(absl::Seconds(1));
+  packet_stream->WritesDone();
+
+  ::p4::bm::PacketStreamResponse expected_response;
+  // Check that packet is routed correctly to the egress port.
+  expected_response.set_port(kEgressPort);
+  expected_response.set_packet(raw_input_packet);
+  expected_response.set_device_id(1);
+
+  ::p4::bm::PacketStreamResponse packet_response;
+  ASSERT_TRUE(packet_stream->Read(&packet_response));
+  EXPECT_THAT(packet_response, EqualsProto(expected_response));
+  EXPECT_FALSE(packet_stream->Read(&packet_response));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BMv2PacketIOTest, BMv2PacketIOTest,
+    testing::ValuesIn(sai::AllSaiInstantiations()),
+    [&](const testing::TestParamInfo<sai::Instantiation>& info) {
+      return InstantiationToString(info.param);
+    });
+}  // namespace
+}  // namespace pins

--- a/sai_p4/instantiations/google/tor.p4
+++ b/sai_p4/instantiations/google/tor.p4
@@ -1,4 +1,4 @@
-#define SAI_INSTANTIATION_FABRIC_BORDER_ROUTER
+#define SAI_INSTANTIATION_TOR
 
 #include <v1model.p4>
 
@@ -7,6 +7,7 @@
 #include "bitwidths.p4"
 #include "minimum_guaranteed_sizes.p4"
 
+#include "../../fixed/packet_io.p4"
 #include "../../fixed/headers.p4"
 #include "../../fixed/metadata.p4"
 #include "../../fixed/parser.p4"
@@ -17,23 +18,31 @@
 #include "../../fixed/mirroring_clone.p4"
 #include "../../fixed/l3_admit.p4"
 #include "../../fixed/ttl.p4"
+#include "../../fixed/drop_martians.p4"
 #include "../../fixed/packet_rewrites.p4"
 #include "acl_egress.p4"
 #include "acl_ingress.p4"
 #include "acl_pre_ingress.p4"
 #include "admit_google_system_mac.p4"
+#include "hashing.p4"
+#include "ids.h"
 
 control ingress(inout headers_t headers,
                 inout local_metadata_t local_metadata,
                 inout standard_metadata_t standard_metadata) {
   apply {
-    acl_pre_ingress.apply(headers, local_metadata, standard_metadata);
-    admit_google_system_mac.apply(headers, local_metadata);
-    l3_admit.apply(headers, local_metadata, standard_metadata);
-    routing.apply(headers, local_metadata, standard_metadata);
-    acl_ingress.apply(headers, local_metadata, standard_metadata);
-    ttl.apply(headers, local_metadata, standard_metadata);
-    mirroring_clone.apply(headers, local_metadata, standard_metadata);
+    packet_out_decap.apply(headers, local_metadata, standard_metadata);
+    if (!local_metadata.bypass_ingress) {
+      acl_pre_ingress.apply(headers, local_metadata, standard_metadata);
+      admit_google_system_mac.apply(headers, local_metadata);
+      l3_admit.apply(headers, local_metadata, standard_metadata);
+      hashing.apply(headers, local_metadata, standard_metadata);
+      routing.apply(headers, local_metadata, standard_metadata);
+      drop_martians.apply(headers, local_metadata, standard_metadata);
+      acl_ingress.apply(headers, local_metadata, standard_metadata);
+      ttl.apply(headers, local_metadata, standard_metadata);
+      mirroring_clone.apply(headers, local_metadata, standard_metadata);
+    }
   }
 }  // control ingress
 
@@ -49,8 +58,12 @@ control egress(inout headers_t headers,
 }  // control egress
 
 #ifndef PKG_INFO_NAME
-#define PKG_INFO_NAME "fabric_border_router.p4"
+#define PKG_INFO_NAME "tor.p4"
 #endif
-@pkginfo(name = PKG_INFO_NAME, organization = "Google")
+@pkginfo(
+  name = PKG_INFO_NAME,
+  organization = "Google",
+  version = SAI_P4_PKGINFO_VERSION_HAS_PACKET_OUT_SUPPORT
+)
 V1Switch(packet_parser(), verify_ipv4_checksum(), ingress(), egress(),
          compute_ipv4_checksum(), packet_deparser()) main;

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -1270,7 +1270,8 @@ controller_packet_metadata {
   metadata {
     id: 3
     name: "unused_pad"
-    bitwidth: 7
+    annotations: "@padding"
+    bitwidth: 6
   }
 }
 type_info {


### PR DESCRIPTION
[SAI P4] Add packet-in padding for BMv2 only. 
Model PacketIn in SAI P4 
[pdpi][p4] Add annotation to ignore padding in pd and ir. 
Annotation only, implementation in follow up cl. 
[pdpi][p4] Add boolean field to metadata definition to denote whether metadata is PI only and zero-valued. 
[sai-p4] Use conditional on table hit/miss.

**Build and Test:**
rkavitha@9e478a70a357:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 270 targets (1 packages loaded, 79 targets configured).
INFO: Found 270 targets...
INFO: Elapsed time: 0.971s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

rkavitha@9e478a70a357:/sonic/src/sonic-p4rt/sonic-pins$ bazel test  $BAZEL_BUILD_OPTS ...
INFO: Analyzed 270 targets (0 packages loaded, 0 targets configured).
INFO: Found 171 targets and 99 test targets...
INFO: Elapsed time: 37.749s, Critical Path: 15.25s
INFO: 100 processes: 107 linux-sandbox, 16 local.
INFO: Build completed successfully, 100 total actions
//gutil:collections_test                                                 PASSED in 0.2s
//gutil:io_test                                                          PASSED in 0.2s
//gutil:proto_matchers_test                                              PASSED in 0.3s
//gutil:proto_test                                                       PASSED in 0.2s
//gutil:status_matchers_test                                             PASSED in 0.2s
//gutil:table_entry_key_test                                             PASSED in 0.0s
//gutil:testing_test                                                     PASSED in 0.2s
//gutil:version_test                                                     PASSED in 0.2s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.3s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.4s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.4s
//p4_fuzzer:switch_state_test                                            PASSED in 0.3s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.3s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.3s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 15.2s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.0s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 0.9s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.3s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.3s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.0s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.0s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.3s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.2s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.3s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.5s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.4s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.4s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.4s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.4s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.2s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 0.8s
//p4rt_app/tests:action_set_test                                         PASSED in 0.6s
//p4rt_app/tests:api_access_test                                         PASSED in 0.5s
//p4rt_app/tests:arbitration_test                                        PASSED in 0.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 0.5s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 1.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 2.2s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.0s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.1s
//p4rt_app/tests:p4_programs_test                                        PASSED in 0.8s
//p4rt_app/tests:packetio_test                                           PASSED in 2.9s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 1.4s
//p4rt_app/tests:response_path_test                                      PASSED in 1.7s
//p4rt_app/tests:role_test                                               PASSED in 0.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 0.8s
//p4rt_app/tests:vrf_table_test                                          PASSED in 0.9s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.3s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.2s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.3s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.5s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.2s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.3s

Executed 99 out of 99 tests: 99 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeoutINFO: Build completed successfully, 100 total actions

**Keyword Check:**
rkavitha@eonms3vm12:~/Google/Jun-05/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/Google/tools/keyword_checks.sh .
Keyword check Passed.
