### PR TITLE
[Thinkit] Moved validator to free functions

### DIFF
--- a/lib/gnmi/gnmi_helper.h
+++ b/lib/gnmi/gnmi_helper.h
@@ -101,7 +101,15 @@ absl::Status PushGnmiConfig(
 absl::Status PushGnmiConfig(thinkit::Switch& chassis,
                             const std::string& gnmi_config);
 
-absl::Status CheckAllInterfaceUpOverGnmi(gnmi::gNMI::Stub& stub);
+absl::Status CanGetAllInterfaceOverGnmi(
+    gnmi::gNMI::Stub& stub, absl::Duration timeout = absl::Seconds(60));
+
+absl::StatusOr<gnmi::GetResponse> GetAllInterfaceOverGnmi(
+    gnmi::gNMI::Stub& stub, absl::Duration timeout = absl::Seconds(60));
+
+// Checks if all interfaces are up.
+absl::Status CheckAllInterfaceUpOverGnmi(
+    gnmi::gNMI::Stub& stub, absl::Duration timeout = absl::Seconds(60));
 
 // Returns gNMI Path for OC strings.
 gnmi::Path ConvertOCStringToPath(absl::string_view oc_path);

--- a/lib/validator/BUILD.bazel
+++ b/lib/validator/BUILD.bazel
@@ -57,16 +57,15 @@ cc_library(
 
 cc_library(
     name = "common_backend",
+    testonly = 1,
     srcs = ["common_backend.cc"],
     hdrs = ["common_backend.h"],
     deps = [
         ":validator",
         ":validator_backend",
-        "//gutil:status",
+        ":validator_lib",
         "//thinkit:ssh_client",
         "@com_google_absl//absl/functional:bind_front",
-        "@com_google_absl//absl/status",
-        "@com_google_absl//absl/strings",
     ],
 )
 
@@ -92,18 +91,34 @@ cc_library(
     deps = [
         ":validator",
         ":validator_backend",
+        ":validator_lib",
+        "//gutil:status",
+        "//thinkit:switch",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/functional:bind_front",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
+    ],
+)
+
+cc_library(
+    name = "validator_lib",
+    testonly = 1,
+    srcs = ["validator_lib.cc"],
+    hdrs = ["validator_lib.h"],
+    deps = [
         "//gutil:status",
         "//lib/gnmi:gnmi_helper",
         "//p4_pdpi:p4_runtime_session",
+        "//thinkit:ssh_client",
         "//thinkit:switch",
         "@com_github_gnmi//proto/gnmi:gnmi_cc_proto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_gnmi//proto/gnmi:gnmi_cc_grpc_proto",
         "@com_github_gnoi//system:system_cc_proto",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/container:flat_hash_set",
-        "@com_google_absl//absl/functional:bind_front",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",

--- a/lib/validator/pins_backend.cc
+++ b/lib/validator/pins_backend.cc
@@ -22,23 +22,12 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
-#include "absl/memory/memory.h"
 #include "absl/status/status.h"
-#include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/string_view.h"
-#include "absl/time/clock.h"
 #include "absl/time/time.h"
-#include "grpcpp/impl/codegen/client_context.h"
-#include "grpcpp/impl/codegen/status_code_enum.h"
 #include "gutil/status.h"
-#include "lib/gnmi/gnmi_helper.h"
-#include "lib/validator/validator_backend.h"
 #include "p4_pdpi/p4_runtime_session.h"
-#include "p4/v1/p4runtime.grpc.pb.h"
-#include "proto/gnmi/gnmi.grpc.pb.h"
-#include "proto/gnmi/gnmi.pb.h"
-#include "system/system.pb.h"
+#include "lib/validator/validator_lib.h"
 #include "thinkit/switch.h"
 
 namespace pins_test {
@@ -54,67 +43,48 @@ PINSBackend::PINSBackend(std::vector<std::unique_ptr<thinkit::Switch>> switches)
   }
 }
 
-absl::Status PINSBackend::CanEstablishP4RuntimeSession(
-    absl::string_view chassis, absl::Duration timeout) {
+absl::Status PINSBackend::P4rtAble(absl::string_view chassis,
+                                   absl::Duration timeout) {
   auto sut = switches_map_.find(chassis);
   if (sut == switches_map_.end()) {
     return absl::InternalError(
         absl::StrCat("ValidatorBackend passed invalid chassis: ", chassis));
   }
   auto& [sut_name, sut_switch] = *sut;
-  ASSIGN_OR_RETURN(auto p4runtime_stub, sut_switch->CreateP4RuntimeStub());
-  return pdpi::P4RuntimeSession::Create(std::move(p4runtime_stub), sut_switch->DeviceId())
-      .status();
+  return pins_test::P4rtAble(*sut_switch);
 }
 
-absl::Status PINSBackend::CanGetAllInterfaceOverGnmi(absl::string_view chassis,
-                                                     absl::Duration timeout) {
+absl::Status PINSBackend::GnmiAble(absl::string_view chassis,
+                                   absl::Duration timeout) {
   auto sut = switches_map_.find(chassis);
   if (sut == switches_map_.end()) {
     return absl::InternalError(
         absl::StrCat("ValidatorBackend passed invalid chassis: ", chassis));
   }
   auto& [sut_name, sut_switch] = *sut;
-  ASSIGN_OR_RETURN(auto gnmi_stub, sut_switch->CreateGnmiStub());
-  ASSIGN_OR_RETURN(auto req, BuildGnmiGetRequest("", gnmi::GetRequest::ALL));
-
-  gnmi::GetResponse resp;
-  grpc::ClientContext context;
-  context.set_deadline(absl::ToChronoTime(absl::Now() + timeout));
-  context.set_wait_for_ready(true);
-  return gutil::GrpcStatusToAbslStatus(gnmi_stub->Get(&context, req, &resp));
+  return pins_test::GnmiAble(*sut_switch, timeout);
 }
 
-absl::Status PINSBackend::CanGetTimeOverGnoiSystem(absl::string_view chassis,
-                                                   absl::Duration timeout) {
+absl::Status PINSBackend::GnoiAble(absl::string_view chassis,
+                                   absl::Duration timeout) {
   auto sut = switches_map_.find(chassis);
   if (sut == switches_map_.end()) {
     return absl::InternalError(
         absl::StrCat("ValidatorBackend passed invalid chassis: ", chassis));
   }
   auto& [sut_name, sut_switch] = *sut;
-  ASSIGN_OR_RETURN(auto gnoi_system_stub, sut_switch->CreateGnoiSystemStub());
-
-  gnoi::system::TimeRequest request;
-  gnoi::system::TimeResponse response;
-  grpc::ClientContext context;
-  context.set_deadline(absl::ToChronoTime(absl::Now() + timeout));
-  context.set_wait_for_ready(true);
-  return gutil::GrpcStatusToAbslStatus(
-      gnoi_system_stub->Time(&context, request, &response));
+  return pins_test::GnoiAble(*sut_switch, timeout);
 }
 
-absl::Status PINSBackend::CheckAllInterfaceUpOverGnmi(absl::string_view chassis,
-                                                      absl::Duration timeout) {
+absl::Status PINSBackend::PortsUp(absl::string_view chassis,
+                                  absl::Duration timeout) {
   auto sut = switches_map_.find(chassis);
   if (sut == switches_map_.end()) {
     return absl::InternalError(
         absl::StrCat("ValidatorBackend passed invalid chassis: ", chassis));
   }
-
   auto& [sut_name, sut_switch] = *sut;
-  ASSIGN_OR_RETURN(auto gnmi_stub, sut_switch->CreateGnmiStub());
-  return pins_test::CheckAllInterfaceUpOverGnmi(*gnmi_stub);
+  return pins_test::PortsUp(*sut_switch, timeout);
 }
 
 }  // namespace pins_test

--- a/lib/validator/pins_backend.h
+++ b/lib/validator/pins_backend.h
@@ -44,42 +44,33 @@ class PINSBackend : public ValidatorBackend {
   PINSBackend(std::vector<std::unique_ptr<thinkit::Switch>> switches);
 
   // Checks if a P4Runtime session could be established.
-  absl::Status CanEstablishP4RuntimeSession(absl::string_view chassis,
-                                            absl::Duration timeout);
+  absl::Status P4rtAble(absl::string_view chassis, absl::Duration timeout);
 
   // Checks if a gNMI get all interface request can be sent and a response
   // received.
-  absl::Status CanGetAllInterfaceOverGnmi(absl::string_view chassis,
-                                          absl::Duration timeout);
+  absl::Status GnmiAble(absl::string_view chassis, absl::Duration timeout);
 
   // Checks if a gNOI system get time request can be sent and a response
   // received.
-  absl::Status CanGetTimeOverGnoiSystem(absl::string_view chassis,
-                                        absl::Duration timeout);
+  absl::Status GnoiAble(absl::string_view chassis, absl::Duration timeout);
 
   // Checks if "oper-status" of all interfaces are "UP".
-  absl::Status CheckAllInterfaceUpOverGnmi(absl::string_view chassis,
-                                           absl::Duration timeout);
+  absl::Status PortsUp(absl::string_view chassis, absl::Duration timeout);
 
  protected:
   void SetupValidations() override {
-    AddCallbacksToValidation(
-        kP4RuntimeUsable,
-        {absl::bind_front(&PINSBackend::CanEstablishP4RuntimeSession, this)});
-    AddCallbacksToValidation(
-        kGnmiUsable,
-        {absl::bind_front(&PINSBackend::CanGetAllInterfaceOverGnmi, this)});
-    AddCallbacksToValidation(
-        kGnoiSystemUsable,
-        {absl::bind_front(&PINSBackend::CanGetTimeOverGnoiSystem, this)});
-    AddCallbacksToValidation(
-        kPortsUp,
-        {absl::bind_front(&PINSBackend::CheckAllInterfaceUpOverGnmi, this)});
-    AddCallbacksToValidation(
-        Validator::kReady,
-        {absl::bind_front(&PINSBackend::CanEstablishP4RuntimeSession, this),
-         absl::bind_front(&PINSBackend::CanGetAllInterfaceOverGnmi, this),
-         absl::bind_front(&PINSBackend::CanGetTimeOverGnoiSystem, this)});
+    AddCallbacksToValidation(kP4RuntimeUsable,
+                             {absl::bind_front(&PINSBackend::P4rtAble, this)});
+    AddCallbacksToValidation(kGnmiUsable,
+                             {absl::bind_front(&PINSBackend::GnmiAble, this)});
+    AddCallbacksToValidation(kGnoiSystemUsable,
+                             {absl::bind_front(&PINSBackend::GnoiAble, this)});
+    AddCallbacksToValidation(kPortsUp,
+                             {absl::bind_front(&PINSBackend::PortsUp, this)});
+    AddCallbacksToValidation(Validator::kReady,
+                             {absl::bind_front(&PINSBackend::P4rtAble, this),
+                              absl::bind_front(&PINSBackend::GnmiAble, this),
+                              absl::bind_front(&PINSBackend::GnoiAble, this)});
   }
 
  private:

--- a/lib/validator/validator_lib.cc
+++ b/lib/validator/validator_lib.cc
@@ -1,0 +1,121 @@
+#include "lib/validator/validator_lib.h"
+
+#include <memory>
+
+#include "absl/memory/memory.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "absl/strings/substitute.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "grpcpp/impl/codegen/client_context.h"
+#include "grpcpp/impl/codegen/status_code_enum.h"
+#include "gutil/status.h"
+#include "lib/gnmi/gnmi_helper.h"
+#include "p4/v1/p4runtime.grpc.pb.h"
+#include "p4_pdpi/p4_runtime_session.h"
+#include "proto/gnmi/gnmi.grpc.pb.h"
+#include "proto/gnmi/gnmi.pb.h"
+#include "system/system.pb.h"
+#include "thinkit/ssh_client.h"
+#include "thinkit/switch.h"
+
+namespace pins_test {
+
+namespace {
+
+using Stub = ::p4::v1::P4Runtime::Stub;
+
+}  // namespace
+
+absl::Status Pingable(absl::string_view chassis_name, absl::Duration timeout) {
+  constexpr char kPingCommand[] = R"(fping -t $0 $1)";
+  FILE* in;
+  char buff[1024];
+  std::string pingCommand = absl::Substitute(
+      kPingCommand, absl::ToInt64Seconds(timeout), chassis_name);
+  if (!(in = popen(pingCommand.c_str(), "r"))) {
+    return absl::UnknownError(
+        absl::StrCat("Failed to run command: ", pingCommand));
+  }
+  std::string response;
+  while (fgets(buff, sizeof(buff), in) != nullptr) {
+    absl::StrAppend(&response, buff);
+  }
+  pclose(in);
+
+  if (!absl::StrContains(response, "alive")) {
+    return absl::UnavailableError(
+        absl::StrCat("Switch ", chassis_name,
+                     " is not reachable. Unexpected result: ", response));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status Pingable(thinkit::Switch& thinkit_switch, absl::Duration timeout) {
+  return Pingable(thinkit_switch.ChassisName(), timeout);
+}
+
+// The switch is SSHable if running the command "echo foo" returns "foo" in
+// stdout with no errors.
+absl::Status SSHable(absl::string_view chassis_name,
+                     thinkit::SSHClient& ssh_client, absl::Duration timeout) {
+  ASSIGN_OR_RETURN(std::string response,
+                   ssh_client.RunCommand(chassis_name, "echo foo", timeout));
+
+  if (response != "foo\n") {
+    return absl::UnavailableError(
+        absl::StrCat("Switch ", chassis_name,
+                     " is not SSHable. Unexpected result: ", response));
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status SSHable(thinkit::Switch& thinkit_switch,
+                     thinkit::SSHClient& ssh_client, absl::Duration timeout) {
+  return SSHable(thinkit_switch.ChassisName(), ssh_client, timeout);
+}
+
+// Checks if a P4Runtime session could be established.
+absl::Status P4rtAble(thinkit::Switch& thinkit_switch) {
+  ASSIGN_OR_RETURN(std::unique_ptr<Stub> p4runtime_stub,
+                   thinkit_switch.CreateP4RuntimeStub());
+  return pdpi::P4RuntimeSession::Create(std::move(p4runtime_stub),
+                                        thinkit_switch.DeviceId())
+      .status();
+}
+
+// Checks if a gNMI get all interface request can be sent and a response
+// received.
+absl::Status GnmiAble(thinkit::Switch& thinkit_switch, absl::Duration timeout) {
+  ASSIGN_OR_RETURN(std::unique_ptr<gnmi::gNMI::Stub> gnmi_stub,
+                   thinkit_switch.CreateGnmiStub());
+  return pins_test::CanGetAllInterfaceOverGnmi(*gnmi_stub, timeout);
+}
+
+// Checks if a gNOI system get time request can be sent and a response
+// received.
+absl::Status GnoiAble(thinkit::Switch& thinkit_switch, absl::Duration timeout) {
+  ASSIGN_OR_RETURN(std::unique_ptr<gnoi::system::System::Stub> gnoi_system_stub,
+                   thinkit_switch.CreateGnoiSystemStub());
+  gnoi::system::TimeRequest request;
+  gnoi::system::TimeResponse response;
+  grpc::ClientContext context;
+  context.set_deadline(absl::ToChronoTime(absl::Now() + timeout));
+  context.set_wait_for_ready(true);
+  return gutil::GrpcStatusToAbslStatus(
+      gnoi_system_stub->Time(&context, request, &response));
+}
+
+// Checks if "oper-status" of all interfaces are "UP".
+absl::Status PortsUp(thinkit::Switch& thinkit_switch, absl::Duration timeout) {
+  ASSIGN_OR_RETURN(std::unique_ptr<gnmi::gNMI::Stub> gnmi_stub,
+                   thinkit_switch.CreateGnmiStub());
+  return pins_test::CheckAllInterfaceUpOverGnmi(*gnmi_stub, timeout);
+}
+
+}  // namespace pins_test

--- a/lib/validator/validator_lib.h
+++ b/lib/validator/validator_lib.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2024, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_LIB_VALIDATOR_VALIDATOR_LIB_H_
+#define GOOGLE_LIB_VALIDATOR_VALIDATOR_LIB_H_
+
+#include "absl/status/status.h"
+#include "thinkit/ssh_client.h"
+#include "thinkit/switch.h"
+
+namespace pins_test {
+
+constexpr absl::Duration kDefaultTimeout = absl::Seconds(60);
+
+// Checks if the switch can be pinged.
+absl::Status Pingable(absl::string_view chassis_name,
+                      absl::Duration timeout = kDefaultTimeout);
+
+absl::Status Pingable(thinkit::Switch& thinkit_switch,
+                      absl::Duration timeout = kDefaultTimeout);
+
+// Checks if ssh access to the switch is working.
+absl::Status SSHable(absl::string_view chassis_name,
+                     thinkit::SSHClient& ssh_client,
+                     absl::Duration timeout = kDefaultTimeout);
+
+absl::Status SSHable(thinkit::Switch& thinkit_switch,
+                     thinkit::SSHClient& ssh_client,
+                     absl::Duration timeout = kDefaultTimeout);
+
+// Checks if a P4Runtime session could be established.
+absl::Status P4rtAble(thinkit::Switch& thinkit_switch);
+
+// Checks if a gNMI get all interface request can be sent and a response
+// received.
+absl::Status GnmiAble(thinkit::Switch& thinkit_switch,
+                      absl::Duration timeout = kDefaultTimeout);
+
+// Checks if a gNOI system get time request can be sent and a response
+// received.
+absl::Status GnoiAble(thinkit::Switch& thinkit_switch,
+                      absl::Duration timeout = kDefaultTimeout);
+
+// Checks if "oper-status" of all interfaces are "UP".
+absl::Status PortsUp(thinkit::Switch& thinkit_switch,
+                     absl::Duration timeout = kDefaultTimeout);
+
+}  // namespace pins_test
+
+#endif  // GOOGLE_LIB_VALIDATOR_VALIDATOR_LIB_H_


### PR DESCRIPTION
PR Description:
Moved validator to free functions

Keyword Check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 358 targets (0 packages loaded, 0 targets configured).
INFO: Found 358 targets...
INFO: Elapsed time: 0.625s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 

UT Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 358 targets (0 packages loaded, 0 targets configured).
INFO: Found 234 targets and 124 test targets...
INFO: Elapsed time: 100.269s, Critical Path: 16.68s
INFO: 129 processes: 136 linux-sandbox, 17 local.
INFO: Build completed successfully, 129 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 1.4s
//lib/gnmi:gnmi_helper_test                                              PASSED in 0.7s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/utils:json_utils_test                                              PASSED in 0.0s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 1.0s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.6s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.5s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.6s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.7s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 2.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.7s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.8s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.7s
//p4rt_app/tests:action_set_test                                         PASSED in 1.2s
//p4rt_app/tests:api_access_test                                         PASSED in 2.3s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.3s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.9s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.1s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.0s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 5.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.9s
//p4rt_app/tests:packetio_test                                           PASSED in 4.1s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.2s
//p4rt_app/tests:resource_limits_test                                    PASSED in 1.7s
//p4rt_app/tests:response_path_test                                      PASSED in 3.7s
//p4rt_app/tests:role_test                                               PASSED in 1.2s
//p4rt_app/tests:state_verification_test                                 PASSED in 3.2s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.7s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.5s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 12.8s
  Stats over 5 runs: max = 12.8s, min = 0.9s, avg = 7.8s, dev = 5.1s

Executed 124 out of 124 tests: 124 tests pass.
INFO: Build completed successfully, 129 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 