### PR TITLE
[Comb] Add an API to wait for a validation to pass.

### DIFF
--- a/lib/validator/BUILD.bazel
+++ b/lib/validator/BUILD.bazel
@@ -123,3 +123,15 @@ cc_library(
         "@com_google_absl//absl/time",
     ],
 )
+
+cc_test(
+    name = "validator_lib_test",
+    srcs = ["validator_lib_test.cc"],
+    deps = [
+        ":validator_lib",
+        "//gutil:status_matchers",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/lib/validator/validator_lib.h
+++ b/lib/validator/validator_lib.h
@@ -15,6 +15,9 @@
 #ifndef PINS_LIB_VALIDATOR_VALIDATOR_LIB_H_
 #define PINS_LIB_VALIDATOR_VALIDATOR_LIB_H_
 
+#include <tuple>
+#include <type_traits>
+
 #include "absl/status/status.h"
 #include "thinkit/ssh_client.h"
 #include "thinkit/switch.h"
@@ -24,6 +27,7 @@ namespace pins_test {
 constexpr absl::Duration kDefaultTimeout = absl::Seconds(60);
 
 // Checks if the switch can be pinged.
+// Will wait up to <timeout> for the switch to respond to the ping.
 absl::Status Pingable(absl::string_view chassis_name,
                       absl::Duration timeout = kDefaultTimeout);
 
@@ -31,6 +35,7 @@ absl::Status Pingable(thinkit::Switch& thinkit_switch,
                       absl::Duration timeout = kDefaultTimeout);
 
 // Checks if ssh access to the switch is working.
+// Will wait up to <timeout> for the switch to respond to SSH.
 absl::Status SSHable(absl::string_view chassis_name,
                      thinkit::SSHClient& ssh_client,
                      absl::Duration timeout = kDefaultTimeout);
@@ -44,37 +49,75 @@ absl::Status P4rtAble(thinkit::Switch& thinkit_switch);
 
 // Checks if a gNMI get all interface request can be sent and a response
 // received.
+// Will wait up to <timeout> for the RPC to return. Peforms one request.
 absl::Status GnmiAble(thinkit::Switch& thinkit_switch,
                       absl::Duration timeout = kDefaultTimeout);
 
 // Checks if a gNOI system get time request can be sent and a response
 // received.
+// Will wait up to <timeout> for the RPC to return. Peforms one request.
 absl::Status GnoiAble(thinkit::Switch& thinkit_switch,
                       absl::Duration timeout = kDefaultTimeout);
 
 // Checks if "oper-status" of all interfaces are "UP". If the interfaces is
 // provided, checks only those interfaces.
+// Will wait up to <timeout> for the RPC to return. Peforms one request.
 absl::Status PortsUp(thinkit::Switch& thinkit_switch,
                      absl::Span<const std::string> interfaces = {},
                      absl::Duration timeout = kDefaultTimeout);
 
+inline absl::Status AllPortsUp(thinkit::Switch& thinkit_switch,
+                               absl::Duration timeout = kDefaultTimeout) {
+  return PortsUp(thinkit_switch, {}, timeout);
+}
+
 // Checks to make sure no alarms are set.
+// Will wait up to <timeout> for the RPC to return. Peforms one request.
 absl::Status NoAlarms(thinkit::Switch& thinkit_switch,
                       absl::Duration timeout = kDefaultTimeout);
 
 // Checks if the switch is ready by running the following validations:
-// Pingable, P4rtAble, GnmiAble, GnoiAble, PortsUp.
+// Pingable, P4rtAble, GnmiAble, GnoiAble.
 absl::Status SwitchReady(thinkit::Switch& thinkit_switch,
                          absl::Span<const std::string> interfaces = {},
-                         absl::Duration timeout = kDefaultTimeout);
+                         absl::Duration /*timeout*/ = kDefaultTimeout);
 
 // Checks if the switch is ready by running the following validations:
-// Pingable, SSHable, P4rtAble, GnmiAble, GnoiAble, PortsUp.
+// Pingable, SSHable, P4rtAble, GnmiAble, GnoiAble, [PortsUp].
 absl::Status SwitchReadyWithSsh(thinkit::Switch& thinkit_switch,
                                 thinkit::SSHClient& ssh_client,
                                 absl::Span<const std::string> interfaces = {},
                                 bool check_interfaces_state = true,
-                                absl::Duration timeout = kDefaultTimeout);
+                                absl::Duration /*timeout*/ = kDefaultTimeout);
+
+// Wait for the expected conditon to return success. The condition will be
+// checked until either the timeout is expired (in which case an error status is
+// returned) or the condition returns ok.
+//
+// Examples:
+//   std::vector<std::string> interfaces = ...;
+//   ASSERT_OK(WaitForCondition(SwitchReady, absl::Minutes(5), interfaces));
+//
+//   ASSERT_OK(WaitForCondition(P4rtAble, absl::Seconds(10)));
+template <typename Func, typename... Args>
+absl::Status WaitForCondition(Func condition, absl::Duration timeout,
+                              Args&&... args) {
+  absl::Time deadline = absl::Now() + timeout;
+  absl::Status final_status = absl::OkStatus();
+  do {
+    if constexpr (std::is_invocable_r_v<absl::Status, Func, Args...,
+                                        absl::Duration>) {
+      final_status = condition(std::forward<Args>(args)...,
+                               /*timeout=*/deadline - absl::Now());
+    } else {
+      final_status = condition(std::forward<Args>(args)...);
+    }
+  } while (!final_status.ok() && absl::Now() < deadline);
+  if (final_status.ok()) return final_status;
+  return absl::DeadlineExceededError(absl::StrCat(
+      "Failed to read requested condition after ",
+      absl::FormatDuration(timeout), ": ", final_status.message()));
+}
 
 }  // namespace pins_test
 

--- a/lib/validator/validator_lib_test.cc
+++ b/lib/validator/validator_lib_test.cc
@@ -1,0 +1,88 @@
+#include "lib/validator/validator_lib.h"
+
+#include "absl/status/status.h"
+#include "absl/time/time.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status_matchers.h"
+
+namespace pins_test {
+namespace {
+
+TEST(WaitForConditionTest, SucceedsInOneTry) {
+  int call_count = 0;
+  auto succeed = [&call_count](absl::Duration /*timeout*/) {
+    ++call_count;
+    return absl::OkStatus();
+  };
+  EXPECT_OK(WaitForCondition(succeed, absl::Milliseconds(1)));
+  EXPECT_EQ(call_count, 1);
+}
+
+TEST(WaitForConditionTest, RunsAtLeastOnce) {
+  auto succeed = [](absl::Duration /*timeout*/) { return absl::OkStatus(); };
+  EXPECT_OK(WaitForCondition(succeed, absl::ZeroDuration()));
+}
+
+TEST(WaitForConditionTest, SucceedsOnNthTry) {
+  int call_count = 0;
+  auto past_deadline = [&call_count](absl::Duration /*timeout*/) {
+    if (++call_count >= 5) return absl::OkStatus();
+    return absl::InternalError("Failed");
+  };
+  EXPECT_OK(WaitForCondition(past_deadline, absl::Milliseconds(100)));
+  EXPECT_EQ(call_count, 5);
+}
+
+TEST(WaitForConditionTest, FailsAfterDeadline) {
+  auto fail = [](absl::Duration /*timeout*/) {
+    return absl::InternalError("Failed");
+  };
+  constexpr absl::Duration kTimeout = absl::Milliseconds(10);
+
+  absl::Time start = absl::Now();
+  EXPECT_THAT(WaitForCondition(fail, kTimeout),
+              gutil::StatusIs(absl::StatusCode::kDeadlineExceeded,
+                              testing::HasSubstr("Failed")));
+  EXPECT_GT(absl::Now() - start, kTimeout);
+}
+
+TEST(WaitForConditionTest, PassesParametersToCondition) {
+  auto ok_if = [](bool condition, absl::Duration /*timeout*/) {
+    return condition ? absl::OkStatus() : absl::InternalError("Failed");
+  };
+  EXPECT_OK(WaitForCondition(ok_if, absl::ZeroDuration(), true));
+  EXPECT_FALSE(WaitForCondition(ok_if, absl::ZeroDuration(), false).ok());
+}
+
+TEST(WaitForConditionTest, WorksWithNonTimeoutCondition) {
+  auto ok_if = [](bool condition) {
+    return condition ? absl::OkStatus() : absl::InternalError("Failed");
+  };
+  EXPECT_OK(WaitForCondition(ok_if, absl::ZeroDuration(), true));
+  EXPECT_FALSE(WaitForCondition(ok_if, absl::ZeroDuration(), false).ok());
+}
+
+MATCHER(IsStrictlyDescending, "") {
+  for (int i = 1; i < arg.size(); ++i) {
+    if (arg.at(i) >= arg.at(i - 1)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+TEST(WaitForConditionTest, PassesTimeoutToCondition) {
+  std::vector<absl::Duration> timeouts;
+  auto record_timeout = [&timeouts](absl::Duration timeout) {
+    timeouts.push_back(timeout);
+    absl::SleepFor(absl::Milliseconds(1));
+    return absl::InternalError("Failed");
+  };
+  EXPECT_FALSE(WaitForCondition(record_timeout, absl::Milliseconds(10)).ok());
+  EXPECT_GT(timeouts.size(), 1);
+  EXPECT_THAT(timeouts, IsStrictlyDescending());
+}
+
+}  // namespace
+}  // namespace pins_test


### PR DESCRIPTION
PR Description:
Add an API to wait for a validation to pass.

Keyword Check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/Google/tools/keyword_checks.sh .
Keyword check Passed.

Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 383 targets (0 packages loaded, 0 targets configured).
INFO: Found 383 targets...
INFO: Elapsed time: 0.896s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 

UT Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 383 targets (0 packages loaded, 2 targets configured).
INFO: Found 251 targets and 132 test targets...
INFO: Elapsed time: 103.430s, Critical Path: 22.61s
INFO: 137 processes: 144 linux-sandbox, 17 local.
INFO: Build completed successfully, 137 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.7s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.7s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.6s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 1.0s
//lib:basic_switch_test                                                  PASSED in 0.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.9s
//lib/utils:generic_testbed_utils_test                                   PASSED in 0.9s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 0.7s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.9s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.6s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.6s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 2.1s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.2s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.8s
//p4rt_app/tests:action_set_test                                         PASSED in 1.3s
//p4rt_app/tests:api_access_test                                         PASSED in 1.1s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.3s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.9s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.2s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.9s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 6.5s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.3s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.3s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.0s
//p4rt_app/tests:packetio_test                                           PASSED in 3.9s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 5.6s
//p4rt_app/tests:response_path_test                                      PASSED in 3.8s
//p4rt_app/tests:role_test                                               PASSED in 1.4s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.2s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.1s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.2s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.8s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 0.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 22.6s
  Stats over 5 runs: max = 22.6s, min = 1.1s, avg = 6.1s, dev = 8.2s

Executed 132 out of 132 tests: 132 tests pass.
INFO: Build completed successfully, 137 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 
