### PR TITLE
[P4RT]: Add APP DB translation for PacketReplicationEntries

### DIFF
--- a/p4rt_app/sonic/BUILD.bazel
+++ b/p4rt_app/sonic/BUILD.bazel
@@ -390,6 +390,44 @@ cc_test(
 )
 
 cc_library(
+    name = "packet_replication_entry_translation",
+    srcs = ["packet_replication_entry_translation.cc"],
+    hdrs = ["packet_replication_entry_translation.h"],
+    deps = [
+        ":app_db_to_pdpi_ir_translator",
+        ":redis_connections",
+        "//gutil:status",
+        "//p4_pdpi:ir",
+        "//p4_pdpi:ir_cc_proto",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@sonic_swss_common//:libswsscommon",
+    ],
+)
+
+cc_test(
+    name = "packet_replication_entry_translation_test",
+    srcs = ["packet_replication_entry_translation_test.cc"],
+    deps = [
+        ":packet_replication_entry_translation",
+        ":redis_connections",
+        "//gutil:proto_matchers",
+        "//gutil:status_matchers",
+        "//p4_pdpi:ir_cc_proto",
+        "//p4rt_app/sonic/adapters:mock_consumer_notifier_adapter",
+        "//p4rt_app/sonic/adapters:mock_notification_producer_adapter",
+        "//p4rt_app/sonic/adapters:mock_table_adapter",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_googleapis//google/rpc:code_cc_proto",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
+        "@sonic_swss_common//:libswsscommon",
+    ],
+)
+
+cc_library(
     name = "hashing",
     srcs = ["hashing.cc"],
     hdrs = ["hashing.h"],

--- a/p4rt_app/sonic/app_db_manager.cc
+++ b/p4rt_app/sonic/app_db_manager.cc
@@ -384,6 +384,12 @@ std::vector<std::string> GetAllP4TableEntryKeys(P4rtTable& p4rt_table) {
                  (split[0] == APP_P4RT_TABLES_DEFINITION_TABLE_NAME))) {
       continue;
     }
+    // Packet replication entries stored in the P4RT_TABLE are handled by
+    // packet replication entry translation.
+    if (split.size() > 1 &&
+        split[0] == APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) {
+      continue;
+    }
 
     p4rt_keys.push_back(key);
   }

--- a/p4rt_app/sonic/app_db_manager_test.cc
+++ b/p4rt_app/sonic/app_db_manager_test.cc
@@ -477,6 +477,17 @@ TEST_F(AppDbManagerTest, GetAllP4KeysReturnsInstalledKeys) {
               ContainerEq(std::vector<std::string>{"TABLE:{key}"}));
 }
 
+TEST_F(AppDbManagerTest, GetAllP4KeysIgnoresCertainTables) {
+  EXPECT_CALL(*mock_p4rt_app_db_, keys)
+      .WillOnce(Return(std::vector<std::string>{
+          "TABLE:{key}",
+          "REPLICATION_IP_MULTICAST_TABLE:{key}",
+          "ACL_TABLE_DEFINITION_TABLE:{key}",
+      }));
+  EXPECT_THAT(GetAllP4TableEntryKeys(mock_p4rt_table_),
+              ContainerEq(std::vector<std::string>{"TABLE:{key}"}));
+}
+
 }  // namespace
 }  // namespace sonic
 }  // namespace p4rt_app

--- a/p4rt_app/sonic/app_db_to_pdpi_ir_translator.cc
+++ b/p4rt_app/sonic/app_db_to_pdpi_ir_translator.cc
@@ -588,5 +588,10 @@ absl::StatusOr<pdpi::IrTableEntry> AppDbKeyAndValuesToIrTableEntry(
   return table_entry;
 }
 
+std::string IrMulticastGroupEntryToAppDbKey(
+    const pdpi::IrMulticastGroupEntry &entry) {
+  return absl::StrCat("0x", absl::Hex(entry.multicast_group_id()));
+}
+
 }  // namespace sonic
 }  // namespace p4rt_app

--- a/p4rt_app/sonic/app_db_to_pdpi_ir_translator.h
+++ b/p4rt_app/sonic/app_db_to_pdpi_ir_translator.h
@@ -46,6 +46,11 @@ absl::StatusOr<pdpi::IrTableEntry> AppDbKeyAndValuesToIrTableEntry(
     const pdpi::IrP4Info &ir_p4_info, absl::string_view app_db_key,
     const std::vector<std::pair<std::string, std::string>> &app_db_values);
 
+// Given a PDPI IrMulticastGroupEntry, generate the SONiC AppDb key for
+// packet replication in the P4RT table.
+std::string IrMulticastGroupEntryToAppDbKey(
+    const pdpi::IrMulticastGroupEntry &entry);
+
 }  // namespace sonic
 }  // namespace p4rt_app
 

--- a/p4rt_app/sonic/app_db_to_pdpi_ir_translator_test.cc
+++ b/p4rt_app/sonic/app_db_to_pdpi_ir_translator_test.cc
@@ -464,6 +464,19 @@ TEST(TranslateAppDbToPdpiTest, InvalidTableNameFails) {
                        HasSubstr("table 'fake_table' does not exist")));
 }
 
+TEST(TranslateAppDbToPdpiTest, MulticastGroupEntrySuccess) {
+  pdpi::IrMulticastGroupEntry entry;
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        multicast_group_id: 17
+        replicas { port: "Ethernet1/1/1" instance: 2 }
+        replicas { port: "Ethernet1/1/1" instance: 3 }
+      )pb",
+      &entry));
+
+  EXPECT_EQ(IrMulticastGroupEntryToAppDbKey(entry), "0x11");
+}
+
 }  // namespace
 }  // namespace sonic
 }  // namespace p4rt_app

--- a/p4rt_app/sonic/packet_replication_entry_translation.cc
+++ b/p4rt_app/sonic/packet_replication_entry_translation.cc
@@ -1,0 +1,186 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "p4rt_app/sonic/packet_replication_entry_translation.h"
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/match.h"
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "glog/logging.h"
+#include "gutil/status.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4rt_app/sonic/app_db_to_pdpi_ir_translator.h"
+#include "p4rt_app/sonic/redis_connections.h"
+#include "swss/schema.h"
+#include "swss/table.h"
+
+namespace p4rt_app {
+namespace sonic {
+namespace {
+
+std::string_view TablePrefix() {
+  static const auto* kTablePrefix = new std::string(
+      absl::StrCat(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME, ":"));
+  return *kTablePrefix;
+}
+
+absl::StatusOr<std::string> StripTableName(absl::string_view app_db_key) {
+  const absl::string_view kTablePrefix = TablePrefix();
+  if (!absl::StartsWith(app_db_key, kTablePrefix)) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Invalid packet replication App DB key " << app_db_key;
+  }
+  return std::string{app_db_key.substr(kTablePrefix.size())};
+}
+
+std::string GetRedisPacketReplicationTableKey(
+    const pdpi::IrPacketReplicationEngineEntry& entry) {
+  // The final AppDb Key format is: <table_name>:<multicast_group_id>
+  return absl::StrCat(TablePrefix(), IrMulticastGroupEntryToAppDbKey(
+                                         entry.multicast_group_entry()));
+}
+
+std::string CreateEntryForInsert(
+    const pdpi::IrPacketReplicationEngineEntry& entry,
+    std::vector<swss::KeyOpFieldsValuesTuple>& p4rt_inserts) {
+  std::string key = GetRedisPacketReplicationTableKey(entry);
+
+  swss::KeyOpFieldsValuesTuple key_value;
+  kfvKey(key_value) = key;
+  kfvOp(key_value) = "SET";
+
+  for (auto& r : entry.multicast_group_entry().replicas()) {
+    // Since port and/or instance are not independently unique for a group, we
+    // make a key here that is a combination, which is guaranteed to be unique.
+    // The value "replica" is not used.
+    std::string port_instance =
+        absl::StrCat(r.port(), ":0x", absl::Hex(r.instance()));
+    kfvFieldsValues(key_value).push_back(
+        std::make_pair(port_instance, "replica"));
+  }
+  p4rt_inserts.push_back(std::move(key_value));
+  return key;
+}
+
+std::string CreateEntryForDelete(
+    const pdpi::IrPacketReplicationEngineEntry& entry,
+    std::vector<swss::KeyOpFieldsValuesTuple>& p4rt_deletes) {
+  std::string key = GetRedisPacketReplicationTableKey(entry);
+
+  swss::KeyOpFieldsValuesTuple key_value;
+  kfvKey(key_value) = key;
+  kfvOp(key_value) = "DEL";
+  p4rt_deletes.push_back(std::move(key_value));
+
+  return key;
+}
+
+}  // namespace
+
+absl::StatusOr<std::string> CreatePacketReplicationTableUpdateForAppDb(
+    P4rtTable& p4rt_table, p4::v1::Update::Type update_type,
+    const pdpi::IrPacketReplicationEngineEntry& entry,
+    std::vector<swss::KeyOpFieldsValuesTuple>& kfv_updates) {
+  VLOG(2) << p4::v1::Update::Type_Name(update_type)
+          << " PDPI IR packet replication entry: " << entry.ShortDebugString();
+  std::string update_key;
+  switch (update_type) {
+    case p4::v1::Update::INSERT:
+    case p4::v1::Update::MODIFY:
+      // Modify looks exactly the same as insert.
+      // The Orchagent layer resolves differences.
+      update_key = CreateEntryForInsert(entry, kfv_updates);
+      break;
+    case p4::v1::Update::DELETE:
+      update_key = CreateEntryForDelete(entry, kfv_updates);
+      break;
+    default:
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Unsupported update type: " << update_type;
+      break;
+  }
+  return update_key;
+}
+
+std::vector<std::string> GetAllPacketReplicationTableEntryKeys(
+    P4rtTable& p4rt_table) {
+  std::vector<std::string> pre_keys;
+  for (const auto& key : p4rt_table.app_db->keys()) {
+    if (absl::StartsWith(key, TablePrefix())) {
+      pre_keys.push_back(key);
+    }
+  }
+  return pre_keys;
+}
+
+absl::StatusOr<std::vector<pdpi::IrPacketReplicationEngineEntry>>
+GetAllAppDbPacketReplicationTableEntries(P4rtTable& p4rt_table) {
+  std::vector<pdpi::IrPacketReplicationEngineEntry> pre_entries;
+
+  // Each key corresponds to a single multicast group, with all its replicas.
+  auto keys = GetAllPacketReplicationTableEntryKeys(p4rt_table);
+  for (const std::string& key : keys) {
+    VLOG(1) << "Read packet replication engine entry " << key << " from App DB";
+    ASSIGN_OR_RETURN(std::string multicast_group_id, StripTableName(key));
+
+    pdpi::IrPacketReplicationEngineEntry pre_entry;
+    auto* multicast_group_entry = pre_entry.mutable_multicast_group_entry();
+
+    // Multicast Group ID.
+    uint32_t group_id;
+    if (absl::SimpleHexAtoi(multicast_group_id, &group_id)) {
+      multicast_group_entry->set_multicast_group_id(group_id);
+    } else {
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Failed to parse multicast_group_id from App DB packet "
+             << "replication entry key '" << key;
+    }
+
+    // Build replicas.
+    for (auto& kfv : p4rt_table.app_db->get(key)) {
+      auto value_split = kfv.first.rfind(":");
+      if (value_split == std::string::npos) {
+        return gutil::InvalidArgumentErrorBuilder()
+               << "Unexpected multicast port/instance format '" << kfv.first
+               << "' for APP DB packet replication";
+      }
+      std::string port = kfv.first.substr(0, value_split);
+      std::string instance_str = kfv.first.substr(value_split + 1);
+
+      uint32_t instance;
+      if (!absl::SimpleHexAtoi(instance_str, &instance)) {
+        return gutil::InvalidArgumentErrorBuilder()
+               << "Unexpected replica instance value '" << instance_str
+               << "' for APP DB packet replication";
+      }
+
+      auto* replica = multicast_group_entry->add_replicas();
+      replica->set_port(port);
+      replica->set_instance(instance);
+      // We ignore the value in the kfv, as it is not used.
+    }
+    pre_entries.push_back(pre_entry);
+  }
+  return pre_entries;
+}
+
+}  // namespace sonic
+}  // namespace p4rt_app

--- a/p4rt_app/sonic/packet_replication_entry_translation.h
+++ b/p4rt_app/sonic/packet_replication_entry_translation.h
@@ -1,0 +1,46 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef PINS_P4RT_APP_SONIC_PACKET_REPLICATION_ENTRY_TRANSLATION_H_
+#define PINS_P4RT_APP_SONIC_PACKET_REPLICATION_ENTRY_TRANSLATION_H_
+
+#include "absl/status/statusor.h"
+#include "gutil/status.h"
+#include "p4_pdpi/ir.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4rt_app/sonic/redis_connections.h"
+
+namespace p4rt_app {
+namespace sonic {
+
+// Take a packet replication engine entry for an update operation (i.e. insert,
+// modify, or delete) and forms the key and KeyOpFieldsValuesTuple that are
+// consumable by App DB.
+absl::StatusOr<std::string> CreatePacketReplicationTableUpdateForAppDb(
+    P4rtTable& p4rt_table, p4::v1::Update::Type update_type,
+    const pdpi::IrPacketReplicationEngineEntry& entry,
+    std::vector<swss::KeyOpFieldsValuesTuple>& kfv_updates);
+
+// Returns all REPLICATION_MULTICAST_TABLE keys currently installed in AppDb.
+std::vector<std::string> GetAllPacketReplicationTableEntryKeys(
+    P4rtTable& p4rt_table);
+
+// Returns all the REPLICATION_MULTICAST_TABLE entries currently installed in
+// the AppDb.
+absl::StatusOr<std::vector<pdpi::IrPacketReplicationEngineEntry>>
+GetAllAppDbPacketReplicationTableEntries(P4rtTable& p4rt_table);
+
+}  // namespace sonic
+}  // namespace p4rt_app
+
+#endif  // PINS_P4RT_APP_SONIC_PACKET_REPLICATION_ENTRY_TRANSLATION_H_

--- a/p4rt_app/sonic/packet_replication_entry_translation_test.cc
+++ b/p4rt_app/sonic/packet_replication_entry_translation_test.cc
@@ -1,0 +1,304 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "p4rt_app/sonic/packet_replication_entry_translation.h"
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "google/protobuf/text_format.h"
+#include "google/rpc/code.pb.h"
+#include "gtest/gtest.h"
+#include "gutil/proto_matchers.h"
+#include "gutil/status_matchers.h"  // IWYU pragma: keep
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4rt_app/sonic/adapters/mock_consumer_notifier_adapter.h"
+#include "p4rt_app/sonic/adapters/mock_notification_producer_adapter.h"
+#include "p4rt_app/sonic/adapters/mock_table_adapter.h"
+#include "p4rt_app/sonic/redis_connections.h"
+#include "swss/rediscommand.h"
+
+namespace p4rt_app {
+namespace sonic {
+namespace {
+
+using ::google::protobuf::TextFormat;
+using ::gutil::EqualsProto;
+using ::gutil::IsOk;
+using ::gutil::IsOkAndHolds;
+using ::testing::ContainerEq;
+using ::testing::Eq;
+using ::testing::IsEmpty;
+using ::testing::Not;
+using ::testing::Return;
+using ::testing::UnorderedElementsAre;
+
+class PacketReplicationEntryTranslationTest : public ::testing::Test {
+ protected:
+  PacketReplicationEntryTranslationTest() {
+    auto pre_notification_producer =
+        std::make_unique<MockNotificationProducerAdapter>();
+    auto pre_producer_state =
+        std::make_unique<MockNotificationProducerAdapter>();
+    auto pre_notifier = std::make_unique<MockConsumerNotifierAdapter>();
+    auto pre_app_db = std::make_unique<MockTableAdapter>();
+    auto pre_counter_db = std::make_unique<MockTableAdapter>();
+
+    // Save a pointer so we can test against the mocks.
+    mock_pre_notification_producer_ = pre_notification_producer.get();
+    mock_pre_producer_state_ = pre_producer_state.get();
+    mock_pre_notifier_ = pre_notifier.get();
+    mock_pre_app_db_ = pre_app_db.get();
+    mock_pre_counter_db_ = pre_counter_db.get();
+
+    mock_p4rt_table_ = P4rtTable{
+        .notification_producer = std::move(pre_notification_producer),
+        .notification_consumer = std::move(pre_notifier),
+        .app_db = std::move(pre_app_db),
+        .counter_db = std::move(pre_counter_db),
+    };
+  }
+
+  MockNotificationProducerAdapter* mock_pre_notification_producer_;
+  MockNotificationProducerAdapter* mock_pre_producer_state_;
+  MockConsumerNotifierAdapter* mock_pre_notifier_;
+  MockTableAdapter* mock_pre_app_db_;
+  MockTableAdapter* mock_pre_counter_db_;
+  P4rtTable mock_p4rt_table_;
+};
+
+TEST_F(PacketReplicationEntryTranslationTest, InsertPacketReplicationEntry) {
+  pdpi::IrPacketReplicationEngineEntry pre_entry;
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(multicast_group_entry {
+             multicast_group_id: 1
+             replicas { port: "Ethernet1/1/1" instance: 1 }
+             replicas { port: "Ethernet3/1/1" instance: 1 }
+             replicas { port: "Ethernet5/1/1" instance: 1 }
+           })pb",
+      &pre_entry));
+
+  // Expected RedisDB entry.
+  const std::vector<std::pair<std::string, std::string>> kfv_values = {
+      std::make_pair("Ethernet1/1/1:0x1", "replica"),
+      std::make_pair("Ethernet3/1/1:0x1", "replica"),
+      std::make_pair("Ethernet5/1/1:0x1", "replica"),
+  };
+  const std::string expected_key = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::vector<swss::KeyOpFieldsValuesTuple> expected_key_value = {
+      std::make_tuple(expected_key, "SET", kfv_values)};
+
+  std::vector<swss::KeyOpFieldsValuesTuple> kfvs;
+  ASSERT_THAT(CreatePacketReplicationTableUpdateForAppDb(
+                  mock_p4rt_table_, p4::v1::Update::INSERT, pre_entry, kfvs),
+              IsOkAndHolds(expected_key));
+  EXPECT_THAT(expected_key_value, ContainerEq(kfvs));
+}
+
+TEST_F(PacketReplicationEntryTranslationTest, ModifyPacketReplicationEntry) {
+  pdpi::IrPacketReplicationEngineEntry pre_entry;
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(multicast_group_entry {
+             multicast_group_id: 1
+             replicas { port: "Ethernet1/1/1" instance: 1 }
+             replicas { port: "Ethernet3/1/1" instance: 1 }
+           })pb",
+      &pre_entry));
+
+  // Expected RedisDB entry.
+  const std::vector<std::pair<std::string, std::string>> kfv_values = {
+      std::make_pair("Ethernet1/1/1:0x1", "replica"),
+      std::make_pair("Ethernet3/1/1:0x1", "replica"),
+  };
+  const std::string expected_key = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::vector<swss::KeyOpFieldsValuesTuple> expected_key_value = {
+      std::make_tuple(expected_key, "SET", kfv_values)};
+
+  std::vector<swss::KeyOpFieldsValuesTuple> kfvs;
+  ASSERT_THAT(CreatePacketReplicationTableUpdateForAppDb(
+                  mock_p4rt_table_, p4::v1::Update::MODIFY, pre_entry, kfvs),
+              IsOkAndHolds(expected_key));
+  EXPECT_THAT(expected_key_value, ContainerEq(kfvs));
+}
+
+TEST_F(PacketReplicationEntryTranslationTest, DeletePacketReplicationEntry) {
+  pdpi::IrPacketReplicationEngineEntry pre_entry;
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(multicast_group_entry {
+             multicast_group_id: 1
+             replicas { port: "Ethernet1/1/1" instance: 1 }
+             replicas { port: "Ethernet3/1/1" instance: 1 }
+           })pb",
+      &pre_entry));
+
+  // Expected RedisDB entry.
+  const std::vector<std::pair<std::string, std::string>> empty_values;
+  const std::string expected_key = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::vector<swss::KeyOpFieldsValuesTuple> expected_key_value = {
+      std::make_tuple("REPLICATION_IP_MULTICAST_TABLE:0x1", "DEL", empty_values)};
+
+  std::vector<swss::KeyOpFieldsValuesTuple> kfvs;
+  ASSERT_THAT(CreatePacketReplicationTableUpdateForAppDb(
+                  mock_p4rt_table_, p4::v1::Update::DELETE, pre_entry, kfvs),
+              IsOkAndHolds(expected_key));
+  EXPECT_THAT(expected_key_value, ContainerEq(kfvs));
+}
+
+TEST_F(PacketReplicationEntryTranslationTest, UnspecifiedOperationFails) {
+  pdpi::IrPacketReplicationEngineEntry pre_entry;
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(multicast_group_entry {
+             multicast_group_id: 1
+             replicas { port: "Ethernet1/1/1" instance: 1 }
+           })pb",
+      &pre_entry));
+
+  // Expected RedisDB entry.
+  const std::vector<std::pair<std::string, std::string>> empty_values;
+  const std::vector<swss::KeyOpFieldsValuesTuple> expected_key_value = {
+      std::make_tuple("REPLICATION_IP_MULTICAST_TABLE:0x1", "SET", empty_values)};
+
+  std::vector<swss::KeyOpFieldsValuesTuple> kfvs;
+  EXPECT_THAT(
+      CreatePacketReplicationTableUpdateForAppDb(
+          mock_p4rt_table_, p4::v1::Update::UNSPECIFIED, pre_entry, kfvs),
+      Not(IsOk()));
+}
+
+TEST_F(PacketReplicationEntryTranslationTest,
+       GetAllPacketReplicationTableEntryKeys) {
+  EXPECT_CALL(*mock_pre_app_db_, keys)
+      .WillOnce(Return(
+          std::vector<std::string>{"REPLICATION_IP_MULTICAST_TABLE:{key1}",
+                                   "REPLICATION_IP_MULTICAST_TABLE:{key2}"}));
+
+  EXPECT_THAT(GetAllPacketReplicationTableEntryKeys(mock_p4rt_table_),
+              ContainerEq(std::vector<std::string>{
+                  "REPLICATION_IP_MULTICAST_TABLE:{key1}",
+                  "REPLICATION_IP_MULTICAST_TABLE:{key2}"}));
+}
+
+TEST_F(PacketReplicationEntryTranslationTest,
+       GetAllAppDbPacketReplicationTableEntries) {
+  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::vector<std::pair<std::string, std::string>> kfv_values1 = {
+      std::make_pair("Ethernet1/1/1:0x1", "replica"),
+      std::make_pair("Ethernet3/1/1:0x1", "replica"),
+  };
+
+  const std::string app_db_key2 = "REPLICATION_IP_MULTICAST_TABLE:0x2";
+  const std::vector<std::pair<std::string, std::string>> kfv_values2 = {
+      std::make_pair("Ethernet1/1/1:0x1", "replica"),
+  };
+
+  EXPECT_CALL(*mock_pre_app_db_, keys)
+      .WillOnce(Return(std::vector<std::string>{app_db_key1, app_db_key2}));
+  EXPECT_CALL(*mock_pre_app_db_, get(Eq(app_db_key1)))
+      .WillOnce(Return(kfv_values1));
+  EXPECT_CALL(*mock_pre_app_db_, get(Eq(app_db_key2)))
+      .WillOnce(Return(kfv_values2));
+
+  EXPECT_THAT(GetAllAppDbPacketReplicationTableEntries(mock_p4rt_table_),
+              IsOkAndHolds(UnorderedElementsAre(
+                  EqualsProto(R"pb(
+                    multicast_group_entry {
+                      multicast_group_id: 1
+                      replicas { port: "Ethernet1/1/1" instance: 1 }
+                      replicas { port: "Ethernet3/1/1" instance: 1 }
+                    })pb"),
+                  EqualsProto(R"pb(
+                    multicast_group_entry {
+                      multicast_group_id: 2
+                      replicas { port: "Ethernet1/1/1" instance: 1 }
+                    })pb"))));
+}
+
+TEST_F(PacketReplicationEntryTranslationTest, InvalidTableName) {
+  const std::string bad_app_db_key =
+      "FIXED_MULTICAST_ROUTER_INTERFACE_TABLE:0x1";
+
+  EXPECT_CALL(*mock_pre_app_db_, keys)
+      .WillOnce(Return(std::vector<std::string>{bad_app_db_key}));
+
+  EXPECT_THAT(GetAllAppDbPacketReplicationTableEntries(mock_p4rt_table_),
+              IsOkAndHolds(IsEmpty()));
+}
+
+TEST_F(PacketReplicationEntryTranslationTest, InvalidMulticastGroupId) {
+  const std::string bad_app_db_key = "REPLICATION_IP_MULTICAST_TABLE:0xzz";
+
+  EXPECT_CALL(*mock_pre_app_db_, keys)
+      .WillOnce(Return(std::vector<std::string>{bad_app_db_key}));
+
+  EXPECT_FALSE(GetAllAppDbPacketReplicationTableEntries(mock_p4rt_table_).ok());
+}
+
+TEST_F(PacketReplicationEntryTranslationTest, InvalidInstance) {
+  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::vector<std::pair<std::string, std::string>> kfv_values1 = {
+      std::make_pair("Ethernet1/1/1:0xZZ", "replica"),
+      std::make_pair("Ethernet3/1/1:0x1", "replica"),
+  };
+
+  EXPECT_CALL(*mock_pre_app_db_, keys)
+      .WillOnce(Return(std::vector<std::string>{app_db_key1}));
+  EXPECT_CALL(*mock_pre_app_db_, get(Eq(app_db_key1)))
+      .WillOnce(Return(kfv_values1));
+
+  EXPECT_FALSE(GetAllAppDbPacketReplicationTableEntries(mock_p4rt_table_).ok());
+}
+
+TEST_F(PacketReplicationEntryTranslationTest, InvalidPortInstanceSplit) {
+  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::vector<std::pair<std::string, std::string>> kfv_values1 = {
+      std::make_pair("Ethernet1/1/1:0x1:Extra", "replica"),
+      std::make_pair("Ethernet3/1/1:0x1", "replica"),
+  };
+
+  EXPECT_CALL(*mock_pre_app_db_, keys)
+      .WillOnce(Return(std::vector<std::string>{app_db_key1}));
+  EXPECT_CALL(*mock_pre_app_db_, get(Eq(app_db_key1)))
+      .WillOnce(Return(kfv_values1));
+
+  EXPECT_FALSE(GetAllAppDbPacketReplicationTableEntries(mock_p4rt_table_).ok());
+}
+
+TEST_F(PacketReplicationEntryTranslationTest, PortNamesWithColonsOk) {
+  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::vector<std::pair<std::string, std::string>> kfv_values1 = {
+      std::make_pair("Ethernet1:1:0x1", "replica"),
+      std::make_pair("Ethernet3:3:3:0x1", "replica"),
+  };
+
+  EXPECT_CALL(*mock_pre_app_db_, keys)
+      .WillOnce(Return(std::vector<std::string>{app_db_key1}));
+  EXPECT_CALL(*mock_pre_app_db_, get(Eq(app_db_key1)))
+      .WillOnce(Return(kfv_values1));
+
+  EXPECT_THAT(GetAllAppDbPacketReplicationTableEntries(mock_p4rt_table_),
+              IsOkAndHolds(UnorderedElementsAre(EqualsProto(R"pb(
+                multicast_group_entry {
+                  multicast_group_id: 1
+                  replicas { port: "Ethernet1:1" instance: 1 }
+                  replicas { port: "Ethernet3:3:3" instance: 1 }
+                })pb"))));
+}
+
+}  // namespace
+}  // namespace sonic
+}  // namespace p4rt_app

--- a/p4rt_app/sonic/redis_connections.h
+++ b/p4rt_app/sonic/redis_connections.h
@@ -27,7 +27,7 @@ namespace p4rt_app {
 namespace sonic {
 
 // The P4RT app needs to:
-//   * Write P4RT_TABLE entries into a notification channel .
+//   * Write P4RT_TABLE entries into a notification channel.
 //   * Read P4RT_TABLE entries out out of the AppDb and CountersDb.
 struct P4rtTable {
   std::unique_ptr<NotificationProducerAdapter> notification_producer;


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 286 targets (0 packages loaded, 37 targets configured).
INFO: Found 286 targets...
...
   45 | absl::StatusOr<mpz_class> ParseInteger(const std::string& int_str) {
      |                           ^~~~~~~~~~~~
INFO: Elapsed time: 256.208s, Critical Path: 59.17s
INFO: 1100 processes: 601 internal, 499 linux-sandbox.
INFO: Build completed successfully, 1100 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 286 targets (2 packages loaded, 127 targets configured).
INFO: Found 181 targets and 105 test targets...
INFO: Elapsed time: 42.027s, Critical Path: 15.62s
INFO: 110 processes: 118 linux-sandbox, 16 local.
INFO: Build completed successfully, 110 total actions
//gutil:collections_test                                                 PASSED in 0.4s
//gutil:io_test                                                          PASSED in 0.2s
//gutil:proto_matchers_test                                              PASSED in 0.3s
//gutil:proto_test                                                       PASSED in 0.2s
//gutil:status_matchers_test                                             PASSED in 0.4s
//gutil:table_entry_key_test                                             PASSED in 0.0s
//gutil:testing_test                                                     PASSED in 0.3s
//gutil:version_test                                                     PASSED in 0.3s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.4s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.4s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.6s
//p4_fuzzer:switch_state_test                                            PASSED in 0.3s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.0s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.3s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.5s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.3s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 15.6s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 0.8s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.3s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.3s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.0s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.0s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.4s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.2s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.3s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.6s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.5s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.5s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.7s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.5s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.6s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.6s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.4s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.4s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.4s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.3s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.4s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.2s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.6s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 0.9s
//p4rt_app/tests:action_set_test                                         PASSED in 0.6s
//p4rt_app/tests:api_access_test                                         PASSED in 0.6s
//p4rt_app/tests:arbitration_test                                        PASSED in 0.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 0.6s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 1.8s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 2.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.0s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.0s
//p4rt_app/tests:packetio_test                                           PASSED in 3.0s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 1.7s
//p4rt_app/tests:resource_limits_test                                    PASSED in 1.4s
//p4rt_app/tests:response_path_test                                      PASSED in 2.0s
//p4rt_app/tests:role_test                                               PASSED in 0.7s
//p4rt_app/tests:state_verification_test                                 PASSED in 0.9s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.0s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.4s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.3s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.3s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.5s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.3s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.4s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.4s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s

Executed 105 out of 105 tests: 105 tests pass.
INFO: Build completed successfully, 110 total actions