### PR TITLE
[Dvaas] Updating packet_injection and test_run_validation files.

### DIFF
--- a/dvaas/packet_injection.h
+++ b/dvaas/packet_injection.h
@@ -15,11 +15,16 @@
 #ifndef PINS_DVAAS_PACKET_INJECTION_H_
 #define PINS_DVAAS_PACKET_INJECTION_H_
 
+#include <functional>
+#include <optional>
+#include <string>
 #include <vector>
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/statusor.h"
 #include "dvaas/test_vector.h"
+#include "dvaas/test_vector.pb.h"
+#include "p4_pdpi/ir.pb.h"
 #include "p4_pdpi/p4_runtime_session.h"
 #include "p4_pdpi/packetlib/packetlib.pb.h"
 
@@ -61,12 +66,17 @@ inline bool DefaultIsExpectedUnsolicitedPacket(
   return false;
 }
 
+// Gets 'ingress_port' value from metadata in `packet_in`. Returns
+// InvalidArgumentError if 'ingress_port' metadata is missing.
+// TODO: Make this function private.
+absl::StatusOr<std::string> GetIngressPortFromIrPacketIn(
+    const pdpi::IrPacketIn& packet_in);
+
 // Determines the switch's behavior when receiving test packets by:
 // - Injecting those packets to the control switch egress to send to the SUT.
 // - Determining the set of packets that were forwarded (punted from control
 //   switch) and punted (punted from SUT) for each input packet.
-absl::StatusOr<std::vector<PacketTestVectorAndActualOutput>>
-SendTestPacketsAndCollectOutputs(
+absl::StatusOr<PacketTestRuns> SendTestPacketsAndCollectOutputs(
     pdpi::P4RuntimeSession& sut, pdpi::P4RuntimeSession& control_switch,
     const PacketTestVectorById& packet_test_vector_by_id,
     PacketStatistics& statistics,

--- a/dvaas/test_run_validation.cc
+++ b/dvaas/test_run_validation.cc
@@ -401,14 +401,14 @@ PacketTestValidationResult ValidateTestRun(
 }
 
 absl::Status ValidateTestRuns(
-    absl::Span<const PacketTestRun> test_runs,
+    const PacketTestRuns& test_runs,
     std::vector<const google::protobuf::FieldDescriptor*> ignored_fields,
     const absl::flat_hash_set<std::string>& ignored_metadata,
     const OutputWriterFunctionType& write_failures) {
   LOG(INFO) << "Validating test runs";
 
   std::vector<std::string> failures;
-  for (const PacketTestRun& test_run : test_runs) {
+  for (const PacketTestRun& test_run : test_runs.test_runs()) {
     PacketTestValidationResult result =
         ValidateTestRun(test_run, ignored_metadata, ignored_fields);
     if (result.has_failure()) {

--- a/dvaas/test_run_validation.h
+++ b/dvaas/test_run_validation.h
@@ -41,7 +41,7 @@ PacketTestValidationResult ValidateTestRun(
 // Like `ValidateTestRun`, but for a collection of `test_runs`. Also
 // writes the results to a test artifact using `write_failures`.
 absl::Status ValidateTestRuns(
-    absl::Span<const PacketTestRun> test_runs,
+    const PacketTestRuns& test_runs,
     std::vector<const google::protobuf::FieldDescriptor*> ignored_fields,
     const absl::flat_hash_set<std::string>& ignored_metadata,
     const OutputWriterFunctionType& write_failures);

--- a/dvaas/test_vector.proto
+++ b/dvaas/test_vector.proto
@@ -94,6 +94,11 @@ message PacketTestRun {
   SwitchOutput actual_output = 2;
 }
 
+// A list of packet test runs.
+message PacketTestRuns {
+  repeated PacketTestRun test_runs = 1;
+}
+
 // The result of validating a single packet test run.
 message PacketTestValidationResult {
   message Failure {
@@ -108,6 +113,11 @@ message PacketTestValidationResult {
 message PacketTestOutcome {
   PacketTestRun test_run = 1;
   PacketTestValidationResult test_result = 2;
+}
+
+// A list of test outcomes.
+message PacketTestOutcomes {
+  repeated PacketTestOutcome outcomes = 1;
 }
 
 // Used to validate the SUT's packet forwarding behavior.


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 332 targets (0 packages loaded, 0 targets configured).
INFO: Found 332 targets...
...
INFO: Elapsed time: 10.796s, Critical Path: 7.87s
INFO: 16 processes: 1 internal, 15 linux-sandbox.
INFO: Build completed successfully, 16 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 331 targets (0 packages loaded, 269 targets configured).
INFO: Found 216 targets and 115 test targets...
INFO: Elapsed time: 71.695s, Critical Path: 16.10s
INFO: 120 processes: 127 linux-sandbox, 17 local.
INFO: Build completed successfully, 120 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_test                                                       PASSED in 0.6s
//gutil:status_matchers_test                                             PASSED in 0.6s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 0.7s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:switch_state_test                                            PASSED in 0.7s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.7s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi:table_entry_key_test                                           PASSED in 0.1s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.1s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 2.1s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.7s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 2.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.6s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.0s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.9s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.9s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.9s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.8s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.5s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.8s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.3s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.5s
//p4rt_app/tests:packetio_test                                           PASSED in 3.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 5.5s
//p4rt_app/tests:response_path_test                                      PASSED in 2.8s
//p4rt_app/tests:role_test                                               PASSED in 1.1s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.7s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.9s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 11.7s
  Stats over 5 runs: max = 11.7s, min = 0.8s, avg = 5.3s, dev = 5.2s

Executed 115 out of 115 tests: 115 tests pass.
INFO: Build completed successfully, 120 total actions