### PR TITLE
[Thinkit] gNMI set admin-status test

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -21,8 +21,13 @@ package(
 cc_library(
     name = "thinkit_sanity_tests",
     testonly = 1,
-    srcs = ["thinkit_sanity_tests.cc"],
-    hdrs = ["thinkit_sanity_tests.h"],
+    srcs = [
+        "thinkit_sanity_tests.cc",
+    ],
+    hdrs = [
+        "thinkit_sanity_tests.h",
+        "thinkit_util.h",
+    ],
     deps = [
         "//gutil:status",
         "//gutil:status_matchers",
@@ -40,6 +45,31 @@ cc_library(
         "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "thinkit_gnmi_tests",
+    testonly = 1,
+    srcs = [
+        "thinkit_gnmi_interface_tests.cc",
+    ],
+    hdrs = [
+        "thinkit_gnmi_interface_tests.h",
+        "thinkit_util.h",
+    ],
+    deps = [
+        "//gutil:status_matchers",
+        "//lib/gnmi:gnmi_helper",
+        "//thinkit:ssh_client",
+        "//thinkit:switch",
+        "@com_github_gnmi//proto/gnmi:gnmi_cc_grpc_proto",
+        "@com_github_google_glog//:glog",
+        "@com_github_nlohmann_json//:nlohmann_json",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",

--- a/tests/thinkit_gnmi_interface_tests.cc
+++ b/tests/thinkit_gnmi_interface_tests.cc
@@ -1,0 +1,118 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tests/thinkit_gnmi_interface_tests.h"
+
+#include <string>
+#include <utility>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/match.h"
+#include "absl/strings/string_view.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "glog/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status_matchers.h"
+#include "lib/gnmi/gnmi_helper.h"
+#include "proto/gnmi/gnmi.grpc.pb.h"
+#include "include/nlohmann/json.hpp"
+#include "tests/thinkit_util.h"
+#include "thinkit/ssh_client.h"
+#include "thinkit/switch.h"
+
+namespace pins_test {
+namespace {
+
+using ::nlohmann::json;
+using ::testing::HasSubstr;
+
+}  // namespace
+
+void TestGnmiInterfaceConfigSetAdminStatus(thinkit::Switch& sut,
+                                           absl::string_view if_name) {
+  ASSERT_OK_AND_ASSIGN(auto sut_gnmi_stub, sut.CreateGnmiStub());
+
+  // Disable front panel port.
+  LOG(INFO) << "Disabling front panel port: " << if_name;
+  const std::string if_enabled_config_path =
+      absl::StrCat("interfaces/interface[name=", if_name, "]/config/enabled");
+  ASSERT_OK(SetGnmiConfigPath(sut_gnmi_stub.get(), if_enabled_config_path,
+                              GnmiSetType::kUpdate, kEnabledFalse));
+
+  // Perform state path verifications.
+  // Verify /interfaces/interface[name=<port>]/state/enabled = false.
+  std::string if_state_path =
+      absl::StrCat("interfaces/interface[name=", if_name, "]/state/enabled");
+  std::string resp_parse_str = "openconfig-interfaces:enabled";
+  ASSERT_OK_AND_ASSIGN(
+      std::string state_path_response,
+      GetGnmiStatePathInfo(sut_gnmi_stub.get(), if_state_path, resp_parse_str));
+  EXPECT_THAT(state_path_response, HasSubstr("false"));
+
+  // Verify /interfaces/interface[name=<port>]/state/admin-status = DOWN.
+  if_state_path = absl::StrCat("interfaces/interface[name=", if_name,
+                               "]/state/admin-status");
+  resp_parse_str = "openconfig-interfaces:admin-status";
+  ASSERT_OK_AND_ASSIGN(
+      state_path_response,
+      GetGnmiStatePathInfo(sut_gnmi_stub.get(), if_state_path, resp_parse_str));
+  EXPECT_THAT(state_path_response, HasSubstr(kStateDown));
+
+  // Verify /interfaces/interface[name=<port>]/state/oper-status = DOWN.
+  if_state_path = absl::StrCat("interfaces/interface[name=", if_name,
+                               "]/state/oper-status");
+  resp_parse_str = "openconfig-interfaces:oper-status";
+  ASSERT_OK_AND_ASSIGN(
+      state_path_response,
+      GetGnmiStatePathInfo(sut_gnmi_stub.get(), if_state_path, resp_parse_str));
+  EXPECT_THAT(state_path_response, HasSubstr(kStateDown));
+
+  // Enable front panel port.
+  LOG(INFO) << "Enabling front panel port: " << if_name;
+  ASSERT_OK(SetGnmiConfigPath(sut_gnmi_stub.get(), if_enabled_config_path,
+                              GnmiSetType::kUpdate, kEnabledTrue));
+
+  // Perform state path verifications.
+  // Verify /interfaces/interface[name=<port>]/state/enabled = true.
+  if_state_path =
+      absl::StrCat("interfaces/interface[name=", if_name, "]/state/enabled");
+  resp_parse_str = "openconfig-interfaces:enabled";
+  ASSERT_OK_AND_ASSIGN(
+      state_path_response,
+      GetGnmiStatePathInfo(sut_gnmi_stub.get(), if_state_path, resp_parse_str));
+  EXPECT_THAT(state_path_response, HasSubstr("true"));
+
+  // Verify /interfaces/interface[name=<port>]/state/admin-status = UP.
+  if_state_path = absl::StrCat("interfaces/interface[name=", if_name,
+                               "]/state/admin-status");
+  resp_parse_str = "openconfig-interfaces:admin-status";
+  ASSERT_OK_AND_ASSIGN(
+      state_path_response,
+      GetGnmiStatePathInfo(sut_gnmi_stub.get(), if_state_path, resp_parse_str));
+  EXPECT_THAT(state_path_response, HasSubstr(kStateUp));
+
+  // Verify /interfaces/interface[name=<port>]/state/oper-status = UP.
+  absl::SleepFor(absl::Seconds(5));
+  if_state_path = absl::StrCat("interfaces/interface[name=", if_name,
+                               "]/state/oper-status");
+  resp_parse_str = "openconfig-interfaces:oper-status";
+  ASSERT_OK_AND_ASSIGN(
+      state_path_response,
+      GetGnmiStatePathInfo(sut_gnmi_stub.get(), if_state_path, resp_parse_str));
+  EXPECT_THAT(state_path_response, HasSubstr(kStateUp));
+}
+
+}  // namespace pins_test

--- a/tests/thinkit_gnmi_interface_tests.h
+++ b/tests/thinkit_gnmi_interface_tests.h
@@ -1,0 +1,28 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_TESTS_THINKIT_GNMI_INTERFACE_TESTS_H_
+#define GOOGLE_TESTS_THINKIT_GNMI_INTERFACE_TESTS_H_
+
+#include "absl/strings/string_view.h"
+#include "thinkit/switch.h"
+
+namespace pins_test {
+
+void TestGnmiInterfaceConfigSetAdminStatus(thinkit::Switch& sut,
+                                           absl::string_view if_name);
+
+}  // namespace pins_test
+
+#endif  // GOOGLE_TESTS_THINKIT_GNMI_INTERFACE_TESTS_H_

--- a/tests/thinkit_sanity_tests.cc
+++ b/tests/thinkit_sanity_tests.cc
@@ -34,6 +34,7 @@
 #include "p4_pdpi/p4_runtime_session.h"
 #include "proto/gnmi/gnmi.grpc.pb.h"
 #include "include/nlohmann/json.hpp"
+#include "tests/thinkit_util.h"
 #include "thinkit/ssh_client.h"
 #include "thinkit/switch.h"
 
@@ -46,8 +47,6 @@ using ::testing::HasSubstr;
 
 }  // namespace
 
-constexpr char kStateUp[] = "UP";
-constexpr char kInterfaces[] = "interfaces";
 constexpr char kMtuJsonVal[] = "{\"mtu\":2000}";
 
 void TestSSHCommand(thinkit::SSHClient& ssh_client, thinkit::Switch& sut) {


### PR DESCRIPTION
### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 349 targets (0 packages loaded, 0 targets configured).
INFO: Found 349 targets...
INFO: Elapsed time: 13.656s, Critical Path: 9.18s
INFO: 12 processes: 1 internal, 11 linux-sandbox.
INFO: Build completed successfully, 12 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 349 targets (0 packages loaded, 0 targets configured).
INFO: Found 228 targets and 121 test targets...
INFO: Elapsed time: 63.435s, Critical Path: 16.43s
INFO: 126 processes: 133 linux-sandbox, 17 local.
INFO: Build completed successfully, 126 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.6s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.6s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 0.7s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.4s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.2s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.6s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.7s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.0s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.8s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.8s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.3s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.3s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.5s
//p4rt_app/tests:packetio_test                                           PASSED in 3.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 1.9s
//p4rt_app/tests:response_path_test                                      PASSED in 2.8s
//p4rt_app/tests:role_test                                               PASSED in 1.1s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.7s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.0s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 14.1s
  Stats over 5 runs: max = 14.1s, min = 1.0s, avg = 8.6s, dev = 5.7s

Executed 121 out of 121 tests: 121 tests pass.
INFO: Build completed successfully, 126 total actions
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ 

### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.