### PR TITLE
[Thinkit] Adding a util function to check equivalence of 2 nlohmann::json objects.

### DIFF
--- a/lib/utils/json_utils.h
+++ b/lib/utils/json_utils.h
@@ -139,6 +139,15 @@ absl::StatusOr<bool> IsJsonSubset(
     const absl::flat_hash_map<std::string, std::string>& yang_path_key_name_map,
     std::vector<std::string>& differences);
 
+// Returns true only if lhs and rhs have the same sets of paths with the same
+// values and false with the differences populated if not. Object/Array members
+// can be in any order. Uses the yang key leaf map to identify array
+// elements.
+absl::StatusOr<bool> AreJsonEqual(
+    const nlohmann::json& lhs, const nlohmann::json& rhs,
+    const absl::flat_hash_map<std::string, std::string>& yang_path_key_name_map,
+    std::vector<std::string>& differences);
+
 }  // namespace json_yang
 
 #endif  // PLATFORMS_NETWORKING_PINS_CONFIG_UTILS_JSON_UTILS_H_

--- a/lib/utils/json_utils.h
+++ b/lib/utils/json_utils.h
@@ -89,12 +89,23 @@ std::string DumpJson(const nlohmann::json& value);
 // Returns a JSON value by recursively replacing the names of name/value pairs
 // in JSON objects using the mapping specified in the old to new names map.
 //   - If source already contains the new name then it may be overwritten.
-//   - The output is undefined if the map of name replacements maps several old
-//     names to the same new name.
+//   - The behavior is undefined if the map of name replacements maps several
+//     old names to the same new name.
 nlohmann::json ReplaceNamesinJsonObject(
     const nlohmann::json& source,
     const absl::flat_hash_map<std::string, std::string>&
         old_name_to_new_name_map);
+
+// Modifies the JSON value in place by recursively replacing the names of
+// name/value pairs in JSON objects using the mapping specified in the old to
+// new names map.
+//   - If root already contains the new name then it may be overwritten.
+//   - The behavior is undefined if the map of name replacements maps several
+//     old names to the same new name.
+void ReplaceNamesinJsonObject(
+    const absl::flat_hash_map<std::string, std::string>&
+        old_name_to_new_name_map,
+    nlohmann::json& root);
 
 // Returns a map of flattened paths to leaves in the JSON encoded YANG modeled
 // data to string values from the input JSON value using the map of yang paths

--- a/lib/utils/json_utils.h
+++ b/lib/utils/json_utils.h
@@ -108,10 +108,12 @@ nlohmann::json ReplaceNamesinJsonObject(
 //  - yang_path_key_name_map contains a map of yang list paths to the name of
 //    the leaf that's defined as the key for that list (currently only supports
 //    one key).
+//  - If ignore_unknown_key_paths is true and the key is not found in the map,
+//    then the entire array will not be included in the output.
 absl::StatusOr<absl::flat_hash_map<std::string, std::string>> FlattenJsonToMap(
     const nlohmann::json& root,
-    const absl::flat_hash_map<std::string, std::string>&
-        yang_path_key_name_map);
+    const absl::flat_hash_map<std::string, std::string>& yang_path_key_name_map,
+    bool ignore_unknown_key_paths);
 
 // Returns true if all yang leaf nodes in 'source' are present in 'target' with
 // the same values or false otherwise.

--- a/lib/utils/json_utils_test.cc
+++ b/lib/utils/json_utils_test.cc
@@ -596,7 +596,7 @@ TEST(ReplaceNamesinJsonObject, TestReplacementEmptyJson) {
   EXPECT_EQ(ReplaceNamesinJsonObject(example_json, StringMap{}), example_json);
 }
 
-TEST(ReplaceJsonPathElements, TestReplacementEmptyNamesMap) {
+TEST(ReplaceNamesinJsonObject, TestReplacementEmptyNamesMap) {
   constexpr char kExampleJson[] = R"({
     "outer_element" : {
       "container1" : [
@@ -723,6 +723,144 @@ TEST(ReplaceNamesinJsonObject, TestReplacementNamesReplaced) {
                                         {"leaf", "new_leaf"},
                                         {"no_such_element", "such_element"}}),
             expected_json);
+}
+
+TEST(ReplaceNamesinJsonObject, TestInPlaceReplacementEmptyJson) {
+  ASSERT_OK_AND_ASSIGN(nlohmann::json empty_json, ParseJson(""));
+  ASSERT_OK_AND_ASSIGN(nlohmann::json expected_json, ParseJson(""));
+  ReplaceNamesinJsonObject(StringMap{}, empty_json);
+  EXPECT_EQ(empty_json, expected_json);
+}
+
+TEST(ReplaceNamesinJsonObject, TestInPlaceReplacementEmptyNamesMap) {
+  constexpr char kExampleJson[] = R"({
+    "outer_element" : {
+      "container1" : [
+        {
+          "leaf": "value1",
+          "key_leaf": "key_value1",
+          "element": {
+            "container2": [
+              {
+                "key_leaf2": "key_value3",
+                "leaf": "value2"
+              }
+            ],
+            "element": {
+              "leaf": "value3"
+            }
+          }
+        },
+        {
+          "key_leaf": "key_value2",
+          "middle_element": {
+            "container2": [
+              {
+                "key_leaf2": "key_value4",
+                "element": {
+                  "inner_element": {
+                    "leaf3": "value6",
+                    "leaf": "value5"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  })";
+
+  ASSERT_OK_AND_ASSIGN(auto example_json, ParseJson(kExampleJson));
+  ASSERT_OK_AND_ASSIGN(auto expected_json, ParseJson(kExampleJson));
+  ReplaceNamesinJsonObject(StringMap{}, example_json);
+  EXPECT_EQ(example_json, expected_json);
+}
+
+TEST(ReplaceNamesinJsonObject, TestInPlaceReplacementNamesReplaced) {
+  constexpr char kExampleJson[] = R"({
+    "outer_element" : {
+      "container1" : [
+        {
+          "leaf": "value1",
+          "key_leaf": "key_value1",
+          "element": {
+            "container2": [
+              {
+                "key_leaf2": "key_value3",
+                "leaf": "value2"
+              }
+            ],
+            "element": {
+              "leaf": "value3"
+            }
+          }
+        },
+        {
+          "key_leaf": "key_value2",
+          "middle_element": {
+            "container2": [
+              {
+                "key_leaf2": "key_value4",
+                "element": {
+                  "inner_element": {
+                    "leaf3": "value6",
+                    "leaf": "value5"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  })";
+
+  constexpr char kExpectedJson[] = R"({
+    "outer_element" : {
+      "container1" : [
+        {
+          "new_leaf": "value1",
+          "key_leaf": "key_value1",
+          "new_element": {
+            "container2": [
+              {
+                "key_leaf2": "key_value3",
+                "new_leaf": "value2"
+              }
+            ],
+            "new_element": {
+              "new_leaf": "value3"
+            }
+          }
+        },
+        {
+          "key_leaf": "key_value2",
+          "middle_element": {
+            "container2": [
+              {
+                "key_leaf2": "key_value4",
+                "new_element": {
+                  "inner_element": {
+                    "leaf3": "value6",
+                    "new_leaf": "value5"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  })";
+
+  ASSERT_OK_AND_ASSIGN(auto example_json, ParseJson(kExampleJson));
+  ASSERT_OK_AND_ASSIGN(auto expected_json, ParseJson(kExpectedJson));
+  ReplaceNamesinJsonObject(StringMap{{"element", "new_element"},
+                                     {"leaf", "new_leaf"},
+                                     {"no_such_element", "such_element"}},
+                           example_json);
+  EXPECT_EQ(example_json, expected_json);
 }
 
 // Map of yang list paths to names of key leaves used for testing.


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 382 targets (1 packages loaded, 66 targets configured).
INFO: Found 382 targets...
...
INFO: Elapsed time: 16.191s, Critical Path: 15.67s
INFO: 9 processes: 2 internal, 7 linux-sandbox.
INFO: Build completed successfully, 9 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 382 targets (0 packages loaded, 285 targets configured).
INFO: Found 251 targets and 131 test targets...
INFO: Elapsed time: 71.438s, Critical Path: 16.38s
INFO: 136 processes: 143 linux-sandbox, 17 local.
INFO: Build completed successfully, 136 total actions
//gutil:collections_test PASSED in 0.5s
//gutil:io_test PASSED in 0.5s
//gutil:proto_matchers_test PASSED in 0.8s
//gutil:proto_ordering_test PASSED in 0.5s
//gutil:proto_test PASSED in 0.5s
//gutil:status_matchers_test PASSED in 0.5s
//gutil:test_artifact_writer_test PASSED in 0.7s
//gutil:testing_test PASSED in 0.5s
//gutil:version_test PASSED in 0.7s
//lib:basic_switch_test PASSED in 0.8s
//lib/gnmi:gnmi_helper_test PASSED in 2.8s
//lib/gnoi:gnoi_helper_test PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test PASSED in 0.8s
//lib/utils:generic_testbed_utils_test PASSED in 0.9s
//lib/utils:json_utils_test PASSED in 0.5s
//lib/validator:validator_backend_test PASSED in 0.5s
//p4_fuzzer:constraints_util_integration_test PASSED in 0.6s
//p4_fuzzer:fuzz_util_test PASSED in 1.0s
//p4_fuzzer:fuzzer_showcase_test PASSED in 1.1s
//p4_fuzzer:switch_state_test PASSED in 0.7s
//p4_fuzzer:table_entry_key_test PASSED in 0.1s
//p4_pdpi:built_ins_test PASSED in 0.5s
//p4_pdpi:entity_keys_test PASSED in 0.5s
//p4_pdpi:ir_tools_test PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test PASSED in 0.6s
//p4_pdpi:reference_annotations_test PASSED in 0.7s
//p4_pdpi:sequencing_util_test PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test PASSED in 16.3s
//p4_pdpi/packetlib:packetlib_matchers_test PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_test PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test PASSED in 1.3s
//p4_pdpi/string_encodings:bit_string_test PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test PASSED in 0.5s
//p4_pdpi/testing:helper_function_test PASSED in 0.6s
//p4_pdpi/testing:info_test PASSED in 0.2s
//p4_pdpi/testing:info_test_runner PASSED in 0.1s
//p4_pdpi/testing:main_pd_test PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test PASSED in 0.7s
//p4_pdpi/testing:packet_io_test PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner PASSED in 0.1s
//p4_pdpi/testing:rpc_test PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_test PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test PASSED in 0.8s
//p4_pdpi/testing:table_entry_test PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test PASSED in 0.5s
//p4_pdpi/utils:ir_test PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test PASSED in 1.0s
//p4rt_app/p4runtime:cpu_queue_translator_test PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test PASSED in 1.0s
//p4rt_app/p4runtime:packetio_helpers_test PASSED in 1.1s
//p4rt_app/p4runtime:resource_utilization_test PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test PASSED in 0.8s
//p4rt_app/sonic:app_db_manager_test PASSED in 0.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test PASSED in 0.8s
//p4rt_app/sonic:hashing_test PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test PASSED in 0.6s
//p4rt_app/sonic:response_handler_test PASSED in 0.7s
//p4rt_app/sonic:state_verification_test PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test PASSED in 0.8s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test PASSED in 0.1s
//p4rt_app/tests:acl_table_test PASSED in 1.4s
//p4rt_app/tests:action_set_test PASSED in 1.1s
//p4rt_app/tests:api_access_test PASSED in 1.0s
//p4rt_app/tests:arbitration_test PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test PASSED in 1.6s
//p4rt_app/tests:debug_data_dump_test PASSED in 1.1s
//p4rt_app/tests:fixed_l3_tables_test PASSED in 2.6s
//p4rt_app/tests:forwarding_pipeline_config_test PASSED in 4.0s
//p4rt_app/tests:grpc_behavior_test PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner PASSED in 0.2s
//p4rt_app/tests:p4_programs_test PASSED in 1.6s
//p4rt_app/tests:packetio_test PASSED in 3.7s
//p4rt_app/tests:port_name_and_id_test PASSED in 2.4s
//p4rt_app/tests:resource_limits_test PASSED in 2.8s
//p4rt_app/tests:response_path_test PASSED in 2.8s
//p4rt_app/tests:role_test PASSED in 1.2s
//p4rt_app/tests:state_verification_test PASSED in 1.8s
//p4rt_app/tests:vrf_table_test PASSED in 1.6s
//p4rt_app/tests/lib:app_db_entry_builder_test PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test PASSED in 0.0s
//p4rt_app/utils:table_utility_test PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:sai_p4info_fetcher_test PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test PASSED in 0.3s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.1s
//sai_p4/instantiations/google/test_tools:test_entries_test PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test PASSED in 0.7s
//sai_p4/tools:p4info_tools_test PASSED in 0.6s
//sai_p4/tools:packetio_tools_test PASSED in 0.7s
//thinkit:bazel_test_environment_test PASSED in 0.5s
//thinkit:generic_testbed_test PASSED in 0.9s
//thinkit:mock_control_device_test PASSED in 0.6s
//thinkit:mock_generic_testbed_test PASSED in 0.7s
//thinkit:mock_mirror_testbed_test PASSED in 0.6s
//thinkit:mock_ssh_client_test PASSED in 0.1s
//thinkit:mock_switch_test PASSED in 0.7s
//thinkit:mock_test_environment_test PASSED in 0.1s
//thinkit:switch_test PASSED in 0.8s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test PASSED in 13.1s
Stats over 5 runs: max = 13.1s, min = 2.2s, avg = 8.2s, dev = 4.9s

Executed 131 out of 131 tests: 131 tests pass.
INFO: Build completed successfully, 136 total actions