### PR TITLE
[P4RT]: P4RT build failure

### DIFF
--- a/p4rt_app/scripts/p4rt_route_measurement_test.cc
+++ b/p4rt_app/scripts/p4rt_route_measurement_test.cc
@@ -610,7 +610,6 @@ absl::StatusOr<P4WriteRequests> ComputeWcmpWriteRequests(
       for (int action_num = 0; action_num < members_per_group; ++action_num) {
         actions[action_num].nexthop_id = nexthops[action_num];
       }
-
       std::vector<int> weights =
           RandmizeWeights(bitgen, actions.size(), total_group_weight);
       for (size_t i = 0; i < actions.size(); ++i) {
@@ -734,52 +733,6 @@ absl::StatusOr<P4WriteRequests> ComputeIpv6WriteRequests(
   return requests;
 }
 
-absl::StatusOr<std::vector<p4::v1::WriteRequest>> ComputeIpv6WriteRequests(
-    absl::BitGen& bitgen, const RouteEntryInfo& routes,
-    const pdpi::IrP4Info& ir_p4info, uint32_t number_batches,
-    uint32_t batch_size) {
-  ASSIGN_OR_RETURN(std::vector<std::string> vrfs, GetKeys(routes.vrfs_by_name),
-                   _ << "VRFs need to be created before IPv6");
-  ASSIGN_OR_RETURN(std::vector<std::string> nexthops,
-                   GetKeys(routes.next_hops_by_name),
-                   _ << "Next hops need to be created before IPv6");
-  ASSIGN_OR_RETURN(
-      auto addresses,
-      RandomSetOfValues<int64_t>(bitgen, /*min_value=*/0x0000'0000'0000'0001,
-                                 /*max_value=*/0x1FFF'FFFF'FFFF'FFFF,
-                                 number_batches * batch_size));
-
-  std::vector<p4::v1::WriteRequest> requests;
-  for (const int64_t address : addresses) {
-    if (requests.empty() || requests.back().updates_size() == batch_size) {
-      requests.push_back(p4::v1::WriteRequest{});
-    }
-
-    netaddr::Ipv6Address ip(absl::MakeUint128(address, /*low=*/0));
-    std::string vrf = vrfs[absl::Uniform<size_t>(bitgen, 0, vrfs.size())];
-    std::string nexthop =
-        nexthops[absl::Uniform<size_t>(bitgen, 0, nexthops.size())];
-    ASSIGN_OR_RETURN(
-        *requests.back().add_updates(),
-        gpins::Ipv6TableUpdate(
-            ir_p4info, p4::v1::Update::INSERT,
-            gpins::IpTableOptions{
-                .vrf_id = vrf,
-                .dst_addr_lpm = std::make_pair(ip.ToString(), 64),
-                .action = gpins::IpTableOptions::Action::kSetNextHopId,
-                .nexthop_id = nexthop,
-            }));
-  }
-
-  // Sanity checks.
-  if (requests.size() != number_batches) {
-    return absl::UnknownError(
-        absl::StrCat("Failed to generate enough batches: want=", number_batches,
-                     " got=", requests.size()));
-  }
-  return requests;
-}
-
 TEST_F(P4rtRouteTest, MeasureWriteLatency) {
   int32_t number_of_batches = FLAGS_number_batches;
   int32_t requests_per_batch = FLAGS_batch_size;
@@ -873,27 +826,6 @@ TEST_F(P4rtRouteTest, MeasureWriteLatency) {
         << std::endl;
   }
 
-  if (FLAGS_run_ipv6) {
-    // Pre-compute all the IPv6 requests so they can be sent as quickly as
-    // possible to the switch under test.
-    ASSERT_OK_AND_ASSIGN(
-        std::vector<p4::v1::WriteRequest> requests,
-        ComputeIpv6WriteRequests(bitgen, routes, ir_p4info_, number_of_batches,
-                                 requests_per_batch));
-    UpdateRequestMetadata(requests);
-    ASSERT_OK_AND_ASSIGN(absl::Duration execution_time,
-                         SendBatchRequest(requests));
-
-    // Write the results to stdout so that the callers can parse the output.
-    int64_t total_entries = number_of_batches * requests_per_batch;
-    std::cout << absl::StreamFormat(
-                     "ipv6_insert_requests=%d ipv6_insert_entry_total=%lld "
-                     "ipv6_insert_time=%lld(msecs)",
-                     number_of_batches, total_entries,
-                     absl::ToInt64Milliseconds(execution_time))
-              << std::endl;
-  }
-
   if (FLAGS_run_wcmp) {
     int members_per_group = FLAGS_wcmp_members_per_group;
     int total_group_weight = FLAGS_wcmp_total_group_weight;
@@ -906,7 +838,6 @@ TEST_F(P4rtRouteTest, MeasureWriteLatency) {
                                  requests_per_batch, members_per_group,
                                  total_group_weight));
     UpdateRequestMetadata(requests);
-
     ASSERT_OK_AND_ASSIGN(absl::Duration insert_time,
                          SendBatchRequest(requests.inserts));
     ASSERT_OK_AND_ASSIGN(absl::Duration modify_time,


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 289 targets (0 packages loaded, 23 targets configured).
INFO: Found 289 targets...
INFO: Elapsed time: 0.976s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 289 targets (0 packages loaded, 0 targets configured).
INFO: Found 183 targets and 106 test targets...
INFO: Elapsed time: 61.135s, Critical Path: 21.21s
INFO: 111 processes: 119 linux-sandbox, 16 local.
INFO: Build completed successfully, 111 total actions
//gutil:collections_test                                                 PASSED in 0.2s
//gutil:io_test                                                          PASSED in 0.2s
//gutil:proto_matchers_test                                              PASSED in 0.3s
//gutil:proto_test                                                       PASSED in 0.2s
//gutil:status_matchers_test                                             PASSED in 0.2s
//gutil:table_entry_key_test                                             PASSED in 0.1s
//gutil:testing_test                                                     PASSED in 0.2s
//gutil:version_test                                                     PASSED in 0.4s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.4s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.4s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.5s
//p4_fuzzer:switch_state_test                                            PASSED in 0.3s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.0s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.3s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.3s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.2s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.2s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 15.0s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.0s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 0.7s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.2s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.4s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.3s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.0s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.0s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.3s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.2s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.3s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.5s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.6s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.4s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.5s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.5s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.4s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.4s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.5s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.4s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.4s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.3s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.3s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.4s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.3s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.5s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 0.8s
//p4rt_app/tests:action_set_test                                         PASSED in 0.6s
//p4rt_app/tests:api_access_test                                         PASSED in 0.5s
//p4rt_app/tests:arbitration_test                                        PASSED in 0.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 0.6s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 1.8s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 2.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.0s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.0s
//p4rt_app/tests:packetio_test                                           PASSED in 3.0s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 1.6s
//p4rt_app/tests:resource_limits_test                                    PASSED in 1.2s
//p4rt_app/tests:response_path_test                                      PASSED in 2.0s
//p4rt_app/tests:role_test                                               PASSED in 0.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 0.9s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.0s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.5s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.2s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.3s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.5s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.2s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.3s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 0.6s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.4s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.4s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.3s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 21.2s
  Stats over 5 runs: max = 21.2s, min = 0.7s, avg = 14.5s, dev = 7.9s

Executed 106 out of 106 tests: 106 tests pass.
INFO: Build completed successfully, 111 total actions
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ 
