### PR TITLE
[Comb] gNMI Subscribe sanity test

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -33,3 +33,32 @@ cc_library(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "thinkit_gnmi_subscribe_tests",
+    testonly = 1,
+    srcs = [
+        "thinkit_gnmi_subscribe_tests.cc",
+    ],
+    hdrs = [
+        "thinkit_gnmi_subscribe_tests.h",
+        "thinkit_util.h",
+    ],
+    deps = [
+        "//gutil:status_matchers",
+        "//lib/gnmi:gnmi_helper",
+        "//p4_pdpi:p4_runtime_session",
+        "//thinkit:ssh_client",
+        "//thinkit:switch",
+        "@com_github_gnmi//proto/gnmi:gnmi_cc_proto",
+        "@com_github_gnmi//proto/gnmi:gnmi_cc_grpc_proto",
+        "@com_github_google_glog//:glog",
+        "@com_github_nlohmann_json//:nlohmann_json",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/tests/thinkit_gnmi_subscribe_tests.cc
+++ b/tests/thinkit_gnmi_subscribe_tests.cc
@@ -1,0 +1,74 @@
+#include "tests/thinkit_gnmi_subscribe_tests.h"
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/string_view.h"
+#include "absl/time/time.h"
+#include "glog/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status_matchers.h"
+#include "lib/gnmi/gnmi_helper.h"
+#include "p4/v1/p4runtime.grpc.pb.h"
+#include "p4_pdpi/p4_runtime_session.h"
+#include "proto/gnmi/gnmi.grpc.pb.h"
+#include "proto/gnmi/gnmi.pb.h"
+#include "include/nlohmann/json.hpp"
+#include "tests/thinkit_util.h"
+#include "thinkit/ssh_client.h"
+#include "thinkit/switch.h"
+
+namespace pins_test {
+
+constexpr absl::Duration kSubscribeWaitTime = absl::Seconds(100);
+
+// This test subscribes to interface and component subtree for updates.
+void TestGnmiInterfaceAndComponentSubscribe(thinkit::Switch& sut) {
+  ASSERT_OK_AND_ASSIGN(auto sut_gnmi_stub, sut.CreateGnmiStub());
+  grpc::ClientContext context;
+  auto stream = sut_gnmi_stub->Subscribe(&context);
+  ASSERT_NE(stream, nullptr) << "cannot create a stream!.";
+  gnmi::SubscribeRequest subscribe_request;
+  gnmi::SubscriptionList* subscription_list =
+      subscribe_request.mutable_subscribe();
+  subscription_list->set_mode(gnmi::SubscriptionList::STREAM);
+  subscription_list->mutable_prefix()->set_origin(kOpenconfigStr);
+  subscription_list->mutable_prefix()->set_target(kTarget);
+  AddSubtreeToGnmiSubscription(kInterfaces, *subscription_list, gnmi::SAMPLE,
+                               /*suppress_redundant=*/false, absl::Seconds(5));
+  AddSubtreeToGnmiSubscription(kComponents, *subscription_list, gnmi::SAMPLE,
+                               /*suppress_redundant=*/false, absl::Seconds(5));
+  LOG(INFO) << "Sending subscription: " << subscribe_request.ShortDebugString();
+  ASSERT_TRUE(stream->Write(subscribe_request))
+      << "Failed Write to forward request: " << subscribe_request.DebugString()
+      << ". Possibly broken stream.";
+  LOG(INFO) << "Wrote subscribe request.";
+  gnmi::SubscribeResponse response;
+  bool intf_response_received = false;
+  bool component_response_received = false;
+  const auto start_time = absl::Now();
+  while (absl::Now() < (start_time + kSubscribeWaitTime) &&
+         stream->Read(&response)) {
+    LOG(INFO) << "Subscribe response received: " << response.DebugString();
+    ASSERT_OK_AND_ASSIGN(auto elem_name_vector,
+                         GnmiGetElementFromTelemetryResponse(response));
+    for (auto elem_name : elem_name_vector) {
+      if (elem_name == kComponents) {
+        component_response_received = true;
+      }
+      if (elem_name == kInterfaces) {
+        intf_response_received = true;
+      }
+    }
+    if (component_response_received && intf_response_received) {
+      break;
+    }
+  }
+  EXPECT_TRUE(component_response_received);
+  EXPECT_TRUE(intf_response_received);
+}
+
+}  // namespace pins_test

--- a/tests/thinkit_gnmi_subscribe_tests.h
+++ b/tests/thinkit_gnmi_subscribe_tests.h
@@ -1,0 +1,11 @@
+#ifndef GOOGLE_TESTS_THINKIT_GNMI_SUBSCRIBE_TESTS_H_
+#define GOOGLE_TESTS_THINKIT_GNMI_SUBSCRIBE_TESTS_H_
+
+#include "thinkit/switch.h"
+
+namespace pins_test {
+
+void TestGnmiInterfaceAndComponentSubscribe(thinkit::Switch& sut);
+
+}
+#endif  // GOOGLE_TESTS_THINKIT_GNMI_SUBSCRIBE_TESTS_H_

--- a/tests/thinkit_util.h
+++ b/tests/thinkit_util.h
@@ -1,0 +1,31 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_TESTS_THINKIT_UTIL_H_
+#define GOOGLE_TESTS_THINKIT_UTIL_H_
+
+namespace pins_test {
+
+constexpr char kEnabledFalse[] = "{\"enabled\":false}";
+constexpr char kEnabledTrue[] = "{\"enabled\":true}";
+constexpr char kStateUp[] = "UP";
+constexpr char kStateDown[] = "DOWN";
+constexpr char kInterfaces[] = "interfaces";
+constexpr char kComponents[] = "components";
+constexpr char kPortSpeed[] = "openconfig-if-ethernet:port-speed";
+constexpr char kPlatformJson[] = "platform.json";
+constexpr char kGB[] = "GB";
+}  // namespace pins_test
+
+#endif  // GOOGLE_TESTS_THINKIT_UTIL_H_


### PR DESCRIPTION
PR Description:
gNMI Subscribe sanity test

Keyword Check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 338 targets (0 packages loaded, 0 targets configured).
INFO: Found 338 targets...
INFO: Elapsed time: 0.587s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 

UT Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 338 targets (0 packages loaded, 0 targets configured).
INFO: Found 222 targets and 116 test targets...
INFO: Elapsed time: 100.464s, Critical Path: 17.30s
INFO: 121 processes: 128 linux-sandbox, 17 local.
INFO: Build completed successfully, 121 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 1.0s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.9s
//p4_fuzzer:switch_state_test                                            PASSED in 0.7s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.7s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 17.3s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 2.4s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.6s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.2s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 2.7s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.0s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.6s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.8s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.8s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.8s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.8s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.5s
//p4rt_app/tests:action_set_test                                         PASSED in 1.3s
//p4rt_app/tests:api_access_test                                         PASSED in 2.3s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.3s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.9s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.1s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.2s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 5.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.8s
//p4rt_app/tests:packetio_test                                           PASSED in 4.0s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.6s
//p4rt_app/tests:response_path_test                                      PASSED in 4.8s
//p4rt_app/tests:role_test                                               PASSED in 1.3s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.2s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.0s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.8s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.3s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.8s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 13.2s
  Stats over 5 runs: max = 13.2s, min = 1.0s, avg = 6.3s, dev = 5.6s

Executed 116 out of 116 tests: 116 tests pass.
INFO: Build completed successfully, 121 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$