### PR TITLE
[Thinkit] Improve performance of Bazel Test Environment by caching open file descriptors, Add a benchmark for append time given a fixed size file, Add SetTestCaseIDs to TestEnvironment to support setting multiple IDs & Add some clarifying documentation to generic interface files.

### DIFF
--- a/thinkit/BUILD.bazel
+++ b/thinkit/BUILD.bazel
@@ -168,7 +168,10 @@ cc_library(
     deps = [
         ":test_environment",
         "//gutil:status",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
         "@com_google_googletest//:gtest",
@@ -282,6 +285,7 @@ cc_library(
     name = "control_interface",
     hdrs = ["control_interface.h"],
     deps = [
+        ":packet_generation_finalizer",
         "@com_github_gnoi//diag:diag_cc_grpc_proto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/container:flat_hash_set",

--- a/thinkit/bazel_test_environment.h
+++ b/thinkit/bazel_test_environment.h
@@ -15,8 +15,16 @@
 #ifndef GOOGLE_THINKIT_BAZEL_TEST_ENVIRONMENT_H_
 #define GOOGLE_THINKIT_BAZEL_TEST_ENVIRONMENT_H_
 
+#include <fstream>
+#include <functional>
 #include <ios>
+#include <string>
+#include <utility>
+#include <vector>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 #include "thinkit/test_environment.h"
@@ -32,9 +40,10 @@ class BazelTestEnvironment : public TestEnvironment {
   BazelTestEnvironment() = delete;
   explicit BazelTestEnvironment(
       bool mask_known_failures,
-      std::function<void(absl::string_view)> set_test_case_id = [](auto) {})
+      std::function<void(const std::vector<std::string>&)> set_test_case_ids =
+          [](auto) {})
       : mask_known_failures_{mask_known_failures},
-        set_test_case_id_(std::move(set_test_case_id)) {}
+        set_test_case_ids_(std::move(set_test_case_ids)) {}
 
   absl::Status StoreTestArtifact(absl::string_view filename,
                                  absl::string_view contents)
@@ -51,13 +60,17 @@ class BazelTestEnvironment : public TestEnvironment {
 
   bool MaskKnownFailures() { return mask_known_failures_; };
 
-  void SetTestCaseID(absl::string_view test_case_id) override {
-    set_test_case_id_(test_case_id);
+  void SetTestCaseIDs(const std::vector<std::string>& test_case_ids) override {
+    set_test_case_ids_(test_case_ids);
   }
 
  private:
   bool mask_known_failures_;
-  std::function<void(absl::string_view)> set_test_case_id_;
+  std::function<void(const std::vector<std::string>&)> set_test_case_ids_;
+  // Open files are cached to avoid closing them after every append. On certain
+  // file systems (e.g. b/111316875) closing files is abnormally slow and this
+  // avoids it. However, this approach should also generally be faster.
+  absl::flat_hash_map<std::string, std::ofstream> open_file_by_filepath_;
   // The mutex is used to ensure that writes to disk are sequential.
   absl::Mutex write_mutex_;
 };

--- a/thinkit/control_interface.h
+++ b/thinkit/control_interface.h
@@ -19,6 +19,7 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "diag/diag.grpc.pb.h"
+#include "thinkit/packet_generation_finalizer.h"
 
 namespace thinkit {
 
@@ -34,9 +35,35 @@ enum class RebootType {
   kCold,
 };
 
+// Callback when a packet is received, first parameter which is control
+// interface port it was received on and second parameter is the hexstring (with
+// 0x prefix) of the packet.
+using PacketCallback =
+    std::function<void(absl::string_view, absl::string_view)>;
+
+// A `ControlInterface` represents any device or devices that can at the very
+// least send and receive packets over their interfaces. It may be able to get
+// and set link state, as well as perform various other operations like link
+// qualification or reboot.
 class ControlInterface {
  public:
   virtual ~ControlInterface() {}
+
+  // Starts collecting packets, calling `callback` whenever a packet is
+  // received. This continues until the `PacketGenerationFinalizer` goes out of
+  // scope.
+  virtual absl::StatusOr<std::unique_ptr<thinkit::PacketGenerationFinalizer>>
+  CollectPackets(PacketCallback callback) = 0;
+
+  // Sends a `packet` hexstring (with 0x prefix) out of the control interface’s
+  // `interface`.
+  virtual absl::Status SendPacket(absl::string_view interface,
+                                  absl::string_view packet) = 0;
+
+  // Sends a list of `packet` hexstring (with 0x prefix) out of the control
+  // interface’s `interface`.
+  virtual absl::Status SendPackets(absl::string_view interface,
+                                   absl::Span<const std::string> packets) = 0;
 
   // Sets the admin link state on the control interface 'interfaces'.
   virtual absl::Status SetAdminLinkState(
@@ -55,12 +82,13 @@ class ControlInterface {
   virtual absl::StatusOr<gnoi::diag::GetBERTResultResponse> GetBERTResult(
       const gnoi::diag::GetBERTResultRequest& request) = 0;
 
-  // Gets the control interface’s `interfaces` with both admin-status and
-  // oper-status up.
+  // Gets which control interface’s `interfaces` are admin and operationally up.
   virtual absl::StatusOr<absl::flat_hash_set<std::string>> GetUpLinks(
       absl::Span<const std::string> interfaces) = 0;
 
-  // Checks if the control interface is up.
+  // Checks if the control interface is up. This implies that it is in a state
+  // that it can perform its operations. This can be used to check when the
+  // control interface is ready after a reboot.
   virtual absl::Status CheckUp() = 0;
 };
 

--- a/thinkit/generic_testbed.h
+++ b/thinkit/generic_testbed.h
@@ -33,6 +33,7 @@ struct HttpResponse {
   std::string response;
 };
 
+// HTTP request types.
 enum class RequestType {
   kGet,
   kPost,
@@ -42,6 +43,13 @@ enum class RequestType {
 
 // InterfaceInfo represents the mode of an interface and the name of the peer
 // interface.
+// - When `interface_mode` is CONTROL_INTERFACE or TRAFFIC_GENERATOR,
+//   `peer_interface_name` will be populated with the name of the interface on
+//   the other end.
+// - In the case of CONTROL_INTERFACE, the `peer_interface_name` should be used
+//   in functions called on the `ControlInterface` returned by Interface().
+// - In the case of TRAFFIC_GENERATOR, the format of the `peer_interface_name`
+//   is "<hostname of generator>/<card number>/<port number>".
 struct InterfaceInfo {
   thinkit::InterfaceMode interface_mode;
   std::string peer_interface_name;  // Empty if not applicable.
@@ -53,17 +61,19 @@ class GenericTestbed {
  public:
   virtual ~GenericTestbed() {}
 
-  // Returns the switch (aka system) under test.
+  // Returns the PINS switch (aka system) under test.
   virtual Switch& Sut() = 0;
 
   // Returns the control interface responsible for packet injection and various
-  // management operations.
+  // management operations. This could be but isn't limited to being another
+  // PINS switch, a non-PINS switch, or a host machine.
   virtual ControlInterface& Interface() = 0;
 
   // Returns the test environment in which the test is run.
   virtual TestEnvironment& Environment() = 0;
 
-  // Returns the information for all SUT interfaces.
+  // Returns a map from SUT interface name (e.g. Ethernet0) to its
+  // `InterfaceInfo`, which describes what it's connected to.
   virtual absl::flat_hash_map<std::string, InterfaceInfo>
   GetSutInterfaceInfo() = 0;
 

--- a/thinkit/mock_control_interface.h
+++ b/thinkit/mock_control_interface.h
@@ -24,6 +24,16 @@
 namespace thinkit {
 class MockControlInterface : public ControlInterface {
  public:
+  MOCK_METHOD(
+      absl::StatusOr<std::unique_ptr<thinkit::PacketGenerationFinalizer>>,
+      CollectPackets, (PacketCallback callback), (override));
+  MOCK_METHOD(absl::Status, SendPacket,
+              (absl::string_view interface, absl::string_view packet),
+              (override));
+  MOCK_METHOD(absl::Status, SendPackets,
+              (absl::string_view interface,
+               absl::Span<const std::string> packets),
+              (override));
   MOCK_METHOD(absl::Status, SetAdminLinkState,
               (absl::Span<const std::string> sut_ports, LinkState state),
               (override));

--- a/thinkit/mock_test_environment.h
+++ b/thinkit/mock_test_environment.h
@@ -15,6 +15,9 @@
 #ifndef THINKIT_MOCK_TEST_ENVIRONMENT_H_
 #define THINKIT_MOCK_TEST_ENVIRONMENT_H_
 
+#include <string>
+#include <vector>
+
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
@@ -32,6 +35,8 @@ class MockTestEnvironment : public TestEnvironment {
               (override));
   MOCK_METHOD(bool, MaskKnownFailures, (), (override));
   MOCK_METHOD(void, SetTestCaseID, (absl::string_view), (override));
+  MOCK_METHOD(void, SetTestCaseIDs, (const std::vector<std::string> &),
+              (override));
 };
 
 }  // namespace thinkit

--- a/thinkit/proto/generic_testbed.proto
+++ b/thinkit/proto/generic_testbed.proto
@@ -18,7 +18,13 @@ package thinkit;
 
 option cc_generic_services = false;
 
-// Mode types for the SUT interfaces are connected..
+// Mode types for how the SUT interfaces are connected.
+// DISCONNECTED      - Nothing is plugged into the interface.
+// LOOPBACK          - A loopback is plugged into the interface.
+// CONTROL_INTERFACE - The interface is connected to another switch or device
+//                     that can send or receive packets.
+// TRAFFIC_GENERATOR - The interface is connected to a traffic generator
+//                     (e.g. Ixia).
 enum InterfaceMode {
   UNKNOWN_MODE = 0;
   DISCONNECTED = 1;

--- a/thinkit/test_environment.h
+++ b/thinkit/test_environment.h
@@ -15,6 +15,9 @@
 #ifndef THINKIT_TEST_ENVIRONMENT_H_
 #define THINKIT_TEST_ENVIRONMENT_H_
 
+#include <string>
+#include <vector>
+
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -51,7 +54,12 @@ class TestEnvironment {
   virtual bool MaskKnownFailures() = 0;
 
   // Set the `test_case_id` for use by tracking tools.
-  virtual void SetTestCaseID(absl::string_view test_case_id) {}
+  virtual void SetTestCaseID(absl::string_view test_case_id) {
+    SetTestCaseIDs({std::string(test_case_id)});
+  }
+
+  // Set the `test_case_ids` for use by tracking tools.
+  virtual void SetTestCaseIDs(const std::vector<std::string>& test_case_ids) {}
 };
 
 }  // namespace thinkit


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 367 targets (240 packages loaded, 19774 targets configured).
INFO: Found 367 targets...
INFO: Elapsed time: 57.811s, Critical Path: 12.91s
INFO: 44 processes: 9 internal, 35 linux-sandbox.
INFO: Build completed successfully, 44 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 367 targets (0 packages loaded, 280 targets configured).
INFO: Found 241 targets and 126 test targets...
INFO: Elapsed time: 73.919s, Critical Path: 16.48s
INFO: 131 processes: 138 linux-sandbox, 17 local.
INFO: Build completed successfully, 131 total actions
//gutil:collections_test PASSED in 0.5s
//gutil:io_test PASSED in 0.5s
//gutil:proto_matchers_test PASSED in 0.8s
//gutil:proto_ordering_test PASSED in 0.5s
//gutil:proto_test PASSED in 0.5s
//gutil:status_matchers_test PASSED in 0.5s
//gutil:test_artifact_writer_test PASSED in 0.6s
//gutil:testing_test PASSED in 0.5s
//gutil:version_test PASSED in 0.8s
//lib/gnmi:gnmi_helper_test PASSED in 0.9s
//lib/gnoi:gnoi_helper_test PASSED in 0.6s
//lib/utils:json_utils_test PASSED in 0.1s
//lib/validator:validator_backend_test PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test PASSED in 0.7s
//p4_fuzzer:fuzz_util_test PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test PASSED in 1.0s
//p4_fuzzer:switch_state_test PASSED in 0.7s
//p4_fuzzer:table_entry_key_test PASSED in 0.1s
//p4_pdpi:built_ins_test PASSED in 0.5s
//p4_pdpi:entity_keys_test PASSED in 0.5s
//p4_pdpi:ir_tools_test PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test PASSED in 0.8s
//p4_pdpi:reference_annotations_test PASSED in 0.7s
//p4_pdpi:sequencing_util_test PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test PASSED in 0.6s
//p4_pdpi/netaddr:mac_address_test PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test PASSED in 16.4s
//p4_pdpi/packetlib:packetlib_matchers_test PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test PASSED in 1.1s
//p4_pdpi/string_encodings:bit_string_test PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test PASSED in 0.5s
//p4_pdpi/testing:helper_function_test PASSED in 0.7s
//p4_pdpi/testing:info_test PASSED in 0.1s
//p4_pdpi/testing:info_test_runner PASSED in 0.1s
//p4_pdpi/testing:main_pd_test PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test PASSED in 2.6s
//p4_pdpi/testing:packet_io_test PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner PASSED in 0.1s
//p4_pdpi/testing:rpc_test PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_test PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test PASSED in 0.8s
//p4_pdpi/testing:table_entry_test PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test PASSED in 0.5s
//p4_pdpi/utils:ir_test PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.2s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test PASSED in 1.0s
//p4rt_app/event_monitoring:state_verification_events_test PASSED in 1.0s
//p4rt_app/p4runtime:cpu_queue_translator_test PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test PASSED in 0.8s
//p4rt_app/sonic:app_db_manager_test PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test PASSED in 0.8s
//p4rt_app/sonic:hashing_test PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test PASSED in 0.7s
//p4rt_app/sonic:packetio_port_test PASSED in 0.6s
//p4rt_app/sonic:response_handler_test PASSED in 0.8s
//p4rt_app/sonic:state_verification_test PASSED in 0.8s
//p4rt_app/sonic:vrf_entry_translation_test PASSED in 0.9s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test PASSED in 0.0s
//p4rt_app/tests:acl_table_test PASSED in 1.5s
//p4rt_app/tests:action_set_test PASSED in 1.1s
//p4rt_app/tests:api_access_test PASSED in 1.0s
//p4rt_app/tests:arbitration_test PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test PASSED in 1.6s
//p4rt_app/tests:debug_data_dump_test PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test PASSED in 3.9s
//p4rt_app/tests:grpc_behavior_test PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner PASSED in 0.2s
//p4rt_app/tests:p4_programs_test PASSED in 1.5s
//p4rt_app/tests:packetio_test PASSED in 3.6s
//p4rt_app/tests:port_name_and_id_test PASSED in 2.3s
//p4rt_app/tests:resource_limits_test PASSED in 3.9s
//p4rt_app/tests:response_path_test PASSED in 2.8s
//p4rt_app/tests:role_test PASSED in 1.1s
//p4rt_app/tests:state_verification_test PASSED in 1.7s
//p4rt_app/tests:vrf_table_test PASSED in 1.5s
//p4rt_app/tests/lib:app_db_entry_builder_test PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test PASSED in 0.0s
//p4rt_app/utils:table_utility_test PASSED in 0.8s
//sai_p4/instantiations/google:clos_stage_test PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:sai_p4info_fetcher_test PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test PASSED in 1.1s
//sai_p4/instantiations/google:sai_pd_proto_test PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.1s
//sai_p4/instantiations/google/test_tools:test_entries_test PASSED in 0.9s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test PASSED in 0.8s
//sai_p4/tools:p4info_tools_test PASSED in 0.6s
//sai_p4/tools:packetio_tools_test PASSED in 0.7s
//thinkit:bazel_test_environment_test PASSED in 0.5s
//thinkit:mock_control_interface_test PASSED in 0.6s
//thinkit:mock_generic_testbed_test PASSED in 0.7s
//thinkit:mock_mirror_testbed_test PASSED in 0.6s
//thinkit:mock_ssh_client_test PASSED in 0.0s
//thinkit:mock_switch_test PASSED in 0.7s
//thinkit:mock_test_environment_test PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test PASSED in 12.0s
Stats over 5 runs: max = 12.0s, min = 1.0s, avg = 6.1s, dev = 4.7s

Executed 126 out of 126 tests: 126 tests pass.
INFO: Build completed successfully, 131 total actions
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$