### PR TITLE
Fix build issue in SAI P4

### DIFF
--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -595,35 +595,6 @@ message AclIngressSecurityTableEntry {
   bytes controller_metadata = 8;
 }
 
-// Table entry restrictions:
-//   dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
-// ## Forbid illegal combinations of IP_TYPE fields.
-//   is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
-//   is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
-//   is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);
-// ## Forbid unsupported combinations of IP_TYPE fields.
-//   is_ipv4::mask != 0 -> (is_ipv4 == 1);
-//   is_ipv6::mask != 0 -> (is_ipv6 == 1);
-message AclIngressCountingTableEntry {
-  message Match {
-    Optional is_ip = 1;    // optional match / Format::HEX_STRING / 1 bits
-    Optional is_ipv4 = 2;  // optional match / Format::HEX_STRING / 1 bits
-    Optional is_ipv6 = 3;  // optional match / Format::HEX_STRING / 1 bits
-    Ternary dscp = 11;     // ternary match / Format::HEX_STRING / 6 bits
-    Ternary route_metadata = 18;  // ternary match / Format::HEX_STRING / 6 bits
-  }
-  Match match = 1;
-  message Action {
-    AclCountAction acl_count = 3;
-  }
-  Action action = 2;
-  int32 priority = 3;
-  BytesMeterConfig meter_config = 4;
-  BytesAndPacketsCounterData counter_data = 6;
-  MeterBytesAndPacketsCounterData meter_counter_data = 9;
-  bytes controller_metadata = 8;
-}
-
 // -- Actions ------------------------------------------------------------------
 
 message SetDstMacAction {


### PR DESCRIPTION
Fix build issue in SAI P4

**Build and UT:**
rkavitha@71e20596914c:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Build option --cache_test_results has changed, discarding analysis cache.
INFO: Analyzed 284 targets (0 packages loaded, 17440 targets configured).
INFO: Found 284 targets...
INFO: Elapsed time: 7.792s, Critical Path: 0.31s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

rkavitha@71e20596914c:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Build option --cache_test_results has changed, discarding analysis cache.
INFO: Analyzed 284 targets (0 packages loaded, 17440 targets configured).
INFO: Found 180 targets and 104 test targets...
INFO: Elapsed time: 74.086s, Critical Path: 17.18s
INFO: 105 processes: 113 linux-sandbox, 16 local.
INFO: Build completed successfully, 105 total actions
//gutil:collections_test                                                 PASSED in 0.6s
//gutil:io_test                                                          PASSED in 0.3s
//gutil:proto_matchers_test                                              PASSED in 0.8s
//gutil:proto_test                                                       PASSED in 0.7s
//gutil:status_matchers_test                                             PASSED in 0.6s
//gutil:table_entry_key_test                                             PASSED in 0.3s
//gutil:testing_test                                                     PASSED in 0.6s
//gutil:version_test                                                     PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 1.0s
//p4_fuzzer:fuzz_util_test                                               PASSED in 1.9s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 1.9s
//p4_fuzzer:switch_state_test                                            PASSED in 0.8s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.2s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.6s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.9s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.8s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 17.1s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.7s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.4s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 2.6s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.6s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.6s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.4s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.2s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.7s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.5s
//p4_pdpi/testing:info_test                                              PASSED in 0.5s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.4s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.9s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.4s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.3s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.6s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.3s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.4s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.6s
//p4_pdpi/testing:table_entry_test                                       PASSED in 1.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.6s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.3s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.4s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.7s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.1s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.6s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 1.2s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 1.3s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 1.3s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 1.3s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.1s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 1.0s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 1.2s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.6s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.7s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.7s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.8s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.3s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.0s
//p4rt_app/tests:action_set_test                                         PASSED in 0.8s
//p4rt_app/tests:api_access_test                                         PASSED in 1.3s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.8s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 0.8s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 5.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.1s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.7s
//p4rt_app/tests:packetio_test                                           PASSED in 3.9s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.2s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.2s
//p4rt_app/tests:response_path_test                                      PASSED in 3.7s
//p4rt_app/tests:role_test                                               PASSED in 1.0s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.5s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.3s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.3s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 2.1s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.3s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.2s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.2s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.0s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.0s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s

Executed 104 out of 104 tests: 104 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeoutINFO: Build completed successfully, 105 total actions

rkavitha@eonms3vm12:~/Google/Jun-22/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/Google/tools/keyword_checks.sh .
Keyword check Passed.
