### PR TITLE
[Thinkit] Added PINSBackend for GPINs validator.

### DIFF
--- a/lib/validator/BUILD.bazel
+++ b/lib/validator/BUILD.bazel
@@ -81,3 +81,25 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "pins_backend",
+    testonly = 1,
+    srcs = ["pins_backend.cc"],
+    hdrs = ["pins_backend.h"],
+    deps = [
+        ":validator",
+        ":validator_backend",
+        "//gutil:status",
+        "//lib/gnmi:gnmi_helper",
+        "//p4_pdpi:p4_runtime_session",
+        "//thinkit:switch",
+        "@com_github_gnmi//proto/gnmi:gnmi_cc_proto",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/functional:bind_front",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
+    ],
+)

--- a/lib/validator/pins_backend.cc
+++ b/lib/validator/pins_backend.cc
@@ -1,0 +1,78 @@
+// Copyright (c) 2024, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lib/validator/pins_backend.h"
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "grpcpp/impl/codegen/client_context.h"
+#include "grpcpp/impl/codegen/status_code_enum.h"
+#include "gutil/status.h"
+#include "lib/gnmi/gnmi_helper.h"
+#include "lib/validator/validator_backend.h"
+#include "p4_pdpi/p4_runtime_session.h"
+#include "proto/gnmi/gnmi.pb.h"
+
+namespace pins_test {
+PINSBackend::PINSBackend(std::vector<std::unique_ptr<thinkit::Switch>> switches)
+    : ValidatorBackend({}), switches_map_() {
+  devices_.reserve(switches.size());
+  switches_map_.reserve(switches.size());
+  for (auto it = switches.begin(); it != switches.end(); it++) {
+    std::string chassis_name((*it)->ChassisName());
+    switches_map_.insert({chassis_name, std::move(*it)});
+    devices_.insert(std::move(chassis_name));
+  }
+}
+
+absl::Status PINSBackend::CanEstablishP4RuntimeSession(
+    absl::string_view chassis, absl::Duration timeout) {
+  // TODO: Remove kDeviceId once device ID is set through gNMI in
+  // P4RT app.
+  static constexpr uint64_t kDeviceId = 183807201;
+  auto sut = switches_map_.find(chassis);
+  if (sut == switches_map_.end()) {
+    return absl::InternalError(
+        absl::StrCat("ValidatorBackend passed invalid chassis: ", chassis));
+  }
+  auto& [sut_name, sut_switch] = *sut;
+  ASSIGN_OR_RETURN(auto p4runtime_stub, sut_switch->CreateP4RuntimeStub());
+  return pdpi::P4RuntimeSession::Create(std::move(p4runtime_stub), kDeviceId)
+      .status();
+
+  return absl::OkStatus();
+}
+
+absl::Status PINSBackend::CanGetAllInterfaceOverGnmi(absl::string_view chassis,
+                                                     absl::Duration timeout) {
+  auto sut = switches_map_.find(chassis);
+  if (sut == switches_map_.end()) {
+    return absl::InternalError(
+        absl::StrCat("ValidatorBackend passed invalid chassis: ", chassis));
+  }
+  auto& [sut_name, sut_switch] = *sut;
+  ASSIGN_OR_RETURN(auto gnmi_stub, sut_switch->CreateGnmiStub());
+  ASSIGN_OR_RETURN(auto req, BuildGnmiGetRequest("", gnmi::GetRequest::ALL));
+
+  gnmi::GetResponse resp;
+  grpc::ClientContext context;
+  context.set_deadline(absl::ToChronoTime(absl::Now() + timeout));
+  context.set_wait_for_ready(true);
+  return gutil::GrpcStatusToAbslStatus(gnmi_stub->Get(&context, req, &resp));
+}
+
+}  // namespace pins_test

--- a/lib/validator/pins_backend.h
+++ b/lib/validator/pins_backend.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2024, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_LIB_VALIDATOR_PINS_BACKEND_H_
+#define GOOGLE_LIB_VALIDATOR_PINS_BACKEND_H_
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/functional/bind_front.h"
+#include "lib/validator/validator.h"
+#include "lib/validator/validator_backend.h"
+#include "thinkit/switch.h"
+
+namespace pins_test {
+
+class PINSBackend : public ValidatorBackend {
+ public:
+  // Validates if a P4Runtime can be connected to and used.
+  static constexpr absl::string_view kP4RuntimeUsable = "P4RuntimeUsable";
+  // Validates if a gNMI can be connected to and used.
+  static constexpr absl::string_view kGnmiUsable = "GnmiUsable";
+
+  PINSBackend(std::vector<std::unique_ptr<thinkit::Switch>> switches);
+
+  // Checks if a P4Runtime session could be established.
+  absl::Status CanEstablishP4RuntimeSession(absl::string_view chassis,
+                                            absl::Duration timeout);
+
+  // Checks if a gNMI get all interface request can be sent and a response
+  // received.
+  absl::Status CanGetAllInterfaceOverGnmi(absl::string_view chassis,
+                                          absl::Duration timeout);
+
+ protected:
+  void SetupValidations() override {
+    AddCallbacksToValidation(
+        kP4RuntimeUsable,
+        {absl::bind_front(&PINSBackend::CanEstablishP4RuntimeSession, this)});
+    AddCallbacksToValidation(
+        kGnmiUsable,
+        {absl::bind_front(&PINSBackend::CanGetAllInterfaceOverGnmi, this)});
+    AddCallbacksToValidation(
+        Validator::kReady,
+        {absl::bind_front(&PINSBackend::CanEstablishP4RuntimeSession, this),
+         absl::bind_front(&PINSBackend::CanGetAllInterfaceOverGnmi, this)});
+  }
+
+ private:
+  absl::flat_hash_map<std::string, std::unique_ptr<thinkit::Switch>>
+      switches_map_;
+};
+
+}  // namespace pins_test
+#endif  // GOOGLE_LIB_VALIDATOR_PINS_BACKEND_H_

--- a/lib/validator/validator_backend.h
+++ b/lib/validator/validator_backend.h
@@ -70,11 +70,11 @@ class ValidatorBackend {
   void AddCallbacksToValidation(absl::string_view validation,
                                 absl::Span<const Callback> callbacks);
 
- private:
   // The set of all devices supported by this backend. Devices not in this set
   // will be ignored by this backend.
   absl::flat_hash_set<std::string> devices_;
 
+ private:
   // The map of validation tag and callbacks.
   absl::flat_hash_map<std::string, std::vector<Callback>> validation_map_;
 };


### PR DESCRIPTION
PR Description:
Added PINSBackend for GPINs validator.

Keyword Check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 333 targets (0 packages loaded, 0 targets configured).
INFO: Found 333 targets...
INFO: Elapsed time: 0.531s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 


UT Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 333 targets (0 packages loaded, 0 targets configured).
INFO: Found 217 targets and 116 test targets...
INFO: Elapsed time: 118.417s, Critical Path: 23.12s
INFO: 121 processes: 128 linux-sandbox, 17 local.
INFO: Build completed successfully, 121 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.7s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 0.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi:table_entry_key_test                                           PASSED in 0.1s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.5s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.4s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.7s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.0s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 1.0s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.6s
//p4rt_app/tests:action_set_test                                         PASSED in 1.2s
//p4rt_app/tests:api_access_test                                         PASSED in 1.1s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.3s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.8s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 5.4s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 2.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.0s
//p4rt_app/tests:packetio_test                                           PASSED in 4.1s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 2.1s
//p4rt_app/tests:response_path_test                                      PASSED in 3.8s
//p4rt_app/tests:role_test                                               PASSED in 1.3s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.3s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.9s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.2s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 23.1s
  Stats over 5 runs: max = 23.1s, min = 2.2s, avg = 16.1s, dev = 8.1s

Executed 116 out of 116 tests: 116 tests pass.
INFO: Build completed successfully, 121 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 