### PR TITLE
[Dvaas] Adding test_vector files.

### DIFF
--- a/dvaas/BUILD.bazel
+++ b/dvaas/BUILD.bazel
@@ -29,3 +29,26 @@ proto_library(
     ],
 )
 
+cc_library(
+    name = "test_vector",
+    testonly = True,
+    srcs = ["test_vector.cc"],
+    hdrs = ["test_vector.h"],
+    deps = [
+        ":test_vector_cc_proto",
+        "//gutil:proto",
+        "//gutil:status",
+        "//p4_pdpi:ir_cc_proto",
+        "//p4_pdpi/packetlib:packetlib_cc_proto",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:optional",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest",
+        "@com_google_protobuf//:protobuf",
+        "@com_googlesource_code_re2//:re2",
+    ],
+)

--- a/dvaas/test_vector.cc
+++ b/dvaas/test_vector.cc
@@ -1,0 +1,408 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dvaas/test_vector.h"
+
+#include <optional>
+#include <ostream>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_replace.h"
+#include "absl/strings/string_view.h"
+#include "absl/strings/strip.h"
+#include "absl/strings/substitute.h"
+#include "absl/types/optional.h"
+#include "absl/types/span.h"
+#include "dvaas/test_vector.pb.h"
+#include "gmock/gmock.h"
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/util/message_differencer.h"
+#include "gtest/gtest.h"
+#include "gutil/proto.h"
+#include "gutil/status.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4_pdpi/packetlib/packetlib.pb.h"
+#include "re2/re2.h"
+
+namespace dvaas {
+namespace {
+
+using ::google::protobuf::util::MessageDifferencer;
+using ::gutil::PrintTextProto;
+using ::testing::MatchResultListener;
+
+// -- Detailed comparison of actual vs expected `SwitchOutput`s ----------------
+
+bool PacketLessThan(const Packet* a, const Packet* b) {
+  return a->hex() < b->hex();
+}
+
+bool PacketInLessThan(const PacketIn* a, const PacketIn* b) {
+  return a->hex() < b->hex();
+}
+
+// Returns a copy of the given `string` with all newlines indented by
+// (an additional) `indentation` number of spaces. Empty lines are not indented.
+std::string Indent(int indentation, absl::string_view string) {
+  // Avoid indenting empty lines: remove here, then add back at the end.
+  bool stripped_trailing_newline = absl::ConsumeSuffix(&string, "\n");
+  std::string result = absl::StrReplaceAll(
+      string, {
+                  {
+                      "\n",
+                      absl::StrCat("\n", std::string(indentation, ' ')),
+                  },
+              });
+  if (stripped_trailing_newline) absl::StrAppend(&result, "\n");
+  return result;
+}
+
+std::optional<pdpi::IrPacketMetadata> GetPacketInMetadataByName(
+    const PacketIn& packet_in, absl::string_view target) {
+  for (const auto& metadata : packet_in.metadata()) {
+    if (metadata.name() == target) return metadata;
+  }
+  return std::nullopt;
+}
+
+bool CompareSwitchOutputs(
+    SwitchOutput actual_output, SwitchOutput expected_output,
+    const absl::flat_hash_set<std::string>& ignored_metadata,
+    const std::vector<const google::protobuf::FieldDescriptor*>& ignored_fields,
+    MatchResultListener* listener) {
+  if (actual_output.packets_size() != expected_output.packets_size()) {
+    *listener << "has mismatched number of packets (actual: "
+              << actual_output.packets_size()
+              << " expected: " << expected_output.packets_size() << ")\n";
+    return false;
+  }
+
+  if (actual_output.packet_ins_size() != expected_output.packet_ins_size()) {
+    *listener << "has mismatched number of packet ins (actual: "
+              << actual_output.packet_ins_size()
+              << " expected: " << expected_output.packet_ins_size() << ")\n";
+    return false;
+  }
+
+  std::sort(actual_output.mutable_packets()->pointer_begin(),
+            actual_output.mutable_packets()->pointer_end(), PacketLessThan);
+  std::sort(expected_output.mutable_packets()->pointer_begin(),
+            expected_output.mutable_packets()->pointer_end(), PacketLessThan);
+  std::sort(actual_output.mutable_packet_ins()->pointer_begin(),
+            actual_output.mutable_packet_ins()->pointer_end(),
+            PacketInLessThan);
+  std::sort(expected_output.mutable_packet_ins()->pointer_begin(),
+            expected_output.mutable_packet_ins()->pointer_end(),
+            PacketInLessThan);
+
+  for (int i = 0; i < expected_output.packets_size(); ++i) {
+    const Packet& actual_packet = actual_output.packets(i);
+    const Packet& expected_packet = expected_output.packets(i);
+    MessageDifferencer differ;
+    for (auto* field : ignored_fields) differ.IgnoreField(field);
+    std::string diff;
+    differ.ReportDifferencesToString(&diff);
+    if (!differ.Compare(expected_packet.parsed(), actual_packet.parsed())) {
+      *listener << "has packet " << i << " with mismatched header fields:\n  "
+                << Indent(2, diff);
+      return false;
+    }
+  }
+
+  for (int i = 0; i < expected_output.packet_ins_size(); ++i) {
+    const PacketIn& actual_packet_in = actual_output.packet_ins(i);
+    const PacketIn& expected_packet_in = expected_output.packet_ins(i);
+
+    MessageDifferencer differ;
+    for (auto* field : ignored_fields) differ.IgnoreField(field);
+    std::string diff;
+    differ.ReportDifferencesToString(&diff);
+    if (!differ.Compare(expected_packet_in.parsed(),
+                        actual_packet_in.parsed())) {
+      *listener << "has packet in " << i
+                << " with mismatched header fields:\n  " << Indent(2, diff);
+      return false;
+    }
+
+    // Check that received packet in has desired metadata (except for ignored
+    // metadata).
+    for (const auto& expected_metadata : expected_packet_in.metadata()) {
+      if (ignored_metadata.contains(expected_metadata.name())) continue;
+
+      std::optional<pdpi::IrPacketMetadata> actual_metadata =
+          GetPacketInMetadataByName(actual_packet_in, expected_metadata.name());
+      if (!actual_metadata.has_value()) {
+        *listener << "has packet in " << i << " with missing metadata field '"
+                  << expected_metadata.name() << "':\n  " << Indent(2, diff);
+        return false;
+      }
+
+      if (!differ.Compare(expected_metadata.value(),
+                          actual_metadata->value())) {
+        *listener << "has packet in " << i
+                  << " with mismatched value for metadata field '"
+                  << expected_metadata.name() << "':\n " << Indent(2, diff);
+        return false;
+      }
+    }
+
+    // Check that received packet in does not have additional metadata (except
+    // for ignored metadata).
+    for (const auto& actual_metadata : actual_packet_in.metadata()) {
+      if (ignored_metadata.contains(actual_metadata.name())) continue;
+
+      std::optional<pdpi::IrPacketMetadata> expected_metadata =
+          GetPacketInMetadataByName(expected_packet_in, actual_metadata.name());
+      if (!expected_metadata.has_value()) {
+        *listener << "has packet in " << i
+                  << " with additional metadata field '"
+                  << actual_metadata.name() << "':\n  " << Indent(2, diff);
+        return false;
+      }
+    }
+  }
+
+  *listener << "matches\n";
+  return true;
+}
+
+// Compares the `actual_output` to the `acceptable_outputs` in the given
+// `single_packet_test_vector`, returning `absl::nullopt` if the actual output
+// is acceptable, or an explanation of why it is not otherwise.
+absl::optional<std::string> CompareSwitchOutputs(
+    const SinglePacketTestVector single_packet_test_vector,
+    const SwitchOutput& actual_output,
+    const absl::flat_hash_set<std::string>& ignored_metadata,
+    const std::vector<const google::protobuf::FieldDescriptor*>&
+        ignored_fields) {
+  testing::StringMatchResultListener listener;
+  for (int i = 0; i < single_packet_test_vector.acceptable_outputs_size();
+       ++i) {
+    const SwitchOutput& expected_output =
+        single_packet_test_vector.acceptable_outputs(i);
+    listener << "- acceptable output #" << (i + 1) << " ";
+    if (CompareSwitchOutputs(actual_output, expected_output, ignored_metadata,
+                             ignored_fields, &listener)) {
+      return absl::nullopt;
+    }
+  }
+  return listener.str();
+}
+
+// -- Simplified switch output characterizations -------------------------------
+
+// Characterization of a `SwitchOutput` in terms of two key metrics: how many
+// packets got forwarded and how many got punted?
+// The purpose of this struct is to give a compact summary of a switch output
+// that is easy to understand. This is useful in error messages, because actual
+// `SwitchOutput`s are complex (they specify packet header fields and payloads,
+// for example) and so dumping them directly is overwhelming.
+struct SwitchOutputCharacterization {
+  int num_forwarded;
+  int num_punted;
+
+  // https://abseil.io/docs/cpp/guides/hash#tldr-how-do-i-make-my-type-hashable
+  template <typename H>
+  friend H AbslHashValue(H h, const SwitchOutputCharacterization& x) {
+    return H::combine(std::move(h), x.num_forwarded, x.num_punted);
+  }
+};
+
+bool operator==(const SwitchOutputCharacterization& x,
+                const SwitchOutputCharacterization& y) {
+  return x.num_forwarded == y.num_forwarded && x.num_punted == y.num_punted;
+}
+
+// Returns a simple characterization of the given `output`.
+SwitchOutputCharacterization CharacterizeSwitchOutput(
+    const SwitchOutput& output) {
+  return SwitchOutputCharacterization{
+      .num_forwarded = output.packets_size(),
+      .num_punted = output.packet_ins_size(),
+  };
+}
+
+// Returns a human-readable description of the given `output`, for use in error
+// messages.
+std::string DescribeSwitchOutput(const SwitchOutputCharacterization& output) {
+  const bool forwarded = output.num_forwarded > 0;
+  const bool punted = output.num_punted > 0;
+  if (forwarded && punted)
+    return absl::Substitute("forwarded ($0 copies) and punted ($1 copies)",
+                            output.num_forwarded, output.num_punted);
+  if (forwarded && !punted)
+    return absl::Substitute("forwarded ($0 copies)", output.num_forwarded);
+  if (!forwarded && punted)
+    return absl::Substitute("punted ($0 copies)", output.num_punted);
+  return "dropped";
+}
+
+// Returns a human-readable description of the expectation encoded by the given
+// `acceptable_output_characterizations`, for use in error messages.
+std::string DescribeExpectation(
+    const SwitchInput& input,
+    const absl::flat_hash_set<SwitchOutputCharacterization>&
+        acceptable_output_characterizations) {
+  // This should never happen, but it is convenient for this function to be pure
+  // and so we handle the case gracefully and without erroring.
+  if (acceptable_output_characterizations.empty())
+    return "false (will always fail)";
+  // In practice, while there are often multiple acceptable outputs
+  // (e.g., due to WCMP), all of them tend to have the same *output
+  // characterization*. So this function is optimized for the case
+  // `acceptable_output_characterizations.size() == 1` and doesn't try to be
+  // clever otherwise.
+  return absl::StrJoin(acceptable_output_characterizations, ", or ",
+                       [&](std::string* output, auto& acceptable_output) {
+                         absl::StrAppend(
+                             output, SwitchInput::Type_Name(input.type()),
+                             " packet gets ",
+                             DescribeSwitchOutput(acceptable_output));
+                       });
+}
+
+// Returns a human-readable description of the given `actual_output`, for use in
+// error messages.
+std::string DescribeActual(const SwitchInput& input,
+                           const SwitchOutputCharacterization& actual_output) {
+  return absl::StrCat(SwitchInput::Type_Name(input.type()), " packet got ",
+                      DescribeSwitchOutput(actual_output));
+}
+
+// Returns whether the packet with the given `characterization` got dropped.
+bool IsCharacterizedAsDrop(
+    const SwitchOutputCharacterization& characterization) {
+  return characterization.num_forwarded == 0 &&
+         characterization.num_punted == 0;
+}
+
+// Returns whether the packet with the given possible `characterizations`
+// surely (according to all characterizations) got dropped.
+bool IsCharacterizedAsDrop(
+    const absl::flat_hash_set<SwitchOutputCharacterization>&
+        characterizations) {
+  return characterizations.size() == 1 &&
+         IsCharacterizedAsDrop(*characterizations.cbegin());
+}
+
+static constexpr absl::string_view kInputBanner =
+    "== INPUT "
+    "=======================================================================";
+static constexpr absl::string_view kActualBanner =
+    "== ACTUAL OUTPUT "
+    "===============================================================";
+static constexpr absl::string_view kExpectationBanner =
+    "== EXPECTED OUTPUT "
+    "=============================================================";
+
+}  // namespace
+
+absl::StatusOr<int> ExtractTestTag(const packetlib::Packet& packet) {
+  // Regexp to extract the ID from a test packet's payload.
+  constexpr LazyRE2 kTestPacketIdRegexp{R"(test packet #([0-9]+):)"};
+  int tag;
+  if (RE2::PartialMatch(packet.payload(), *kTestPacketIdRegexp, &tag))
+    return tag;
+  return absl::InvalidArgumentError(absl::StrCat(
+      "Payload does not contain a packet id: ", packet.DebugString()));
+}
+
+absl::StatusOr<std::string> GetIngressPortFromIrPacketIn(
+    const pdpi::IrPacketIn& packet_in) {
+  for (const auto& metadata : packet_in.metadata()) {
+    if (metadata.name() == "ingress_port") return metadata.value().str();
+  }
+  return absl::InvalidArgumentError(
+      "IrPacketIn does not contain 'ingress_port' metadata.");
+}
+
+absl::optional<std::string> CheckForSinglePacketTestVectorFailure(
+    const SinglePacketTestVector& single_packet_test_vector,
+    const SwitchOutput& actual_output,
+    const absl::flat_hash_set<std::string>& ignored_packet_in_metadata,
+    const std::vector<const google::protobuf::FieldDescriptor*>&
+        ignored_fields) {
+  const absl::optional<std::string> diff =
+      CompareSwitchOutputs(single_packet_test_vector, actual_output,
+                           ignored_packet_in_metadata, ignored_fields);
+  if (!diff.has_value()) return absl::nullopt;
+
+  // To make the diff more digestible, we first give an abstract
+  // characterization of the expected and actual outputs.
+  absl::flat_hash_set<SwitchOutputCharacterization>
+      acceptable_output_characterizations;
+  for (auto& acceptable_output :
+       single_packet_test_vector.acceptable_outputs()) {
+    acceptable_output_characterizations.insert(
+        CharacterizeSwitchOutput(acceptable_output));
+  }
+  const SwitchOutputCharacterization actual_output_characterization =
+      CharacterizeSwitchOutput(actual_output);
+  const bool actual_matches_expected =
+      acceptable_output_characterizations.contains(
+          actual_output_characterization);
+
+  std::string expectation = DescribeExpectation(
+      single_packet_test_vector.input(), acceptable_output_characterizations);
+  if (!ignored_fields.empty()) {
+    absl::StrAppend(
+        &expectation, "\n          (ignoring the field(s) ",
+        absl::StrJoin(ignored_fields, ",",
+                      [](std::string* out,
+                         const google::protobuf::FieldDescriptor* field) {
+                        absl::StrAppend(out, "'", field->name(), "'");
+                      }),
+        ")");
+  }
+  std::string actual = DescribeActual(single_packet_test_vector.input(),
+                                      actual_output_characterization);
+  if (actual_matches_expected) {
+    absl::StrAppend(&actual, ", but with unexpected modifications");
+  }
+  std::string failure = absl::Substitute(
+      "Expected: $0\n  Actual: $1\n$2\nDetails dumped below.\n\n", expectation,
+      actual, *diff);
+
+  // Dump input.
+  absl::StrAppend(&failure, kInputBanner, "\n",
+                  PrintTextProto(single_packet_test_vector.input()));
+
+  // Dump actual output, if any.
+  if (!IsCharacterizedAsDrop(actual_output_characterization)) {
+    absl::StrAppend(&failure, kActualBanner, "\n",
+                    PrintTextProto(actual_output));
+  }
+
+  // Dump expected output, if any.
+  if (!IsCharacterizedAsDrop(acceptable_output_characterizations)) {
+    absl::StrAppend(&failure, kExpectationBanner, "\n");
+    for (int i = 0; i < single_packet_test_vector.acceptable_outputs_size();
+         ++i) {
+      absl::StrAppendFormat(
+          &failure, "-- Acceptable output: Alternative #%d --\n%s", (i + 1),
+          PrintTextProto(single_packet_test_vector.acceptable_outputs(i)));
+    }
+  }
+
+  return failure;
+}
+
+}  // namespace dvaas

--- a/dvaas/test_vector.h
+++ b/dvaas/test_vector.h
@@ -1,0 +1,72 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PINS_TESTS_FORWARDING_TEST_VECTOR_H_
+#define PINS_TESTS_FORWARDING_TEST_VECTOR_H_
+
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/types/optional.h"
+#include "dvaas/test_vector.pb.h"
+#include "google/protobuf/descriptor.h"
+#include "p4_pdpi/ir.pb.h"
+
+namespace dvaas {
+
+// Given a tagged packet, extracts the tag in its payload. Returns an
+// error if the payload has an unexpected format, e.g. for untagged packets.
+// TODO: Implement and use a unified (open-source) API for test
+// packet tag embedding and extraction.
+absl::StatusOr<int> ExtractTestTag(const packetlib::Packet& packet);
+
+// Needed to make gUnit produce human-readable output in open source.
+inline std::ostream& operator<<(std::ostream& os, const SwitchOutput& output) {
+  return os << output.DebugString();
+}
+
+using SinglePacketTestVectorById = absl::btree_map<int, SinglePacketTestVector>;
+
+// Holds a SinglePacketTestVector along with the actual SUT output generated in
+// response to the test vector's input. The actual output may be empty, if the
+// switch drops the input packet. The test vector may be empty, if the switch
+// generates packets that do not correspond to an input, or if the output cannot
+// be mapped to a test input.
+struct SinglePacketTestVectorAndActualOutput {
+  SinglePacketTestVector single_packet_test_vector;
+  SwitchOutput actual_output;
+};
+
+// Gets 'ingress_port' value from metadata in `packet_in`. Returns
+// InvalidArgumentError if 'ingress_port' metadata is missing.
+absl::StatusOr<std::string> GetIngressPortFromIrPacketIn(
+    const pdpi::IrPacketIn& packet_in);
+
+// Checks if the `actual_output` conforms to the `single_packet_test_vector`
+// when ignoring the given `ignored_fields` and 'ignored_packet_in_metadata', if
+// any. All `ignored_fields` should belong to packetlib::Packet. Returns a
+// failure description in case of a mismatch, or `absl::nullopt` otherwise.
+absl::optional<std::string> CheckForSinglePacketTestVectorFailure(
+    const SinglePacketTestVector& single_packet_test_vector,
+    const SwitchOutput& actual_output,
+    const absl::flat_hash_set<std::string>& ignored_packet_in_metadata = {},
+    const std::vector<const google::protobuf::FieldDescriptor*>&
+        ignored_fields = {});
+
+}  // namespace dvaas
+
+#endif  // PINS_TESTS_FORWARDING_TEST_VECTOR_H_

--- a/lib/gnmi/gnmi_helper.cc
+++ b/lib/gnmi/gnmi_helper.cc
@@ -1,0 +1,1109 @@
+// Copyright (c) 2021, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lib/gnmi/gnmi_helper.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/container/btree_set.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/numeric/int128.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/string_view.h"
+#include "absl/strings/strip.h"
+#include "absl/strings/substitute.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "absl/types/span.h"
+#include "github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.pb.h"
+#include "github.com/openconfig/gnoi/types/types.pb.h"
+#include "glog/logging.h"
+#include "google/protobuf/any.pb.h"
+#include "google/protobuf/map.h"
+#include "grpcpp/impl/codegen/client_context.h"
+#include "gutil/proto.h"
+#include "gutil/status.h"
+#include "include/nlohmann/json.hpp"
+#include "lib/gnmi/openconfig.pb.h"
+#include "p4_pdpi/p4_runtime_session.h"
+#include "proto/gnmi/gnmi.grpc.pb.h"
+#include "proto/gnmi/gnmi.pb.h"
+#include "re2/re2.h"
+#include "thinkit/switch.h"
+
+namespace pins_test {
+namespace {
+
+using ::nlohmann::json;
+
+// Splits string to tokens seperated by a char '/' as long as '/' is not
+// included in [].
+const LazyRE2 kSplitBreakSquareBraceRE = {R"(([^\[\/]+(\[[^\]]+\])?)\/?)"};
+
+// Given a JSON string for OpenConfig interfaces. This function will parse
+// through the JSON and identify any ports with an 'openconfig-p4rt:id' value
+// set, and return a map of the Port Name to the Port ID.
+//
+// `field_type` is the type of open config data this function should parse (e.g.
+// "config" or "state").
+absl::StatusOr<absl::flat_hash_map<std::string, std::string>>
+GetPortNameToIdMapFromJsonString(absl::string_view json_string,
+                                 absl::string_view field_type) {
+  VLOG(2) << "Getting Port Name -> ID Map from JSON string: " << json_string;
+  const nlohmann::basic_json<> response_json = json::parse(json_string);
+
+  const auto oc_intf_json =
+      response_json.find("openconfig-interfaces:interfaces");
+  if (oc_intf_json == response_json.end()) {
+    return absl::NotFoundError(
+        absl::StrCat("'openconfig-interfaces:interfaces' not found: ",
+                     response_json.dump()));
+  }
+  const auto oc_intf_list_json = oc_intf_json->find("interface");
+  if (oc_intf_list_json == oc_intf_json->end()) {
+    return absl::NotFoundError(
+        absl::StrCat("'interface' not found: ", oc_intf_json->dump()));
+  }
+
+  absl::flat_hash_map<std::string, std::string> interface_name_to_port_id;
+  for (const auto& element : oc_intf_list_json->items()) {
+    const auto element_name_json = element.value().find("name");
+    if (element_name_json == element.value().end()) {
+      return absl::NotFoundError(
+          absl::StrCat("'name' not found: ", element.value().dump()));
+    }
+    std::string name = element_name_json->get<std::string>();
+
+    const auto element_interface_json = element.value().find(field_type);
+    if (element_interface_json == element.value().end()) {
+      return gutil::NotFoundErrorBuilder()
+             << "'" << field_type << "' not found: " << element.value().dump();
+    }
+
+    const auto element_id_json =
+        element_interface_json->find("openconfig-p4rt:id");
+    if (element_id_json == element_interface_json->end()) {
+      continue;
+    }
+
+    interface_name_to_port_id[name] = absl::StrCat(element_id_json->get<int>());
+  }
+  return interface_name_to_port_id;
+}
+
+absl::StatusOr<json> GetField(const json& object,
+                              absl::string_view field_name) {
+  auto field = object.find(field_name);
+  if (field == object.end()) {
+    return absl::NotFoundError(
+        absl::StrCat(field_name, " not found in ", object.dump(), "."));
+  }
+  return absl::StatusOr<json>(*std::move(field));
+}
+
+absl::StatusOr<gnmi::GetResponse> SendGnmiGetRequest(
+    gnmi::gNMI::StubInterface* gnmi_stub, const gnmi::GetRequest& request,
+    std::optional<absl::Duration> timeout) {
+  LOG(INFO) << "Sending GET request: " << request.ShortDebugString();
+  gnmi::GetResponse response;
+  grpc::ClientContext context;
+  if (timeout.has_value()) {
+    context.set_deadline(absl::ToChronoTime(absl::Now() + *timeout));
+  }
+  RETURN_IF_ERROR(gutil::GrpcStatusToAbslStatus(
+                      gnmi_stub->Get(&context, request, &response)))
+          .SetPrepend()
+      << "GET request failed with error: ";
+  LOG(INFO) << "Received GET response: " << response.ShortDebugString();
+  return response;
+}
+
+}  // namespace
+
+std::string GnmiFieldTypeToString(GnmiFieldType field_type) {
+  switch (field_type) {
+    case GnmiFieldType::kConfig:
+      return "config";
+    case GnmiFieldType::kState:
+      return "state";
+  }
+  LOG(DFATAL) << "invalid GnmiFieldType: " << static_cast<int>(field_type);
+  return "";
+}
+
+std::string OpenConfigWithInterfaces(
+    GnmiFieldType field_type,
+    absl::Span<const OpenConfigInterfaceDescription> interfaces) {
+  using json = nlohmann::json;
+  std::vector<json> port_configs;
+  for (const auto& interface : interfaces) {
+    port_configs.push_back({{"name", interface.port_name},
+                            {GnmiFieldTypeToString(field_type),
+                             {{"openconfig-p4rt:id", interface.port_id}}}});
+  }
+  json open_config{
+      {"openconfig-interfaces:interfaces", {{"interface", port_configs}}}};
+  return open_config.dump();
+}
+
+std::string EmptyOpenConfig() {
+  return OpenConfigWithInterfaces(GnmiFieldType::kConfig, /*interfaces=*/{});
+}
+
+// This API generates gNMI path from OC path string.
+// Example1:
+// components/component[name=integrated_circuit0]/integrated-circuit/state.
+// Example2:
+// components/component[name=1/1]/integrated-circuit/state.
+gnmi::Path ConvertOCStringToPath(absl::string_view oc_path) {
+  absl::string_view element;
+  std::vector<absl::string_view> elements;
+  while (RE2::FindAndConsume(&oc_path, *kSplitBreakSquareBraceRE, &element)) {
+    elements.push_back(element);
+  }
+  gnmi::Path path;
+  for (absl::string_view node : elements) {
+    // Splits string in format "component[name=integrated_circuit0]" to three
+    // tokens.
+    static constexpr LazyRE2 kSplitNameValueRE = {R"((.+)\[(.+)=(.+)\])"};
+    std::string key;
+    std::string attribute;
+    std::string value;
+    // "key/[attribute=value]" requests are in the format
+    // Ex:interface[name=Ethernet0].
+    if (RE2::FullMatch(node, *kSplitNameValueRE, &key, &attribute, &value)) {
+      auto* elem = path.add_elem();
+      elem->set_name(key);
+      (*elem->mutable_key())[attribute] = value;
+    } else {
+      path.add_elem()->set_name(std::string(node));
+    }
+  }
+  return path;
+}
+
+gnoi::types::Path GnmiToGnoiPath(gnmi::Path path) {
+  gnoi::types::Path gnoi_path;
+  gnoi_path.set_origin(std::move(*path.mutable_origin()));
+  for (gnmi::PathElem& element : *path.mutable_elem()) {
+    gnoi::types::PathElem& gnoi_element = *gnoi_path.add_elem();
+    gnoi_element.set_name(std::move(*element.mutable_name()));
+    *gnoi_element.mutable_key() = std::move(*element.mutable_key());
+  }
+  return gnoi_path;
+}
+
+absl::StatusOr<gnmi::SetRequest> BuildGnmiSetRequest(
+    absl::string_view oc_path, GnmiSetType set_type,
+    absl::string_view json_val) {
+  gnmi::SetRequest req;
+  req.mutable_prefix()->set_origin(kOpenconfigStr);
+  gnmi::Path* path;
+
+  switch (set_type) {
+    case GnmiSetType::kUpdate: {
+      gnmi::Update* update = req.add_update();
+      path = update->mutable_path();
+      update->mutable_val()->set_json_ietf_val(std::string(json_val));
+    } break;
+
+    case GnmiSetType::kReplace: {
+      gnmi::Update* replace = req.add_replace();
+      path = replace->mutable_path();
+      replace->mutable_val()->set_json_ietf_val(std::string(json_val));
+    } break;
+
+    case GnmiSetType::kDelete: {
+      path = req.add_delete_();
+    } break;
+
+    default:
+      return gutil::InternalErrorBuilder().LogError()
+             << "Unknown gNMI Set Request";
+  }
+
+  *path = ConvertOCStringToPath(oc_path);
+  return req;
+}
+
+absl::StatusOr<gnmi::GetRequest> BuildGnmiGetRequest(
+    absl::string_view oc_path, gnmi::GetRequest::DataType req_type) {
+  gnmi::GetRequest req;
+  req.set_type(req_type);
+  req.mutable_prefix()->set_origin(kOpenconfigStr);
+  if (oc_path.empty()) {
+    return req;
+  }
+  *req.add_path() = ConvertOCStringToPath(oc_path);
+  return req;
+}
+
+absl::StatusOr<std::string> ParseJsonResponse(absl::string_view val,
+                                              absl::string_view match_tag) {
+  if (match_tag.empty()) return std::string(val);
+  const auto resp_json = json::parse(val);
+  const auto match_tag_json = resp_json.find(match_tag);
+  if (match_tag_json == resp_json.end()) {
+    return gutil::InternalErrorBuilder().LogError()
+           << match_tag << " not present in JSON response " << val;
+  }
+  return match_tag_json->dump();
+}
+
+absl::StatusOr<std::string> ParseGnmiGetResponse(
+    const gnmi::GetResponse& response, absl::string_view match_tag) {
+  if (response.notification_size() != 1)
+    return gutil::InternalErrorBuilder().LogError()
+           << "Unexpected size in response (should be 1): "
+           << response.notification_size();
+
+  if (response.notification(0).update_size() != 1)
+    return gutil::InternalErrorBuilder().LogError()
+           << "Unexpected update size in response (should be 1): "
+           << response.notification(0).update_size();
+  switch (response.notification(0).update(0).val().value_case()) {
+    case gnmi::TypedValue::kStringVal:
+      return response.notification(0).update(0).val().string_val();
+    case gnmi::TypedValue::kJsonVal:
+      return ParseJsonResponse(
+          response.notification(0).update(0).val().json_val(), match_tag);
+    case gnmi::TypedValue::kJsonIetfVal:
+      return ParseJsonResponse(
+          response.notification(0).update(0).val().json_ietf_val(), match_tag);
+    default:
+      return gutil::InternalErrorBuilder().LogError()
+             << "Unexpected data type: "
+             << response.notification(0).update(0).val().value_case();
+  }
+}
+
+absl::Status SetGnmiConfigPath(gnmi::gNMI::StubInterface* gnmi_stub,
+                               absl::string_view config_path,
+                               GnmiSetType operation, absl::string_view value) {
+  ASSIGN_OR_RETURN(gnmi::SetRequest request,
+                   BuildGnmiSetRequest(config_path, operation, value));
+  LOG(INFO) << "Sending SET request: " << request.ShortDebugString();
+  gnmi::SetResponse response;
+  grpc::ClientContext context;
+  auto status = gnmi_stub->Set(&context, request, &response);
+  if (!status.ok()) {
+    return gutil::UnknownErrorBuilder().LogError()
+           << "SET request failed! Error code: " << status.error_code()
+           << " , Error message: " << status.error_message();
+  }
+  LOG(INFO) << "Received SET response: " << response.ShortDebugString();
+  return absl::OkStatus();
+}
+
+absl::Status PushGnmiConfig(gnmi::gNMI::StubInterface& stub,
+                            const std::string& chassis_name,
+                            const std::string& gnmi_config,
+                            absl::uint128 election_id) {
+  gnmi::SetRequest req;
+  req.mutable_prefix()->set_origin("openconfig");
+  req.mutable_prefix()->set_target(chassis_name);
+  gnmi::Update* replace = req.add_replace();
+  replace->mutable_path();
+  replace->mutable_val()->set_json_ietf_val(gnmi_config);
+  gnmi_ext::MasterArbitration* arbitration =
+      req.add_extension()->mutable_master_arbitration();
+  arbitration->mutable_role()->set_id("dataplane test");
+  arbitration->mutable_election_id()->set_high(
+      absl::Uint128High64(election_id));
+  arbitration->mutable_election_id()->set_low(absl::Uint128Low64(election_id));
+
+  gnmi::SetResponse resp;
+  grpc::ClientContext context;
+  grpc::Status status = stub.Set(&context, req, &resp);
+  if (!status.ok()) return gutil::GrpcStatusToAbslStatus(status);
+  LOG(INFO) << "Config push response: " << resp.ShortDebugString();
+  return absl::OkStatus();
+}
+
+absl::Status PushGnmiConfig(thinkit::Switch& chassis,
+                            const std::string& gnmi_config) {
+  ASSIGN_OR_RETURN(auto stub, chassis.CreateGnmiStub());
+  return pins_test::PushGnmiConfig(
+      *stub, chassis.ChassisName(),
+      UpdateDeviceIdInJsonConfig(gnmi_config,
+                                 absl::StrCat(chassis.DeviceId())));
+}
+
+absl::Status WaitForGnmiPortIdConvergence(gnmi::gNMI::StubInterface& stub,
+                                          const std::string& gnmi_config,
+                                          const absl::Duration& timeout) {
+  VLOG(1) << "Waiting for gNMI to converge.";
+  // Get expected port ID mapping from the gNMI config.
+  absl::flat_hash_map<std::string, std::string> expected_port_id_by_name;
+  ASSIGN_OR_RETURN(
+      expected_port_id_by_name,
+      GetPortNameToIdMapFromJsonString(gnmi_config, /*field_type=*/"config"));
+  VLOG(1) << "gNMI has converged.";
+
+  // Poll the switch's state waiting for the port name and ID mappings to match.
+  absl::Time start_time = absl::Now();
+  bool converged = false;
+  LOG(INFO) << "Waiting for port name & ID mappings to converge.";
+  while (!converged && (absl::Now() < (start_time + timeout))) {
+    ASSIGN_OR_RETURN(gnmi::GetResponse response,
+                     GetAllInterfaceOverGnmi(stub, absl::Seconds(60)));
+    if (response.notification_size() < 1) {
+      return absl::InternalError(
+          absl::StrCat("Invalid response: ", response.DebugString()));
+    }
+
+    absl::flat_hash_map<std::string, std::string> actual_port_id_by_name;
+    ASSIGN_OR_RETURN(
+        actual_port_id_by_name,
+        GetPortNameToIdMapFromJsonString(
+            response.notification(0).update(0).val().json_ietf_val(),
+            /*field_type=*/"state"));
+
+    if (expected_port_id_by_name == actual_port_id_by_name) {
+      converged = true;
+    }
+  }
+
+  if (!converged) {
+    return gutil::FailedPreconditionErrorBuilder()
+           << "gNMI config did not coverge after " << timeout << ".";
+  }
+  return absl::OkStatus();
+}
+
+absl::Status WaitForGnmiPortIdConvergence(thinkit::Switch& chassis,
+                                          const std::string& gnmi_config,
+                                          const absl::Duration& timeout) {
+  ASSIGN_OR_RETURN(auto stub, chassis.CreateGnmiStub());
+  return WaitForGnmiPortIdConvergence(*stub, gnmi_config, timeout);
+}
+
+absl::Status CanGetAllInterfaceOverGnmi(gnmi::gNMI::StubInterface& stub,
+                                        absl::Duration timeout) {
+  return GetAllInterfaceOverGnmi(stub).status();
+}
+
+absl::StatusOr<gnmi::GetResponse> GetAllInterfaceOverGnmi(
+    gnmi::gNMI::StubInterface& stub, absl::Duration timeout) {
+  ASSIGN_OR_RETURN(auto req,
+                   BuildGnmiGetRequest("interfaces", gnmi::GetRequest::STATE));
+  return SendGnmiGetRequest(&stub, req, timeout);
+}
+
+absl::StatusOr<absl::flat_hash_map<std::string, std::string>>
+GetInterfaceToOperStatusMapOverGnmi(gnmi::gNMI::StubInterface& stub,
+                                    absl::Duration timeout) {
+  ASSIGN_OR_RETURN(auto req,
+                   BuildGnmiGetRequest("interfaces", gnmi::GetRequest::STATE));
+  ASSIGN_OR_RETURN(gnmi::GetResponse resp,
+                   SendGnmiGetRequest(&stub, req, timeout));
+  if (resp.notification_size() < 1 || resp.notification(0).update_size() < 1) {
+    return absl::InternalError(
+        absl::StrCat("Invalid response: ", resp.DebugString()));
+  }
+
+  const auto resp_json = nlohmann::json::parse(
+      resp.notification(0).update(0).val().json_ietf_val());
+  const auto oc_intf_json = resp_json.find("openconfig-interfaces:interfaces");
+  if (oc_intf_json == resp_json.end()) {
+    return absl::NotFoundError(absl::StrCat(
+        "'openconfig-interfaces:interfaces' not found: ", resp_json.dump()));
+  }
+  const auto oc_intf_list_json = oc_intf_json->find("interface");
+  if (oc_intf_list_json == oc_intf_json->end()) {
+    return absl::NotFoundError(
+        absl::StrCat("'interface' not found: ", oc_intf_json->dump()));
+  }
+
+  absl::flat_hash_map<std::string, std::string> interface_to_oper_status_map;
+  for (auto const& element : oc_intf_list_json->items()) {
+    const auto element_name_json = element.value().find("name");
+    if (element_name_json == element.value().end()) {
+      return absl::NotFoundError(
+          absl::StrCat("'name' not found: ", element.value().dump()));
+    }
+    std::string name = std::string(StripQuotes(element_name_json->dump()));
+
+    // TODO: Remove once CPU contains the oper-state subtree.
+    if (absl::StartsWith(name, "CPU")) {
+      LOG(INFO) << "Skipping " << name << ".";
+      continue;
+    }
+
+    const auto element_interface_state_json = element.value().find("state");
+    if (element_interface_state_json == element.value().end()) {
+      return absl::NotFoundError(absl::StrCat("'state' not found: ", name));
+    }
+    const auto element_status_json =
+        element_interface_state_json->find("oper-status");
+    if (element_status_json == element_interface_state_json->end()) {
+      return absl::NotFoundError(
+          absl::StrCat("'oper-status' not found: ", name));
+    }
+    interface_to_oper_status_map[name] =
+        std::string(StripQuotes(element_status_json->dump()));
+  }
+
+  return interface_to_oper_status_map;
+}
+
+absl::Status CheckInterfaceOperStateOverGnmi(
+    gnmi::gNMI::StubInterface& stub, absl::string_view interface_oper_state,
+    absl::Span<const std::string> interfaces, bool skip_non_ethernet_interfaces,
+    absl::Duration timeout) {
+  ASSIGN_OR_RETURN(const auto interface_to_oper_status_map,
+                   GetInterfaceToOperStatusMapOverGnmi(stub, timeout));
+
+  std::vector<std::string> all_interfaces;
+  absl::flat_hash_set<std::string> matching_interfaces;
+  for (const auto& [interface, oper_status] : interface_to_oper_status_map) {
+    all_interfaces.push_back(interface);
+    if (oper_status == interface_oper_state) {
+      matching_interfaces.insert(interface);
+    }
+  }
+  if (interfaces.empty()) {
+    interfaces = all_interfaces;
+  }
+
+  std::vector<std::string> unavailable_interfaces;
+  for (const std::string& interface : interfaces) {
+    if (skip_non_ethernet_interfaces &&
+        !absl::StrContains(interface, "Ethernet")) {
+      LOG(INFO) << "Skipping check on interface: " << interface;
+      continue;
+    }
+    if (!matching_interfaces.contains(interface)) {
+      LOG(INFO) << "Interface "
+                << interface << " not found in interfaces that are "
+                << interface_oper_state;
+      unavailable_interfaces.push_back(interface);
+    }
+  }
+
+  if (!unavailable_interfaces.empty()) {
+    return absl::UnavailableError(absl::StrCat(
+        "Some interfaces are not in the expected state ", interface_oper_state,
+        ": \n", absl::StrJoin(unavailable_interfaces, "\n"),
+        "\n\nInterfaces provided: \n", absl::StrJoin(interfaces, "\n")));
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::string> ReadGnmiPath(gnmi::gNMI::StubInterface* gnmi_stub,
+                                         absl::string_view path,
+                                         gnmi::GetRequest::DataType req_type,
+                                         absl::string_view resp_parse_str) {
+  ASSIGN_OR_RETURN(gnmi::GetRequest request,
+                   BuildGnmiGetRequest(path, req_type));
+  ASSIGN_OR_RETURN(
+      gnmi::GetResponse response,
+      SendGnmiGetRequest(gnmi_stub, request, /*timeout=*/std::nullopt));
+  return ParseGnmiGetResponse(response, resp_parse_str);
+}
+
+absl::StatusOr<std::string> GetGnmiStatePathInfo(
+    gnmi::gNMI::StubInterface* gnmi_stub, absl::string_view state_path,
+    absl::string_view resp_parse_str) {
+  return ReadGnmiPath(gnmi_stub, state_path, gnmi::GetRequest::STATE,
+                      resp_parse_str);
+}
+
+absl::StatusOr<ResultWithTimestamp> GetGnmiStatePathAndTimestamp(
+    gnmi::gNMI::StubInterface* gnmi_stub, absl::string_view path,
+    absl::string_view resp_parse_str) {
+  ASSIGN_OR_RETURN(gnmi::GetRequest request,
+                   BuildGnmiGetRequest(path, gnmi::GetRequest::STATE));
+  ASSIGN_OR_RETURN(
+      gnmi::GetResponse response,
+      SendGnmiGetRequest(gnmi_stub, request, /*timeout=*/std::nullopt));
+  ASSIGN_OR_RETURN(std::string result,
+                   ParseGnmiGetResponse(response, resp_parse_str));
+
+  if (response.notification().empty()) {
+    return absl::InternalError("Invalid response");
+  }
+
+  return ResultWithTimestamp{.response = std::string(StripQuotes(result)),
+                             .timestamp = response.notification(0).timestamp()};
+}
+
+void AddSubtreeToGnmiSubscription(absl::string_view subtree_root,
+                                  gnmi::SubscriptionList& subscription_list,
+                                  gnmi::SubscriptionMode mode,
+                                  bool suppress_redundant,
+                                  absl::Duration interval) {
+  gnmi::Subscription* subscription = subscription_list.add_subscription();
+  subscription->set_mode(mode);
+  if (mode == gnmi::SAMPLE) {
+    subscription->set_sample_interval(absl::ToInt64Nanoseconds(interval));
+  }
+  subscription->set_suppress_redundant(suppress_redundant);
+  *subscription->mutable_path() = ConvertOCStringToPath(subtree_root);
+}
+
+absl::StatusOr<std::vector<absl::string_view>>
+GnmiGetElementFromTelemetryResponse(const gnmi::SubscribeResponse& response) {
+  if (response.update().update_size() <= 0)
+    return gutil::InternalErrorBuilder().LogError()
+           << "Unexpected update size in response (should be > 0): "
+           << response.update().update_size();
+  LOG(INFO) << "Update size in response: " << response.update().update_size();
+
+  std::vector<absl::string_view> elements;
+  for (const auto& u : response.update().update()) {
+    if (u.path().elem_size() <= 0)
+      return gutil::InternalErrorBuilder().LogError()
+             << "Unexpected element size in response (should be > 0): "
+             << u.path().elem_size();
+
+    for (const auto& e : u.path().elem()) {
+      elements.push_back(e.name());
+    }
+  }
+  return elements;
+}
+
+absl::StatusOr<std::vector<std::string>> GetUpInterfacesOverGnmi(
+    gnmi::gNMI::StubInterface& stub, absl::Duration timeout) {
+  ASSIGN_OR_RETURN(const auto interface_to_oper_status_map,
+                   GetInterfaceToOperStatusMapOverGnmi(stub, timeout));
+
+  std::vector<std::string> up_interfaces;
+  for (const auto& [interface, oper_status] : interface_to_oper_status_map) {
+    // Ignore the interfaces that is not EthernetXX. For example: bond0,
+    // Loopback0, etc.
+    if (!absl::StartsWith(interface, "Ethernet")) {
+      LOG(INFO) << "Ignoring interface: " << interface;
+      continue;
+    }
+    if (oper_status == "UP") {
+      up_interfaces.push_back(interface);
+    }
+  }
+
+  return up_interfaces;
+}
+
+absl::StatusOr<OperStatus> GetInterfaceOperStatusOverGnmi(
+    gnmi::gNMI::StubInterface& stub, absl::string_view if_name) {
+  std::string if_req = absl::StrCat("interfaces/interface[name=", if_name,
+                                    "]/state/oper-status");
+  ASSIGN_OR_RETURN(auto request,
+                   BuildGnmiGetRequest(if_req, gnmi::GetRequest::STATE));
+  ASSIGN_OR_RETURN(
+      gnmi::GetResponse response,
+      SendGnmiGetRequest(&stub, request, /*timeout=*/std::nullopt));
+
+  if (response.notification_size() != 1 ||
+      response.notification(0).update_size() != 1) {
+    return absl::InternalError(
+        absl::StrCat("Invalid response: ", response.DebugString()));
+  }
+  ASSIGN_OR_RETURN(
+      std::string oper_status,
+      ParseGnmiGetResponse(response, "openconfig-interfaces:oper-status"));
+
+  if (absl::StrContains(oper_status, "UP")) {
+    return OperStatus::kUp;
+  }
+  if (absl::StrContains(oper_status, "DOWN")) {
+    return OperStatus::kDown;
+  }
+  if (absl::StrContains(oper_status, "TESTING")) {
+    return OperStatus::kTesting;
+  }
+  return OperStatus::kUnknown;
+}
+
+absl::StatusOr<absl::flat_hash_map<std::string, std::string>>
+GetAllEnabledInterfaceNameToPortId(gnmi::gNMI::StubInterface& stub,
+                                   absl::Duration timeout) {
+  // Gets the config path for all interfaces.
+  ASSIGN_OR_RETURN(auto request,
+                   BuildGnmiGetRequest("interfaces", gnmi::GetRequest::CONFIG));
+  ASSIGN_OR_RETURN(gnmi::GetResponse response,
+                   SendGnmiGetRequest(&stub, request, timeout));
+
+  ASSIGN_OR_RETURN(openconfig::Config proto,
+                   gutil::ParseJsonAsProto<openconfig::Config>(
+                       response.notification(0).update(0).val().json_ietf_val(),
+                       /*ignore_unknown_fields=*/true));
+
+  absl::flat_hash_map<std::string, std::string> port_id_by_interface;
+  for (const openconfig::Interfaces::Interface& interface :
+       proto.interfaces().interfaces()) {
+    // Only return enabled ports.
+    if (interface.config().enabled()) {
+      port_id_by_interface[interface.name()] =
+          absl::StrCat(interface.config().p4rt_id());
+    }
+  }
+  return port_id_by_interface;
+}
+
+absl::StatusOr<absl::flat_hash_map<std::string, std::string>>
+GetAllInterfaceNameToPortId(absl::string_view gnmi_config) {
+  return GetPortNameToIdMapFromJsonString(gnmi_config, /*field_type=*/"config");
+}
+
+absl::StatusOr<absl::flat_hash_map<std::string, std::string>>
+GetAllInterfaceNameToPortId(gnmi::gNMI::StubInterface& stub) {
+  ASSIGN_OR_RETURN(gnmi::GetResponse response,
+                   pins_test::GetAllInterfaceOverGnmi(stub, absl::Seconds(60)));
+  if (response.notification_size() < 1) {
+    return absl::InternalError(
+        absl::StrCat("Invalid response: ", response.DebugString()));
+  }
+  return GetPortNameToIdMapFromJsonString(
+      response.notification(0).update(0).val().json_ietf_val(),
+      /*field_type=*/"state");
+}
+
+absl::StatusOr<absl::btree_set<std::string>> GetAllPortIds(
+    absl::string_view gnmi_config) {
+  ASSIGN_OR_RETURN(auto interface_name_to_port_id,
+                   GetAllInterfaceNameToPortId(gnmi_config));
+
+  absl::btree_set<std::string> port_ids;
+  for (const auto& [_, port_id] : interface_name_to_port_id) {
+    port_ids.insert(port_id);
+  }
+  return port_ids;
+}
+
+absl::StatusOr<absl::btree_set<std::string>> GetAllPortIds(
+    gnmi::gNMI::StubInterface& stub) {
+  ASSIGN_OR_RETURN(auto interface_name_to_port_id,
+                   GetAllInterfaceNameToPortId(stub));
+
+  absl::btree_set<std::string> port_ids;
+  for (const auto& [_, port_id] : interface_name_to_port_id) {
+    port_ids.insert(port_id);
+  }
+  return port_ids;
+}
+
+absl::StatusOr<std::vector<std::string>> ParseAlarms(
+    const std::string& alarms_json) {
+  auto alarms_array = json::parse(alarms_json);
+  if (!alarms_array.is_array()) {
+    return absl::InvalidArgumentError(
+        "Input JSON should be an array of alarms.");
+  }
+
+  std::vector<std::string> alarm_messages;
+  for (const auto& alarm : alarms_array) {
+    auto state = alarm.find("state");
+    if (state == alarm.end()) {
+      return absl::InvalidArgumentError(
+          "Input JSON alarm does not have a state field.");
+    }
+
+    // The state of an alarm will look like:
+    // {
+    //   "id": ...
+    //   "resource": "linkqual:linkqual"
+    //   "severity": "openconfig-alarm-types:WARNING"
+    //   "text": "INACTIVE: Unknown"
+    //   "time-created": ...
+    //   "type-id": "Software Error"
+    // }
+    //
+    // We can build an error message to look like (missing fields will be
+    // omitted):
+    // [linkqual:linkqual WARNING] Software Error INACTIVE: Unknown
+    std::string message = "[";
+    auto resource = state->find("resource");
+    if (resource != state->end()) {
+      absl::StrAppend(&message, StripQuotes(resource->dump()), " ");
+    }
+    auto severity = state->find("severity");
+    if (severity != state->end()) {
+      // We only need the last part.
+      std::vector<std::string> parts =
+          absl::StrSplit(StripQuotes(severity->dump()), ':');
+      absl::StrAppend(&message, parts.back());
+    }
+    absl::StrAppend(&message, "] ");
+    auto type_id = state->find("type-id");
+    if (type_id != state->end()) {
+      absl::StrAppend(&message, StripQuotes(type_id->dump()), " ");
+    }
+    auto text = state->find("text");
+    if (text != state->end()) {
+      absl::StrAppend(&message, StripQuotes(text->dump()));
+    }
+    alarm_messages.push_back(std::move(message));
+  }
+  return alarm_messages;
+}
+
+absl::StatusOr<std::vector<std::string>> GetAlarms(
+    gnmi::gNMI::StubInterface& gnmi_stub) {
+  ASSIGN_OR_RETURN(
+      gnmi::GetRequest request,
+      BuildGnmiGetRequest("system/alarms", gnmi::GetRequest::STATE));
+  LOG(INFO) << "Sending GET request: " << request.ShortDebugString();
+  ASSIGN_OR_RETURN(
+      gnmi::GetResponse response,
+      SendGnmiGetRequest(&gnmi_stub, request, /*timeout=*/std::nullopt));
+
+  if (response.notification_size() != 1) {
+    return gutil::InternalErrorBuilder().LogError()
+           << "Unexpected size in response (should be 1): "
+           << response.notification_size();
+  }
+  if (response.notification(0).update_size() != 1) {
+    return gutil::InternalErrorBuilder().LogError()
+           << "Unexpected update size in response (should be 1): "
+           << response.notification(0).update_size();
+  }
+
+  const auto response_json =
+      json::parse(response.notification(0).update(0).val().json_ietf_val());
+  const auto alarms_json = response_json.find("openconfig-system:alarms");
+  // If alarms returns an empty subtree, assume no alarms and return an empty
+  // list.
+  if (alarms_json == response_json.end()) {
+    return std::vector<std::string>();
+  }
+
+  const auto alarm_json = alarms_json->find("alarm");
+  if (alarm_json == alarms_json->end()) {
+    return std::vector<std::string>();
+  }
+  return ParseAlarms(alarm_json->dump());
+}
+
+absl::StatusOr<gnmi::GetResponse> GetAllSystemProcesses(
+    gnmi::gNMI::StubInterface& gnmi_stub) {
+  ASSIGN_OR_RETURN(
+      gnmi::GetRequest request,
+      BuildGnmiGetRequest("system/processes", gnmi::GetRequest::STATE));
+  LOG(INFO) << "Sending GET request: " << request.ShortDebugString();
+  return SendGnmiGetRequest(&gnmi_stub, request, /*timeout=*/std::nullopt);
+}
+
+absl::StatusOr<gnmi::GetResponse> GetSystemMemory(
+    gnmi::gNMI::StubInterface& gnmi_stub) {
+  ASSIGN_OR_RETURN(
+      gnmi::GetRequest request,
+      BuildGnmiGetRequest("system/memory", gnmi::GetRequest::STATE));
+  LOG(INFO) << "Sending GET request: " << request.ShortDebugString();
+  return SendGnmiGetRequest(&gnmi_stub, request, /*timeout=*/std::nullopt);
+}
+
+absl::string_view StripQuotes(absl::string_view string) {
+  return absl::StripPrefix(absl::StripSuffix(string, "\""), "\"");
+}
+
+absl::string_view StripBrackets(absl::string_view string) {
+  return absl::StripPrefix(absl::StripSuffix(string, "]"), "[");
+}
+
+absl::StatusOr<absl::flat_hash_map<std::string, std::string>>
+GetInterfaceToTransceiverMap(gnmi::gNMI::StubInterface& gnmi_stub) {
+  ASSIGN_OR_RETURN(
+      std::string response,
+      pins_test::GetGnmiStatePathInfo(&gnmi_stub, "interfaces",
+                                      "openconfig-interfaces:interfaces"));
+  json response_json = json::parse(response);
+  ASSIGN_OR_RETURN(json interfaces, GetField(response_json, "interface"));
+
+  absl::flat_hash_map<std::string, std::string> interface_to_transceiver;
+  for (const auto& interface : interfaces.items()) {
+    ASSIGN_OR_RETURN(json name, GetField(interface.value(), "name"));
+    if (!absl::StartsWith(name.get<std::string>(), "Ethernet")) {
+      continue;
+    }
+
+    ASSIGN_OR_RETURN(json state, GetField(interface.value(), "state"));
+    ASSIGN_OR_RETURN(
+        json transceiver,
+        GetField(state, "openconfig-platform-transceiver:transceiver"));
+    interface_to_transceiver[name.get<std::string>()] =
+        transceiver.get<std::string>();
+  }
+  return interface_to_transceiver;
+}
+
+absl::StatusOr<absl::flat_hash_map<std::string, TransceiverPart>>
+GetTransceiverPartInformation(gnmi::gNMI::StubInterface& gnmi_stub) {
+  ASSIGN_OR_RETURN(std::string response, pins_test::GetGnmiStatePathInfo(
+                                             &gnmi_stub, "components",
+                                             "openconfig-platform:components"));
+  json response_json = json::parse(response);
+  ASSIGN_OR_RETURN(json components, GetField(response_json, "component"));
+
+  absl::flat_hash_map<std::string, TransceiverPart> part_information;
+  for (const auto& component : components.items()) {
+    ASSIGN_OR_RETURN(json name, GetField(component.value(), "name"));
+    if (!absl::StartsWith(name.get<std::string>(), "Ethernet")) {
+      continue;
+    }
+
+    ASSIGN_OR_RETURN(json state, GetField(component.value(), "state"));
+    ASSIGN_OR_RETURN(json empty, GetField(state, "empty"));
+    if (empty.get<bool>()) {
+      continue;
+    }
+    ASSIGN_OR_RETURN(json vendor,
+                     GetField(state, "openconfig-platform-ext:vendor-name"));
+    ASSIGN_OR_RETURN(json part_number, GetField(state, "part-no"));
+    ASSIGN_OR_RETURN(json rev, GetField(state, "firmware-version"));
+    part_information[name.get<std::string>()] = TransceiverPart{
+        .vendor = vendor.get<std::string>(),
+        .part_number = part_number.get<std::string>(),
+        .rev = rev.get<std::string>(),
+    };
+  }
+  return part_information;
+}
+
+// We cannot "replace" the node-id value directly because if the
+// "integrated_circuit0" component doesn't exist the gNMI set path will reject
+// the request. Instead we "update" just the node-id, but include the entire
+// "integrated_circuit0" component as part of the value. This way if it doesn't
+// exist gNMI will create a new component and set the node-id. If it does exist
+// gNMI will simply update the value in the existing component.
+absl::Status SetDeviceId(gnmi::gNMI::StubInterface& gnmi_stub,
+                         uint32_t device_id) {
+  std::string config_value = absl::Substitute(
+      R"json({
+        "component" : [
+          {
+            "integrated-circuit" : {
+              "config" : {
+                "openconfig-p4rt:node-id" : "$0"
+              }
+            },
+            "name" : "integrated_circuit0"
+          }
+        ]
+      })json",
+      device_id);
+  RETURN_IF_ERROR(SetGnmiConfigPath(&gnmi_stub,
+                                    /*config_path=*/"components/component",
+                                    GnmiSetType::kUpdate, config_value));
+  return absl::OkStatus();
+}
+
+std::string UpdateDeviceIdInJsonConfig(const std::string& gnmi_config,
+                                       const std::string& device_id) {
+  LOG(INFO) << "Forcing P4RT device ID to be '" << device_id << "'.";
+
+  nlohmann::basic_json<> json =
+      gnmi_config.empty() ? json::object() : json::parse(gnmi_config);
+  auto oc_component =
+      json.emplace("openconfig-platform:components", json::object()).first;
+  auto component_list =
+      oc_component->emplace("component", nlohmann::json::array()).first;
+
+  // The Device ID should always be written to integrated_circuit0. If this
+  // component exist then we update that field.
+  bool found_integrated_circuit = false;
+  for (nlohmann::basic_json<>& component : *component_list) {
+    if (component["name"] == "integrated_circuit0") {
+      found_integrated_circuit = true;
+      component["integrated-circuit"]["config"]["openconfig-p4rt:node-id"] =
+          device_id;
+    }
+  }
+
+  // If the integrated_circuit0 object does not exist then we will create it.
+  if (!found_integrated_circuit) {
+    nlohmann::basic_json<> component = json::object();
+    component["name"] = "integrated_circuit0";
+    component["integrated-circuit"]["config"]["openconfig-p4rt:node-id"] =
+        device_id;
+    component_list->insert(component_list->end(), component);
+  }
+  return json.dump();
+}
+
+absl::StatusOr<absl::flat_hash_map<std::string, std::string>>
+GetTransceiverToEthernetPmdMap(gnmi::gNMI::StubInterface& gnmi_stub) {
+  ASSIGN_OR_RETURN(std::string response, pins_test::GetGnmiStatePathInfo(
+                                             &gnmi_stub, "components",
+                                             "openconfig-platform:components"));
+  json response_json = json::parse(response);
+  ASSIGN_OR_RETURN(json components, GetField(response_json, "component"));
+
+  absl::flat_hash_map<std::string, std::string> pmd_types;
+  for (const auto& component : components.items()) {
+    ASSIGN_OR_RETURN(json name, GetField(component.value(), "name"));
+    if (!absl::StartsWith(name.get<std::string>(), "Ethernet")) {
+      continue;
+    }
+
+    ASSIGN_OR_RETURN(json state, GetField(component.value(), "state"));
+    ASSIGN_OR_RETURN(json empty, GetField(state, "empty"));
+    if (empty.get<bool>()) {
+      continue;
+    }
+
+    ASSIGN_OR_RETURN(json transceiver,
+                     GetField(component.value(),
+                              "openconfig-platform-transceiver:transceiver"));
+    ASSIGN_OR_RETURN(json xcvr_state, GetField(transceiver, "state"));
+    ASSIGN_OR_RETURN(json ethernet_pmd, GetField(xcvr_state, "ethernet-pmd"));
+    pmd_types[name.get<std::string>()] = ethernet_pmd.get<std::string>();
+  }
+  return pmd_types;
+}
+
+absl::StatusOr<absl::flat_hash_map<std::string, int>>
+GetInterfaceToLaneSpeedMap(gnmi::gNMI::StubInterface& gnmi_stub,
+                           absl::flat_hash_set<std::string>& interface_names) {
+  // Map of Openconfig SPEED enum strings to integer speed in Kbps (this ensures
+  // all speeds are divisible by 8).
+  const absl::flat_hash_map<std::string, int> kOcSpeedToInt = {
+      {"openconfig-if-ethernet:SPEED_10MB", 10'000},
+      {"openconfig-if-ethernet:SPEED_100MB", 100'000},
+      {"openconfig-if-ethernet:SPEED_1GB", 1'000'000},
+      {"openconfig-if-ethernet:SPEED_2500MB", 2'500'000},
+      {"openconfig-if-ethernet:SPEED_5GB", 5'000'000},
+      {"openconfig-if-ethernet:SPEED_10GB", 10'000'000},
+      {"openconfig-if-ethernet:SPEED_25GB", 25'000'000},
+      {"openconfig-if-ethernet:SPEED_40GB", 40'000'000},
+      {"openconfig-if-ethernet:SPEED_50GB", 50'000'000},
+      {"openconfig-if-ethernet:SPEED_100GB", 100'000'000},
+      {"openconfig-if-ethernet:SPEED_200GB", 200'000'000},
+      {"openconfig-if-ethernet:SPEED_400GB", 400'000'000},
+      {"openconfig-if-ethernet:SPEED_600GB", 600'000'000},
+      {"openconfig-if-ethernet:SPEED_800GB", 800'000'000},
+  };
+  ASSIGN_OR_RETURN(
+      std::string response,
+      pins_test::GetGnmiStatePathInfo(&gnmi_stub, "interfaces",
+                                      "openconfig-interfaces:interfaces"));
+  json response_json = json::parse(response);
+  ASSIGN_OR_RETURN(json interfaces, GetField(response_json, "interface"));
+
+  absl::flat_hash_map<std::string, int> interface_to_lane_speed;
+  for (const auto& interface : interfaces.items()) {
+    ASSIGN_OR_RETURN(json name, GetField(interface.value(), "name"));
+    if (!interface_names.contains(name.get<std::string>())) {
+      continue;
+    }
+    ASSIGN_OR_RETURN(
+        json ethernet,
+        GetField(interface.value(), "openconfig-if-ethernet:ethernet"));
+
+    ASSIGN_OR_RETURN(json ethernet_state, GetField(ethernet, "state"));
+    ASSIGN_OR_RETURN(json oc_port_speed,
+                     GetField(ethernet_state, "port-speed"));
+    ASSIGN_OR_RETURN(json state, GetField(interface.value(), "state"));
+    ASSIGN_OR_RETURN(
+        json physical_channel,
+        GetField(state, "openconfig-platform-transceiver:physical-channel"));
+    int lanes = physical_channel.size();
+    if (lanes == 0) {
+      LOG(WARNING) << "Interface " << name.get<std::string>()
+                   << " has physical-channel size of 0, skipping.";
+      continue;
+    }
+    auto total_speed_it = kOcSpeedToInt.find(oc_port_speed.get<std::string>());
+    if (total_speed_it == kOcSpeedToInt.end()) {
+      LOG(WARNING) << "Interface " << name.get<std::string>()
+                   << " has unknown speed: "
+                   << oc_port_speed.get<std::string>();
+      continue;
+    }
+    int total_speed = total_speed_it->second;
+    interface_to_lane_speed[name.get<std::string>()] = total_speed / lanes;
+  }
+  return interface_to_lane_speed;
+}
+
+absl::Status SetPortSpeedInBitsPerSecond(const std::string& port_speed,
+                                         const std::string& interface_name,
+                                         gnmi::gNMI::StubInterface& gnmi_stub) {
+  std::string ops_config_path =
+      absl::StrCat("interfaces/interface[name=", interface_name,
+                   "]/ethernet/config/port-speed");
+  std::string ops_val =
+      absl::StrCat("{\"openconfig-if-ethernet:port-speed\":", port_speed, "}");
+
+  RETURN_IF_ERROR(pins_test::SetGnmiConfigPath(&gnmi_stub, ops_config_path,
+                                               GnmiSetType::kUpdate, ops_val));
+
+  return absl::OkStatus();
+}
+
+absl::StatusOr<int64_t> GetPortSpeedInBitsPerSecond(
+    const std::string& interface_name, gnmi::gNMI::StubInterface& gnmi_stub) {
+  // Map keyed on openconfig speed string to value in bits per second.
+  // http://ops.openconfig.net/branches/models/master/docs/openconfig-interfaces.html#mod-openconfig-if-ethernet
+  const auto kPortSpeedTable =
+      absl::flat_hash_map<absl::string_view, uint64_t>({
+          {"openconfig-if-ethernet:SPEED_100GB", 100000000000},
+          {"openconfig-if-ethernet:SPEED_200GB", 200000000000},
+          {"openconfig-if-ethernet:SPEED_400GB", 400000000000},
+      });
+  std::string speed_state_path =
+      absl::StrCat("interfaces/interface[name=", interface_name,
+                   "]/ethernet/state/port-speed");
+
+  std::string parse_str = "openconfig-if-ethernet:port-speed";
+  ASSIGN_OR_RETURN(
+      std::string response,
+      GetGnmiStatePathInfo(&gnmi_stub, speed_state_path, parse_str));
+
+  auto speed = kPortSpeedTable.find(StripQuotes(response));
+  if (speed == kPortSpeedTable.end()) {
+    return absl::NotFoundError(response);
+  }
+  return speed->second;
+}
+
+absl::Status SetPortMtu(int port_mtu, const std::string& interface_name,
+                        gnmi::gNMI::StubInterface& gnmi_stub) {
+  std::string config_path = absl::StrCat(
+      "interfaces/interface[name=", interface_name, "]/config/mtu");
+  std::string value = absl::StrCat("{\"config:mtu\":", port_mtu, "}");
+
+  RETURN_IF_ERROR(pins_test::SetGnmiConfigPath(&gnmi_stub, config_path,
+                                               GnmiSetType::kUpdate, value));
+
+  return absl::OkStatus();
+}
+
+absl::StatusOr<bool> CheckLinkUp(const std::string& interface_name,
+                                 gnmi::gNMI::StubInterface& gnmi_stub) {
+  std::string oper_status_state_path = absl::StrCat(
+      "interfaces/interface[name=", interface_name, "]/state/oper-status");
+
+  std::string parse_str = "openconfig-interfaces:oper-status";
+  ASSIGN_OR_RETURN(
+      std::string ops_response,
+      GetGnmiStatePathInfo(&gnmi_stub, oper_status_state_path, parse_str));
+
+  return ops_response == "\"UP\"";
+}
+
+}  // namespace pins_test

--- a/lib/p4rt/BUILD.bazel
+++ b/lib/p4rt/BUILD.bazel
@@ -1,0 +1,31 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+cc_library(
+    name = "p4rt_port",
+    srcs = ["p4rt_port.cc"],
+    hdrs = ["p4rt_port.h"],
+    deps = [
+        "//p4_pdpi/string_encodings:decimal_string",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+

--- a/lib/p4rt/p4rt_port.cc
+++ b/lib/p4rt/p4rt_port.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "lib/p4rt/p4rt_port.h"
+
+#include <cstdint>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "gutil/status.h"
+#include "p4_pdpi/string_encodings/decimal_string.h"
+
+namespace pins_test {
+
+absl::StatusOr<P4rtPortId> P4rtPortId::OfP4rtEncoding(
+    absl::string_view p4rt_port_id) {
+  ASSIGN_OR_RETURN(uint32_t p4rt_port_id_int,
+                   pdpi::DecimalStringToUint32(p4rt_port_id));
+  return P4rtPortId(p4rt_port_id_int);
+}
+
+P4rtPortId P4rtPortId::OfOpenConfigEncoding(uint32_t p4rt_port_id) {
+  return P4rtPortId(p4rt_port_id);
+}
+
+uint32_t P4rtPortId::GetOpenConfigEncoding() const { return p4rt_port_id_; }
+
+std::string P4rtPortId::GetP4rtEncoding() const {
+  return absl::StrCat(p4rt_port_id_);
+}
+
+bool P4rtPortId::operator==(const P4rtPortId& other) const {
+  return p4rt_port_id_ == other.p4rt_port_id_;
+}
+
+bool P4rtPortId::operator<(const P4rtPortId& other) const {
+  return p4rt_port_id_ < other.p4rt_port_id_;
+}
+
+std::ostream& operator<<(std::ostream& os, const P4rtPortId& p4rt_port_id) {
+  return os << absl::StrCat("(p4rt_port_id: ", p4rt_port_id.GetP4rtEncoding(),
+                            ")");
+}
+
+}  // namespace pins_test

--- a/lib/p4rt/p4rt_port.h
+++ b/lib/p4rt/p4rt_port.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/p4rt/p4rt_port.h
+++ b/lib/p4rt/p4rt_port.h
@@ -13,47 +13,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef PINS_LIB_P4RT_P4RT_PORT_H_
-#define PINS_LIB_P4RT_P4RT_PORT_H_
+
+#ifndef GOOGLE_LIB_P4RT_P4RT_PORT_H_
+#define GOOGLE_LIB_P4RT_P4RT_PORT_H_
 
 #include <cstdint>
-#include <ostream>
 #include <string>
-#include <vector>
 
 #include "absl/status/statusor.h"
-#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/span.h"
 
 namespace pins_test {
 
 // Class representing a P4Runtime port ID.
 //
-// For historical reasons, there exists three encodings of P4Runtime port IDs:
+// For historical reasons, there exists two encodings of P4Runtime port IDs:
 // - As an integer (uint32_t) `42`, e.g. in OpenConfig.
 // - As a decimal string `"42"`, e.g. in P4Runtime messages such as table
 // entries.
-// - As a binary string `"\x2A"`, e.g. in P4Runtime messages to BMv2, which
-// doesn't currently support decimal strings. This class represents a P4Runtime
-// port ID, abstracting away the encoding.
+//
+// This class represents a P4Runtime port ID, abstracting away the encoding.
 // TODO: Agree on a single encoding so this class becomes obsolete.
 class P4rtPortId {
  public:
   // Constructors.
-  P4rtPortId() = default;
-
   // Expects a decimal string. Else returns InvalidArgumentError.
-  static absl::StatusOr<P4rtPortId> MakeFromP4rtEncoding(
+  static absl::StatusOr<P4rtPortId> OfP4rtEncoding(
       absl::string_view p4rt_port_id);
-  static absl::StatusOr<std::vector<P4rtPortId>> MakeVectorFromP4rtEncodings(
-      absl::Span<const std::string> p4rt_port_id);
 
   // Constructs a P4rtPortId from an OpenConfig encoding, i.e. a uint32. Never
   // fails.
-  static P4rtPortId MakeFromOpenConfigEncoding(uint32_t p4rt_port_id);
-  static std::vector<P4rtPortId> MakeVectorFromOpenConfigEncodings(
-      absl::Span<const uint32_t> p4rt_port_id);
+  static P4rtPortId OfOpenConfigEncoding(uint32_t p4rt_port_id);
 
   // Getters.
   // Returns OpenConfig encoding of the port ID, e.g. the uint32 `42`.
@@ -62,30 +52,17 @@ class P4rtPortId {
   // Returns P4Runtime encoding of the port ID, e.g. the string `"42"`.
   std::string GetP4rtEncoding() const;
 
-  // Returns BMv2 P4Runtime encoding of the port ID, e.g. the byte string
-  // `"\x2A"`.
-  absl::StatusOr<std::string> GetBmv2P4rtEncoding() const;
-
   bool operator==(const P4rtPortId& other) const;
   bool operator<(const P4rtPortId& other) const;
-
-  template <typename H>
-  friend H AbslHashValue(H h, const P4rtPortId& port_id) {
-    return H::combine(std::move(h), port_id.p4rt_port_id_);
-  }
 
  private:
   explicit P4rtPortId(uint32_t p4rt_port_id) : p4rt_port_id_(p4rt_port_id) {}
   uint32_t p4rt_port_id_ = 0;
 };
 
+// TODO: Remove and update the class to use AbslStringify.
 std::ostream& operator<<(std::ostream& os, const P4rtPortId& p4rt_port_id);
-
-template <typename Sink>
-inline void AbslStringify(Sink& sink, const P4rtPortId& p4rt_port_id) {
-  absl::Format(&sink, "%s", p4rt_port_id.GetP4rtEncoding());
-}
 
 }  // namespace pins_test
 
-#endif  // PINS_LIB_P4RT_P4RT_PORT_H_
+#endif  // GOOGLE_LIB_P4RT_P4RT_PORT_H_

--- a/thinkit/ssh_client.h
+++ b/thinkit/ssh_client.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2024, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef THINKIT_SSH_CLIENT_H_
+#define THINKIT_SSH_CLIENT_H_
+
+#include <string>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "absl/time/time.h"
+
+namespace thinkit {
+
+// RemoteFile represents a file on a remote device. It is meant to be used as a
+// parameter object with designated initializers.
+struct RemoteFile {
+  absl::string_view device;
+  absl::string_view file_path;
+};
+
+// SSHClient handles running remote commands or getting/putting remote files
+// onto a specified device. As these operations are whitebox and platform
+// specific, this interface should be used sparingly and only when needed.
+class SSHClient {
+ public:
+  virtual ~SSHClient() {}
+
+  // Runs the specified command on the device and returns stdout. If SSH
+  // succeeds but the command returns stderr, then this returns an UNKNOWN_ERROR
+  // status.
+  virtual absl::StatusOr<std::string> RunCommand(absl::string_view device,
+                                                 absl::string_view command,
+                                                 absl::Duration timeout) = 0;
+
+  // Copies a local file's contents to a remote destination file, creating a new
+  // file if needed and replacing any existing contents that was there.
+  virtual absl::Status PutFile(absl::string_view source,
+                               const RemoteFile& destination,
+                               absl::Duration timeout) = 0;
+
+  // Puts the provided contents into a remote destination file, creating a new
+  // file if needed and replacing any existing contents that was there.
+  virtual absl::Status PutFileContents(absl::string_view contents,
+                                       const RemoteFile& destination,
+                                       absl::Duration timeout) = 0;
+
+  // Copies a remote file's contents to a local file, creating a new
+  // file if needed and replacing any existing contents that was there.
+  virtual absl::Status GetFile(const RemoteFile& source,
+                               absl::string_view destination,
+                               absl::Duration timeout) = 0;
+
+  // Returns the contents of a remote file.
+  virtual absl::StatusOr<std::string> GetFileContents(
+      const RemoteFile& source, absl::Duration timeout) = 0;
+};
+
+}  // namespace thinkit
+
+#endif  // THINKIT_SSH_CLIENT_H_


### PR DESCRIPTION
### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 328 targets (3 packages loaded, 75 targets configured).
INFO: Found 328 targets...
INFO: Elapsed time: 6.878s, Critical Path: 5.78s
INFO: 13 processes: 5 internal, 8 linux-sandbox.
INFO: Build completed successfully, 13 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 328 targets (0 packages loaded, 24 targets configured).
INFO: Found 211 targets and 117 test targets...
INFO: Elapsed time: 69.566s, Critical Path: 16.33s
INFO: 122 processes: 129 linux-sandbox, 17 local.
INFO: Build completed successfully, 122 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 0.8s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.9s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi:table_entry_key_test                                           PASSED in 0.1s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.3s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.2s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 2.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.0s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 1.0s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.9s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.5s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.3s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.3s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.5s
//p4rt_app/tests:packetio_test                                           PASSED in 3.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.7s
//p4rt_app/tests:response_path_test                                      PASSED in 2.7s
//p4rt_app/tests:role_test                                               PASSED in 1.1s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.7s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:authz_logger_test                                       PASSED in 1.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:lru_cache_test                                          PASSED in 0.0s
//p4rt_app/utils:metric_recorder_test                                    PASSED in 1.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.6s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.3s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 13.2s
  Stats over 5 runs: max = 13.2s, min = 0.9s, avg = 8.2s, dev = 5.9s

Executed 117 out of 117 tests: 117 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones thesINFO: Build completed successfully, 122 total actions
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ 

### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.