### PR TITLE
[Thinkit] [3/4] Create library for parsing and comparing json strings using json library.

### DIFF
--- a/lib/utils/BUILD.bazel
+++ b/lib/utils/BUILD.bazel
@@ -28,10 +28,12 @@ cc_library(
     copts = ["-fexceptions"],
     features = ["-use_header_modules"],  # Incompatible with -fexceptions.
     deps = [
+        "//gutil:status",
         "@com_github_google_glog//:glog",
         "@com_github_nlohmann_json//:nlohmann_json",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_jsoncpp//:json",

--- a/lib/utils/json_utils.cc
+++ b/lib/utils/json_utils.cc
@@ -19,13 +19,139 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/substitute.h"
 #include "glog/logging.h"
+#include "gutil/status.h"
 #include "include/nlohmann/json.hpp"
 
 namespace json_yang {
+
+namespace {
+
+using StringMap = absl::flat_hash_map<std::string, std::string>;
+
+// Helper function to return the simple JSON value (number, boolean, string).
+// - returns an empty string if not a simple JSON value (object, array, null).
+std::string GetSimpleJsonValue(const nlohmann::json& source) {
+  switch (source.type()) {
+    case nlohmann::json::value_t::number_integer:
+      return absl::StrCat(source.get<int>());
+    case nlohmann::json::value_t::number_unsigned:
+      return absl::StrCat(source.get<uint>());
+    case nlohmann::json::value_t::number_float:
+      return absl::StrCat(source.get<float>());
+    case nlohmann::json::value_t::string:
+      return source.get<std::string>();
+    case nlohmann::json::value_t::boolean:
+      return source.get<bool>() ? "true" : "false";
+    default:
+      return "";
+  }
+}
+
+// Helper function to perform flattening recursively.
+//
+// A list data node in YANG is represented as an array in JSON. The YANG model
+// is required to define one or more leaf data nodes as keys that uniquely
+// identify the elements in the list. (see rfc7950#section-7.8.2).
+//
+//  - path contains the currently traversed JSON value and includes the
+//    key/value pairs for array elements. This is used in the output map.
+//    e. g. /outer_element/array_container/array_element[key='value']/leaf
+//  - path_without_keys contains the currently traversed JSON value without
+//    key/value pairs for array elements. This is used to look up key leaves.
+//    e. g. /outer_element/array_container/array_element/leaf
+//  - yang_path_key_name_map contains a map of yang list paths to the name of
+//    the leaf that's defined as the key for that list (currently only supports
+//    one key).
+absl::Status FlattenJson(const absl::string_view path,
+                         const absl::string_view path_without_keys,
+                         const nlohmann::json& source,
+                         const StringMap& yang_path_key_name_map,
+                         StringMap& flattened_map) {
+  switch (source.type()) {
+    case nlohmann::json::value_t::object: {
+      // Traverse recursively through all the members of the object type after
+      // adding the path element to the path.
+      for (const auto& [name, value] : source.items()) {
+        const std::string member_path = absl::StrCat(path, "/", name);
+        const std::string member_path_without_keys =
+            absl::StrCat(path_without_keys, "/", name);
+        RETURN_IF_ERROR(FlattenJson(member_path, member_path_without_keys,
+                                    value, yang_path_key_name_map,
+                                    flattened_map));
+      }
+      break;
+    }
+    case nlohmann::json::value_t::array: {
+      // Find the name of the leaf that is considered the key for the elements
+      // in the array.
+      auto key_name_iter = yang_path_key_name_map.find(path_without_keys);
+      if (key_name_iter == yang_path_key_name_map.end()) {
+        return absl::InvalidArgumentError(
+            absl::StrCat("No key found for path [", path_without_keys,
+                         "] while parsing path [", path, "]."));
+      }
+      const std::string& key_name = key_name_iter->second;
+
+      // Find the value of the key leaf for each element in the array to
+      // construct the path element.
+      for (int i = 0; i < source.size(); ++i) {
+        if (!source[i].contains(key_name)) {
+          return absl::InvalidArgumentError(absl::StrCat(
+              "No key leaf '", key_name, "' found for array element ", i,
+              " under path: [", path, "]."));
+        }
+        std::string key_value;
+        switch (source[i][key_name].type()) {
+          case nlohmann::json::value_t::number_integer:
+          case nlohmann::json::value_t::number_unsigned:
+          case nlohmann::json::value_t::number_float:
+          case nlohmann::json::value_t::string:
+          case nlohmann::json::value_t::boolean:
+            key_value = GetSimpleJsonValue(source[i][key_name]);
+            break;
+          default:
+            // This is an error case. The key leaf must be a simple value.
+            return absl::InvalidArgumentError(absl::StrCat(
+                "Invalid type '", source[i][key_name].type_name(),
+                "' for key leaf '", key_name, "' for array element ", i,
+                " under path [", path,
+                "]. Expected: integer, unsigned, float, string, bool."));
+            break;
+        }
+        const std::string member_path =
+            absl::StrCat(path, "[", key_name, "='", key_value, "']");
+        // Traverse each array element recursively after adding the path element
+        // to the path.
+        RETURN_IF_ERROR(FlattenJson(member_path, path_without_keys, source[i],
+                                    yang_path_key_name_map, flattened_map));
+      }
+      break;
+    }
+    case nlohmann::json::value_t::number_integer:
+    case nlohmann::json::value_t::number_unsigned:
+    case nlohmann::json::value_t::number_float:
+    case nlohmann::json::value_t::string:
+    case nlohmann::json::value_t::boolean:
+      flattened_map[path] = GetSimpleJsonValue(source);
+      break;
+    case nlohmann::json::value_t::null:
+      // No yang path.
+      break;
+    default:
+      return absl::InvalidArgumentError(
+          absl::StrCat("Invalid json type '", source.type_name(),
+                       "' for path: [", path, "]."));
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace
 
 absl::StatusOr<nlohmann::json> ParseJson(absl::string_view json_str) {
   // Return a null json if the input is an empty string.
@@ -81,6 +207,14 @@ nlohmann::json ReplaceNamesinJsonObject(
       // Leaf value or null. Nothing to replace.
       return source;
   }
+}
+
+absl::StatusOr<StringMap> FlattenJsonToMap(
+    const nlohmann::json& root, const StringMap& yang_path_key_name_map) {
+  StringMap flattened_json;
+  RETURN_IF_ERROR(
+      FlattenJson("", "", root, yang_path_key_name_map, flattened_json));
+  return flattened_json;
 }
 
 }  // namespace json_yang

--- a/lib/utils/json_utils.h
+++ b/lib/utils/json_utils.h
@@ -113,6 +113,19 @@ absl::StatusOr<absl::flat_hash_map<std::string, std::string>> FlattenJsonToMap(
     const absl::flat_hash_map<std::string, std::string>&
         yang_path_key_name_map);
 
+// Returns true if all yang leaf nodes in 'source' are present in 'target' with
+// the same values or false otherwise.
+// - Returns an error if the source/target cannot be parsed into JSON values.
+// - Populates the yang paths missing or have mismatched values wtih 'target' in
+//   'differences'.
+// - Object/Array members can be in any order.
+// - Flattens the JSON values using the map of yang list paths to the name of
+//   the leaf that's defined as the key.
+absl::StatusOr<bool> IsJsonSubset(
+    const nlohmann::json& source, const nlohmann::json& target,
+    const absl::flat_hash_map<std::string, std::string>& yang_path_key_name_map,
+    std::vector<std::string>& differences);
+
 }  // namespace json_yang
 
 #endif  // PLATFORMS_NETWORKING_PINS_CONFIG_UTILS_JSON_UTILS_H_

--- a/lib/utils/json_utils.h
+++ b/lib/utils/json_utils.h
@@ -72,6 +72,7 @@ bool JsonValueIsEqual(const Json::Value& value1, const Json::Value& value2);
 namespace json_yang {
 // Helper functions to manipulate JSON that encode data modeled with YANG.
 // See http://datatracker.ietf.org/doc/html/rfc7159 for JSON.
+// See http://datatracker.ietf.org/doc/html/rfc7950 for YANG modeling language.
 // See http://datatracker.ietf.org/doc/html/rfc7951 for JSON encoding of YANG.
 
 // Returns a JSON value from the input JSON string that contains data modeled
@@ -94,6 +95,23 @@ nlohmann::json ReplaceNamesinJsonObject(
     const nlohmann::json& source,
     const absl::flat_hash_map<std::string, std::string>&
         old_name_to_new_name_map);
+
+// Returns a map of flattened paths to leaves in the JSON encoded YANG modeled
+// data to string values from the input JSON value using the map of yang paths
+// (representing array-link containers) to the leaf that is defined as the key
+// for the elements in the array in the yang model.
+//
+// A list data node in YANG is represented as an array in JSON. The YANG model
+// is required to define one or more leaf data nodes as keys that uniquely
+// identify the elements in the list. (see rfc7950#section-7.8.2).
+//
+//  - yang_path_key_name_map contains a map of yang list paths to the name of
+//    the leaf that's defined as the key for that list (currently only supports
+//    one key).
+absl::StatusOr<absl::flat_hash_map<std::string, std::string>> FlattenJsonToMap(
+    const nlohmann::json& root,
+    const absl::flat_hash_map<std::string, std::string>&
+        yang_path_key_name_map);
 
 }  // namespace json_yang
 


### PR DESCRIPTION
### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 381 targets (0 packages loaded, 0 targets configured).
INFO: Found 381 targets...
...
INFO: Elapsed time: 6.188s, Critical Path: 5.69s
INFO: 7 processes: 2 internal, 5 linux-sandbox.
INFO: Build completed successfully, 7 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 381 targets (0 packages loaded, 0 targets configured).
INFO: Found 250 targets and 131 test targets...
INFO: Elapsed time: 72.303s, Critical Path: 16.27s
INFO: 136 processes: 143 linux-sandbox, 17 local.
INFO: Build completed successfully, 136 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.6s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 0.8s
//lib:basic_switch_test                                                  PASSED in 0.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 0.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 0.9s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.9s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.2s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.3s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 4.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.0s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.8s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.9s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.5s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.4s
//p4rt_app/tests:action_set_test                                         PASSED in 1.2s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.1s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 4.0s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.6s
//p4rt_app/tests:packetio_test                                           PASSED in 3.7s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.4s
//p4rt_app/tests:resource_limits_test                                    PASSED in 1.9s
//p4rt_app/tests:response_path_test                                      PASSED in 2.8s
//p4rt_app/tests:role_test                                               PASSED in 1.2s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.8s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.6s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.0s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.7s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 14.5s
  Stats over 5 runs: max = 14.5s, min = 1.0s, avg = 6.4s, dev = 6.1s

Executed 131 out of 131 tests: 131 tests pass.
INFO: Build completed successfully, 136 total actions
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ 

### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.