### PR TITLE
[Thinkit] gNMI port component tests, Changing integrated-circuit to integrated_circuit based on gNMI naming convention & gNOI system stub integration in thinkit.

### DIFF
--- a/lib/gnmi/gnmi_helper.h
+++ b/lib/gnmi/gnmi_helper.h
@@ -16,8 +16,11 @@
 #define GOOGLE_LIB_GNMI_GNMI_HELPER_H_
 
 #include <cstddef>
+#include <string>
+#include <type_traits>
 
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
 #include "p4_pdpi/p4_runtime_session.h"

--- a/tests/thinkit_gnmi_interface_tests.cc
+++ b/tests/thinkit_gnmi_interface_tests.cc
@@ -14,6 +14,7 @@
 
 #include "tests/thinkit_gnmi_interface_tests.h"
 
+#include <algorithm>
 #include <string>
 #include <utility>
 
@@ -113,6 +114,83 @@ void TestGnmiInterfaceConfigSetAdminStatus(thinkit::Switch& sut,
       state_path_response,
       GetGnmiStatePathInfo(sut_gnmi_stub.get(), if_state_path, resp_parse_str));
   EXPECT_THAT(state_path_response, HasSubstr(kStateUp));
+}
+
+void TestGnmiPortComponentPaths(thinkit::SSHClient& ssh_client,
+                                thinkit::Switch& sut,
+                                absl::string_view platform_json_path) {
+  ASSERT_OK_AND_ASSIGN(auto sut_gnmi_stub, sut.CreateGnmiStub());
+
+  // Configure integrated circuit name on the switch.
+  const std::string ic_name = "integrated-circuit0";
+  const std::string ic_name_config_path =
+      absl::StrCat("components/component[name=", ic_name, "]/config/name");
+  ASSERT_OK(SetGnmiConfigPath(sut_gnmi_stub.get(), ic_name_config_path,
+                              GnmiSetType::kUpdate,
+                              ConstructGnmiConfigSetString("name", ic_name)));
+
+  // Fetch platform.json from the switch.
+  const std::string ssh_command =
+      absl::StrCat("cat ", platform_json_path, kPlatformJson);
+  LOG(INFO) << "Fetching " << kPlatformJson
+            << " contents from switch path: " << platform_json_path;
+  ASSERT_OK_AND_ASSIGN(std::string platform_json_contents,
+                       ssh_client.RunCommand(sut.ChassisName(), ssh_command,
+                                             absl::ZeroDuration()));
+  LOG(INFO) << kPlatformJson << " contents: " << platform_json_contents;
+
+  // Fetch interface information from platform.json.
+  const auto platform_json = json::parse(platform_json_contents);
+  const auto interface_json = platform_json.find(kInterfaces);
+  ASSERT_NE(interface_json, platform_json.end());
+
+  for (const auto& interface : interface_json->items()) {
+    const std::string port_name = interface.key();
+    const auto port_info = interface.value();
+    ASSERT_EQ(port_info.count("index"), 1);
+
+    // Fetch /interfaces/interface[name=<port>]/state/hardware-port.
+    const std::string hw_port_state_path = absl::StrCat(
+        "interfaces/interface[name=", port_name, "]/state/hardware-port");
+    const std::string hw_port_parse_str =
+        "openconfig-platform-port:hardware-port";
+    ASSERT_OK_AND_ASSIGN(
+        std::string hw_port,
+        GetGnmiStatePathInfo(sut_gnmi_stub.get(), hw_port_state_path,
+                             hw_port_parse_str));
+    hw_port.erase(std::remove(hw_port.begin(), hw_port.end(), '"'),
+                  hw_port.end());
+
+    // hardware-port is in the format 1/<port_no>. Fetch port number from this
+    // information and verify that it is same as index attribute of the port in
+    // platform.json.
+    const auto separator_location = hw_port.find("/");
+    ASSERT_NE(separator_location, std::string::npos);
+    const std::string port_number = hw_port.substr(separator_location + 1);
+    ASSERT_EQ(port_info["index"], port_number);
+
+    // Verify that hardware-port attribute matches information in path
+    // /components/component[name=<port>]/state/name.
+    const std::string component_name_state_path =
+        absl::StrCat("components/component[name=", hw_port, "]/state/name");
+    const std::string component_name_parse_str = "openconfig-platform:name";
+    ASSERT_OK_AND_ASSIGN(
+        const std::string component_name,
+        GetGnmiStatePathInfo(sut_gnmi_stub.get(), component_name_state_path,
+                             component_name_parse_str));
+    EXPECT_THAT(component_name, HasSubstr(hw_port));
+
+    // Verify that integrated circuit name matches information in path
+    // /components/component[name=<port>]/state/parent.
+    const std::string component_parent_state_path =
+        absl::StrCat("components/component[name=", hw_port, "]/state/parent");
+    const std::string component_parent_parse_str = "openconfig-platform:parent";
+    ASSERT_OK_AND_ASSIGN(
+        const std::string component_parent,
+        GetGnmiStatePathInfo(sut_gnmi_stub.get(), component_parent_state_path,
+                             component_parent_parse_str));
+    EXPECT_THAT(component_parent, HasSubstr(ic_name));
+  }
 }
 
 }  // namespace pins_test

--- a/tests/thinkit_gnmi_interface_tests.h
+++ b/tests/thinkit_gnmi_interface_tests.h
@@ -16,12 +16,17 @@
 #define GOOGLE_TESTS_THINKIT_GNMI_INTERFACE_TESTS_H_
 
 #include "absl/strings/string_view.h"
+#include "thinkit/ssh_client.h"
 #include "thinkit/switch.h"
 
 namespace pins_test {
 
 void TestGnmiInterfaceConfigSetAdminStatus(thinkit::Switch& sut,
                                            absl::string_view if_name);
+
+void TestGnmiPortComponentPaths(thinkit::SSHClient& ssh_client,
+                                thinkit::Switch& sut,
+                                absl::string_view platform_json_path);
 
 }  // namespace pins_test
 

--- a/tests/thinkit_sanity_tests.cc
+++ b/tests/thinkit_sanity_tests.cc
@@ -16,14 +16,17 @@
 
 #include <stdint.h>
 
+#include <cstdlib>
 #include <string>
 #include <utility>
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
+#include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "glog/logging.h"
 #include "gmock/gmock.h"
@@ -34,6 +37,7 @@
 #include "p4_pdpi/p4_runtime_session.h"
 #include "proto/gnmi/gnmi.grpc.pb.h"
 #include "include/nlohmann/json.hpp"
+#include "system/system.pb.h"
 #include "tests/thinkit_util.h"
 #include "thinkit/ssh_client.h"
 #include "thinkit/switch.h"
@@ -42,12 +46,80 @@ namespace pins_test {
 namespace {
 
 using ::nlohmann::json;
+using ::std::abs;
 using ::testing::Eq;
 using ::testing::HasSubstr;
 
 }  // namespace
-
+constexpr int kEpochMarginalError = 2;
+constexpr absl::Duration kColdRebootDelayTime = absl::Seconds(1);
+constexpr absl::Duration kColdRebootTotalWaitTime = absl::Seconds(30);
 constexpr char kMtuJsonVal[] = "{\"mtu\":2000}";
+constexpr char kV3ReleaseConfigBlob[] = R"({
+   "openconfig-platform:components" : {
+      "component" : [
+         {
+           "name" : "integrated_circuit0",
+           "config" : {
+               "name" : "integrated_circuit0"
+           },
+           "integrated-circuit" : {
+               "config" : {
+                  "node-id" : "183930889"
+               }
+            }
+         }
+      ]
+   },
+   "openconfig-system:system" : {
+       "config" : {
+           "config-meta-data" : "v4"
+       }
+   },
+   "openconfig-interfaces:interfaces" : {
+      "interface" : [
+         {
+            "name": "Ethernet0",
+            "config" : {
+               "name" : "Ethernet0",
+               "enabled" : true,
+               "id": 1
+            },
+            "ethernet" : {
+               "config" : {
+                  "port-speed" : "SPEED_400GB"
+               }
+            }
+         },
+         {
+            "name": "Ethernet8",
+            "config" : {
+               "name" : "Ethernet8",
+               "enabled" : true,
+               "id": 2
+            },
+            "ethernet" : {
+               "config" : {
+                  "port-speed" : "SPEED_200GB"
+               }
+            }
+         },
+         {
+            "name": "Ethernet12",
+            "config" : {
+               "name" : "Ethernet12",
+               "enabled" : true,
+               "id": 518
+            },
+            "ethernet" : {
+               "config" : {
+                  "port-speed" : "SPEED_200GB"
+               }
+            }
+         }
+      ]
+   }
+})";
 
 void TestSSHCommand(thinkit::SSHClient& ssh_client, thinkit::Switch& sut) {
   ASSERT_OK_AND_ASSIGN(std::string output,
@@ -63,6 +135,119 @@ void TestP4Session(thinkit::Switch& sut) {
   ASSERT_OK_AND_ASSIGN(auto sut_p4runtime_stub, sut.CreateP4RuntimeStub());
   EXPECT_OK(
       pdpi::P4RuntimeSession::Create(std::move(sut_p4runtime_stub), kDeviceId));
+}
+
+// This test sets the config blob and verifies corresponding state paths.
+void TestGnmiConfigBlobSet(thinkit::Switch& sut) {
+  ASSERT_OK_AND_ASSIGN(auto sut_gnmi_stub, sut.CreateGnmiStub());
+  ASSERT_OK_AND_ASSIGN(
+      gnmi::SetRequest req,
+      BuildGnmiSetRequest("", GnmiSetType::kUpdate, kV3ReleaseConfigBlob));
+  LOG(INFO) << "Sending SET request: " << req.ShortDebugString();
+  gnmi::SetResponse resp;
+  grpc::ClientContext context;
+  ASSERT_OK(sut_gnmi_stub->Set(&context, req, &resp));
+  LOG(INFO) << "Received SET response: " << resp.ShortDebugString();
+
+  auto config_json = json::parse(kV3ReleaseConfigBlob);
+  const auto components_json =
+      config_json.find("openconfig-platform:components");
+  ASSERT_NE(components_json, config_json.end());
+  const auto component_list_json = components_json->find("component");
+  ASSERT_NE(component_list_json, components_json->end());
+
+  std::map<std::string, std::string> ic_nodeid_map;
+  for (auto const& element : component_list_json->items()) {
+    auto const element_name_json = element.value().find("name");
+    const auto element_integrated_circuit_json =
+        element.value().find("integrated-circuit");
+    const auto element_ic_config_json =
+        element_integrated_circuit_json.value().find("config");
+    const auto element_node_json =
+        element_ic_config_json.value().find("node-id");
+    // Converting "integrated_circuit0" to integrated_circuit0
+    ic_nodeid_map[element_name_json->dump().substr(
+        1, element_name_json->dump().size() - 2)] =
+        element_node_json->dump().substr(1,
+                                         element_node_json->dump().size() - 2);
+  }
+  //  Only one integrated-circuit configuration is present in config blob.
+  ASSERT_EQ(ic_nodeid_map.size(), 1);
+  gnmi::GetRequest get_req;
+  gnmi::GetResponse get_resp;
+  grpc::ClientContext get_context;
+  std::string component_req =
+      absl::StrCat("components/component[name=", ic_nodeid_map.begin()->first,
+                   "]/integrated-circuit/state");
+  ASSERT_OK_AND_ASSIGN(
+      get_req, BuildGnmiGetRequest(component_req, gnmi::GetRequest::STATE));
+  LOG(INFO) << "Sending GET request: " << get_req.ShortDebugString();
+
+  ASSERT_OK(sut_gnmi_stub->Get(&get_context, get_req, &get_resp));
+  LOG(INFO) << "Received GET response: " << get_resp.ShortDebugString();
+  ASSERT_OK_AND_ASSIGN(
+      std::string nodeid_respose,
+      ParseGnmiGetResponse(get_resp, "openconfig-platform:state"));
+  EXPECT_THAT(nodeid_respose, HasSubstr(ic_nodeid_map.begin()->second));
+
+  std::map<std::string, std::string> intf_speed_map;
+  const auto interfaces_json =
+      config_json.find("openconfig-interfaces:interfaces");
+  const auto interface_list_json = interfaces_json->find("interface");
+
+  for (auto const& element : interface_list_json->items()) {
+    auto const element_name_json = element.value().find("name");
+    const auto element_ethernet_json = element.value().find("ethernet");
+    const auto element_ethernet_config_json =
+        element_ethernet_json.value().find("config");
+    const auto element_port_speed_json =
+        element_ethernet_config_json.value().find("port-speed");
+    intf_speed_map[element_name_json->dump()] =
+        element_port_speed_json->dump().substr(
+            1, element_port_speed_json->dump().size() - 2);
+  }
+
+  if (intf_speed_map.empty()) {
+    return;
+  }
+  ASSERT_OK_AND_ASSIGN(
+      get_req, BuildGnmiGetRequest(kInterfaces, gnmi::GetRequest::STATE));
+  LOG(INFO) << "Sending GET request: " << get_req.ShortDebugString();
+
+  grpc::ClientContext get_state_context;
+  ASSERT_OK(sut_gnmi_stub->Get(&get_state_context, get_req, &get_resp));
+  LOG(INFO) << "Received GET response: " << get_resp.ShortDebugString();
+  ASSERT_EQ(get_resp.notification_size(), 1);
+  ASSERT_EQ(get_resp.notification(0).update_size(), 1);
+  auto intf_state_json =
+      json::parse(get_resp.notification(0).update(0).val().json_ietf_val());
+  const auto oc_intf_json =
+      intf_state_json.find("openconfig-interfaces:interfaces");
+  ASSERT_NE(oc_intf_json, intf_state_json.end());
+  const auto oc_intf_list_json = oc_intf_json->find("interface");
+  ASSERT_NE(oc_intf_list_json, oc_intf_json->end());
+  for (auto const& element : oc_intf_list_json->items()) {
+    auto const element_name_json = element.value().find("name");
+    ASSERT_NE(element_name_json, element.value().end());
+    auto if_speed_elem = intf_speed_map.find(element_name_json->dump());
+    if (if_speed_elem == intf_speed_map.end()) {
+      continue;
+    }
+    const auto element_ethernet_json =
+        element.value().find("openconfig-if-ethernet:ethernet");
+    ASSERT_NE(element_ethernet_json, element.value().end())
+        << element.value().find("name")->dump();
+    const auto element_interface_state_json =
+        element_ethernet_json->find("state");
+    ASSERT_NE(element_interface_state_json, element_ethernet_json->end())
+        << element.value().find("name")->dump();
+    const auto element_speed_json =
+        element_interface_state_json->find("port-speed");
+    ASSERT_NE(element_speed_json, element_interface_state_json->end())
+        << element.value().find("name")->dump();
+    EXPECT_THAT(element_speed_json->dump(), HasSubstr(if_speed_elem->second))
+        << element_interface_state_json->find("name")->dump();
+  }
 }
 
 void TestGnmiInterfaceConfigSetMtu(thinkit::Switch& sut,
@@ -183,5 +368,57 @@ void TestGnmiGetAllOperation(thinkit::Switch& sut) {
   ASSERT_OK(sut_gnmi_stub->Get(&context, req, &resp));
   LOG(INFO) << "Received GET response: " << resp.ShortDebugString();
 }
+//  Returns last boot time of SUT.
+absl::StatusOr<int> GetGnmiSystemBootTime(thinkit::Switch& sut,
+                                          gnmi::gNMI::Stub* sut_gnmi_stub) {
+  ASSIGN_OR_RETURN(
+      gnmi::GetRequest request,
+      BuildGnmiGetRequest("system/state/boot-time", gnmi::GetRequest::STATE));
+  LOG(INFO) << "Sending GET request: " << request.ShortDebugString();
+  gnmi::GetResponse response;
+  grpc::ClientContext context;
+  EXPECT_OK(sut_gnmi_stub->Get(&context, request, &response));
+  LOG(INFO) << "Received GET response: " << response.ShortDebugString();
 
+  ASSIGN_OR_RETURN(
+      std::string parsed_str,
+      ParseGnmiGetResponse(response, "openconfig-system:boot-time"));
+  // Remove characters <"">  in the parsed string.
+  std::string boot_time_string = parsed_str.substr(1, parsed_str.size() - 2);
+  int boot_time;
+  if (!absl::SimpleAtoi(boot_time_string, &boot_time)) {
+    return gutil::InternalErrorBuilder().LogError()
+           << absl::StrCat("SimpleAtoi Error while parsing ")
+           << boot_time_string;
+  }
+  LOG(INFO) << "Boot Time: " << boot_time;
+  return boot_time;
+}
+void TestGnoiSystemColdReboot(thinkit::Switch& sut) {
+  ASSERT_OK_AND_ASSIGN(auto sut_gnmi_stub, sut.CreateGnmiStub());
+  ASSERT_OK_AND_ASSIGN(auto first_boot_time,
+                       GetGnmiSystemBootTime(sut, sut_gnmi_stub.get()));
+
+  ASSERT_OK_AND_ASSIGN(auto sut_gnoi_system_stub, sut.CreateGnoiSystemStub());
+  gnoi::system::RebootRequest request;
+  request.set_method(gnoi::system::RebootMethod::COLD);
+  request.set_delay(absl::ToInt64Nanoseconds(kColdRebootDelayTime));
+  request.set_message("Testing Purpose");
+  gnoi::system::RebootResponse response;
+  grpc::ClientContext context;
+  LOG(INFO) << "Sending Reboot request: " << request.ShortDebugString();
+  ASSERT_OK(sut_gnoi_system_stub->Reboot(&context, request, &response));
+  LOG(INFO) << "Received Reboot response: " << response.ShortDebugString();
+
+  const auto start_time = absl::Now();
+  int latest_boot_time = first_boot_time;
+
+  while (abs(latest_boot_time - first_boot_time) < kEpochMarginalError &&
+         absl::Now() < (start_time + kColdRebootTotalWaitTime)) {
+    absl::SleepFor(kColdRebootDelayTime);
+    ASSERT_OK_AND_ASSIGN(latest_boot_time,
+                         GetGnmiSystemBootTime(sut, sut_gnmi_stub.get()));
+  }
+  EXPECT_GT(abs(latest_boot_time - first_boot_time), kEpochMarginalError);
+}
 }  // namespace pins_test

--- a/tests/thinkit_sanity_tests.h
+++ b/tests/thinkit_sanity_tests.h
@@ -42,6 +42,12 @@ void TestGnmiCheckSpecificInterfaceStateOperation(thinkit::Switch& sut,
 // Tests that SUT specific port MTU can be updated.
 void TestGnmiInterfaceConfigSetMtu(thinkit::Switch& sut,
                                    absl::string_view if_name);
+
+// Tests that SUT is updated with a config Blob.
+void TestGnmiConfigBlobSet(thinkit::Switch& sut);
+
+// Tests gNOI Cold Reboot on SUT.
+void TestGnoiSystemColdReboot(thinkit::Switch& sut);
 }  // namespace pins_test
 
 #endif  // GOOGLE_TESTS_THINKIT_SANITY_TESTS_H_

--- a/tests/thinkit_util.h
+++ b/tests/thinkit_util.h
@@ -27,6 +27,11 @@ constexpr char kPortSpeed[] = "openconfig-if-ethernet:port-speed";
 constexpr char kPlatformJson[] = "platform.json";
 constexpr char kGB[] = "GB";
 
+#if 0
+constexpr char kPlatformJson[] =
+    "/lib/google/experimental/syncd/sonic/platform/GPINs/platform.json";
+#endif
+
 }  // namespace pins_test
 
 #endif  // GOOGLE_TESTS_THINKIT_UTIL_H_


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 352 targets (26 packages loaded, 359 targets configured).
INFO: Found 352 targets...
INFO: Elapsed time: 20.940s, Critical Path: 9.20s
INFO: 32 processes: 10 internal, 22 linux-sandbox.
INFO: Build completed successfully, 32 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 352 targets (0 packages loaded, 276 targets configured).
INFO: Found 230 targets and 122 test targets...
INFO: Elapsed time: 72.284s, Critical Path: 16.26s
INFO: 127 processes: 134 linux-sandbox, 17 local.
INFO: Build completed successfully, 127 total actions
//gutil:collections_test PASSED in 0.5s
//gutil:io_test PASSED in 0.5s
//gutil:proto_matchers_test PASSED in 0.6s
//gutil:proto_ordering_test PASSED in 0.5s
//gutil:proto_test PASSED in 0.5s
//gutil:status_matchers_test PASSED in 0.5s
//gutil:test_artifact_writer_test PASSED in 0.6s
//gutil:testing_test PASSED in 0.5s
//gutil:version_test PASSED in 0.8s
//lib/gnoi:gnoi_helper_test PASSED in 0.5s
//lib/utils:json_utils_test PASSED in 0.0s
//lib/validator:validator_backend_test PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test PASSED in 1.7s
//p4_fuzzer:fuzz_util_test PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test PASSED in 0.9s
//p4_fuzzer:switch_state_test PASSED in 0.6s
//p4_fuzzer:table_entry_key_test PASSED in 0.1s
//p4_pdpi:built_ins_test PASSED in 0.5s
//p4_pdpi:entity_keys_test PASSED in 0.5s
//p4_pdpi:ir_tools_test PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test PASSED in 0.7s
//p4_pdpi:reference_annotations_test PASSED in 0.7s
//p4_pdpi:sequencing_util_test PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_fuzzer_test PASSED in 16.2s
//p4_pdpi/packetlib:packetlib_matchers_test PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test PASSED in 1.4s
//p4_pdpi/string_encodings:bit_string_test PASSED in 0.6s
//p4_pdpi/string_encodings:byte_string_test PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test PASSED in 0.3s
//p4_pdpi/string_encodings:decimal_string_test_runner PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test PASSED in 0.5s
//p4_pdpi/testing:helper_function_test PASSED in 0.6s
//p4_pdpi/testing:info_test PASSED in 0.1s
//p4_pdpi/testing:info_test_runner PASSED in 0.1s
//p4_pdpi/testing:main_pd_test PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test PASSED in 0.7s
//p4_pdpi/testing:packet_io_test PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner PASSED in 0.1s
//p4_pdpi/testing:rpc_test PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_test PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test PASSED in 0.8s
//p4_pdpi/testing:table_entry_test PASSED in 0.4s
//p4_pdpi/testing:table_entry_test_runner PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test PASSED in 0.5s
//p4_pdpi/utils:ir_test PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test PASSED in 1.1s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test PASSED in 1.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test PASSED in 1.0s
//p4rt_app/event_monitoring:state_verification_events_test PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test PASSED in 1.0s
//p4rt_app/sonic:app_db_acl_def_table_manager_test PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test PASSED in 0.8s
//p4rt_app/sonic:hashing_test PASSED in 0.8s
//p4rt_app/sonic:packet_replication_entry_translation_test PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test PASSED in 0.5s
//p4rt_app/sonic:packetio_port_test PASSED in 0.6s
//p4rt_app/sonic:response_handler_test PASSED in 0.7s
//p4rt_app/sonic:state_verification_test PASSED in 0.7s
//p4rt_app/sonic:vrf_entry_translation_test PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test PASSED in 0.0s
//p4rt_app/tests:acl_table_test PASSED in 1.3s
//p4rt_app/tests:action_set_test PASSED in 1.1s
//p4rt_app/tests:api_access_test PASSED in 1.0s
//p4rt_app/tests:arbitration_test PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test PASSED in 1.6s
//p4rt_app/tests:debug_data_dump_test PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test PASSED in 3.8s
//p4rt_app/tests:grpc_behavior_test PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test PASSED in 1.2s
//p4rt_app/tests:p4_constraints_test_runner PASSED in 0.2s
//p4rt_app/tests:p4_programs_test PASSED in 1.5s
//p4rt_app/tests:packetio_test PASSED in 3.6s
//p4rt_app/tests:port_name_and_id_test PASSED in 2.4s
//p4rt_app/tests:resource_limits_test PASSED in 3.6s
//p4rt_app/tests:response_path_test PASSED in 2.9s
//p4rt_app/tests:role_test PASSED in 1.1s
//p4rt_app/tests:state_verification_test PASSED in 1.7s
//p4rt_app/tests:vrf_table_test PASSED in 1.5s
//p4rt_app/tests/lib:app_db_entry_builder_test PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test PASSED in 0.0s
//p4rt_app/utils:table_utility_test PASSED in 0.8s
//sai_p4/instantiations/google:clos_stage_test PASSED in 0.6s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:sai_p4info_fetcher_test PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.2s
//sai_p4/instantiations/google/test_tools:test_entries_test PASSED in 0.9s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test PASSED in 0.8s
//sai_p4/tools:p4info_tools_test PASSED in 0.6s
//sai_p4/tools:packetio_tools_test PASSED in 0.7s
//thinkit:mock_mirror_testbed_test PASSED in 0.6s
//thinkit:mock_ssh_client_test PASSED in 0.0s
//thinkit:mock_switch_test PASSED in 0.6s
//thinkit:mock_test_environment_test PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test PASSED in 13.1s
Stats over 5 runs: max = 13.1s, min = 1.0s, avg = 8.2s, dev = 5.4s

Executed 122 out of 122 tests: 122 tests pass.
INFO: Build completed successfully, 127 total actions
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$