### PR TITLE
[Comb]Remove internal device ID hack and cleanup. Maks known failures till the back end code is fixed. Moving the sanity_tests to use validator_lib. Remove MaskKnownFailures from TestGnmiCheckInterfaceStateOperation. Adding gNMI alarm checks to the ready validations. Fix formatting.

### DIFF
--- a/lib/utils/BUILD.bazel
+++ b/lib/utils/BUILD.bazel
@@ -14,11 +14,6 @@
 #
 # PINS test functions that can be run on any infrastructure that supports ThinKit.
 
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test", "diff_test")
-load("//p4_pdpi:pdgen.bzl", "p4_pd_proto")
-load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
-
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/lib/validator/BUILD.bazel
+++ b/lib/validator/BUILD.bazel
@@ -15,11 +15,6 @@
 # The validator library is designed to provide a backend-agnostic method
 # to query the status of entities used in tests.
 
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test", "diff_test")
-load("//p4_pdpi:pdgen.bzl", "p4_pd_proto")
-load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
-
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/lib/validator/validator_lib.cc
+++ b/lib/validator/validator_lib.cc
@@ -118,14 +118,26 @@ absl::Status PortsUp(thinkit::Switch& thinkit_switch, absl::Duration timeout) {
   return pins_test::CheckAllInterfaceUpOverGnmi(*gnmi_stub, timeout);
 }
 
+absl::Status NoAlarms(thinkit::Switch& thinkit_switch, absl::Duration timeout) {
+  ASSIGN_OR_RETURN(std::unique_ptr<gnmi::gNMI::Stub> gnmi_stub,
+                   thinkit_switch.CreateGnmiStub());
+  ASSIGN_OR_RETURN(std::vector<std::string> alarms,
+                   pins_test::GetAlarms(*gnmi_stub));
+  if (alarms.empty()) {
+    return absl::OkStatus();
+  }
+  return absl::FailedPreconditionError(
+      absl::StrCat("The system has alarms set: ", absl::StrJoin(alarms, "; ")));
+}
+
 absl::Status SwitchReady(thinkit::Switch& thinkit_switch,
                          absl::Duration timeout) {
   RETURN_IF_ERROR(Pingable(thinkit_switch));
   RETURN_IF_ERROR(P4rtAble(thinkit_switch));
   RETURN_IF_ERROR(GnmiAble(thinkit_switch));
-  // TODO (b/176913347): Add validation once gNMI response flakiness is fixed.
-  // RETURN_IF_ERROR(PortsUp(thinkit_switch));
-  return GnoiAble(thinkit_switch);
+  RETURN_IF_ERROR(PortsUp(thinkit_switch));
+  RETURN_IF_ERROR(GnoiAble(thinkit_switch));
+  return NoAlarms(thinkit_switch);
 }
 
 absl::Status SwitchReadyWithSsh(thinkit::Switch& thinkit_switch,
@@ -135,9 +147,8 @@ absl::Status SwitchReadyWithSsh(thinkit::Switch& thinkit_switch,
   RETURN_IF_ERROR(SSHable(thinkit_switch, ssh_client));
   RETURN_IF_ERROR(P4rtAble(thinkit_switch));
   RETURN_IF_ERROR(GnmiAble(thinkit_switch));
-  // TODO (b/176913347): Add validation once gNMI response flakiness is fixed.
-  // RETURN_IF_ERROR(PortsUp(thinkit_switch));
-  return GnoiAble(thinkit_switch);
+  RETURN_IF_ERROR(GnoiAble(thinkit_switch));
+  return NoAlarms(thinkit_switch);
 }
 
 }  // namespace pins_test

--- a/lib/validator/validator_lib.h
+++ b/lib/validator/validator_lib.h
@@ -56,6 +56,10 @@ absl::Status GnoiAble(thinkit::Switch& thinkit_switch,
 absl::Status PortsUp(thinkit::Switch& thinkit_switch,
                      absl::Duration timeout = kDefaultTimeout);
 
+// Checks to make sure no alarms are set.
+absl::Status NoAlarms(thinkit::Switch& thinkit_switch,
+                      absl::Duration timeout = kDefaultTimeout);
+
 // Checks if the switch is ready by running the following validations:
 // Pingable, P4rtAble, GnmiAble, GnoiAble, PortsUp.
 absl::Status SwitchReady(thinkit::Switch& thinkit_switch,

--- a/p4_fuzzer/BUILD.bazel
+++ b/p4_fuzzer/BUILD.bazel
@@ -1,6 +1,3 @@
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test", "diff_test")
-load("//p4_pdpi:pdgen.bzl", "p4_pd_proto")
 load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
 
 package(

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -33,6 +33,8 @@ cc_library(
         "//gutil:status_matchers",
         "//lib/gnmi:gnmi_helper",
         "//p4_pdpi:p4_runtime_session",
+        "//lib/validator:validator_lib",
+        "//thinkit:mirror_testbed",
         "//thinkit:ssh_client",
         "//thinkit:switch",
         "@com_github_gnmi//proto/gnmi:gnmi_cc_proto",

--- a/tests/gnoi/BUILD.bazel
+++ b/tests/gnoi/BUILD.bazel
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test", "diff_test")
-load("//p4_pdpi:pdgen.bzl", "p4_pd_proto")
-load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
-
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/tests/thinkit_sanity_tests.cc
+++ b/tests/thinkit_sanity_tests.cc
@@ -14,29 +14,35 @@
 
 #include "tests/thinkit_sanity_tests.h"
 
-#include <stdint.h>
-
 #include <cstdlib>
+#include <map>
+#include <memory>
 #include <string>
 #include <utility>
+#include <valarray>
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/match.h"
+#include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "glog/logging.h"
 #include "gmock/gmock.h"
+#include "grpcpp/impl/codegen/client_context.h"
+#include "grpcpp/impl/codegen/status.h"
 #include "gtest/gtest.h"
+#include "gutil/status.h"
 #include "gutil/status_matchers.h"
 #include "lib/gnmi/gnmi_helper.h"
+#include "lib/validator/validator_lib.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4_pdpi/p4_runtime_session.h"
 #include "proto/gnmi/gnmi.grpc.pb.h"
 #include "include/nlohmann/json.hpp"
+#include "proto/gnmi/gnmi.pb.h"
+#include "system/system.grpc.pb.h"
 #include "system/system.pb.h"
 #include "tests/thinkit_util.h"
 #include "thinkit/ssh_client.h"
@@ -47,10 +53,8 @@ namespace {
 
 using ::nlohmann::json;
 using ::std::abs;
-using ::testing::Eq;
 using ::testing::HasSubstr;
 
-}  // namespace
 constexpr int kEpochMarginalError = 2;
 constexpr absl::Duration kColdRebootDelayTime = absl::Seconds(1);
 constexpr absl::Duration kColdRebootTotalWaitTime = absl::Seconds(30);
@@ -121,20 +125,35 @@ constexpr char kV3ReleaseConfigBlob[] = R"({
    }
 })";
 
+}  // namespace
+
 void TestSSHCommand(thinkit::SSHClient& ssh_client, thinkit::Switch& sut) {
-  ASSERT_OK_AND_ASSIGN(std::string output,
-                       ssh_client.RunCommand(sut.ChassisName(), "echo foo",
-                                             absl::ZeroDuration()));
-  EXPECT_THAT(output, Eq("foo\n"));
+  EXPECT_OK(SSHable(sut, ssh_client));
 }
 
-void TestP4Session(thinkit::Switch& sut) {
-  // TODO: Remove kDeviceId once device ID is set through gNMI in
-  // P4RT app.
-  static constexpr uint64_t kDeviceId = 183807201;
-  ASSERT_OK_AND_ASSIGN(auto sut_p4runtime_stub, sut.CreateP4RuntimeStub());
-  EXPECT_OK(
-      pdpi::P4RuntimeSession::Create(std::move(sut_p4runtime_stub), kDeviceId));
+void TestP4Session(thinkit::Switch& sut) { EXPECT_OK(P4rtAble(sut)); }
+
+void TestGnmiGetInterfaceOperation(thinkit::Switch& sut) {
+  EXPECT_OK(GnmiAble(sut));
+}
+
+void TestGnmiGetAllOperation(thinkit::Switch& sut) {
+  ASSERT_OK_AND_ASSIGN(auto sut_gnmi_stub, sut.CreateGnmiStub());
+  ASSERT_OK_AND_ASSIGN(gnmi::GetRequest req,
+                       BuildGnmiGetRequest("", gnmi::GetRequest::ALL));
+  LOG(INFO) << "Sending GET request: " << req.ShortDebugString();
+  gnmi::GetResponse resp;
+  grpc::ClientContext context;
+  ASSERT_OK(sut_gnmi_stub->Get(&context, req, &resp));
+  LOG(INFO) << "Received GET response: " << resp.ShortDebugString();
+}
+
+void TestGnmiCheckInterfaceStateOperation(thinkit::MirrorTestbed& testbed) {
+  EXPECT_OK(PortsUp(testbed.Sut()));
+}
+
+void TestGnmiCheckAlarms(thinkit::MirrorTestbed& testbed) {
+  EXPECT_OK(NoAlarms(testbed.Sut()));
 }
 
 // This test sets the config blob and verifies corresponding state paths.
@@ -305,69 +324,6 @@ void TestGnmiCheckSpecificInterfaceStateOperation(thinkit::Switch& sut,
   EXPECT_THAT(oper_response, HasSubstr(kStateUp));
 }
 
-void TestGnmiCheckInterfaceStateOperation(thinkit::Switch& sut) {
-  const absl::flat_hash_set<std::string> k1Ethernet10GBInterfaces = {
-      "\"Ethernet256\"", "\"Ethernet260\""};
-  ASSERT_OK_AND_ASSIGN(auto sut_gnmi_stub, sut.CreateGnmiStub());
-  ASSERT_OK_AND_ASSIGN(
-      gnmi::GetRequest req,
-      BuildGnmiGetRequest(kInterfaces, gnmi::GetRequest::STATE));
-  LOG(INFO) << "Sending GET request: " << req.ShortDebugString();
-
-  gnmi::GetResponse resp;
-  grpc::ClientContext context;
-  ASSERT_OK(sut_gnmi_stub->Get(&context, req, &resp));
-  LOG(INFO) << "Received GET response: " << resp.ShortDebugString();
-  ASSERT_EQ(resp.notification_size(), 1);
-  ASSERT_EQ(resp.notification(0).update_size(), 1);
-  const auto resp_json =
-      json::parse(resp.notification(0).update(0).val().json_ietf_val());
-  const auto oc_intf_json = resp_json.find("openconfig-interfaces:interfaces");
-  ASSERT_NE(oc_intf_json, resp_json.end());
-  const auto oc_intf_list_json = oc_intf_json->find("interface");
-  ASSERT_NE(oc_intf_list_json, oc_intf_json->end());
-  for (auto const& element : oc_intf_list_json->items()) {
-    auto const element_name_json = element.value().find("name");
-    ASSERT_NE(element_name_json, element.value().end());
-    // TODO : Revert back to interface port-speed check.
-    // Arista chassis have 2 additional 10G SFP ports, skipping checks for these
-    // ports as they aren't connected.
-    if (!k1Ethernet10GBInterfaces.contains(element_name_json->dump())) {
-      const auto element_interface_state_json = element.value().find("state");
-      ASSERT_NE(element_interface_state_json, element.value().end())
-          << element.value().find("name")->dump();
-
-      const auto element_status_json =
-          element_interface_state_json->find("oper-status");
-      ASSERT_NE(element_status_json, element_interface_state_json->end())
-          << element.value().find("name")->dump();
-
-      EXPECT_THAT(element_status_json->dump(), HasSubstr(kStateUp))
-          << element_interface_state_json->find("name")->dump();
-    }
-  }
-}
-void TestGnmiGetInterfaceOperation(thinkit::Switch& sut) {
-  ASSERT_OK_AND_ASSIGN(auto sut_gnmi_stub, sut.CreateGnmiStub());
-  ASSERT_OK_AND_ASSIGN(gnmi::GetRequest req,
-                       BuildGnmiGetRequest(kInterfaces, gnmi::GetRequest::ALL));
-  LOG(INFO) << "Sending GET request: " << req.ShortDebugString();
-  gnmi::GetResponse resp;
-  grpc::ClientContext context;
-  ASSERT_OK(sut_gnmi_stub->Get(&context, req, &resp));
-  LOG(INFO) << "Received GET response: " << resp.ShortDebugString();
-}
-
-void TestGnmiGetAllOperation(thinkit::Switch& sut) {
-  ASSERT_OK_AND_ASSIGN(auto sut_gnmi_stub, sut.CreateGnmiStub());
-  ASSERT_OK_AND_ASSIGN(gnmi::GetRequest req,
-                       BuildGnmiGetRequest("", gnmi::GetRequest::ALL));
-  LOG(INFO) << "Sending GET request: " << req.ShortDebugString();
-  gnmi::GetResponse resp;
-  grpc::ClientContext context;
-  ASSERT_OK(sut_gnmi_stub->Get(&context, req, &resp));
-  LOG(INFO) << "Received GET response: " << resp.ShortDebugString();
-}
 //  Returns last boot time of SUT.
 absl::StatusOr<int> GetGnmiSystemBootTime(thinkit::Switch& sut,
                                           gnmi::gNMI::Stub* sut_gnmi_stub) {
@@ -394,6 +350,7 @@ absl::StatusOr<int> GetGnmiSystemBootTime(thinkit::Switch& sut,
   LOG(INFO) << "Boot Time: " << boot_time;
   return boot_time;
 }
+
 void TestGnoiSystemColdReboot(thinkit::Switch& sut) {
   ASSERT_OK_AND_ASSIGN(auto sut_gnmi_stub, sut.CreateGnmiStub());
   ASSERT_OK_AND_ASSIGN(auto first_boot_time,
@@ -421,4 +378,5 @@ void TestGnoiSystemColdReboot(thinkit::Switch& sut) {
   }
   EXPECT_GT(abs(latest_boot_time - first_boot_time), kEpochMarginalError);
 }
+
 }  // namespace pins_test

--- a/tests/thinkit_sanity_tests.h
+++ b/tests/thinkit_sanity_tests.h
@@ -16,6 +16,7 @@
 #define GOOGLE_TESTS_THINKIT_SANITY_TESTS_H_
 
 #include "absl/strings/string_view.h"
+#include "thinkit/mirror_testbed.h"
 #include "thinkit/ssh_client.h"
 #include "thinkit/switch.h"
 
@@ -34,7 +35,10 @@ void TestGnmiGetInterfaceOperation(thinkit::Switch& sut);
 void TestGnmiGetAllOperation(thinkit::Switch& sut);
 
 // Tests that SUT all ports state is UP.
-void TestGnmiCheckInterfaceStateOperation(thinkit::Switch& sut);
+void TestGnmiCheckInterfaceStateOperation(thinkit::MirrorTestbed& testbed);
+
+// Tests that no gNMI alarms are set.
+void TestGnmiCheckAlarms(thinkit::MirrorTestbed& testbed);
 
 // Tests that SUT specific port state is UP.
 void TestGnmiCheckSpecificInterfaceStateOperation(thinkit::Switch& sut,

--- a/thinkit/BUILD.bazel
+++ b/thinkit/BUILD.bazel
@@ -14,11 +14,6 @@
 #
 # Thinkit is a set of interfaces to enable PINS testing to be infrastructure agnostic.
 
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test", "diff_test")
-load("//p4_pdpi:pdgen.bzl", "p4_pd_proto")
-load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
-
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],


### PR DESCRIPTION
PR Description:
Remove internal device ID hack and cleanup.
Maks known failures till the back end code is fixed.
Moving the sanity_tests to use validator_lib.
Remove MaskKnownFailures from TestGnmiCheckInterfaceStateOperation.
Adding gNMI alarm checks to the ready validations.
Fix formatting.

Keyword Check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 367 targets (0 packages loaded, 0 targets configured).
INFO: Found 367 targets...
INFO: Elapsed time: 1.163s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test

UT Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 367 targets (0 packages loaded, 81 targets configured).
INFO: Found 241 targets and 126 test targets...
INFO: Elapsed time: 96.181s, Critical Path: 16.72s
INFO: 131 processes: 138 linux-sandbox, 17 local.
INFO: Build completed successfully, 131 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.7s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.6s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 1.1s
//lib/gnmi:gnmi_helper_test                                              PASSED in 0.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/utils:json_utils_test                                              PASSED in 0.0s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.9s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.8s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.7s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.4s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.7s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.0s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.0s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 1.0s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.8s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.7s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.6s
//p4rt_app/tests:action_set_test                                         PASSED in 1.2s
//p4rt_app/tests:api_access_test                                         PASSED in 1.1s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.3s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.9s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.1s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 5.7s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.3s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.8s
//p4rt_app/tests:packetio_test                                           PASSED in 3.9s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.4s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.7s
//p4rt_app/tests:response_path_test                                      PASSED in 3.7s
//p4rt_app/tests:role_test                                               PASSED in 1.3s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.9s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.9s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.6s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.1s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:mock_control_interface_test                                    PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 12.8s
  Stats over 5 runs: max = 12.8s, min = 1.0s, avg = 6.0s, dev = 5.1s

Executed 126 out of 126 tests: 126 tests pass.
INFO: Build completed successfully, 131 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 