### PR TITLE
 Patch grpc to log the authz policy as debug level & Update gRPC version to 1.54.0.

### DIFF
--- a/bazel/patches/grpc-001-fix_file_watcher_race_condition.patch
+++ b/bazel/patches/grpc-001-fix_file_watcher_race_condition.patch
@@ -1,0 +1,12 @@
+diff --git a/src/core/lib/iomgr/load_file.cc b/src/core/lib/iomgr/load_file.cc
+index 9068670118..a4d9bc95b2 100644
+--- a/src/core/lib/iomgr/load_file.cc
++++ b/src/core/lib/iomgr/load_file.cc
+@@ -55,7 +55,6 @@ grpc_error_handle grpc_load_file(const char* filename, int add_null_terminator,
+   if (bytes_read < contents_size) {
+     gpr_free(contents);
+     error = GRPC_OS_ERROR(errno, "fread");
+-    GPR_ASSERT(ferror(file));
+     goto end;
+   }
+   if (add_null_terminator) {

--- a/bazel/patches/grpc-002-change_authz_log_level.patch
+++ b/bazel/patches/grpc-002-change_authz_log_level.patch
@@ -1,0 +1,22 @@
+diff --git a/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc b/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
+index bbc69de7c2..5595dcc86d 100644
+--- a/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
++++ b/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
+@@ -104,7 +104,7 @@ FileWatcherAuthorizationPolicyProvider::FileWatcherAuthorizationPolicyProvider(
+       }
+       absl::Status status = provider->ForceUpdate();
+       if (GRPC_TRACE_FLAG_ENABLED(grpc_authz_trace) && !status.ok()) {
+-        gpr_log(GPR_ERROR,
++        gpr_log(GPR_DEBUG,
+                 "authorization policy reload status. code=%d error_details=%s",
+                 status.code(), std::string(status.message()).c_str());
+       }
+@@ -136,7 +136,7 @@ absl::Status FileWatcherAuthorizationPolicyProvider::ForceUpdate() {
+   deny_engine_ = MakeRefCounted<GrpcAuthorizationEngine>(
+       std::move(rbac_policies_or->deny_policy));
+   if (GRPC_TRACE_FLAG_ENABLED(grpc_authz_trace)) {
+-    gpr_log(GPR_INFO,
++    gpr_log(GPR_DEBUG,
+             "authorization policy reload status: successfully loaded new "
+             "policy\n%s",
+             file_contents_.c_str());

--- a/pins_infra_deps.bzl
+++ b/pins_infra_deps.bzl
@@ -26,6 +26,11 @@ def pins_infra_deps():
             url = "https://github.com/grpc/grpc/archive/v1.46.0.zip",
             strip_prefix = "grpc-1.46.0",
             sha256 = "1cbd6d6dfc9b1235766fc6b1d66d4f1dbb87f877a44c2a799bc8ee6b383af0fa",
+            patch_args = ["-p1"],
+            patches = [
+                "@com_github_google_pins_infra//:bazel/patches/grpc-001-fix_file_watcher_race_condition.patch",
+                "@com_github_google_pins_infra//:bazel/patches/grpc-002-change_authz_log_level.patch",
+            ],
         )
     if not native.existing_rule("com_google_absl"):
         http_archive(

--- a/pins_infra_deps.bzl
+++ b/pins_infra_deps.bzl
@@ -23,9 +23,9 @@ def pins_infra_deps():
     if not native.existing_rule("com_github_grpc_grpc"):
         http_archive(
             name = "com_github_grpc_grpc",
-            url = "https://github.com/grpc/grpc/archive/v1.46.0.zip",
-            strip_prefix = "grpc-1.46.0",
-            sha256 = "1cbd6d6dfc9b1235766fc6b1d66d4f1dbb87f877a44c2a799bc8ee6b383af0fa",
+            url = "https://github.com/grpc/grpc/archive/v1.55.0.zip",
+            strip_prefix = "grpc-1.55.0",
+            sha256 = "c1f26622796e975a50f314e54c8bc558021ab1dabac308b9d97390c863aade9d",
             patch_args = ["-p1"],
             patches = [
                 "@com_github_google_pins_infra//:bazel/patches/grpc-001-fix_file_watcher_race_condition.patch",
@@ -49,9 +49,9 @@ def pins_infra_deps():
     if not native.existing_rule("com_google_protobuf"):
         http_archive(
             name = "com_google_protobuf",
-            url = "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protobuf-all-3.20.1.tar.gz",
-            strip_prefix = "protobuf-3.20.1",
-            sha256 = "3a400163728db996e8e8d21c7dfb3c239df54d0813270f086c4030addeae2fad",
+            url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v23.1.zip",
+            strip_prefix = "protobuf-23.1",
+            sha256 = "c0ea9f4d75b37ea8e9d78ce4c670d066bcb7cebdba190fa5fc8c57b1f00c0c2c",
         )
     if not native.existing_rule("com_googlesource_code_re2"):
         http_archive(


### PR DESCRIPTION
### Build Results:
divya@1ce2fff47237:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
...
p4_fuzzer/constraints_util.cc: At global scope:
p4_fuzzer/constraints_util.cc:45:27: warning: 'absl::lts_20230802::StatusOr<__gmp_expr<__mpz_struct [1], __mpz_struct [1]> > p4_fuzzer::{anonymous}::ParseInteger(const string&)' defined but not used [-Wunused-function]
   45 | absl::StatusOr<mpz_class> ParseInteger(const std::string& int_str) {
      |                           ^~~~~~~~~~~~
INFO: Elapsed time: 1212.290s, Critical Path: 55.25s
INFO: 6471 processes: 1470 internal, 5001 linux-sandbox.
INFO: Build completed successfully, 6471 total actions

### Test Results:
divya@1ce2fff47237:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Analyzed 278 targets (1 packages loaded, 65 targets configured).
INFO: Found 176 targets and 102 test targets...
INFO: Elapsed time: 39.212s, Critical Path: 15.65s
INFO: 103 processes: 111 linux-sandbox, 16 local.
INFO: Build completed successfully, 103 total actions
//gutil:collections_test                                                 PASSED in 0.4s
//gutil:io_test                                                          PASSED in 0.2s
//gutil:proto_matchers_test                                              PASSED in 0.4s
//gutil:proto_test                                                       PASSED in 0.2s
//gutil:status_matchers_test                                             PASSED in 0.2s
//gutil:table_entry_key_test                                             PASSED in 0.0s
//gutil:testing_test                                                     PASSED in 0.2s
//gutil:version_test                                                     PASSED in 0.2s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.4s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.5s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.6s
//p4_fuzzer:switch_state_test                                            PASSED in 0.4s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.0s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.4s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.3s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 15.6s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 0.7s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.3s
//p4_pdpi/testing:info_test                                              PASSED in 0.2s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.5s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.0s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.0s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.3s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.2s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.3s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 2.3s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.7s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.4s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.5s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.4s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.4s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.4s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.3s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.4s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.2s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 0.8s
//p4rt_app/tests:action_set_test                                         PASSED in 0.6s
//p4rt_app/tests:api_access_test                                         PASSED in 0.5s
//p4rt_app/tests:arbitration_test                                        PASSED in 0.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 0.5s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 1.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 2.4s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.0s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.1s
//p4rt_app/tests:p4_programs_test                                        PASSED in 0.9s
//p4rt_app/tests:packetio_test                                           PASSED in 2.9s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 1.5s
//p4rt_app/tests:resource_limits_test                                    PASSED in 1.2s
//p4rt_app/tests:response_path_test                                      PASSED in 1.7s
//p4rt_app/tests:role_test                                               PASSED in 0.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 0.8s
//p4rt_app/tests:vrf_table_test                                          PASSED in 0.9s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.4s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.2s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.3s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.5s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.2s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.4s

Executed 102 out of 102 tests: 102 tests pass.
INFO: Build completed successfully, 103 total actions