### PR TITLE
[P4RT App] Tolerate P4Infos with @unsupported tables/actions/match fields.

### DIFF
--- a/gutil/status_matchers.h
+++ b/gutil/status_matchers.h
@@ -78,7 +78,7 @@ MATCHER_P2(StatusIs, status_code, message_matcher,
            absl::StrFormat("is %s%s, %s has a status message that %s",
                            negation ? "not " : "",
                            absl::StatusCodeToString(status_code),
-                           negation ? "and" : "or",
+                           negation ? "or" : "and",
                            testing::DescribeMatcher<const std::string&>(
                                message_matcher, negation))) {
   const absl::Status& status = internal::GetStatus(arg);

--- a/p4rt_app/p4runtime/BUILD.bazel
+++ b/p4rt_app/p4runtime/BUILD.bazel
@@ -116,6 +116,7 @@ cc_test(
         "//sai_p4/instantiations/google:sai_p4info_cc",
         "@com_github_google_glog//:glog",
         "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",

--- a/p4rt_app/p4runtime/p4info_verification.cc
+++ b/p4rt_app/p4runtime/p4info_verification.cc
@@ -113,6 +113,9 @@ absl::Status ValidateP4Info(const p4::config::v1::P4Info& p4info) {
   ASSIGN_OR_RETURN(P4InfoVerificationSchema schema, SupportedSchema());
   ASSIGN_OR_RETURN(auto ir_result, pdpi::CreateIrP4Info(p4info),
                    _.SetPayload(kLibraryUrl, absl::Cord("PDPI")));
+  // We allow arbitrary `@unsupported` entities in the P4Info and reject
+  // programming those entities only at runtime.
+  pdpi::RemoveUnsupportedEntities(ir_result);
   RETURN_IF_ERROR(IsSupportedBySchema(ir_result, schema));
 
   for (const auto& [table_name, table] : ir_result.tables_by_name()) {

--- a/p4rt_app/p4runtime/p4runtime_impl.cc
+++ b/p4rt_app/p4runtime/p4runtime_impl.cc
@@ -1268,6 +1268,8 @@ grpc::Status P4RuntimeImpl::ReconcileAndCommitPipelineConfig(
           ir_p4info.status().code(),
           absl::StrCat("[P4RT/PDPI] ", ir_p4info.status().message())));
     }
+    // Remove `@unsupported` entities so their use in requests will be rejected.
+    pdpi::RemoveUnsupportedEntities(*ir_p4info);
     TranslateIrP4InfoForOrchAgent(*ir_p4info);
 
     // Apply a config if we don't currently have one.


### PR DESCRIPTION
PR Description:
[P4RT App] Tolerate P4Infos with @unsupported tables/actions/match fields.

Keyword check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Build option --cache_test_results has changed, discarding analysis cache.
INFO: Analyzed 281 targets (0 packages loaded, 17436 targets configured).
INFO: Found 281 targets...
INFO: Elapsed time: 8.601s, Critical Path: 4.80s
INFO: 3 processes: 1 internal, 2 linux-sandbox.
INFO: Build completed successfully, 3 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 

UT Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Build option --cache_test_results has changed, discarding analysis cache.
INFO: Analyzed 281 targets (0 packages loaded, 17436 targets configured).
INFO: Found 178 targets and 103 test targets...
INFO: Elapsed time: 52.403s, Critical Path: 15.53s
INFO: 104 processes: 112 linux-sandbox, 16 local.
INFO: Build completed successfully, 104 total actions
//gutil:collections_test                                                 PASSED in 0.2s
//gutil:io_test                                                          PASSED in 0.2s
//gutil:proto_matchers_test                                              PASSED in 0.3s
//gutil:proto_test                                                       PASSED in 0.2s
//gutil:status_matchers_test                                             PASSED in 0.2s
//gutil:table_entry_key_test                                             PASSED in 0.1s
//gutil:testing_test                                                     PASSED in 0.2s
//gutil:version_test                                                     PASSED in 0.4s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.3s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.3s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.5s
//p4_fuzzer:switch_state_test                                            PASSED in 0.3s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.0s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.3s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.3s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 15.5s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.0s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 0.7s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.3s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.3s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.0s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.0s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.0s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.3s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.2s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.3s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.5s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.5s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.5s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.5s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.4s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.4s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.4s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.3s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.2s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.2s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.3s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.2s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.0s
//p4rt_app/tests:action_set_test                                         PASSED in 0.7s
//p4rt_app/tests:api_access_test                                         PASSED in 0.7s
//p4rt_app/tests:arbitration_test                                        PASSED in 0.7s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 0.6s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.9s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 4.5s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.0s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.3s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.3s
//p4rt_app/tests:packetio_test                                           PASSED in 3.3s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.5s
//p4rt_app/tests:resource_limits_test                                    PASSED in 1.1s
//p4rt_app/tests:response_path_test                                      PASSED in 2.6s
//p4rt_app/tests:role_test                                               PASSED in 0.8s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.3s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.2s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.3s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.2s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.3s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.5s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.2s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.0s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.4s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.3s

Executed 103 out of 103 tests: 103 tests pass.
INFO: Build completed successfully, 104 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$