### PR TITLE
[Comb][multicast] Rename PD->IR/PI to set up for deprecation.

### DIFF
--- a/p4_pdpi/ir_tools_test.cc
+++ b/p4_pdpi/ir_tools_test.cc
@@ -36,23 +36,23 @@ TEST(TransformValuesOfTypeTest, RewriteMatchString) {
   p4::config::v1::P4NamedType target_type;
   target_type.set_name("string_id_t");
 
-  ASSERT_OK_AND_ASSIGN(
-      IrTableEntry original_entry,
-      PdTableEntryToIr(info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
-                         one_match_field_table_entry {
-                           match { id: "string" }
-                           action { do_thing_4 {} }
-                         }
-                       )pb")));
+  ASSERT_OK_AND_ASSIGN(IrTableEntry original_entry,
+                       PartialPdTableEntryToIrTableEntry(
+                           info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
+                             one_match_field_table_entry {
+                               match { id: "string" }
+                               action { do_thing_4 {} }
+                             }
+                           )pb")));
 
-  ASSERT_OK_AND_ASSIGN(
-      IrTableEntry goal_entry,
-      PdTableEntryToIr(info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
-                         one_match_field_table_entry {
-                           match { id: "another_string" }
-                           action { do_thing_4 {} }
-                         }
-                       )pb")));
+  ASSERT_OK_AND_ASSIGN(IrTableEntry goal_entry,
+                       PartialPdTableEntryToIrTableEntry(
+                           info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
+                             one_match_field_table_entry {
+                               match { id: "another_string" }
+                               action { do_thing_4 {} }
+                             }
+                           )pb")));
 
   ASSERT_OK(TransformValuesOfType(info, target_type, original_entry,
                                   /*transformer=*/AddAnotherToString));
@@ -66,33 +66,33 @@ TEST(TransformValuesOfTypeTest, RewriteActionStrings) {
   p4::config::v1::P4NamedType target_type;
   target_type.set_name("string_id_t");
 
-  ASSERT_OK_AND_ASSIGN(
-      IrTableEntry original_entry,
-      PdTableEntryToIr(info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
-                         referring_by_action_table_entry {
-                           match { val: "0x001" }
-                           action {
-                             referring_to_two_match_fields_action {
-                               referring_id_1: "string1",
-                               referring_id_2: "0x004",
+  ASSERT_OK_AND_ASSIGN(IrTableEntry original_entry,
+                       PartialPdTableEntryToIrTableEntry(
+                           info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
+                             referring_by_action_table_entry {
+                               match { val: "0x001" }
+                               action {
+                                 referring_to_two_match_fields_action {
+                                   referring_id_1: "string1",
+                                   referring_id_2: "0x004",
+                                 }
+                               }
                              }
-                           }
-                         }
-                       )pb")));
+                           )pb")));
 
-  ASSERT_OK_AND_ASSIGN(
-      IrTableEntry goal_entry,
-      PdTableEntryToIr(info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
-                         referring_by_action_table_entry {
-                           match { val: "0x001" }
-                           action {
-                             referring_to_two_match_fields_action {
-                               referring_id_1: "another_string1",
-                               referring_id_2: "0x004",
+  ASSERT_OK_AND_ASSIGN(IrTableEntry goal_entry,
+                       PartialPdTableEntryToIrTableEntry(
+                           info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
+                             referring_by_action_table_entry {
+                               match { val: "0x001" }
+                               action {
+                                 referring_to_two_match_fields_action {
+                                   referring_id_1: "another_string1",
+                                   referring_id_2: "0x004",
+                                 }
+                               }
                              }
-                           }
-                         }
-                       )pb")));
+                           )pb")));
 
   ASSERT_OK(TransformValuesOfType(info, target_type, original_entry,
                                   /*transformer=*/AddAnotherToString));
@@ -106,27 +106,27 @@ TEST(VisitValuesOfTypeTest, CollectStrings) {
   p4::config::v1::P4NamedType target_type;
   target_type.set_name("string_id_t");
 
-  ASSERT_OK_AND_ASSIGN(
-      IrTableEntry entry1,
-      PdTableEntryToIr(info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
-                         one_match_field_table_entry {
-                           match { id: "string1" }
-                           action { do_thing_4 {} }
-                         }
-                       )pb")));
-  ASSERT_OK_AND_ASSIGN(
-      IrTableEntry entry2,
-      PdTableEntryToIr(info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
-                         referring_by_action_table_entry {
-                           match { val: "0x001" }
-                           action {
-                             referring_to_two_match_fields_action {
-                               referring_id_1: "string2",
-                               referring_id_2: "0x003",
+  ASSERT_OK_AND_ASSIGN(IrTableEntry entry1,
+                       PartialPdTableEntryToIrTableEntry(
+                           info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
+                             one_match_field_table_entry {
+                               match { id: "string1" }
+                               action { do_thing_4 {} }
                              }
-                           }
-                         }
-                       )pb")));
+                           )pb")));
+  ASSERT_OK_AND_ASSIGN(IrTableEntry entry2,
+                       PartialPdTableEntryToIrTableEntry(
+                           info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
+                             referring_by_action_table_entry {
+                               match { val: "0x001" }
+                               action {
+                                 referring_to_two_match_fields_action {
+                                   referring_id_1: "string2",
+                                   referring_id_2: "0x003",
+                                 }
+                               }
+                             }
+                           )pb")));
 
   std::vector<IrTableEntry> entries{entry1, entry2};
   absl::flat_hash_set<std::string> string_collection;

--- a/p4_pdpi/p4_runtime_session_extras.cc
+++ b/p4_pdpi/p4_runtime_session_extras.cc
@@ -19,8 +19,9 @@ absl::Status InstallPdTableEntries(
   ASSIGN_OR_RETURN(p4::v1::GetForwardingPipelineConfigResponse config,
                    GetForwardingPipelineConfig(&p4rt));
   ASSIGN_OR_RETURN(IrP4Info info, CreateIrP4Info(config.config().p4info()));
-  ASSIGN_OR_RETURN(std::vector<p4::v1::TableEntry> pi_entries,
-                   PdTableEntriesToPi(info, pd_table_entries));
+  ASSIGN_OR_RETURN(
+      std::vector<p4::v1::TableEntry> pi_entries,
+      PartialPdTableEntriesToPiTableEntries(info, pd_table_entries));
 
   // Install entries.
   return InstallPiTableEntries(&p4rt, info, pi_entries);
@@ -33,7 +34,7 @@ absl::Status InstallPdTableEntry(
                    GetForwardingPipelineConfig(&p4rt));
   ASSIGN_OR_RETURN(IrP4Info info, CreateIrP4Info(config.config().p4info()));
   ASSIGN_OR_RETURN(p4::v1::TableEntry pi_entry,
-                   PdTableEntryToPi(info, pd_table_entry));
+                   PartialPdTableEntryToPiTableEntry(info, pd_table_entry));
 
   // Install entry.
   return InstallPiTableEntry(&p4rt, pi_entry);

--- a/p4_pdpi/pd.h
+++ b/p4_pdpi/pd.h
@@ -109,12 +109,22 @@ absl::Status PiStreamMessageResponseToPd(
     google::protobuf::Message *pd);
 
 // -- Conversions from PD to PI ------------------------------------------------
-absl::StatusOr<p4::v1::TableEntry> PdTableEntryToPi(
+
+// Translates a PdTableEntry into an IrTableEntry. 'Partial' functions do not
+// support 'MulticastGroupTableEntry', returning an InvalidArgumentError if one
+// is provided. Use of this function is discouraged since P4 infrastructure has
+// moved towards units of Entity instead of TableEntry.
+//
+// TODO: Remove deprecated functions from header file.
+ABSL_DEPRECATED("Use PdTableEntryToPiEntity instead")
+absl::StatusOr<p4::v1::TableEntry> PartialPdTableEntryToPiTableEntry(
     const IrP4Info &info, const google::protobuf::Message &pd,
     TranslationOptions options = {});
-absl::StatusOr<std::vector<p4::v1::TableEntry>> PdTableEntriesToPi(
-    const IrP4Info &info, const google::protobuf::Message &pd,
-    TranslationOptions options = {});
+ABSL_DEPRECATED("Use PdTableEntriesToPiEntities instead")
+absl::StatusOr<std::vector<p4::v1::TableEntry>>
+PartialPdTableEntriesToPiTableEntries(const IrP4Info &info,
+                                      const google::protobuf::Message &pd,
+                                      TranslationOptions options = {});
 
 absl::StatusOr<p4::v1::PacketIn> PdPacketInToPi(
     const IrP4Info &info, const google::protobuf::Message &packet);
@@ -209,10 +219,18 @@ absl::Status IrWriteRpcStatusToPd(const IrWriteRpcStatus &ir_write_status,
 
 // -- Conversions from PD to IR (intermediate representation) ------------------
 
-absl::StatusOr<IrTableEntry> PdTableEntryToIr(
+// Translates a PdTableEntry into a PI TableEntry. 'Partial' functions do not
+// support 'MulticastGroupTableEntry', returning an InvalidArgumentError if one
+// is provided. Use of this function is discouraged since P4 infrastructure has
+// moved towards units of Entity instead of TableEntry.
+//
+// TODO: Remove deprecated functions from header file.
+ABSL_DEPRECATED("Use PdTableEntryToIrEntity instead")
+absl::StatusOr<IrTableEntry> PartialPdTableEntryToIrTableEntry(
     const IrP4Info &ir_p4info, const google::protobuf::Message &pd,
     TranslationOptions options = {});
-absl::StatusOr<IrTableEntries> PdTableEntriesToIr(
+ABSL_DEPRECATED("Use PdTableEntriesToIrEntities instead")
+absl::StatusOr<IrTableEntries> PartialPdTableEntriesToIrTableEntries(
     const IrP4Info &ir_p4info, const google::protobuf::Message &pd,
     TranslationOptions options = {});
 

--- a/p4_pdpi/testing/sequencing_test_runner.cc
+++ b/p4_pdpi/testing/sequencing_test_runner.cc
@@ -104,7 +104,8 @@ void SortTest(const pdpi::IrP4Info& info, const std::string& test_name,
     const auto pd_entry =
         gutil::ParseProtoOrDie<pdpi::TableEntry>(pd_entry_string);
     pd_entries.push_back(pd_entry);
-    const auto pi_entry_or_status = pdpi::PdTableEntryToPi(info, pd_entry);
+    const auto pi_entry_or_status =
+        pdpi::PartialPdTableEntryToPiTableEntry(info, pd_entry);
     if (!pi_entry_or_status.status().ok()) {
       std::cerr << "Unable to convert TableEntry from PD to PI."
                 << pi_entry_or_status.status() << std::endl;
@@ -156,7 +157,8 @@ void GetEntriesUnreachableFromRootsTest(
     const auto pd_entry =
         gutil::ParseProtoOrDie<pdpi::TableEntry>(pd_entry_string);
     pd_entries.push_back(pd_entry);
-    const auto pi_entry_or_status = pdpi::PdTableEntryToPi(info, pd_entry);
+    const auto pi_entry_or_status =
+        pdpi::PartialPdTableEntryToPiTableEntry(info, pd_entry);
     if (!pi_entry_or_status.status().ok()) {
       std::cerr << "Unable to convert TableEntry from PD to PI."
                 << pi_entry_or_status.status() << std::endl;

--- a/p4_pdpi/testing/sequencing_util_test_runner.cc
+++ b/p4_pdpi/testing/sequencing_util_test_runner.cc
@@ -56,8 +56,8 @@ void EntriesReferredToByTableEntryTest(absl::string_view test_name,
   pdpi::TableEntry pd_entry =
       gutil::ParseProtoOrDie<pdpi::TableEntry>(pd_string);
 
-  const auto pi_table_entry =
-      pdpi::PdTableEntryToPi(pdpi::GetTestIrP4Info(), pd_entry);
+  const auto pi_table_entry = pdpi::PartialPdTableEntryToPiTableEntry(
+      pdpi::GetTestIrP4Info(), pd_entry);
   CHECK(pi_table_entry.ok());  // Crash ok
 
   std::cout << kInputBanner << "-- PD table entry --\n";

--- a/p4_pdpi/testing/table_entry_test_runner.cc
+++ b/p4_pdpi/testing/table_entry_test_runner.cc
@@ -80,9 +80,9 @@ static void RunPdTableEntryTest(const pdpi::IrP4Info& info,
                                 pdpi::TranslationOptions options = {}) {
   absl::StrAppend(&test_name, "\n", options);
   RunGenericPdTest<pdpi::TableEntry, pdpi::IrTableEntry, p4::v1::TableEntry>(
-      info, test_name, pd, options, pdpi::PdTableEntryToIr,
+      info, test_name, pd, options, pdpi::PartialPdTableEntryToIrTableEntry,
       pdpi::IrTableEntryToPd, pdpi::IrTableEntryToPi, pdpi::PiTableEntryToIr,
-      pdpi::PdTableEntryToPi, pdpi::PiTableEntryToPd, validity,
+      pdpi::PartialPdTableEntryToPiTableEntry, pdpi::PiTableEntryToPd, validity,
       /*relevant_pd_fields=*/
       [&](const pdpi::IrP4Info& info, const pdpi::TableEntry& pd) {
         if (!options.key_only) return pd;

--- a/sai_p4/instantiations/google/test_tools/test_entries.cc
+++ b/sai_p4/instantiations/google/test_tools/test_entries.cc
@@ -129,7 +129,7 @@ MakePiEntriesForwardingIpPacketsToGivenPort(absl::string_view egress_port,
                                             const pdpi::IrP4Info& ir_p4info) {
   ASSIGN_OR_RETURN(sai::TableEntries pd_entries,
                    MakePdEntriesForwardingIpPacketsToGivenPort(egress_port));
-  return pdpi::PdTableEntriesToPi(ir_p4info, pd_entries);
+  return pdpi::PartialPdTableEntriesToPiTableEntries(ir_p4info, pd_entries);
 }
 
 absl::StatusOr<pdpi::IrTableEntries> 
@@ -138,18 +138,18 @@ MakeIrEntriesForwardingIpPacketsToGivenPort(
                         const pdpi::IrP4Info& ir_p4info) {
   ASSIGN_OR_RETURN(sai::TableEntries pd_entries,
                    MakePdEntriesForwardingIpPacketsToGivenPort(egress_port));
-  return pdpi::PdTableEntriesToIr(ir_p4info, pd_entries);
+  return pdpi::PartialPdTableEntriesToIrTableEntries(ir_p4info, pd_entries);
 }
 
 absl::StatusOr<p4::v1::TableEntry> MakePiEntryPuntingAllPackets(
     PuntAction action, const pdpi::IrP4Info& ir_p4info) {
   ASSIGN_OR_RETURN(sai::TableEntry pd, MakePdEntryPuntingAllPackets(action));
-  return pdpi::PdTableEntryToPi(ir_p4info, pd);
+  return pdpi::PartialPdTableEntryToPiTableEntry(ir_p4info, pd);
 }
 absl::StatusOr<pdpi::IrTableEntry> MakeIrEntryPuntingAllPackets(
     PuntAction action, const pdpi::IrP4Info& ir_p4info) {
   ASSIGN_OR_RETURN(sai::TableEntry pd, MakePdEntryPuntingAllPackets(action));
-  return pdpi::PdTableEntryToIr(ir_p4info, pd);
+  return pdpi::PartialPdTableEntryToIrTableEntry(ir_p4info, pd);
 }
 
 }  // namespace sai


### PR DESCRIPTION
PR Description:
[pd][multicast] Rename PD->IR/PI to set up for deprecation.

Keyword Check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 284 targets (0 packages loaded, 0 targets configured).
INFO: Found 284 targets...
INFO: Elapsed time: 0.866s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

UT Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 284 targets (0 packages loaded, 91 targets configured).
INFO: Found 180 targets and 104 test targets...
INFO: Elapsed time: 53.736s, Critical Path: 17.09s
INFO: 105 processes: 113 linux-sandbox, 16 local.
INFO: Build completed successfully, 105 total actions
//gutil:collections_test                                                 PASSED in 0.3s
//gutil:io_test                                                          PASSED in 0.2s
//gutil:proto_matchers_test                                              PASSED in 0.4s
//gutil:proto_test                                                       PASSED in 0.2s
//gutil:status_matchers_test                                             PASSED in 0.3s
//gutil:table_entry_key_test                                             PASSED in 0.1s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.5s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.4s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.6s
//p4_fuzzer:switch_state_test                                            PASSED in 0.3s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.4s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.3s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 17.1s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 0.9s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.4s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.4s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.4s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.2s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.3s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.6s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.6s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.6s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.6s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.6s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.5s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.5s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.6s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.6s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.5s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.5s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.5s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.3s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.4s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.3s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.0s
//p4rt_app/tests:action_set_test                                         PASSED in 0.7s
//p4rt_app/tests:api_access_test                                         PASSED in 0.8s
//p4rt_app/tests:arbitration_test                                        PASSED in 0.8s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 0.7s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.8s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 4.1s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.1s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.3s
//p4rt_app/tests:packetio_test                                           PASSED in 3.4s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.5s
//p4rt_app/tests:resource_limits_test                                    PASSED in 1.3s
//p4rt_app/tests:response_path_test                                      PASSED in 3.0s
//p4rt_app/tests:role_test                                               PASSED in 0.8s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.3s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.3s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.4s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.2s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.4s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.6s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.3s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.4s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.5s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.3s

Executed 104 out of 104 tests: 104 tests pass.
INFO: Build completed successfully, 105 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$