### PR TITLE
[Thinkit] Update ThinKit to return StubInterface for unit test mocking, Add SupportsSendPacket to ControlDevice interface, Enhanced the error logging in link_flap_test. Fixed peer_interface format mismatch issue, Improved naming: Device() -> ControlDevice(), Added multiple control devices to generic testbed & Added peer_device_index to InterfaceInfo in GenericTestbed and added multiple host control device feature to generic test fixture.

### DIFF
--- a/lib/gpins_control_device.h
+++ b/lib/gpins_control_device.h
@@ -58,6 +58,8 @@ class GpinsControlDevice : public thinkit::ControlDevice {
   absl::Status SendPacket(absl::string_view interface,
                           absl::string_view packet) override;
 
+  bool SupportsSendPacket() const override { return true; }
+
   absl::Status SendPackets(absl::string_view interface,
                            absl::Span<const std::string> packets) override;
 

--- a/thinkit/control_device.h
+++ b/thinkit/control_device.h
@@ -67,6 +67,10 @@ class ControlDevice {
   virtual absl::Status SendPacket(absl::string_view interface,
                                   absl::string_view packet) = 0;
 
+  // Check whether the ControlDevice implementation supports SendPacket - not
+  // all control devices support it.
+  virtual bool SupportsSendPacket() const = 0;
+
   // Sends a list of `packet` raw byte string out of the control
   // device’s `interface`.
   virtual absl::Status SendPackets(absl::string_view interface,

--- a/thinkit/generic_testbed.h
+++ b/thinkit/generic_testbed.h
@@ -49,14 +49,19 @@ enum class RequestType {
 //   the other end.
 // - In the case of CONTROL_INTERFACE, the `peer_interface_name` should be used
 //   in functions called on the `ControlDevice` returned by ControlDevice().
+// - In the case of multiple CONTROL_INTERFACE, the `peer_device_index` will be
+//   used to identify the connected control device. If `peer_device_index` is
+//   not provided, ControlDevice(0) will be returned by default.
 // - In the case of TRAFFIC_GENERATOR, the format of the `peer_interface_name`
 //   is "<hostname of generator>/<card number>/<port number>".
 struct InterfaceInfo {
   thinkit::InterfaceMode interface_mode;
+  int peer_device_index;            // Ignore if not applicable.
   std::string peer_interface_name;  // Empty if not applicable.
   bool operator==(const InterfaceInfo& other) const {
-    return std::tie(interface_mode, peer_interface_name) ==
-           std::tie(other.interface_mode, other.peer_interface_name);
+    return std::tie(interface_mode, peer_device_index, peer_interface_name) ==
+           std::tie(other.interface_mode, other.peer_device_index,
+                    other.peer_interface_name);
   }
 };
 
@@ -69,10 +74,13 @@ class GenericTestbed {
   // Returns the PINS switch (aka system) under test.
   virtual Switch& Sut() = 0;
 
-  // Returns the control device responsible for packet injection and various
-  // management operations. This could be but isn't limited to being another
-  // PINS switch, a non-PINS switch, or a host machine.
-  virtual ControlDevice& Device() = 0;
+  // Returns a default control device responsible for packet injection and
+  // various management operations. This could be but isn't limited to being
+  // another PINS switch, a non-PINS switch, or a host machine.
+  virtual class ControlDevice& ControlDevice() = 0;
+
+  // Returns a control device in the Generic Testbed at the specified index.
+  virtual class ControlDevice& ControlDevice(int index) = 0;
 
   // Returns the test environment in which the test is run.
   virtual TestEnvironment& Environment() = 0;

--- a/thinkit/mock_control_device.h
+++ b/thinkit/mock_control_device.h
@@ -39,6 +39,7 @@ class MockControlDevice : public ControlDevice {
   MOCK_METHOD(absl::Status, SendPacket,
               (absl::string_view interface, absl::string_view packet),
               (override));
+  MOCK_METHOD(bool, SupportsSendPacket, (), (const, override));
   MOCK_METHOD(absl::Status, SendPackets,
               (absl::string_view interface,
                absl::Span<const std::string> packets),

--- a/thinkit/mock_generic_testbed.h
+++ b/thinkit/mock_generic_testbed.h
@@ -28,7 +28,8 @@ namespace thinkit {
 class MockGenericTestbed : public GenericTestbed {
  public:
   MOCK_METHOD(Switch&, Sut, (), (override));
-  MOCK_METHOD(ControlDevice&, Device, (), (override));
+  MOCK_METHOD(class ControlDevice&, ControlDevice, (), (override));
+  MOCK_METHOD(class ControlDevice&, ControlDevice, (int index), (override));
   MOCK_METHOD(TestEnvironment&, Environment, (), (override));
   MOCK_METHOD((absl::flat_hash_map<std::string, InterfaceInfo>),
               GetSutInterfaceInfo, (), (override));

--- a/thinkit/mock_switch.h
+++ b/thinkit/mock_switch.h
@@ -36,23 +36,23 @@ class MockSwitch : public Switch {
  public:
   MOCK_METHOD(const std::string&, ChassisName, (), (override));
   MOCK_METHOD(uint32_t, DeviceId, (), (override));
-  MOCK_METHOD(absl::StatusOr<std::unique_ptr<p4::v1::P4Runtime::Stub>>,
+  MOCK_METHOD(absl::StatusOr<std::unique_ptr<p4::v1::P4Runtime::StubInterface>>,
               CreateP4RuntimeStub, (), (override));
-  MOCK_METHOD(absl::StatusOr<std::unique_ptr<gnmi::gNMI::Stub>>, CreateGnmiStub,
+  MOCK_METHOD(absl::StatusOr<std::unique_ptr<gnmi::gNMI::StubInterface>>, CreateGnmiStub,
               (), (override));
   MOCK_METHOD(
       absl::StatusOr<
-          std::unique_ptr<gnoi::factory_reset::FactoryReset::Stub>>,
+          std::unique_ptr<gnoi::factory_reset::FactoryReset::StubInterface>>,
       CreateGnoiFactoryResetStub, (), (override));
-  MOCK_METHOD(absl::StatusOr<std::unique_ptr<gnoi::system::System::Stub>>,
+  MOCK_METHOD(absl::StatusOr<std::unique_ptr<gnoi::system::System::StubInterface>>,
               CreateGnoiSystemStub, (), (override));
-  MOCK_METHOD(absl::StatusOr<std::unique_ptr<gnoi::diag::Diag::Stub>>,
+  MOCK_METHOD(absl::StatusOr<std::unique_ptr<gnoi::diag::Diag::StubInterface>>,
               CreateGnoiDiagStub, (), (override));
   MOCK_METHOD(
       absl::StatusOr<
-          std::unique_ptr<gnoi::certificate::CertificateManagement::Stub>>,
+          std::unique_ptr<gnoi::certificate::CertificateManagement::StubInterface>>,
       CreateGnoiCertificateStub, (), (override));
-  MOCK_METHOD(absl::StatusOr<std::unique_ptr<gnoi::os::OS::Stub>>,
+  MOCK_METHOD(absl::StatusOr<std::unique_ptr<gnoi::os::OS::StubInterface>>,
               CreateGnoiOsStub, (), (override));
 };
 

--- a/thinkit/switch.h
+++ b/thinkit/switch.h
@@ -45,14 +45,14 @@ class Switch {
   virtual uint32_t DeviceId() = 0;
 
   // Creates and returns a stub to the P4Runtime service.
-  virtual absl::StatusOr<std::unique_ptr<p4::v1::P4Runtime::Stub>>
+  virtual absl::StatusOr<std::unique_ptr<p4::v1::P4Runtime::StubInterface>>
   CreateP4RuntimeStub() {
     return absl::UnimplementedError(
         absl::StrCat(__func__, " is not implemented."));
   }
 
   // Creates and returns a stub to the gNMI service.
-  virtual absl::StatusOr<std::unique_ptr<gnmi::gNMI::Stub>>
+  virtual absl::StatusOr<std::unique_ptr<gnmi::gNMI::StubInterface>>
   CreateGnmiStub() {
     return absl::UnimplementedError(
         absl::StrCat(__func__, " is not implemented."));
@@ -60,21 +60,21 @@ class Switch {
 
   // Creates and returns a stub to the gNOI Factory Reset service.
   virtual absl::StatusOr<
-      std::unique_ptr<gnoi::factory_reset::FactoryReset::Stub>>
+      std::unique_ptr<gnoi::factory_reset::FactoryReset::StubInterface>>
   CreateGnoiFactoryResetStub() {
     return absl::UnimplementedError(
         absl::StrCat(__func__, " is not implemented."));
   }
 
   // Creates and returns a stub to the gNOI System service.
-  virtual absl::StatusOr<std::unique_ptr<gnoi::system::System::Stub>>
+  virtual absl::StatusOr<std::unique_ptr<gnoi::system::System::StubInterface>>
   CreateGnoiSystemStub() {
     return absl::UnimplementedError(
         absl::StrCat(__func__, " is not implemented."));
   }
 
   // Creates and returns a stub to the gNOI Diag service.
-  virtual absl::StatusOr<std::unique_ptr<gnoi::diag::Diag::Stub>>
+  virtual absl::StatusOr<std::unique_ptr<gnoi::diag::Diag::StubInterface>>
   CreateGnoiDiagStub() {
     return absl::UnimplementedError(
         absl::StrCat(__func__, " is not implemented."));
@@ -82,14 +82,14 @@ class Switch {
 
   // Creates and returns a stub to the gNOI Certificate service.
   virtual absl::StatusOr<
-      std::unique_ptr<gnoi::certificate::CertificateManagement::Stub>>
+      std::unique_ptr<gnoi::certificate::CertificateManagement::StubInterface>>
   CreateGnoiCertificateStub() {
     return absl::UnimplementedError(
         absl::StrCat(__func__, " is not implemented."));
   }
 
   // Creates and returns a stub to the gNOI OS service.
-  virtual absl::StatusOr<std::unique_ptr<gnoi::os::OS::Stub>>
+  virtual absl::StatusOr<std::unique_ptr<gnoi::os::OS::StubInterface>>
   CreateGnoiOsStub() {
     return absl::UnimplementedError(
         absl::StrCat(__func__, " is not implemented."));


### PR DESCRIPTION
### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 372 targets (0 packages loaded, 0 targets configured).
INFO: Found 372 targets...
INFO: Elapsed time: 17.796s, Critical Path: 10.90s
INFO: 15 processes: 1 internal, 14 linux-sandbox.
INFO: Build completed successfully, 15 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 372 targets (0 packages loaded, 0 targets configured).
INFO: Found 245 targets and 127 test targets...
INFO: Elapsed time: 68.035s, Critical Path: 16.31s
INFO: 132 processes: 139 linux-sandbox, 17 local.
INFO: Build completed successfully, 132 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.6s
//gutil:test_artifact_writer_test                                        PASSED in 0.7s
//gutil:testing_test                                                     PASSED in 0.8s
//gutil:version_test                                                     PASSED in 0.9s
//lib/gnmi:gnmi_helper_test                                              PASSED in 0.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/utils:json_utils_test                                              PASSED in 0.0s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.6s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.3s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 2.0s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.0s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.9s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.8s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.5s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.3s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.6s
//p4rt_app/tests:packetio_test                                           PASSED in 3.7s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 1.9s
//p4rt_app/tests:response_path_test                                      PASSED in 2.8s
//p4rt_app/tests:role_test                                               PASSED in 1.2s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.8s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.6s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.1s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.7s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.6s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 13.0s
  Stats over 5 runs: max = 13.0s, min = 1.0s, avg = 4.2s, dev = 4.5s

Executed 127 out of 127 tests: 127 tests pass.
INFO: Build completed successfully, 132 total actions
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ 

### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

Pins-infra commit IDs:
3a4a9237ed4e075e9f622865f2091570dfa01135
4eb39223792b3caf8b2b934d16c534cd103360c8
3033dc2fc65f2d2bbd3d32aee22000c8fa27d034
f98b1b05b5727b34c20ee0780107a1376ae04513
a32b2d14db7687133d9e3ca057d2871802fb0501