### PR TITLE
[Thinkit] Add default implementation of stub functions to return unimplemented,  remove sai dependecy from mirror testbed fixture and Addinv switch_test file.

### DIFF
--- a/thinkit/BUILD.bazel
+++ b/thinkit/BUILD.bazel
@@ -54,8 +54,27 @@ cc_library(
         "@com_github_gnoi//system:system_cc_grpc_proto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "switch_test",
+    srcs = ["switch_test.cc"],
+    deps = [
+        ":switch",
+        "//gutil:status_matchers",
+        "@com_github_gnmi//proto/gnmi:gnmi_cc_grpc_proto",
+        "@com_github_gnoi//cert:cert_cc_grpc_proto",
+        "@com_github_gnoi//diag:diag_cc_grpc_proto",
+        "@com_github_gnoi//factory_reset:factory_reset_cc_grpc_proto",
+        "@com_github_gnoi//os:os_cc_grpc_proto",
+        "@com_github_gnoi//system:system_cc_grpc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
+        "@com_google_absl//absl/status",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -73,7 +92,6 @@ cc_library(
         "@com_github_gnoi//system:system_cc_grpc_proto",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest",
     ],
 )
@@ -105,7 +123,7 @@ cc_library(
         "//gutil:status",
         "//p4_pdpi:ir",
         "//p4_pdpi:ir_cc_proto",
-        "//sai_p4/instantiations/google:sai_p4info_cc",
+        "@com_github_google_glog//:glog",
         "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/status",

--- a/thinkit/mirror_testbed_fixture.h
+++ b/thinkit/mirror_testbed_fixture.h
@@ -22,12 +22,12 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "glog/logging.h"
 #include "gtest/gtest.h"
 #include "gutil/status.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "p4_pdpi/ir.h"
 #include "p4_pdpi/ir.pb.h"
-#include "sai_p4/instantiations/google/sai_p4info.h"
 #include "thinkit/mirror_testbed.h"
 
 namespace thinkit {

--- a/thinkit/mock_switch.h
+++ b/thinkit/mock_switch.h
@@ -15,10 +15,11 @@
 #ifndef THINKIT_MOCK_SWITCH_H_
 #define THINKIT_MOCK_SWITCH_H_
 
+#include <cstdint>
 #include <memory>
+#include <string>
 
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
 #include "cert/cert.grpc.pb.h"
 #include "diag/diag.grpc.pb.h"
 #include "factory_reset/factory_reset.grpc.pb.h"

--- a/thinkit/switch.h
+++ b/thinkit/switch.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Google Inc.
+// Copyright (c) 2024, Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <memory>
 
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "cert/cert.grpc.pb.h"
@@ -45,33 +46,54 @@ class Switch {
 
   // Creates and returns a stub to the P4Runtime service.
   virtual absl::StatusOr<std::unique_ptr<p4::v1::P4Runtime::Stub>>
-  CreateP4RuntimeStub() = 0;
+  CreateP4RuntimeStub() {
+    return absl::UnimplementedError(
+        absl::StrCat(__func__, " is not implemented."));
+  }
 
   // Creates and returns a stub to the gNMI service.
   virtual absl::StatusOr<std::unique_ptr<gnmi::gNMI::Stub>>
-  CreateGnmiStub() = 0;
+  CreateGnmiStub() {
+    return absl::UnimplementedError(
+        absl::StrCat(__func__, " is not implemented."));
+  }
 
   // Creates and returns a stub to the gNOI Factory Reset service.
   virtual absl::StatusOr<
       std::unique_ptr<gnoi::factory_reset::FactoryReset::Stub>>
-  CreateGnoiFactoryResetStub() = 0;
+  CreateGnoiFactoryResetStub() {
+    return absl::UnimplementedError(
+        absl::StrCat(__func__, " is not implemented."));
+  }
 
-   // Creates and returns a stub to the gNOI System service.
+  // Creates and returns a stub to the gNOI System service.
   virtual absl::StatusOr<std::unique_ptr<gnoi::system::System::Stub>>
-  CreateGnoiSystemStub() = 0;
+  CreateGnoiSystemStub() {
+    return absl::UnimplementedError(
+        absl::StrCat(__func__, " is not implemented."));
+  }
 
   // Creates and returns a stub to the gNOI Diag service.
   virtual absl::StatusOr<std::unique_ptr<gnoi::diag::Diag::Stub>>
-  CreateGnoiDiagStub() = 0;
+  CreateGnoiDiagStub() {
+    return absl::UnimplementedError(
+        absl::StrCat(__func__, " is not implemented."));
+  }
 
   // Creates and returns a stub to the gNOI Certificate service.
   virtual absl::StatusOr<
       std::unique_ptr<gnoi::certificate::CertificateManagement::Stub>>
-  CreateGnoiCertificateStub() = 0;
+  CreateGnoiCertificateStub() {
+    return absl::UnimplementedError(
+        absl::StrCat(__func__, " is not implemented."));
+  }
 
   // Creates and returns a stub to the gNOI OS service.
   virtual absl::StatusOr<std::unique_ptr<gnoi::os::OS::Stub>>
-  CreateGnoiOsStub() = 0;
+  CreateGnoiOsStub() {
+    return absl::UnimplementedError(
+        absl::StrCat(__func__, " is not implemented."));
+  }
 };
 
 }  // namespace thinkit

--- a/thinkit/switch_test.cc
+++ b/thinkit/switch_test.cc
@@ -1,0 +1,61 @@
+// Copyright (c) 2024, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "thinkit/switch.h"
+
+#include <cstdint>
+#include <string>
+
+#include "absl/status/status.h"
+#include "cert/cert.grpc.pb.h"
+#include "diag/diag.grpc.pb.h"
+#include "factory_reset/factory_reset.grpc.pb.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status_matchers.h"
+#include "os/os.grpc.pb.h"
+#include "p4/v1/p4runtime.grpc.pb.h"
+#include "proto/gnmi/gnmi.grpc.pb.h"
+#include "system/system.grpc.pb.h"
+
+namespace thinkit {
+namespace {
+
+using ::gutil::StatusIs;
+
+class TestSwitch : public Switch {
+  const std::string& ChassisName() override { return chassis_name_; }
+  uint32_t DeviceId() override { return 0; }
+  std::string chassis_name_;
+};
+
+TEST(Switch, FunctionsReturnUnimplemented) {
+  TestSwitch sut;
+  EXPECT_THAT(sut.CreateP4RuntimeStub(),
+              StatusIs(absl::StatusCode::kUnimplemented));
+  EXPECT_THAT(sut.CreateGnmiStub(), StatusIs(absl::StatusCode::kUnimplemented));
+  EXPECT_THAT(sut.CreateGnoiFactoryResetStub(),
+              StatusIs(absl::StatusCode::kUnimplemented));
+  EXPECT_THAT(sut.CreateGnoiSystemStub(),
+              StatusIs(absl::StatusCode::kUnimplemented));
+  EXPECT_THAT(sut.CreateGnoiDiagStub(),
+              StatusIs(absl::StatusCode::kUnimplemented));
+  EXPECT_THAT(sut.CreateGnoiCertificateStub(),
+              StatusIs(absl::StatusCode::kUnimplemented));
+  EXPECT_THAT(sut.CreateGnoiOsStub(),
+              StatusIs(absl::StatusCode::kUnimplemented));
+}
+
+}  // namespace
+}  // namespace thinkit


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 371 targets (0 packages loaded, 0 targets configured).
INFO: Found 371 targets...
...
INFO: Elapsed time: 1719.137s, Critical Path: 82.94s
INFO: 7286 processes: 1991 internal, 5295 linux-sandbox.
INFO: Build completed successfully, 7286 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 371 targets (0 packages loaded, 281 targets configured).
INFO: Found 244 targets and 127 test targets...
INFO: Elapsed time: 67.675s, Critical Path: 16.66s
INFO: 132 processes: 139 linux-sandbox, 17 local.
INFO: Build completed successfully, 132 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.6s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 0.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 0.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/utils:json_utils_test                                              PASSED in 0.0s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.9s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.3s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.6s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.6s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 2.0s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.7s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.0s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.1s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.1s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 1.0s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.8s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.3s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.5s
//p4rt_app/tests:packetio_test                                           PASSED in 3.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 1.8s
//p4rt_app/tests:response_path_test                                      PASSED in 2.7s
//p4rt_app/tests:role_test                                               PASSED in 1.1s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.7s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.6s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.2s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.0s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.0s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:mock_control_interface_test                                    PASSED in 0.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.8s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 12.8s
  Stats over 5 runs: max = 12.8s, min = 1.1s, avg = 7.9s, dev = 5.1s

Executed 127 out of 127 tests: 127 tests pass.
INFO: Build completed successfully, 132 total actions

Pins-infra Commit IDs:
cbb8a37b4bc11114bd24fe0ac4fd7ab6e062400c
ce2c26c4d0d73ae751181c4773aaf400cff783f5
cdc67b5b045681ed1f7f1db44d08b29282c306f0