### PR TITLE
[Thinkit] [1/4] Create library for parsing and comparing json strings using json library.

### DIFF
--- a/lib/utils/BUILD.bazel
+++ b/lib/utils/BUILD.bazel
@@ -25,9 +25,14 @@ cc_library(
     hdrs = [
         "json_utils.h",
     ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
     deps = [
         "@com_github_google_glog//:glog",
+        "@com_github_nlohmann_json//:nlohmann_json",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_jsoncpp//:json",
     ],
@@ -38,6 +43,8 @@ cc_test(
     srcs = ["json_utils_test.cc"],
     deps = [
         ":json_utils",
+        "//gutil:status_matchers",
+        "@com_github_nlohmann_json//:nlohmann_json",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
         "@com_jsoncpp//:json",

--- a/lib/utils/json_utils.h
+++ b/lib/utils/json_utils.h
@@ -15,8 +15,14 @@
 #ifndef PINS_LIB_UTILS_JSON_UTILS_H_
 #define PINS_LIB_UTILS_JSON_UTILS_H_
 
+#include <string>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "include/json/value.h"
+#include "include/nlohmann/json.hpp"
 
 namespace pins_test {
 
@@ -63,4 +69,32 @@ bool JsonValueIsEqual(const Json::Value& value1, const Json::Value& value2);
 
 }  // namespace pins_test
 
-#endif  // PINS_LIB_UTILS_JSON_UTILS_H_
+namespace json_yang {
+// Helper functions to manipulate JSON that encode data modeled with YANG.
+// See http://datatracker.ietf.org/doc/html/rfc7159 for JSON.
+// See http://datatracker.ietf.org/doc/html/rfc7951 for JSON encoding of YANG.
+
+// Returns a JSON value from the input JSON string that contains data modeled
+// with YANG.
+// - Returns a null JSON value if the input is an empty string.
+// - Returns an invalid argument error if the input could not be parsed.
+absl::StatusOr<nlohmann::json> ParseJson(absl::string_view json_str);
+
+// Returns a pretty-printed JSON string from the JSON value.
+// - Returns an empty string if the JSON value is null.
+// - Replaces invalid UTF-8 sequences with U+FFFD.
+std::string DumpJson(const nlohmann::json& value);
+
+// Returns a JSON value by recursively replacing the names of name/value pairs
+// in JSON objects using the mapping specified in the old to new names map.
+//   - If source already contains the new name then it may be overwritten.
+//   - The output is undefined if the map of name replacements maps several old
+//     names to the same new name.
+nlohmann::json ReplaceNamesinJsonObject(
+    const nlohmann::json& source,
+    const absl::flat_hash_map<std::string, std::string>&
+        old_name_to_new_name_map);
+
+}  // namespace json_yang
+
+#endif  // PLATFORMS_NETWORKING_PINS_CONFIG_UTILS_JSON_UTILS_H_


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 381 targets (1 packages loaded, 10 targets configured).
INFO: Found 381 targets...
INFO: From Compiling lib/utils/json_utils.cc:
...
INFO: Elapsed time: 18.841s, Critical Path: 18.24s
INFO: 13 processes: 5 internal, 8 linux-sandbox.
INFO: Build completed successfully, 13 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 381 targets (0 packages loaded, 2 targets configured).
INFO: Found 250 targets and 131 test targets...
INFO: Elapsed time: 63.545s, Critical Path: 16.29s
INFO: 136 processes: 143 linux-sandbox, 17 local.
INFO: Build completed successfully, 136 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.7s
//gutil:status_matchers_test                                             PASSED in 0.6s
//gutil:test_artifact_writer_test                                        PASSED in 0.6s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 1.2s
//lib:basic_switch_test                                                  PASSED in 0.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 0.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 0.9s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.8s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.3s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.7s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.6s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.6s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.2s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.2s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.0s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.9s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.8s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.4s
//p4rt_app/tests:action_set_test                                         PASSED in 1.2s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.1s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.6s
//p4rt_app/tests:packetio_test                                           PASSED in 3.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.4s
//p4rt_app/tests:resource_limits_test                                    PASSED in 2.8s
//p4rt_app/tests:response_path_test                                      PASSED in 2.8s
//p4rt_app/tests:role_test                                               PASSED in 1.2s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.8s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.6s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.5s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 11.7s
  Stats over 5 runs: max = 11.7s, min = 1.0s, avg = 4.2s, dev = 3.9s

Executed 131 out of 131 tests: 131 tests pass.
INFO: Build completed successfully, 136 total actions