### PR TITLE
[Thinkit][P4rtPortIds] Add functions to construct vectors of P4rtPortIds from spans.

### DIFF
--- a/lib/p4rt/BUILD.bazel
+++ b/lib/p4rt/BUILD.bazel
@@ -26,6 +26,8 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:span",
     ],
 )
 

--- a/lib/p4rt/p4rt_port.cc
+++ b/lib/p4rt/p4rt_port.cc
@@ -25,15 +25,34 @@
 
 namespace pins_test {
 
-absl::StatusOr<P4rtPortId> P4rtPortId::OfP4rtEncoding(
+absl::StatusOr<P4rtPortId> P4rtPortId::MakeFromP4rtEncoding(
     absl::string_view p4rt_port_id) {
   ASSIGN_OR_RETURN(uint32_t p4rt_port_id_int,
                    pdpi::DecimalStringToUint32(p4rt_port_id));
   return P4rtPortId(p4rt_port_id_int);
 }
 
-P4rtPortId P4rtPortId::OfOpenConfigEncoding(uint32_t p4rt_port_id) {
+absl::StatusOr<std::vector<P4rtPortId>> P4rtPortId::MakeVectorFromP4rtEncodings(
+    absl::Span<const std::string> p4rt_port_ids) {
+  std::vector<P4rtPortId> result;
+  for (absl::string_view p4rt_port_id_str : p4rt_port_ids) {
+    ASSIGN_OR_RETURN(P4rtPortId port_id,
+                     P4rtPortId::MakeFromP4rtEncoding(p4rt_port_id_str));
+    result.push_back(port_id);
+  }
+  return result;
+}
+
+P4rtPortId P4rtPortId::MakeFromOpenConfigEncoding(uint32_t p4rt_port_id) {
   return P4rtPortId(p4rt_port_id);
+}
+std::vector<P4rtPortId> P4rtPortId::MakeVectorFromOpenConfigEncodings(
+    absl::Span<const uint32_t> p4rt_port_ids) {
+  std::vector<P4rtPortId> result;
+  for (uint32_t p4rt_port_id : p4rt_port_ids) {
+    result.push_back(P4rtPortId::MakeFromOpenConfigEncoding(p4rt_port_id));
+  }
+  return result;
 }
 
 uint32_t P4rtPortId::GetOpenConfigEncoding() const { return p4rt_port_id_; }

--- a/lib/p4rt/p4rt_port.h
+++ b/lib/p4rt/p4rt_port.h
@@ -22,6 +22,7 @@
 
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 
 namespace pins_test {
 
@@ -40,12 +41,16 @@ class P4rtPortId {
   // Constructors.
 
   // Expects a decimal string. Else returns InvalidArgumentError.
-  static absl::StatusOr<P4rtPortId> OfP4rtEncoding(
+  static absl::StatusOr<P4rtPortId> MakeFromP4rtEncoding(
       absl::string_view p4rt_port_id);
+  static absl::StatusOr<std::vector<P4rtPortId>> MakeVectorFromP4rtEncodings(
+      absl::Span<const std::string> p4rt_port_id);
 
   // Constructs a P4rtPortId from an OpenConfig encoding, i.e. a uint32. Never
   // fails.
-  static P4rtPortId OfOpenConfigEncoding(uint32_t p4rt_port_id);
+  static P4rtPortId MakeFromOpenConfigEncoding(uint32_t p4rt_port_id);
+  static std::vector<P4rtPortId> MakeVectorFromOpenConfigEncodings(
+      absl::Span<const uint32_t> p4rt_port_id);
 
   // Getters.
   // Returns OpenConfig encoding of the port ID, e.g. the uint32 `42`.
@@ -56,6 +61,11 @@ class P4rtPortId {
 
   bool operator==(const P4rtPortId& other) const;
   bool operator<(const P4rtPortId& other) const;
+
+  template <typename H>
+  friend H AbslHashValue(H h, const P4rtPortId& port_id) {
+    return H::combine(std::move(h), port_id.p4rt_port_id_);
+  }
 
  private:
   explicit P4rtPortId(uint32_t p4rt_port_id) : p4rt_port_id_(p4rt_port_id) {}


### PR DESCRIPTION
PR Description:
[P4rtPortIds] Add functions to construct vectors of P4rtPortIds from spans.

Keyword Check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 323 targets (2 packages loaded, 63 targets configured).
INFO: Found 323 targets...
INFO: Elapsed time: 0.910s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 

UT Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 323 targets (0 packages loaded, 5 targets configured).
INFO: Found 208 targets and 115 test targets...
INFO: Elapsed time: 145.228s, Critical Path: 47.34s
INFO: 120 processes: 127 linux-sandbox, 17 local.
INFO: Build completed successfully, 120 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.6s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.6s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 1.0s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.0s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:switch_state_test                                            PASSED in 0.7s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.6s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.9s
//p4_pdpi:table_entry_key_test                                           PASSED in 0.2s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 18.1s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.2s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.3s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.6s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.8s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.1s
//p4_pdpi/testing:info_test                                              PASSED in 0.4s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 2.8s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.3s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.3s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.9s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.6s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.1s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 2.0s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 2.1s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 1.6s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.8s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 1.1s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.7s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.2s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.9s
//p4rt_app/tests:action_set_test                                         PASSED in 1.2s
//p4rt_app/tests:api_access_test                                         PASSED in 1.1s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.3s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.9s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.1s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 5.3s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.5s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.8s
//p4rt_app/tests:packetio_test                                           PASSED in 3.9s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.4s
//p4rt_app/tests:resource_limits_test                                    PASSED in 6.4s
//p4rt_app/tests:response_path_test                                      PASSED in 3.3s
//p4rt_app/tests:role_test                                               PASSED in 1.3s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.0s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.9s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 9.4s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.7s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.1s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 47.3s
  Stats over 5 runs: max = 47.3s, min = 4.4s, avg = 21.6s, dev = 15.4s

Executed 115 out of 115 tests: 115 tests pass.
INFO: Build completed successfully, 120 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 
