### PR TITLE
Cache table entries in software to improve Read performance.

### DIFF
--- a/p4rt_app/p4runtime/p4runtime_impl.h
+++ b/p4rt_app/p4runtime/p4runtime_impl.h
@@ -36,6 +36,7 @@
 #include "grpcpp/support/status.h"
 #include "grpcpp/support/sync_stream.h"
 #include "gutil/table_entry_key.h"
+#include "p4/config/v1/p4info.pb.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
 #include "p4_constraints/backend/constraint_info.h"
@@ -328,7 +329,7 @@ class P4RuntimeImpl : public p4::v1::P4Runtime::Service {
 
   // Some switch enviornments cannot rely on the SONiC port names, and can
   // instead choose to use port ID's configured through gNMI.
-  const bool translate_port_ids_;
+  const bool translate_port_ids_ ABSL_GUARDED_BY(server_state_lock_);
 
   // Reading a large number of entries from Redis is costly. To improve the
   // read performance we cache table entries in software.


### PR DESCRIPTION
### Build Results:
divya@1ce2fff47237:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 274 targets (0 packages loaded, 0 targets configured).
INFO: Found 274 targets...
...
INFO: Elapsed time: 1425.634s, Critical Path: 106.19s
INFO: 6460 processes: 1464 internal, 4996 linux-sandbox.
INFO: Build completed successfully, 6460 total actions

### Test Results:
divya@1ce2fff47237:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Analyzed 274 targets (1 packages loaded, 62 targets configured).
INFO: Found 173 targets and 101 test targets...
INFO: Elapsed time: 45.771s, Critical Path: 15.41s
INFO: 102 processes: 109 linux-sandbox, 16 local.
INFO: Build completed successfully, 102 total actions
//gutil:collections_test PASSED in 0.2s
//gutil:io_test PASSED in 0.2s
//gutil:proto_matchers_test PASSED in 0.4s
//gutil:proto_test PASSED in 0.3s
//gutil:status_matchers_test PASSED in 0.3s
//gutil:table_entry_key_test PASSED in 0.1s
//gutil:testing_test PASSED in 0.2s
//gutil:version_test PASSED in 0.2s
//p4_fuzzer:constraints_util_integration_test PASSED in 0.4s
//p4_fuzzer:fuzz_util_test PASSED in 0.4s
//p4_fuzzer:fuzzer_showcase_test PASSED in 0.6s
//p4_fuzzer:switch_state_test PASSED in 0.3s
//p4_fuzzer:table_entry_key_test PASSED in 0.1s
//p4_pdpi:ir_tools_test PASSED in 0.4s
//p4_pdpi:p4_runtime_matchers_test PASSED in 0.3s
//p4_pdpi:sequencing_util_test PASSED in 0.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test PASSED in 15.4s
//p4_pdpi/packetlib:packetlib_matchers_test PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_test PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test PASSED in 0.9s
//p4_pdpi/string_encodings:bit_string_test PASSED in 0.7s
//p4_pdpi/string_encodings:byte_string_test PASSED in 0.7s
//p4_pdpi/string_encodings:decimal_string_test PASSED in 0.3s
//p4_pdpi/string_encodings:decimal_string_test_runner PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test PASSED in 0.3s
//p4_pdpi/testing:helper_function_test PASSED in 0.3s
//p4_pdpi/testing:info_test PASSED in 0.1s
//p4_pdpi/testing:info_test_runner PASSED in 0.1s
//p4_pdpi/testing:main_pd_test PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test PASSED in 0.4s
//p4_pdpi/testing:packet_io_test PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner PASSED in 0.1s
//p4_pdpi/testing:rpc_test PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_test PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test PASSED in 0.3s
//p4_pdpi/testing:table_entry_test PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test PASSED in 0.2s
//p4_pdpi/utils:ir_test PASSED in 0.3s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test PASSED in 0.6s
//p4rt_app/event_monitoring:debug_data_dump_events_test PASSED in 1.0s
//p4rt_app/event_monitoring:state_verification_events_test PASSED in 0.9s
//p4rt_app/p4runtime:ir_translation_test PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test PASSED in 0.6s
//p4rt_app/p4runtime:packetio_helpers_test PASSED in 0.5s
//p4rt_app/p4runtime:resource_utilization_test PASSED in 0.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test PASSED in 0.5s
//p4rt_app/sonic:app_db_manager_test PASSED in 0.5s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test PASSED in 0.5s
//p4rt_app/sonic:hashing_test PASSED in 0.5s
//p4rt_app/sonic:packetio_impl_test PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test PASSED in 0.3s
//p4rt_app/sonic:response_handler_test PASSED in 0.4s
//p4rt_app/sonic:state_verification_test PASSED in 0.2s
//p4rt_app/sonic:vrf_entry_translation_test PASSED in 0.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test PASSED in 0.1s
//p4rt_app/tests:acl_table_test PASSED in 0.9s
//p4rt_app/tests:action_set_test PASSED in 0.6s
//p4rt_app/tests:api_access_test PASSED in 0.6s
//p4rt_app/tests:arbitration_test PASSED in 0.6s
//p4rt_app/tests:debug_data_dump_test PASSED in 0.6s
//p4rt_app/tests:fixed_l3_tables_test PASSED in 1.7s
//p4rt_app/tests:forwarding_pipeline_config_test PASSED in 2.3s
//p4rt_app/tests:grpc_behavior_test PASSED in 5.3s
//p4rt_app/tests:p4_constraints_test PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner PASSED in 0.1s
//p4rt_app/tests:p4_programs_test PASSED in 0.9s
//p4rt_app/tests:packetio_test PASSED in 3.0s
//p4rt_app/tests:port_name_and_id_test PASSED in 1.5s
//p4rt_app/tests:resource_limits_test PASSED in 1.2s
//p4rt_app/tests:response_path_test PASSED in 1.9s
//p4rt_app/tests:role_test PASSED in 0.6s
//p4rt_app/tests:state_verification_test PASSED in 0.8s
//p4rt_app/tests:vrf_table_test PASSED in 0.9s
//p4rt_app/tests/lib:app_db_entry_builder_test PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test PASSED in 0.1s
//p4rt_app/utils:table_utility_test PASSED in 0.4s
//sai_p4/instantiations/google:clos_stage_test PASSED in 0.2s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test PASSED in 0.4s
//sai_p4/instantiations/google:sai_p4info_test PASSED in 0.5s
//sai_p4/instantiations/google:sai_pd_proto_test PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test PASSED in 0.3s
//sai_p4/instantiations/google:union_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/tools:p4info_tools_test PASSED in 0.4s

Executed 101 out of 101 tests: 101 tests pass.
INFO: Build completed successfully, 102 total actions

### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.