### PR TITLE
[Thinkit] Added CommonBackend for GPINs validator. Add initial implementation of Validator and ValidatorBackend.

### DIFF
--- a/lib/validator/BUILD.bazel
+++ b/lib/validator/BUILD.bazel
@@ -31,6 +31,8 @@ cc_library(
     hdrs = ["validator.h"],
     deps = [
         ":validator_backend",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
@@ -43,10 +45,39 @@ cc_library(
     srcs = ["validator_backend.cc"],
     hdrs = ["validator_backend.h"],
     deps = [
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_library(
+    name = "common_backend",
+    srcs = ["common_backend.cc"],
+    hdrs = ["common_backend.h"],
+    deps = [
+        ":validator",
+        ":validator_backend",
+        "//gutil:status",
+        "//thinkit:ssh_client",
+        "@com_google_absl//absl/functional:bind_front",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "validator_backend_test",
+    srcs = ["validator_backend_test.cc"],
+    deps = [
+        ":validator_backend",
+        "//gutil:status_matchers",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/lib/validator/common_backend.cc
+++ b/lib/validator/common_backend.cc
@@ -1,0 +1,65 @@
+// Copyright (c) 2024, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lib/validator/common_backend.h"
+
+#include "absl/status/status.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/substitute.h"
+#include "gutil/status.h"
+
+namespace pins_test {
+
+absl::Status CommonBackend::IsPingable(absl::string_view chassis,
+                                       absl::Duration timeout) {
+  constexpr char kPingCommand[] = R"(fping -t $0 $1)";
+  FILE* in;
+  char buff[1024];
+  std::string pingCommand =
+      absl::Substitute(kPingCommand, absl::ToInt64Seconds(timeout), chassis);
+  if (!(in = popen(pingCommand.c_str(), "r"))) {
+    return absl::UnknownError(
+        absl::StrCat("Failed to run command: ", pingCommand));
+  }
+  std::string response;
+  while (fgets(buff, sizeof(buff), in) != nullptr) {
+    absl::StrAppend(&response, buff);
+  }
+  pclose(in);
+
+  if (!absl::StrContains(response, "alive")) {
+    return absl::UnavailableError(
+        absl::StrCat("Switch ", chassis,
+                     " is not reachable. Unexpected result: ", response));
+  }
+  return absl::OkStatus();
+}
+
+// The switch is SSHable if running the command "echo foo" returns "foo" in
+// stdout with no errors.
+absl::Status CommonBackend::IsSSHable(absl::string_view chassis,
+                                      absl::Duration timeout) {
+  ASSIGN_OR_RETURN(std::string response,
+                   ssh_client_->RunCommand(chassis, "echo foo", timeout));
+
+  if (response != "foo\n") {
+    return absl::UnavailableError(absl::StrCat(
+        "Switch ", chassis, " is not SSHable. Unexpected result: ", response));
+  }
+
+  return absl::OkStatus();
+}
+
+}  // namespace pins_test

--- a/lib/validator/common_backend.h
+++ b/lib/validator/common_backend.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2024, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_LIB_VALIDATOR_COMMON_BACKEND_H_
+#define GOOGLE_LIB_VALIDATOR_COMMON_BACKEND_H_
+
+#include "absl/functional/bind_front.h"
+#include "lib/validator/validator.h"
+#include "lib/validator/validator_backend.h"
+#include "thinkit/ssh_client.h"
+
+namespace pins_test {
+
+class CommonBackend : public ValidatorBackend {
+ public:
+  // Tags for a single validation.
+  static constexpr absl::string_view kPingable = "Pingable";
+  static constexpr absl::string_view kSSHable = "Sshable";
+
+  CommonBackend(absl::flat_hash_set<std::string> chassis,
+                std::unique_ptr<thinkit::SSHClient> ssh_client)
+      : ValidatorBackend(std::move(chassis)),
+        ssh_client_(std::move(ssh_client)) {}
+
+  // Checks if the switch can be pinged.
+  absl::Status IsPingable(absl::string_view chassis, absl::Duration timeout);
+
+  // Checks if ssh access to the switch is working.
+  absl::Status IsSSHable(absl::string_view chassis, absl::Duration timeout);
+
+ protected:
+  void SetupValidations() override {
+    Callback pingable = absl::bind_front(&CommonBackend::IsPingable, this);
+    Callback sshable = absl::bind_front(&CommonBackend::IsSSHable, this);
+
+    AddCallbacksToValidation(kPingable, {pingable});
+    AddCallbacksToValidation(kSSHable, {sshable});
+    AddCallbacksToValidation(Validator::kReady, {pingable, sshable});
+  }
+
+  std::unique_ptr<thinkit::SSHClient> ssh_client_;
+};
+
+}  // namespace pins_test
+
+#endif  // GOOGLE_LIB_VALIDATOR_COMMON_BACKEND_H_

--- a/lib/validator/validator.cc
+++ b/lib/validator/validator.cc
@@ -18,10 +18,13 @@
 #include <utility>
 #include <vector>
 
+#include "absl/algorithm/container.h"
 #include "absl/status/status.h"
+#include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
+#include "glog/logging.h"
 #include "lib/validator/validator_backend.h"
 
 namespace pins_test {
@@ -33,6 +36,39 @@ absl::Status Validator::RunValidations(
     absl::Span<const absl::string_view> devices,
     absl::Span<const absl::string_view> validations, int retry_count,
     absl::Duration timeout) {
+  std::vector<std::string> messages;
+  auto validate_device = [&](absl::string_view device, const auto& backend) {
+    return backend->RunValidations(device, validations, retry_count, timeout);
+  };
+
+  for (const auto& device : devices) {
+    std::vector<absl::Status> validation_statuses;
+    std::vector<std::string> validation_messages;
+    absl::c_transform(
+        backends_, std::back_inserter(validation_statuses),
+        [&](const auto& backend) { return validate_device(device, backend); });
+
+    absl::c_for_each(validation_statuses, [&](const absl::Status& status) {
+      if (!status.ok() && status.code() != absl::StatusCode::kNotFound) {
+        validation_messages.push_back(
+            absl::StrCat(device, " failed with: ", status.message()));
+      }
+    });
+
+    bool any_validation_passed =
+        absl::c_any_of(validation_statuses, std::mem_fn(&absl::Status::ok));
+    // If all statuses failed but there are no messages, then all statuses were
+    // NOT_FOUND.
+    if (!any_validation_passed && validation_messages.empty()) {
+      validation_messages.push_back(
+          absl::StrCat("No backends ran any validations on ", device));
+    }
+    messages.insert(messages.begin(), validation_messages.begin(),
+                    validation_messages.end());
+  }
+  if (!messages.empty()) {
+    return absl::InternalError(absl::StrJoin(messages, "; "));
+  }
   return absl::OkStatus();
 }
 

--- a/lib/validator/validator.h
+++ b/lib/validator/validator.h
@@ -22,6 +22,7 @@
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
+#include "glog/logging.h"
 #include "lib/validator/validator_backend.h"
 
 namespace pins_test {

--- a/lib/validator/validator_backend.h
+++ b/lib/validator/validator_backend.h
@@ -19,11 +19,13 @@
 #include <string>
 #include <utility>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
+#include "glog/logging.h"
 
 namespace pins_test {
 
@@ -72,6 +74,9 @@ class ValidatorBackend {
   // The set of all devices supported by this backend. Devices not in this set
   // will be ignored by this backend.
   absl::flat_hash_set<std::string> devices_;
+
+  // The map of validation tag and callbacks.
+  absl::flat_hash_map<std::string, std::vector<Callback>> validation_map_;
 };
 
 }  // namespace pins_test

--- a/lib/validator/validator_backend_test.cc
+++ b/lib/validator/validator_backend_test.cc
@@ -1,0 +1,152 @@
+#include "lib/validator/validator_backend.h"
+
+#include "absl/status/status.h"
+#include "absl/time/time.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status_matchers.h"
+
+namespace pins_test {
+namespace testing {
+
+namespace {
+
+using ::testing::_;
+using ::testing::HasSubstr;
+using ::testing::MockFunction;
+using ::testing::Return;
+
+constexpr int kDefaultRetryCount = 1;
+constexpr char kDeviceOne[] = "device_one";
+constexpr char kDeviceTwo[] = "device_two";
+constexpr char kPingable[] = "Pingable";
+constexpr char kSshAble[] = "SshAble";
+constexpr char kReady[] = "Ready";
+constexpr char kPortsUp[] = "PortsUp";
+constexpr absl::Duration kDefaultTime = absl::Minutes(5);
+
+absl::Status CallbackSuccess(absl::string_view, absl::Duration) {
+  return absl::OkStatus();
+}
+
+absl::Status CallbackError(absl::string_view, absl::Duration) {
+  return absl::InternalError("internal error");
+}
+
+}  // namespace
+
+class ValidatorBackendTest : public ValidatorBackend {
+ public:
+  ValidatorBackendTest(absl::flat_hash_set<std::string> devices)
+      : ValidatorBackend(devices) {}
+
+  void SetupValidations() override {
+    AddCallbacksToValidation(kPingable, {CallbackSuccess});
+    AddCallbacksToValidation(kSshAble, {CallbackSuccess});
+    AddCallbacksToValidation(kReady, {CallbackSuccess, CallbackError});
+  }
+
+  void SetupRetryCallback(absl::string_view validation_tag,
+                          const Callback callback) {
+    AddCallbacksToValidation(validation_tag, {callback});
+  }
+};
+
+TEST(ValidatorBackendTest, OneDeviceSuccessTest) {
+  ValidatorBackendTest validator_backend_test({kDeviceOne});
+  validator_backend_test.SetupValidations();
+  EXPECT_OK(validator_backend_test.RunValidations(
+      kDeviceOne, {kPingable}, kDefaultRetryCount, kDefaultTime));
+}
+
+TEST(ValidatorBackendTest, MultiDevicesSuccessTest) {
+  ValidatorBackendTest validator_backend_test({kDeviceOne, kDeviceTwo});
+  validator_backend_test.SetupValidations();
+  EXPECT_OK(validator_backend_test.RunValidations(
+      kDeviceOne, {kPingable}, kDefaultRetryCount, kDefaultTime));
+}
+
+TEST(ValidatorBackendTest, InvalidateDeviceIdTest) {
+  ValidatorBackendTest validator_backend_test({kDeviceOne});
+  validator_backend_test.SetupValidations();
+  EXPECT_THAT(validator_backend_test.RunValidations(
+                  kDeviceTwo, {kPingable}, kDefaultRetryCount, kDefaultTime),
+              gutil::StatusIs(absl::StatusCode::kNotFound,
+                              HasSubstr(absl::StrCat(
+                                  kDeviceTwo, " not supported by backend"))));
+}
+
+TEST(ValidatorBackendTest, InvalidateValidationTest) {
+  ValidatorBackendTest validator_backend_test({kDeviceOne});
+  validator_backend_test.SetupValidations();
+  EXPECT_THAT(
+      validator_backend_test.RunValidations(kDeviceOne, {"StackOk"},
+                                            kDefaultRetryCount, kDefaultTime),
+      gutil::StatusIs(absl::StatusCode::kNotFound,
+                      HasSubstr(absl::StrCat(
+                          "Validations are not supported by backend."))));
+}
+
+TEST(ValidatorBackendTest, MultiValidationsTest) {
+  ValidatorBackendTest validator_backend_test({kDeviceOne});
+  validator_backend_test.SetupValidations();
+  EXPECT_OK(validator_backend_test.RunValidations(
+      kDeviceOne, {kPingable, kSshAble}, kDefaultRetryCount, kDefaultTime));
+}
+
+TEST(ValidatorBackendTest, MultiDevicesAndValidationsTest) {
+  ValidatorBackendTest validator_backend_test({kDeviceOne, kDeviceTwo});
+  validator_backend_test.SetupValidations();
+  EXPECT_OK(validator_backend_test.RunValidations(
+      kDeviceOne, {kPingable}, kDefaultRetryCount, kDefaultTime));
+  EXPECT_OK(validator_backend_test.RunValidations(
+      kDeviceTwo, {kPingable}, kDefaultRetryCount, kDefaultTime));
+}
+
+TEST(ValidatorBackendTest, CallbackFailureTest) {
+  ValidatorBackendTest validator_backend_test({kDeviceOne});
+  validator_backend_test.SetupValidations();
+  EXPECT_THAT(validator_backend_test.RunValidations(
+                  kDeviceOne, {kReady}, kDefaultRetryCount, kDefaultTime),
+              gutil::StatusIs(
+                  absl::StatusCode::kInternal,
+                  HasSubstr(absl::StrCat("Running ", kReady, " on ", kDeviceOne,
+                                         " fails with internal error after ",
+                                         kDefaultRetryCount, " retries"))));
+}
+
+TEST(ValidatorBackendTest, RetryFailureTest) {
+  MockFunction<absl::Status(absl::string_view, absl::Duration)> retry_mock;
+  EXPECT_CALL(retry_mock, Call(_, _))
+      .WillOnce(Return(absl::InternalError("internal error")))
+      .WillOnce(Return(absl::InternalError("internal error")))
+      .WillRepeatedly(Return(absl::OkStatus()));
+
+  ValidatorBackendTest validator_backend_test({kDeviceOne});
+  validator_backend_test.SetupRetryCallback(kPortsUp,
+                                            retry_mock.AsStdFunction());
+  EXPECT_THAT(validator_backend_test.RunValidations(
+                  kDeviceOne, {kPortsUp}, kDefaultRetryCount, kDefaultTime),
+              gutil::StatusIs(absl::StatusCode::kInternal,
+                              HasSubstr(absl::StrCat(
+                                  "Running ", kPortsUp, " on ", kDeviceOne,
+                                  " fails with internal error after ",
+                                  kDefaultRetryCount, " retries"))));
+}
+
+TEST(ValidatorBackendTest, RetrySuccessTest) {
+  MockFunction<absl::Status(absl::string_view, absl::Duration)> retry_mock;
+  EXPECT_CALL(retry_mock, Call(_, _))
+      .WillOnce(Return(absl::InternalError("internal error")))
+      .WillOnce(Return(absl::InternalError("internal error")))
+      .WillRepeatedly(Return(absl::OkStatus()));
+
+  ValidatorBackendTest validator_backend_test({kDeviceOne});
+  validator_backend_test.SetupRetryCallback(kPortsUp,
+                                            retry_mock.AsStdFunction());
+  EXPECT_OK(validator_backend_test.RunValidations(kDeviceOne, {kPortsUp}, 2,
+                                                  kDefaultTime));
+}
+
+}  // namespace testing
+}  // namespace pins_test


### PR DESCRIPTION
PR Description:
Added CommonBackend for GPINs validator.
Add initial implementation of Validator and ValidatorBackend.

Keyword Check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 332 targets (1 packages loaded, 11 targets configured).
INFO: Found 332 targets...
INFO: Elapsed time: 2.534s, Critical Path: 1.56s
INFO: 7 processes: 1 internal, 6 linux-sandbox.
INFO: Build completed successfully, 7 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 


UT Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 332 targets (0 packages loaded, 1 target configured).
INFO: Found 216 targets and 116 test targets...
INFO: Elapsed time: 118.959s, Critical Path: 22.31s
INFO: 121 processes: 128 linux-sandbox, 17 local.
INFO: Build completed successfully, 121 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.7s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 0.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.6s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.9s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.7s
//p4_pdpi:table_entry_key_test                                           PASSED in 0.1s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.6s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.5s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.7s
//p4rt_app/tests:action_set_test                                         PASSED in 1.2s
//p4rt_app/tests:api_access_test                                         PASSED in 2.2s
//p4rt_app/tests:arbitration_test                                        PASSED in 2.6s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.9s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.1s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 5.1s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.9s
//p4rt_app/tests:packetio_test                                           PASSED in 4.0s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.4s
//p4rt_app/tests:resource_limits_test                                    PASSED in 2.7s
//p4rt_app/tests:response_path_test                                      PASSED in 3.9s
//p4rt_app/tests:role_test                                               PASSED in 1.2s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.3s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.8s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.4s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 22.3s
  Stats over 5 runs: max = 22.3s, min = 11.7s, avg = 14.5s, dev = 3.9s

Executed 116 out of 116 tests: 116 tests pass.
INFO: Build completed successfully, 121 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 