### PR TITLE
[Comb]Add PortsUp back to SwitchReadyWithSsh.Fixes for gRPC usage. Added example link flap test using generic testbed. Add missing license comment to files under lib/.Add license file to remaining files.

### DIFF
--- a/lib/gnmi/gnmi_helper_test.cc
+++ b/lib/gnmi/gnmi_helper_test.cc
@@ -515,7 +515,7 @@ TEST(GetInterfacePortIdMap, SuccessfullyReturnsInterfacePortIdMap) {
                  update {
                    path { elem { name: "interfaces" } }
                    val {
-                     json_ietf_val: "{\"openconfig-interfaces:interfaces\":{\"interface\":[{\"name\":\"Ethernet0\",\"state\":{\"id\":\"1\"}}]}}"
+                     json_ietf_val: "{\"openconfig-interfaces:interfaces\":{\"interface\":[{\"name\":\"Ethernet0\",\"state\":{\"openconfig-pins-interfaces:id\":1}}]}}"
                    }
                  }
                })pb")),
@@ -545,9 +545,9 @@ TEST(GetInterfacePortIdMap, PortIdNotFoundInState) {
                })pb")),
       Return(grpc::Status::OK)));
 
-  EXPECT_THAT(
-      GetAllInterfaceNameToPortId(stub),
-      StatusIs(absl::StatusCode::kNotFound, HasSubstr("'id' not found")));
+  EXPECT_THAT(GetAllInterfaceNameToPortId(stub),
+              StatusIs(absl::StatusCode::kNotFound,
+                       HasSubstr("'openconfig-pins-interfaces:id' not found")));
 }
 
 TEST(GetInterfacePortIdMap, InterfaceStateNotFound) {

--- a/lib/p4rt/packet_listener.cc
+++ b/lib/p4rt/packet_listener.cc
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "lib/p4rt/packet_listener.h"
 
 namespace pins_test {

--- a/lib/p4rt/packet_listener.h
+++ b/lib/p4rt/packet_listener.h
@@ -1,3 +1,16 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef GOOGLE_LIB_P4RT_PACKET_LISTENER_H_
 #define GOOGLE_LIB_P4RT_PACKET_LISTENER_H_
 

--- a/lib/utils/json_utils.cc
+++ b/lib/utils/json_utils.cc
@@ -1,3 +1,16 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include "lib/utils/json_utils.h"
 
 #include "absl/container/flat_hash_set.h"

--- a/lib/utils/json_utils.h
+++ b/lib/utils/json_utils.h
@@ -1,5 +1,19 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef GOOGLE_LIB_UTILS_JSON_UTILS_H_
 #define GOOGLE_LIB_UTILS_JSON_UTILS_H_
+
 #include "absl/strings/string_view.h"
 #include "include/json/value.h"
 

--- a/lib/utils/json_utils_test.cc
+++ b/lib/utils/json_utils_test.cc
@@ -1,3 +1,16 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include "lib/utils/json_utils.h"
 
 #include "absl/strings/string_view.h"

--- a/lib/validator/BUILD.bazel
+++ b/lib/validator/BUILD.bazel
@@ -113,6 +113,7 @@ cc_library(
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_gnmi//proto/gnmi:gnmi_cc_grpc_proto",
         "@com_github_gnoi//system:system_cc_proto",
+        "@com_github_grpc_grpc//:grpc++_public_hdrs",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/status",

--- a/lib/validator/validator_lib.cc
+++ b/lib/validator/validator_lib.cc
@@ -1,3 +1,16 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include "lib/validator/validator_lib.h"
 
 #include <memory>
@@ -12,7 +25,7 @@
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "grpcpp/impl/codegen/client_context.h"
-#include "grpcpp/impl/codegen/status_code_enum.h"
+#include "grpcpp/support/status.h"
 #include "gutil/status.h"
 #include "lib/gnmi/gnmi_helper.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
@@ -149,6 +162,7 @@ absl::Status SwitchReadyWithSsh(thinkit::Switch& thinkit_switch,
   RETURN_IF_ERROR(SSHable(thinkit_switch, ssh_client));
   RETURN_IF_ERROR(P4rtAble(thinkit_switch));
   RETURN_IF_ERROR(GnmiAble(thinkit_switch));
+  RETURN_IF_ERROR(PortsUp(thinkit_switch));
   RETURN_IF_ERROR(GnoiAble(thinkit_switch));
   return NoAlarms(thinkit_switch);
 }

--- a/tests/gnmi/BUILD.bazel
+++ b/tests/gnmi/BUILD.bazel
@@ -1,0 +1,41 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+cc_library(
+    name = "link_flap_tests",
+    testonly = True,
+    srcs = ["link_flap_tests.cc"],
+    hdrs = ["link_flap_tests.h"],
+    deps = [
+        "//gutil:status",
+        "//gutil:status_matchers",
+        "//gutil:testing",
+        "//lib/gnmi:gnmi_helper",
+        "//thinkit:generic_testbed",
+        "//thinkit:generic_testbed_fixture",
+        "//thinkit:switch",
+        "//thinkit/proto:generic_testbed_cc_proto",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
+    ],
+    alwayslink = True,
+)

--- a/tests/gnmi/link_flap_tests.cc
+++ b/tests/gnmi/link_flap_tests.cc
@@ -1,0 +1,130 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "tests/gnmi/link_flap_tests.h"
+
+#include <string>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/status.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "glog/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status.h"
+#include "gutil/status_matchers.h"
+#include "gutil/testing.h"
+#include "lib/gnmi/gnmi_helper.h"
+#include "thinkit/generic_testbed.h"
+#include "thinkit/proto/generic_testbed.pb.h"
+#include "thinkit/switch.h"
+
+namespace pins_test {
+namespace {
+
+using ::gutil::IsOkAndHolds;
+
+constexpr char kEnabledFalse[] = "{\"enabled\":false}";
+constexpr char kEnabledTrue[] = "{\"enabled\":true}";
+
+absl::Status SetAdminStatus(gnmi::gNMI::Stub* gnmi_stub,
+                            absl::string_view if_name,
+                            absl::string_view if_status) {
+  std::string enable_status;
+  if (if_status == "UP") {
+    enable_status = kEnabledTrue;
+  } else if (if_status == "DOWN") {
+    enable_status = kEnabledFalse;
+  } else {
+    return absl::InvalidArgumentError("Interface status invalid.");
+  }
+
+  // Enable/Disable front panel port.
+  LOG(INFO) << "Set front panel port " << if_name << " status: " << if_status;
+  const std::string if_enabled_config_path =
+      absl::StrCat("interfaces/interface[name=", if_name, "]/config/enabled");
+  RETURN_IF_ERROR(pins_test::SetGnmiConfigPath(
+      gnmi_stub, if_enabled_config_path, GnmiSetType::kUpdate, enable_status));
+  absl::SleepFor(absl::Seconds(15));
+
+  // Verifies /interfaces/interface[name=<port>]/state/admin-status = UP/DOWN.
+  std::string if_state_path =
+      absl::StrCat("interfaces/interface[name=", if_name, "]/state");
+  std::string resp_parse_str = "openconfig-interfaces:state";
+  ASSIGN_OR_RETURN(
+      std::string state_path_response,
+      GetGnmiStatePathInfo(gnmi_stub, if_state_path, resp_parse_str));
+  if (!absl::StrContains(state_path_response, if_status)) {
+    return absl::InternalError(
+        absl::StrCat("Unable to set admin status: ", if_status));
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace
+
+TEST_P(ExampleTestFixture, LinkFlapTest) {
+  thinkit::TestRequirements requirements =
+      gutil::ParseProtoOrDie<thinkit::TestRequirements>(
+          R"pb(interface_requirements {
+                 count: 1
+                 interface_mode: CONTROL_INTERFACE
+               })pb");
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<thinkit::GenericTestbed> generic_testbed,
+                       GetTestbedWithRequirements(requirements));
+  absl::flat_hash_map<std::string, thinkit::InterfaceInfo> interface_info =
+      generic_testbed->GetSutInterfaceInfo();
+  std::string sut_interface;
+  std::string peer_interface;
+  for (const auto& [interface, info] : interface_info) {
+    if (info.interface_mode == thinkit::CONTROL_INTERFACE) {
+      sut_interface = interface;
+      peer_interface = info.peer_interface_name;
+      break;
+    }
+  }
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<gnmi::gNMI::Stub> gnmi_stub,
+                       generic_testbed->Sut().CreateGnmiStub());
+
+  // Flaps SUT port through gNMI (admin state) and checks that the control
+  // switch detects it.
+
+  // Sets admin-status Down through gNMI.
+  LOG(INFO) << "Set sut " << sut_interface << " admin link state down.";
+  EXPECT_OK(SetAdminStatus(gnmi_stub.get(), sut_interface, "DOWN"));
+  EXPECT_THAT(generic_testbed->Interface().GetUpLinks({peer_interface}),
+              IsOkAndHolds(testing::IsEmpty()));
+  // Sets admin-status Up through gNMI.
+  EXPECT_OK(SetAdminStatus(gnmi_stub.get(), sut_interface, "UP"));
+  EXPECT_THAT(generic_testbed->Interface().GetUpLinks({peer_interface}),
+              IsOkAndHolds(testing::Contains(sut_interface)));
+
+  // Flaps control switch port and checks that SUT’s gNMI reflects that.
+  LOG(INFO) << "Set control switch " << peer_interface
+            << " admin link state down.";
+  EXPECT_OK(generic_testbed->Interface().SetAdminLinkState(
+      {peer_interface}, thinkit::LinkState::kDown));
+  absl::SleepFor(absl::Seconds(15));
+  // Checks oper-status through gNMI.
+  EXPECT_THAT(GetInterfaceOperStatusOverGnmi(*gnmi_stub, sut_interface),
+              IsOkAndHolds(OperStatus::kDown));
+  EXPECT_OK(generic_testbed->Interface().SetAdminLinkState(
+      {peer_interface}, thinkit::LinkState::kUp));
+  absl::SleepFor(absl::Seconds(15));
+  EXPECT_THAT(GetInterfaceOperStatusOverGnmi(*gnmi_stub, sut_interface),
+              IsOkAndHolds(OperStatus::kUp));
+}
+
+}  // namespace pins_test

--- a/tests/gnmi/link_flap_tests.h
+++ b/tests/gnmi/link_flap_tests.h
@@ -1,0 +1,25 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef GOOGLE_TESTS_GNMI_LINK_FLAP_TESTS_H_
+#define GOOGLE_TESTS_GNMI_LINK_FLAP_TESTS_H_
+
+#include "thinkit/generic_testbed_fixture.h"
+
+namespace pins_test {
+
+class ExampleTestFixture : public thinkit::GenericTestbedFixture {};
+
+}  // namespace pins_test
+
+#endif  // GOOGLE_TESTS_GNMI_LINK_FLAP_TESTS_H_

--- a/tests/thinkit_sanity_tests.cc
+++ b/tests/thinkit_sanity_tests.cc
@@ -58,6 +58,9 @@ using ::testing::HasSubstr;
 constexpr int kEpochMarginalError = 2;
 constexpr absl::Duration kColdRebootDelayTime = absl::Seconds(1);
 constexpr absl::Duration kColdRebootTotalWaitTime = absl::Seconds(30);
+constexpr absl::Duration kColdRebootWaitForDownTime = absl::Seconds(30);
+// TODO: Reduce reboot up time.
+constexpr absl::Duration kColdRebootWaitForUpTime = absl::Minutes(6);
 constexpr char kMtuJsonVal[] = "{\"mtu\":2000}";
 constexpr char kV3ReleaseConfigBlob[] = R"({
    "openconfig-platform:components" : {

--- a/thinkit/bazel_test_environment_test.cc
+++ b/thinkit/bazel_test_environment_test.cc
@@ -1,3 +1,16 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include "thinkit/bazel_test_environment.h"
 
 #include <cstdlib>


### PR DESCRIPTION
PR Description:
Add PortsUp back to SwitchReadyWithSsh.Fixes for gRPC usage. Added example link flap test using generic testbed.
Add missing license comment to files under lib/.Add license file to remaining files.

Keyword Check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 370 targets (0 packages loaded, 0 targets configured).
INFO: Found 370 targets...
INFO: Elapsed time: 0.615s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 

UT Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 370 targets (0 packages loaded, 1 target configured).
INFO: Found 244 targets and 126 test targets...
INFO: Elapsed time: 98.207s, Critical Path: 16.42s
INFO: 131 processes: 138 linux-sandbox, 17 local.
INFO: Build completed successfully, 131 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.6s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 1.0s
//lib/gnmi:gnmi_helper_test                                              PASSED in 0.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/utils:json_utils_test                                              PASSED in 0.0s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.6s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.4s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.7s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.2s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 2.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.0s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 1.0s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 1.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.8s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.7s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 1.1s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.3s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.0s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.1s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.8s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 6.7s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.3s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.9s
//p4rt_app/tests:packetio_test                                           PASSED in 4.0s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.7s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.7s
//p4rt_app/tests:response_path_test                                      PASSED in 5.4s
//p4rt_app/tests:role_test                                               PASSED in 1.2s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.1s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.8s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 3.0s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:mock_control_interface_test                                    PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 11.8s
  Stats over 5 runs: max = 11.8s, min = 0.9s, avg = 5.5s, dev = 5.1s

Executed 126 out of 126 tests: 126 tests pass.
INFO: Build completed successfully, 131 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 
