### PR TITLE
[Thinkit] Added GenericTestbed and ControlInterface interfaces. 

### DIFF
--- a/thinkit/BUILD.bazel
+++ b/thinkit/BUILD.bazel
@@ -27,6 +27,7 @@ package(
 cc_library(
     name = "thinkit",
     deps = [
+        ":control_interface",
         ":generic_testbed",
         ":mirror_testbed",
         ":switch",
@@ -38,6 +39,7 @@ cc_library(
     name = "thinkit_mocks",
     testonly = 1,
     deps = [
+        ":mock_control_interface",
         ":mock_generic_testbed",
         ":mock_mirror_testbed",
         ":mock_switch",
@@ -221,10 +223,24 @@ cc_library(
     name = "generic_testbed",
     hdrs = ["generic_testbed.h"],
     deps = [
+        ":control_interface",
         ":switch",
         ":test_environment",
+        "//thinkit/proto:generic_testbed_cc_proto",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "generic_testbed_fixture",
+    testonly = 1,
+    hdrs = ["generic_testbed_fixture.h"],
+    deps = [
+        ":generic_testbed",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -233,6 +249,7 @@ cc_library(
     testonly = 1,
     hdrs = ["mock_generic_testbed.h"],
     deps = [
+        ":control_interface",
         ":generic_testbed",
         ":switch",
         ":test_environment",
@@ -260,6 +277,28 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
+    name = "mock_control_interface",
+    testonly = 1,
+    hdrs = ["mock_control_interface.h"],
+    deps = [
+        ":control_interface",
+        "@com_github_gnoi//diag:diag_cc_grpc_proto",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "mock_control_interface_test",
+    srcs = ["mock_control_interface_test.cc"],
+    deps = [
+        ":mock_control_interface",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/thinkit/BUILD.bazel
+++ b/thinkit/BUILD.bazel
@@ -27,9 +27,21 @@ package(
 cc_library(
     name = "thinkit",
     deps = [
+        ":generic_testbed",
         ":mirror_testbed",
         ":switch",
         ":test_environment",
+    ],
+)
+
+cc_library(
+    name = "thinkit_mocks",
+    testonly = 1,
+    deps = [
+        ":mock_generic_testbed",
+        ":mock_mirror_testbed",
+        ":mock_switch",
+        ":mock_test_environment",
     ],
 )
 
@@ -201,6 +213,40 @@ cc_test(
     srcs = ["mock_ssh_client_test.cc"],
     deps = [
         ":mock_ssh_client",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "generic_testbed",
+    hdrs = ["generic_testbed.h"],
+    deps = [
+        ":switch",
+        ":test_environment",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "mock_generic_testbed",
+    testonly = 1,
+    hdrs = ["mock_generic_testbed.h"],
+    deps = [
+        ":generic_testbed",
+        ":switch",
+        ":test_environment",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "mock_generic_testbed_test",
+    srcs = ["mock_generic_testbed_test.cc"],
+    deps = [
+        ":mock_generic_testbed",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/thinkit/bazel_test_environment.h
+++ b/thinkit/bazel_test_environment.h
@@ -32,10 +32,11 @@ class BazelTestEnvironment : public TestEnvironment {
 
   absl::Status StoreTestArtifact(absl::string_view filename,
                                  absl::string_view contents) override;
+  using TestEnvironment::StoreTestArtifact; // Inherit protobuf overload.
 
   absl::Status AppendToTestArtifact(absl::string_view filename,
                                     absl::string_view contents) override;
-
+  using TestEnvironment::AppendToTestArtifact; // Inherit protobuf overload.
 
   bool MaskKnownFailures() { return mask_known_failures_; };
 

--- a/thinkit/generic_testbed.h
+++ b/thinkit/generic_testbed.h
@@ -17,8 +17,11 @@
 
 #include <string>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "thinkit/control_interface.h"
+#include "thinkit/proto/generic_testbed.pb.h"
 #include "thinkit/switch.h"
 #include "thinkit/test_environment.h"
 
@@ -37,6 +40,13 @@ enum class RequestType {
   kDelete,
 };
 
+// InterfaceInfo represents the mode of an interface and the name of the peer
+// interface.
+struct InterfaceInfo {
+  third_party::pins_infra::thinkit::InterfaceMode interface_mode;
+  std::string peer_interface_name;  // Empty if not applicable.
+};
+
 // The GenericTestbed interface represents a testbed with control interface and
 // Ixia interface.
 class GenericTestbed {
@@ -46,8 +56,16 @@ class GenericTestbed {
   // Returns the switch (aka system) under test.
   virtual Switch& Sut() = 0;
 
+  // Returns the control interface responsible for packet injection and various
+  // management operations.
+  virtual ControlInterface& Interface() = 0;
+
   // Returns the test environment in which the test is run.
   virtual TestEnvironment& Environment() = 0;
+
+  // Returns the information for all SUT interfaces.
+  virtual absl::flat_hash_map<std::string, InterfaceInfo>
+  GetSutInterfaceInfo() = 0;
 
   // Sends a REST request to the Ixia and returns the response.
   virtual absl::StatusOr<HttpResponse> SendRestRequestToIxia(

--- a/thinkit/generic_testbed.h
+++ b/thinkit/generic_testbed.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2024, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_THINKIT_GENERIC_TESTBED_H_
+#define GOOGLE_THINKIT_GENERIC_TESTBED_H_
+
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "thinkit/switch.h"
+#include "thinkit/test_environment.h"
+
+namespace thinkit {
+
+// HttpResponse represents an HTTP response from an Ixia device.
+struct HttpResponse {
+  int response_code;
+  std::string response;
+};
+
+enum class RequestType {
+  kGet,
+  kPost,
+  kPut,
+  kDelete,
+};
+
+// The GenericTestbed interface represents a testbed with control interface and
+// Ixia interface.
+class GenericTestbed {
+ public:
+  virtual ~GenericTestbed() {}
+
+  // Returns the switch (aka system) under test.
+  virtual Switch& Sut() = 0;
+
+  // Returns the test environment in which the test is run.
+  virtual TestEnvironment& Environment() = 0;
+
+  // Sends a REST request to the Ixia and returns the response.
+  virtual absl::StatusOr<HttpResponse> SendRestRequestToIxia(
+      RequestType type, absl::string_view url, absl::string_view payload) = 0;
+};
+
+}  // namespace thinkit
+#endif  // GOOGLE_THINKIT_GENERIC_TESTBED_H_

--- a/thinkit/generic_testbed_fixture.h
+++ b/thinkit/generic_testbed_fixture.h
@@ -1,0 +1,101 @@
+// Copyright (c) 2024, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_THINKIT_GENERIC_TESTBED_TEST_FIXTURE_H_
+#define GOOGLE_THINKIT_GENERIC_TESTBED_TEST_FIXTURE_H_
+
+#include <memory>
+
+#include "absl/memory/memory.h"
+#include "gtest/gtest.h"
+#include "thinkit/generic_testbed.h"
+
+namespace thinkit {
+
+// The ThinKit `GenericTestbedInterface` defines an interface every test
+// platform should implement. The expectations are such that the GenericTestbed
+// should only be accessed after SetUp() is called and before TearDown() is
+// called.
+class GenericTestbedInterface {
+ public:
+  virtual ~GenericTestbedInterface() = default;
+
+  virtual void SetUp() = 0;
+  virtual void TearDown() = 0;
+
+  virtual GenericTestbed& GetGenericTestbed() = 0;
+};
+
+// The Thinkit `TestParams` defines test parameters to
+// `GenericTestbedFixture` class.
+struct TestParams {
+  // Ownership transferred in GenericTestbedFixture class.
+  GenericTestbedInterface* generic_testbed;
+  std::string gnmi_config;
+  absl::optional<std::vector<int>> port_ids;
+};
+
+// The ThinKit `GenericTestbedFixture` class acts as a base test fixture for
+// platform independent PINS tests. Any platform specific SetUp or TearDown
+// requirements are abstracted through the ThinKit GenericTestbedInterface which
+// is passed as a parameter.
+//
+// New PINS tests should extend this fixture, and if needed can extend the
+// SetUp() and/or TearDown() methods:
+//    class MyPinsTest : public thinkit::GenericTestbedFixture {
+//      void SetUp() override {
+//        GenericTestbedFixture::SetUp();  // called first.
+//
+//        // custom setup steps ...
+//      }
+//
+//      void TearDown() override {
+//        // custom tear down steps ...
+//
+//        GenericTestbedFixture::TearDown();  // called last.
+//      }
+//    };
+//
+//  Individual tests should use the new suite name:
+//    TEST_P(MyPinsTest, MyTestName) {}
+class GenericTestbedFixture : public testing::TestWithParam<TestParams> {
+ protected:
+  // A derived class that needs/wants to do its own setup can override this
+  // method. However, it should take care to call this base setup first. That
+  // will ensure the platform is ready, and in a healthy state.
+  void SetUp() override { generic_testbed_interface_->SetUp(); }
+
+  // A derived class that needs/wants to do its own teardown can override this
+  // method. However, it should take care to call this base teardown last. Once
+  // this method is called accessing the platform can result in unexpected
+  // behaviors.
+  void TearDown() override { generic_testbed_interface_->TearDown(); }
+
+  // Accessor for the Generic testbed. This is only safe to be called after the
+  // SetUp has completed.
+  GenericTestbed& GetGenericTestbed() {
+    return generic_testbed_interface_->GetGenericTestbed();
+  }
+
+  std::string GetGnmiConfig() { return GetParam().gnmi_config; }
+
+ private:
+  // Takes ownership of the GenericTestbedInterface parameter.
+  std::unique_ptr<GenericTestbedInterface> generic_testbed_interface_ =
+      absl::WrapUnique<GenericTestbedInterface>(GetParam().generic_testbed);
+};
+
+}  // namespace thinkit
+
+#endif  // GOOGLE_THINKIT_GENERIC_TESTBED_TEST_FIXTURE_H_

--- a/thinkit/mock_control_interface.h
+++ b/thinkit/mock_control_interface.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2024, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_THINKIT_MOCK_CONTROL_INTERFACE_H_
+#define GOOGLE_THINKIT_MOCK_CONTROL_INTERFACE_H_
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "diag/diag.grpc.pb.h"
+#include "gmock/gmock.h"
+#include "thinkit/control_interface.h"
+
+namespace thinkit {
+class MockControlInterface : public ControlInterface {
+ public:
+  MOCK_METHOD(absl::Status, SetAdminLinkState,
+              (absl::Span<const std::string> sut_ports, LinkState state),
+              (override));
+  MOCK_METHOD(absl::Status, Reboot, (RebootType reboot_Type), (override));
+  MOCK_METHOD(absl::StatusOr<gnoi::diag::StartBERTResponse>, StartBERT,
+              (const gnoi::diag::StartBERTRequest& request), (override));
+  MOCK_METHOD(absl::StatusOr<gnoi::diag::StopBERTResponse>, StopBERT,
+              (const gnoi::diag::StopBERTRequest& request), (override));
+  MOCK_METHOD(absl::StatusOr<gnoi::diag::GetBERTResultResponse>, GetBERTResult,
+              (const gnoi::diag::GetBERTResultRequest& request));
+  MOCK_METHOD(absl::StatusOr<absl::flat_hash_set<std::string>>, GetUpLinks,
+              (absl::Span<const std::string> sut_ports), (override));
+  MOCK_METHOD(absl::Status, CheckUp, (), (override));
+};
+
+}  // namespace thinkit
+
+#endif  // GOOGLE_THINKIT_MOCK_CONTROL_INTERFACE_H_

--- a/thinkit/mock_control_interface_test.cc
+++ b/thinkit/mock_control_interface_test.cc
@@ -1,0 +1,25 @@
+// Copyright (c) 2024, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "thinkit/mock_control_interface.h"
+
+#include "gtest/gtest.h"
+
+namespace thinkit {
+namespace {
+
+TEST(MockControlInterface, TestBuild) { MockControlInterface mock; }
+
+}  // namespace
+}  // namespace thinkit

--- a/thinkit/mock_generic_testbed.h
+++ b/thinkit/mock_generic_testbed.h
@@ -12,28 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef THINKIT_MOCK_TEST_ENVIRONMENT_H_
-#define THINKIT_MOCK_TEST_ENVIRONMENT_H_
+#ifndef GOOGLE_THINKIT_MOCK_GENERIC_TESTBED_H_
+#define GOOGLE_THINKIT_MOCK_GENERIC_TESTBED_H_
 
-#include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
+#include "thinkit/generic_testbed.h"
+#include "thinkit/switch.h"
 #include "thinkit/test_environment.h"
 
 namespace thinkit {
 
-class MockTestEnvironment : public TestEnvironment {
+class MockGenericTestbed : public GenericTestbed {
  public:
-  MOCK_METHOD(absl::Status, StoreTestArtifact,
-              (absl::string_view filename, absl::string_view contents),
+  MOCK_METHOD(Switch&, Sut, (), (override));
+  MOCK_METHOD(TestEnvironment&, Environment, (), (override));
+  MOCK_METHOD(absl::StatusOr<HttpResponse>, SendRestRequestToIxia,
+              (RequestType type, absl::string_view url,
+               absl::string_view payload),
               (override));
-  MOCK_METHOD(absl::Status, AppendToTestArtifact,
-              (absl::string_view filename, absl::string_view contents),
-              (override));
-  MOCK_METHOD(bool, MaskKnownFailures, (), (override));
-  MOCK_METHOD(void, SetTestCaseID, (absl::string_view), (override));
 };
 
 }  // namespace thinkit
 
-#endif  // THINKIT_MOCK_TEST_ENVIRONMENT_H_
+#endif  // GOOGLE_THINKIT_MOCK_GENERIC_TESTBED_H_

--- a/thinkit/mock_generic_testbed.h
+++ b/thinkit/mock_generic_testbed.h
@@ -18,6 +18,7 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
+#include "thinkit/control_interface.h"
 #include "thinkit/generic_testbed.h"
 #include "thinkit/switch.h"
 #include "thinkit/test_environment.h"
@@ -27,7 +28,10 @@ namespace thinkit {
 class MockGenericTestbed : public GenericTestbed {
  public:
   MOCK_METHOD(Switch&, Sut, (), (override));
+  MOCK_METHOD(ControlInterface&, Interface, (), (override));
   MOCK_METHOD(TestEnvironment&, Environment, (), (override));
+  MOCK_METHOD((absl::flat_hash_map<std::string, InterfaceInfo>),
+              GetSutInterfaceInfo, (), (override));
   MOCK_METHOD(absl::StatusOr<HttpResponse>, SendRestRequestToIxia,
               (RequestType type, absl::string_view url,
                absl::string_view payload),

--- a/thinkit/mock_generic_testbed_test.cc
+++ b/thinkit/mock_generic_testbed_test.cc
@@ -1,0 +1,25 @@
+// Copyright (c) 2024, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "thinkit/mock_generic_testbed.h"
+
+#include "gtest/gtest.h"
+
+namespace thinkit {
+namespace {
+
+TEST(MockGenericTestbed, TestBuild) { MockGenericTestbed mock; }
+
+}  // namespace
+}  // namespace thinkit

--- a/thinkit/mock_ssh_client.h
+++ b/thinkit/mock_ssh_client.h
@@ -32,16 +32,19 @@ class MockSSHClient : public SSHClient {
               (absl::string_view, absl::string_view, absl::Duration),
               (override));
   MOCK_METHOD(absl::Status, PutFile,
-              (absl::string_view, const RemoteFile&, absl::Duration),
+              (absl::string_view, const RemotePath&, absl::Duration),
               (override));
   MOCK_METHOD(absl::Status, PutFileContents,
-              (absl::string_view, const RemoteFile&, absl::Duration),
+              (absl::string_view, const RemotePath&, absl::Duration),
               (override));
   MOCK_METHOD(absl::Status, GetFile,
-              (const RemoteFile&, absl::string_view, absl::Duration),
+              (const RemotePath&, absl::string_view, absl::Duration),
               (override));
   MOCK_METHOD(absl::StatusOr<std::string>, GetFileContents,
-              (const RemoteFile&, absl::Duration), (override));
+              (const RemotePath&, absl::Duration), (override));
+  MOCK_METHOD(absl::Status, GetDirectory,
+              (const RemotePath&, absl::string_view, absl::Duration),
+              (override));
 };
 
 }  // namespace thinkit

--- a/thinkit/proto/BUILD.bazel
+++ b/thinkit/proto/BUILD.bazel
@@ -19,6 +19,16 @@ package(
 )
 
 proto_library(
+    name = "generic_testbed_proto",
+    srcs = ["generic_testbed.proto"],
+)
+
+cc_proto_library(
+    name = "generic_testbed_cc_proto",
+    deps = [":generic_testbed_proto"],
+)
+
+proto_library(
     name = "metrics_proto",
     srcs = ["metrics.proto"],
 )

--- a/thinkit/proto/generic_testbed.proto
+++ b/thinkit/proto/generic_testbed.proto
@@ -1,0 +1,40 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package third_party.pins_infra.thinkit;
+
+option cc_generic_services = false;
+
+// Mode types for the SUT interfaces are connected..
+enum InterfaceMode {
+  UNKNOWN_MODE = 0;
+  DISCONNECTED = 1;
+  LOOPBACK = 2;
+  CONTROL_INTERFACE = 3;
+  TRAFFIC_GENERATOR = 4;
+}
+
+// This message represents the mode of interface(s) and the number of
+// which are required.
+message InterfaceRequirement {
+  InterfaceMode interface_mode = 1;
+  int32 count = 2;
+}
+
+// This message represents interface(s) requirement for a test.
+message TestRequirements {
+  repeated InterfaceRequirement interface_requirements = 1;
+}

--- a/thinkit/ssh_client.h
+++ b/thinkit/ssh_client.h
@@ -24,9 +24,9 @@
 
 namespace thinkit {
 
-// RemoteFile represents a file on a remote device. It is meant to be used as a
-// parameter object with designated initializers.
-struct RemoteFile {
+// RemoteFile represents a file path on a remote device. It is meant to be used
+// as a parameter object with designated initializers.
+struct RemotePath {
   absl::string_view device;
   absl::string_view file_path;
 };
@@ -48,24 +48,30 @@ class SSHClient {
   // Copies a local file's contents to a remote destination file, creating a new
   // file if needed and replacing any existing contents that was there.
   virtual absl::Status PutFile(absl::string_view source,
-                               const RemoteFile& destination,
+                               const RemotePath& destination,
                                absl::Duration timeout) = 0;
 
   // Puts the provided contents into a remote destination file, creating a new
   // file if needed and replacing any existing contents that was there.
   virtual absl::Status PutFileContents(absl::string_view contents,
-                                       const RemoteFile& destination,
+                                       const RemotePath& destination,
                                        absl::Duration timeout) = 0;
 
   // Copies a remote file's contents to a local file, creating a new
   // file if needed and replacing any existing contents that was there.
-  virtual absl::Status GetFile(const RemoteFile& source,
+  virtual absl::Status GetFile(const RemotePath& source,
                                absl::string_view destination,
                                absl::Duration timeout) = 0;
 
   // Returns the contents of a remote file.
   virtual absl::StatusOr<std::string> GetFileContents(
-      const RemoteFile& source, absl::Duration timeout) = 0;
+      const RemotePath& source, absl::Duration timeout) = 0;
+
+  // Copies a remote directory to a local directory, creating a new directory if
+  // needed.
+  virtual absl::Status GetDirectory(const RemotePath& source,
+                                    absl::string_view destination,
+                                    absl::Duration timeout) = 0;
 };
 
 }  // namespace thinkit

--- a/thinkit/test_environment.h
+++ b/thinkit/test_environment.h
@@ -49,6 +49,9 @@ class TestEnvironment {
 
   // Should known failures be masked, or should the test fail instead?
   virtual bool MaskKnownFailures() = 0;
+
+  // Set the `test_case_id` for use by tracking tools.
+  virtual void SetTestCaseID(absl::string_view test_case_id) {}
 };
 
 }  // namespace thinkit


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 366 targets (1 packages loaded, 66 targets configured).
INFO: Found 366 targets...
INFO: Elapsed time: 8.388s, Critical Path: 7.24s
INFO: 21 processes: 10 internal, 11 linux-sandbox.
INFO: Build completed successfully, 21 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 366 targets (0 packages loaded, 8 targets configured).
INFO: Found 240 targets and 126 test targets...
INFO: Elapsed time: 71.923s, Critical Path: 23.19s
INFO: 131 processes: 138 linux-sandbox, 17 local.
INFO: Build completed successfully, 131 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.6s
//gutil:version_test                                                     PASSED in 1.1s
//lib/gnmi:gnmi_helper_test                                              PASSED in 0.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/utils:json_utils_test                                              PASSED in 0.0s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.6s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.6s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.4s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.7s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.7s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.2s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.7s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.0s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.0s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.1s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.7s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.8s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.8s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.8s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.8s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.8s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.3s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.5s
//p4rt_app/tests:packetio_test                                           PASSED in 3.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 2.7s
//p4rt_app/tests:response_path_test                                      PASSED in 2.7s
//p4rt_app/tests:role_test                                               PASSED in 1.1s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.7s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.3s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.1s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:mock_control_interface_test                                    PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 23.2s
  Stats over 5 runs: max = 23.2s, min = 0.9s, avg = 8.0s, dev = 8.5s

Executed 126 out of 126 tests: 126 tests pass.
INFO: Build completed successfully, 131 total actions
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ 