### PR TITLE
[gutil] Address deficencies of gmock status matchers. [gutil] Create ...OrDie version for ParseVersion. [PinsInfra] Add support for Partially matcher. [gutil] Add gmock matchers for proto pairs and sequences.

### DIFF
--- a/gutil/BUILD.bazel
+++ b/gutil/BUILD.bazel
@@ -71,6 +71,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/gutil/proto_matchers.h
+++ b/gutil/proto_matchers.h
@@ -21,6 +21,7 @@
 
 #include "absl/strings/string_view.h"
 #include "glog/logging.h"
+#include "gmock/gmock.h"
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/message.h"
 #include "google/protobuf/util/message_differencer.h"
@@ -141,6 +142,19 @@ inline ::testing::PolymorphicMatcher<ProtobufEqMatcher> EqualsProto(
 inline ::testing::PolymorphicMatcher<ProtobufEqMatcher> EqualsProto(
     absl::string_view proto_text) {
   return ::testing::MakePolymorphicMatcher(ProtobufEqMatcher(proto_text));
+}
+
+// Checks that a pair of protos are equal. Useful in combination with
+// `Pointwise`.
+MATCHER(EqualsProto, "is a pair of equal protobufs") {
+  const auto& [x, y] = arg;
+  return testing::ExplainMatchResult(EqualsProto(x), y, result_listener);
+}
+
+// Checks that a sequences of protos is equal to a given sequence.
+template <class T>
+auto EqualsProtoSequence(T&& sequence) {
+  return testing::Pointwise(EqualsProto(), std::forward<T>(sequence));
 }
 
 // -- HasOneofCaseMatcher matcher ----------------------------------------------

--- a/gutil/proto_matchers_test.cc
+++ b/gutil/proto_matchers_test.cc
@@ -75,6 +75,40 @@ table_name: "router_interface_table" priority: 123>)");
 table_name: "router_interface_table" priority: 123>)");
 }
 
+TEST(PartiallyMatcherTest, IdenticalProtosAreAlsoPartiallyEqual) {
+  pdpi::IrTableEntry table_entry;
+  table_entry.set_table_name("router_interface_table");
+  table_entry.set_priority(123);
+
+  EXPECT_THAT(table_entry, Partially(EqualsProto(table_entry)));
+}
+
+TEST(PartiallyMatcherTest, PartiallyEqualsProtoOnlyComparePresentFields) {
+  pdpi::IrTableEntry table_entry;
+  table_entry.set_table_name("router_interface_table");
+  table_entry.set_priority(123);
+
+  EXPECT_THAT(table_entry, Partially(EqualsProto(R"pb(
+                table_name: "router_interface_table"
+                priority: 123)pb")));
+}
+
+TEST(PartiallyMatcherTest, DifferentlProtosDoNotMatch) {
+  pdpi::IrTableEntry table_entry;
+  table_entry.set_table_name("router_interface_table");
+  table_entry.set_priority(123);
+
+  // Proto differs in one field and remains the same for another field does not
+  // match.
+  EXPECT_THAT(table_entry, Not(Partially(EqualsProto(R"pb(
+                table_name: "big_table"
+                priority: 123)pb"))));
+  // Proto differs in both fields should not match.
+  EXPECT_THAT(table_entry, Not(Partially(EqualsProto(R"pb(
+                table_name: "big_table"
+                priority: 1234)pb"))));
+}
+
 TEST(HasOneofCaseTest, NotHasOneofCase) {
   EXPECT_THAT(gutil::ParseProtoOrDie<TestMessageWithOneof>(R"pb()pb"),
               Not(HasOneofCase<TestMessageWithOneof>(

--- a/gutil/status_matchers.h
+++ b/gutil/status_matchers.h
@@ -22,52 +22,30 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "gutil/status.h"
 
-namespace absl {
-
-// Overload the absl::StatusOr insertion operator to output its status. This
-// makes it so test matchers output the status instead of byte strings.
-//
-// NOTE: the insertion operator must be in the same namespace as the object for
-// the matching framework to work correctly.
-template <typename T>
-std::ostream& operator<<(std::ostream& out, const StatusOr<T>& status_or) {
-  return out << status_or.status();
-}
-
-}  // namespace absl
-
 namespace gutil {
 
-// Implements a status matcher interface to verify a status variable is okay.
-//
-// Sample usage:
-//   EXPECT_THAT(MyCall, IsOk());
-//   EXPECT_OK(MyCall());
-//
-// Sample output on failure:
-//   Value of: MyCall()
-//   Expected: is Ok.
-//     Actual: UNKNOWN: descriptive error (of type absl::lts_2020_02_25::Status)
-class StatusIsOkMatcher {
- public:
-  void DescribeTo(std::ostream* os) const { *os << "is OK"; }
-  void DescribeNegationTo(std::ostream* os) const { *os << "is not OK"; }
+namespace internal {
 
-  template <typename StatusType>
-  bool MatchAndExplain(const StatusType& actual,
-                       testing::MatchResultListener* /*listener*/) const {
-    return actual.ok();
-  }
-};
+template <class Status>
+const Status& GetStatus(const Status& status) {
+  return status;
+}
 
-// Status matcher that confirms the status is okay.
-inline testing::PolymorphicMatcher<StatusIsOkMatcher> IsOk() {
-  return testing::MakePolymorphicMatcher(StatusIsOkMatcher());
+template <class T>
+const absl::Status& GetStatus(const absl::StatusOr<T>& statusor) {
+  return statusor.status();
+}
+
+}  // namespace internal
+
+MATCHER(IsOk, negation ? "is not OK" : "is OK") {
+  return internal::GetStatus(arg).ok();
 }
 
 // Convenience macros for checking that a status return type is okay.
@@ -90,94 +68,77 @@ inline testing::PolymorphicMatcher<StatusIsOkMatcher> IsOk() {
   }                                                                     \
   lhs = std::move(__ASSIGN_OR_RETURN_VAL(__LINE__)).value();
 
-namespace internal {
-
-inline const absl::Status& GetStatus(const absl::Status& status) {
-  return status;
+MATCHER_P(StatusIs, status_code,
+          absl::StrCat(negation ? "is not " : "is ",
+                       absl::StatusCodeToString(status_code))) {
+  return internal::GetStatus(arg).code() == status_code;
 }
 
-template <typename T>
-const absl::Status& GetStatus(const absl::StatusOr<T>& status) {
-  return status.status();
+MATCHER_P2(StatusIs, status_code, message_matcher,
+           absl::StrFormat("is %s%s, %s has a status message that %s",
+                           negation ? "not " : "",
+                           absl::StatusCodeToString(status_code),
+                           negation ? "and" : "or",
+                           testing::DescribeMatcher<const std::string&>(
+                               message_matcher, negation))) {
+  const absl::Status& status = internal::GetStatus(arg);
+  return status.code() == status_code &&
+         testing::ExplainMatchResult(message_matcher, status.message(),
+                                     result_listener);
 }
 
-}  // namespace internal
-
-// Implements a status matcher interface to verify a status error code, and
-// error message if set, matches an expected value.
-//
-// Sample usage:
-//   EXPECT_THAT(MyCall(), StatusIs(absl::StatusCode::kNotFound,
-//                                  HasSubstr("message")));
-//
-// Sample output on failure:
-//   Value of: MyCall()
-//   Expected: NOT_FOUND and has substring "message"
-//     Actual: UNKNOWN: descriptive error (of type absl::lts_2020_02_25::Status)
-class StatusIsMatcher {
+template <class StatusOrT>
+class IsOkAndHoldsMatcherImpl : public testing::MatcherInterface<StatusOrT> {
  public:
-  StatusIsMatcher(const absl::StatusCode& status_code,
-                  const testing::Matcher<const std::string&>& message_matcher)
-      : status_code_(status_code), message_matcher_(message_matcher) {}
+  using T = typename std::remove_reference_t<StatusOrT>::value_type;
 
-  void DescribeTo(std::ostream* os) const {
-    *os << status_code_ << " status code where the message ";
-    message_matcher_.DescribeTo(os);
+  template <class InnerMatcher>
+  explicit IsOkAndHoldsMatcherImpl(InnerMatcher&& inner_matcher)
+      : inner_matcher_(testing::SafeMatcherCast<T>(
+            std::forward<InnerMatcher>(inner_matcher))) {}
+
+  bool MatchAndExplain(StatusOrT t,
+                       testing::MatchResultListener* listener) const override {
+    if (!t.ok()) {
+      *listener << "which has status " << t.status();
+      return false;
+    }
+    return inner_matcher_.MatchAndExplain(*t, listener);
   }
 
-  void DescribeNegationTo(std::ostream* os) const {
-    *os << "not (";
-    DescribeTo(os);
-    *os << ")";
+  void DescribeTo(std::ostream* os) const override {
+    *os << "is OK and has a value that ";
+    inner_matcher_.DescribeTo(os);
   }
-
-  template <typename StatusType>
-  bool MatchAndExplain(const StatusType& actual,
-                       testing::MatchResultListener* listener) const {
-    const absl::Status& actual_status = internal::GetStatus(actual);
-    return actual_status.code() == status_code_ &&
-           message_matcher_.MatchAndExplain(
-               std::string{actual_status.message()}, listener);
+  void DescribeNegationTo(std::ostream* os) const override {
+    *os << "is not OK or has a value that ";
+    inner_matcher_.DescribeNegationTo(os);
   }
 
  private:
-  const absl::StatusCode status_code_;
-  const testing::Matcher<const std::string&> message_matcher_;
+  testing::Matcher<T> inner_matcher_;
 };
 
-// Status matcher that checks the StatusCode for an expected value.
-inline testing::PolymorphicMatcher<StatusIsMatcher> StatusIs(
-    const absl::StatusCode& code) {
-  return testing::MakePolymorphicMatcher(StatusIsMatcher(code, testing::_));
-}
+template <class InnerMatcher>
+class IsOkAndHoldsMatcher {
+ public:
+  explicit IsOkAndHoldsMatcher(InnerMatcher&& inner_matcher)
+      : inner_matcher_(std::forward<InnerMatcher>(inner_matcher)) {}
 
-// Status matcher that checks the StatusCode and message for expected values.
-template <typename MessageMatcher>
-testing::PolymorphicMatcher<StatusIsMatcher> StatusIs(
-    const absl::StatusCode& code, const MessageMatcher& message) {
-  return testing::MakePolymorphicMatcher(
-      StatusIsMatcher(code, testing::MatcherCast<const std::string&>(message)));
-}
-
-// Implements a status_or matcher interface to verify a status_or value is
-// successfully set, and equal to an expected value.
-//
-// Sample usage:
-//   EXPECT_THAT(MyCall(), IsOkAndHolds(1));
-//
-// Sample output on failure:
-//   Value of: MyCall()
-//   Expected: is OK and holds 1
-//     Actual: OK (of type absl::StatusOr<int>)
-MATCHER_P(IsOkAndHolds, value, "") {
-  if (!arg.ok()) {
-    return false;
+  template <class StatusOrT>
+  operator testing::Matcher<StatusOrT>() const {  // NOLINT
+    return testing::Matcher<StatusOrT>(
+        new IsOkAndHoldsMatcherImpl<StatusOrT>(inner_matcher_));
   }
 
-  *result_listener << "with value: " << testing::PrintToString(*arg);
-  auto matcher = testing::MatcherCast<
-      typename std::remove_reference<decltype(arg)>::type::value_type>(value);
-  return ExplainMatchResult(matcher, arg.value(), result_listener);
+ private:
+  InnerMatcher inner_matcher_;
+};
+
+template <class InnerMatcher>
+IsOkAndHoldsMatcher<InnerMatcher> IsOkAndHolds(InnerMatcher&& inner_matcher) {
+  return IsOkAndHoldsMatcher<InnerMatcher>(
+      std::forward<InnerMatcher>(inner_matcher));
 }
 
 }  // namespace gutil

--- a/gutil/status_matchers_test.cc
+++ b/gutil/status_matchers_test.cc
@@ -25,6 +25,8 @@
 namespace gutil {
 namespace {
 
+using ::testing::_;
+using ::testing::Eq;
 using ::testing::HasSubstr;
 using ::testing::Not;
 
@@ -99,6 +101,16 @@ TEST(AbslStatusOrMatcher, AssignOrReturnWorksWithMoveOnlyTypes) {
   ASSERT_OK_AND_ASSIGN(
       auto value_from_expression,
       absl::StatusOr<std::unique_ptr<int>>(absl::make_unique<int>(0)));
+}
+
+TEST(IsOkAndHoldsTest, Description) {
+  auto describe = [](const auto& matcher) {
+    return testing::DescribeMatcher<absl::StatusOr<int>>(matcher);
+  };
+  EXPECT_EQ(describe(IsOkAndHolds(_)),
+            "is OK and has a value that is anything");
+  EXPECT_EQ(describe(Not(IsOkAndHolds(Eq(4)))),
+            "is not OK or has a value that isn't equal to 4");
 }
 
 }  // namespace

--- a/gutil/version.cc
+++ b/gutil/version.cc
@@ -18,8 +18,10 @@
 #include <string>
 #include <tuple>
 
+#include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+#include "glog/logging.h"
 #include "gutil/status.h"
 #include "re2/re2.h"
 
@@ -67,20 +69,19 @@ absl::StatusOr<Version> ParseVersion(absl::string_view version_string) {
   return version;
 }
 
-std::string VersionToString(const Version& v) {
-  // TODO: Use this simpler implementation once Abseil has been
-  // upgraded upstream.
-  // return absl::StrCat(v);
-  return absl::StrFormat("%d.%d.%d", v.major_version, v.minor_version,
-                         v.patch_version);
+Version ParseVersionOrDie(absl::string_view version_string) {
+  absl::StatusOr<Version> version = ParseVersion(version_string);
+  if (!version.ok()) {
+    LOG(FATAL) << version.status();  // Crash OK since that's the point of the
+                                     // function.
+  }
+  return std::move(*version);
 }
 
+std::string VersionToString(const Version& v) { return absl::StrCat(v); }
+
 std::ostream& operator<<(std::ostream& os, const Version& v) {
-  // TODO: Use this simpler implementation once Abseil has been
-  // upgraded upstream.
-  // return os << absl::StrCat(v);
-  return os << absl::StreamFormat("%d.%d.%d", v.major_version, v.minor_version,
-                                  v.patch_version);
+  return os << absl::StrCat(v);
 }
 
 }  // namespace gutil

--- a/gutil/version.h
+++ b/gutil/version.h
@@ -42,6 +42,11 @@ struct Version {
 // of `MAJOR`, `MINOR`, and `PATCH` is an unsigned decimal string.
 absl::StatusOr<Version> ParseVersion(absl::string_view version_string);
 
+// Parses semantic version string of the form `MAJOR.MINOR.PATCH`, where each
+// of `MAJOR`, `MINOR`, and `PATCH` is an unsigned decimal string. Causes a
+// fatal error if the given `version_string` is malformed.
+Version ParseVersionOrDie(absl::string_view version_string);
+
 // Returns semantic version string of the form `MAJOR.MINOR.PATCH`.
 std::string VersionToString(const Version& v);
 


### PR DESCRIPTION
PR Description:
[gutil] Address deficencies of gmock status matchers.
[gutil] Create ...OrDie version for ParseVersion.
[PinsInfra] Add support for Partially matcher.
[gutil] Add gmock matchers for proto pairs and sequences.

Keyword check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 278 targets (0 packages loaded, 0 targets configured).
INFO: Found 278 targets...
INFO: Elapsed time: 93.854s, Critical Path: 12.09s
INFO: 33 processes: 1 internal, 32 linux-sandbox.
INFO: Build completed successfully, 33 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 

UT Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Analyzed 278 targets (0 packages loaded, 0 targets configured).
INFO: Found 176 targets and 102 test targets...
INFO: Elapsed time: 1.506s, Critical Path: 0.48s
INFO: 6 processes: 1 internal, 5 linux-sandbox.
INFO: Build completed successfully, 6 total actions
//gutil:collections_test                                        (cached) PASSED in 0.2s
//gutil:io_test                                                 (cached) PASSED in 0.2s
//gutil:proto_test                                              (cached) PASSED in 0.2s
//gutil:status_matchers_test                                    (cached) PASSED in 0.2s
//gutil:table_entry_key_test                                    (cached) PASSED in 0.0s
//gutil:testing_test                                            (cached) PASSED in 0.2s
//gutil:version_test                                            (cached) PASSED in 0.4s
//p4_fuzzer:constraints_util_integration_test                   (cached) PASSED in 0.4s
//p4_fuzzer:fuzz_util_test                                      (cached) PASSED in 0.4s
//p4_fuzzer:fuzzer_showcase_test                                (cached) PASSED in 0.5s
//p4_fuzzer:switch_state_test                                   (cached) PASSED in 0.3s
//p4_fuzzer:table_entry_key_test                                (cached) PASSED in 0.1s
//p4_pdpi:ir_tools_test                                         (cached) PASSED in 0.3s
//p4_pdpi:sequencing_util_test                                  (cached) PASSED in 0.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test         (cached) PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                             (cached) PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                              (cached) PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                       (cached) PASSED in 15.3s
//p4_pdpi/packetlib:packetlib_test                              (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                         (cached) PASSED in 0.8s
//p4_pdpi/string_encodings:bit_string_test                      (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                     (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                  (cached) PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test_runner           (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                      (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner               (cached) PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test            (cached) PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                          (cached) PASSED in 0.3s
//p4_pdpi/testing:info_test                                     (cached) PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                              (cached) PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                  (cached) PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                   (cached) PASSED in 0.3s
//p4_pdpi/testing:packet_io_test                                (cached) PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                         (cached) PASSED in 0.0s
//p4_pdpi/testing:rpc_test                                      (cached) PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                               (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                        (cached) PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                          (cached) PASSED in 0.0s
//p4_pdpi/testing:sequencing_util_test_runner                   (cached) PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                        (cached) PASSED in 0.3s
//p4_pdpi/testing:table_entry_test                              (cached) PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                       (cached) PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                          (cached) PASSED in 0.2s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test  (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test     (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:debug_data_dump_events_test         (cached) PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test      (cached) PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                        (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test            (cached) PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                   (cached) PASSED in 0.6s
//p4rt_app/p4runtime:packetio_helpers_test                      (cached) PASSED in 0.5s
//p4rt_app/p4runtime:resource_utilization_test                  (cached) PASSED in 0.4s
//p4rt_app/sonic:app_db_acl_def_table_manager_test              (cached) PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test              (cached) PASSED in 0.4s
//p4rt_app/sonic:hashing_test                                   (cached) PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                             (cached) PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                             (cached) PASSED in 0.2s
//p4rt_app/sonic:response_handler_test                          (cached) PASSED in 0.3s
//p4rt_app/sonic:state_verification_test                        (cached) PASSED in 0.2s
//p4rt_app/sonic:vrf_entry_translation_test                     (cached) PASSED in 0.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test              (cached) PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                 (cached) PASSED in 1.0s
//p4rt_app/tests:action_set_test                                (cached) PASSED in 0.8s
//p4rt_app/tests:api_access_test                                (cached) PASSED in 0.6s
//p4rt_app/tests:arbitration_test                               (cached) PASSED in 0.7s
//p4rt_app/tests:debug_data_dump_test                           (cached) PASSED in 0.6s
//p4rt_app/tests:fixed_l3_tables_test                           (cached) PASSED in 2.4s
//p4rt_app/tests:forwarding_pipeline_config_test                (cached) PASSED in 3.6s
//p4rt_app/tests:grpc_behavior_test                             (cached) PASSED in 5.1s
//p4rt_app/tests:p4_constraints_test                            (cached) PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                     (cached) PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                               (cached) PASSED in 1.3s
//p4rt_app/tests:packetio_test                                  (cached) PASSED in 3.3s
//p4rt_app/tests:port_name_and_id_test                          (cached) PASSED in 2.3s
//p4rt_app/tests:resource_limits_test                           (cached) PASSED in 1.6s
//p4rt_app/tests:response_path_test                             (cached) PASSED in 2.6s
//p4rt_app/tests:role_test                                      (cached) PASSED in 0.7s
//p4rt_app/tests:state_verification_test                        (cached) PASSED in 1.2s
//p4rt_app/tests:vrf_table_test                                 (cached) PASSED in 1.2s
//p4rt_app/tests/lib:app_db_entry_builder_test                  (cached) PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                        (cached) PASSED in 0.0s
//p4rt_app/utils:table_utility_test                             (cached) PASSED in 0.4s
//sai_p4/instantiations/google:clos_stage_test                  (cached) PASSED in 0.2s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test (cached) PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test (cached) PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test          (cached) PASSED in 0.5s
//sai_p4/instantiations/google:sai_p4info_test                  (cached) PASSED in 0.5s
//sai_p4/instantiations/google:sai_pd_proto_test                (cached) PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                 (cached) PASSED in 0.2s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test       (cached) PASSED in 0.2s
//sai_p4/instantiations/google:union_p4info_up_to_date_test     (cached) PASSED in 0.0s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test       (cached) PASSED in 0.0s
//sai_p4/tools:p4info_tools_test                                (cached) PASSED in 0.3s
//gutil:proto_matchers_test                                              PASSED in 0.4s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.3s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.3s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.5s

Executed 5 out of 102 tests: 102 tests pass.
INFO: Build completed successfully, 6 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$