### PR TITLE
[Thinkit]Adding openconfig.proto to gnmi lib.

### DIFF
--- a/lib/gnmi/BUILD.bazel
+++ b/lib/gnmi/BUILD.bazel
@@ -1,0 +1,31 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PINS test functions that can be run on any infrastructure that supports ThinKit.
+
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+proto_library(
+    name = "openconfig_proto",
+    srcs = ["openconfig.proto"],
+)
+
+cc_proto_library(
+    name = "openconfig_cc_proto",
+    deps = [":openconfig_proto"],
+)

--- a/lib/gnmi/openconfig.proto
+++ b/lib/gnmi/openconfig.proto
@@ -1,0 +1,223 @@
+// This file contains proto definitions mirroring OpenConfig YANG models,
+// allowing us to parse JSON values following these YANG models automatically
+// using proto2's json_util.
+//
+// We only model the fields we're interested in, since we can ignore other
+// fields during parsing using json_util's `ignore_unknown_fields` option.
+//
+// This file also contains proto messages that do not mirror YANG models
+// directly, but are more convenient representations, e.g. for diffing.
+
+syntax = "proto3";
+
+package pins_test.openconfig;
+
+// -- Proto messages mirroring YANG models -------------------------------------
+
+// Mirrors the root of the config tree.
+message Config {
+  Interfaces interfaces = 1 [json_name = "openconfig-interfaces:interfaces"];
+  Qos qos = 3 [json_name = "openconfig-qos:qos"];
+}
+
+// Mirrors `container interfaces` in `openconfig-interfaces.yang`.
+message Interfaces {
+  repeated Interface interfaces = 1 [json_name = "interface"];
+
+  // Mirrors `interfaces/interface` in `openconfig-interfaces.yang`.
+  message Interface {
+    string name = 1;
+    Config config = 2;
+    Config state = 4;
+    Subinterfaces subinterfaces = 3;
+    Ethernet ethernet = 5 [json_name = "openconfig-if-ethernet:ethernet"];
+
+    message Config {
+      optional string name = 1;
+      optional string type = 2;
+      optional bool enabled = 3;
+      optional uint32 p4rt_id = 4 [json_name = "openconfig-p4rt:id"];
+      optional string ecmp_hash_algorithm = 5
+          [json_name = "google-pins-interfaces:ecmp-hash-algorithm"];
+      optional uint32 ecmp_hash_offset = 6
+          [json_name = "google-pins-interfaces:ecmp-hash-offset"];
+      optional bool cpu = 7;
+      optional bool management = 8;
+      // State subtree only
+      optional string oper_status = 9 [json_name = "oper-status"];
+    }
+  }
+}
+
+// Mirrors `container subinterfaces` in `openconfig-interfaces.yang`.
+message Subinterfaces {
+  repeated Subinterface subinterfaces = 1 [json_name = "subinterface"];
+
+  // Mirrors `subinterfaces/subinterface` in `openconfig-interfaces.yang`.
+  message Subinterface {
+    Ip ipv4 = 1 [json_name = "openconfig-if-ip:ipv4"];
+    Ip ipv6 = 2 [json_name = "openconfig-if-ip:ipv6"];
+
+    message Ip {
+      Addresses addresses = 1;
+    }
+  }
+}
+
+// Mirrors `container ethernet` in `openconfig-interfaces.yang`.
+message Ethernet {
+  message Config {
+    optional string aggregate_id = 1
+        [json_name = "openconfig-if-aggregate:aggregate-id"];
+  }
+
+  Config config = 1;
+  Config state = 2;
+}
+
+// Mirror `container addresses` in `openconfig-if-ip.yang`
+message Addresses {
+  repeated Address addresses = 1 [json_name = "address"];
+
+  message Address {
+    string ip = 1;
+  }
+}
+
+// Mirrors `container queues` in `openconfig-qos-elements.yang`.
+message Queues {
+  repeated Queue queues = 1 [json_name = "queue"];
+
+  // Mirrors `queues/queue` in `openconfig-qos-elements.yang`.
+  message Queue {
+    string name = 1;
+    State state = 2;
+
+    // Mirrors `queues/queue/state` in `openconfig-qos-elements.yang`.
+    message State {
+      string dropped_pkts = 1 [json_name = "dropped-pkts"];
+      string transmit_pkts = 2 [json_name = "transmit-pkts"];
+    }
+  }
+}
+
+// Mirrors `openconfig-qos:qos`.
+// All leaves are `optional`, since JSON differentiates between absence vs
+// precense with default value.
+message Qos {
+  SchedulerPolicies scheduler_policies = 5 [json_name = "scheduler-policies"];
+
+  message SchedulerPolicies {
+    repeated SchedulerPolicy scheduler_policy = 1
+        [json_name = "scheduler-policy"];
+  }
+  message SchedulerPolicy {
+    optional string name = 1;  // List key.
+    Schedulers schedulers = 2;
+  }
+  message Schedulers {
+    repeated Scheduler scheduler = 1;
+  }
+  message Scheduler {
+    optional uint32 sequence = 1;  // List key.
+    Config config = 2;
+    Config state = 3;
+    Inputs inputs = 4;
+    TwoRateThreeColor two_rate_three_color = 5
+        [json_name = "two-rate-three-color"];
+
+    message Config {
+      optional string priority = 1;
+      optional uint32 sequence = 2;
+      optional string type = 3;
+    }
+    message Inputs {
+      repeated Input input = 1;
+    }
+    message Input {
+      optional string id = 1;  // List key.
+      Config config = 2;
+      Config state = 3;
+
+      message Config {
+        optional string id = 1;
+        optional string input_type = 2 [json_name = "input-type"];
+        optional string queue = 3;
+        optional string weight = 4;  // uint64
+      }
+    }
+    message TwoRateThreeColor {
+      Config config = 1;
+      Config state = 2;
+
+      message Config {
+        optional string cir = 1;  // uint64
+        optional string pir = 2;  // uint64
+        optional uint32 bc = 3;   // uint32
+        optional uint32 be = 4;   // uint32
+      }
+    }
+  }
+  BufferAllocationProfiles buffer_allocation_profiles = 6
+      [json_name = "buffer-allocation-profiles"];
+
+  message BufferAllocationProfiles {
+    repeated BufferAllocationProfile buffer_allocation_profile = 1
+        [json_name = "buffer-allocation-profile"];
+  }
+  message BufferAllocationProfile {
+    optional string name = 1;  // List key.
+    Queues queues = 2;
+    Config config = 3;
+    message Config {
+      optional string name = 1;
+    }
+  }
+  message Queues {
+    repeated Queue queue = 1;
+  }
+  message Queue {
+    optional string name = 1;  // List key.
+    Config config = 2;
+    Config state = 3;
+
+    message Config {
+      optional string name = 1;
+      optional string dedicated_buffer = 2 [json_name = "dedicated-buffer"];
+      optional bool use_shared_buffer = 3 [json_name = "use-shared-buffer"];
+      optional string shared_buffer_limit_type = 4
+          [json_name = "shared-buffer-limit-type"];
+      optional uint32 static_shared_buffer_limit = 5
+          [json_name = "static-shared-buffer-limit"];
+      optional int32 dynamic_limit_scaling_factor = 6
+          [json_name = "dynamic-limit-scaling-factor"];
+    }
+  }
+
+  Interfaces interfaces = 7;
+  message Interfaces {
+    repeated Interface interface = 1;
+  }
+  message Interface {
+    optional string interface_id = 1 [json_name = "interface-id"];
+    optional Config config = 2;
+    message Config {
+      optional string interface_id = 1 [json_name = "interface-id"];
+    }
+    optional Output output = 3 [json_name = "output"];
+    message Output {
+      optional Config config = 1 [json_name = "config"];
+      message Config {
+        optional string buffer_allocation_profile = 1
+            [json_name = "buffer-allocation-profile"];
+      }
+    }
+  }
+}
+
+// -- Proto messages defined for convenience -----------------------------------
+
+// Equivalent to `Queues`, but results in more readable diffs.
+message QueuesByName {
+  map<string, Queues.Queue.State> queues = 1;
+}


### PR DESCRIPTION
PR Description:
Adding openconfig.proto to gnmi lib.

Keyword Check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.


Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 322 targets (0 packages loaded, 0 targets configured).
INFO: Found 322 targets...
INFO: Elapsed time: 1.149s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins

UT Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 322 targets (1 packages loaded, 3 targets configured).
INFO: Found 205 targets and 117 test targets...
INFO: Elapsed time: 118.841s, Critical Path: 24.57s
INFO: 122 processes: 129 linux-sandbox, 17 local.
INFO: Build completed successfully, 122 total actions
//gutil:collections_test                                                 PASSED in 0.7s
//gutil:io_test                                                          PASSED in 0.6s
//gutil:proto_matchers_test                                              PASSED in 1.8s
//gutil:proto_test                                                       PASSED in 0.6s
//gutil:status_matchers_test                                             PASSED in 0.7s
//gutil:test_artifact_writer_test                                        PASSED in 0.8s
//gutil:testing_test                                                     PASSED in 0.6s
//gutil:version_test                                                     PASSED in 1.4s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.8s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:switch_state_test                                            PASSED in 0.7s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.7s
//p4_pdpi:table_entry_key_test                                           PASSED in 0.1s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 18.7s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 2.9s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.6s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.9s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.3s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 2.7s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.3s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 1.4s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.0s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.5s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.0s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.0s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 2.0s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 1.0s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 1.0s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.9s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.8s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.8s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.8s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.6s
//p4rt_app/tests:action_set_test                                         PASSED in 1.2s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.2s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.9s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.1s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 6.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 1.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.9s
//p4rt_app/tests:packetio_test                                           PASSED in 4.1s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.2s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.9s
//p4rt_app/tests:response_path_test                                      PASSED in 5.8s
//p4rt_app/tests:role_test                                               PASSED in 1.2s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.1s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.8s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:authz_logger_test                                       PASSED in 1.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.2s
//p4rt_app/utils:lru_cache_test                                          PASSED in 0.1s
//p4rt_app/utils:metric_recorder_test                                    PASSED in 1.3s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.8s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.0s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.6s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.9s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 24.5s
  Stats over 5 runs: max = 24.5s, min = 2.3s, avg = 11.2s, dev = 8.0s

Executed 117 out of 117 tests: 117 tests pass.
INFO: Build completed successfully, 122 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$