### PR TITLE
[Thinkit] Add auxiliary function for switch and P4RT configuration.

### DIFF
--- a/tests/lib/BUILD.bazel
+++ b/tests/lib/BUILD.bazel
@@ -32,3 +32,22 @@ cc_library(
         "@com_google_absl//absl/strings",
     ],
 )
+
+cc_library(
+    name = "switch_test_setup_helpers",
+    testonly = True,
+    srcs = ["switch_test_setup_helpers.cc"],
+    hdrs = ["switch_test_setup_helpers.h"],
+    deps = [
+        "//lib/gnmi:gnmi_helper",
+        "//p4_pdpi:p4_runtime_session",
+        "//thinkit:switch",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:optional",
+    ],
+)

--- a/tests/lib/switch_test_setup_helpers.cc
+++ b/tests/lib/switch_test_setup_helpers.cc
@@ -1,159 +1,46 @@
 #include "tests/lib/switch_test_setup_helpers.h"
 
-#include <deque>
-#include <functional>
-#include <future>  // NOLINT: third_party library.
 #include <memory>
-#include <optional>
 #include <string>
-#include <utility>
-#include <vector>
 
-#include "absl/container/btree_map.h"
-#include "absl/container/btree_set.h"
-#include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
-#include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
-#include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "absl/types/optional.h"
-#include "absl/types/span.h"
-#include "glog/logging.h"
-#include "gtest/gtest.h"
-#include "gutil/collections.h"
-#include "gutil/proto.h"
 #include "gutil/status.h"
 #include "lib/gnmi/gnmi_helper.h"
-#include "lib/gnmi/openconfig.pb.h"
-#include "lib/p4rt/p4rt_port.h"
-#include "lib/validator/validator_lib.h"
-#include "p4/config/v1/p4types.pb.h"
 #include "p4/v1/p4runtime.pb.h"
-#include "p4_pdpi/ir_tools.h"
 #include "p4_pdpi/p4_runtime_session.h"
-#include "proto/gnmi/gnmi.grpc.pb.h"
-#include "tests/thinkit_sanity_tests.h"
-#include "thinkit/mirror_testbed.h"
-#include "thinkit/switch.h"
 
 namespace pins_test {
 namespace {
 
-constexpr absl::Duration kGnmiTimeoutDefault = absl::Minutes(3);
-constexpr char kPortNamedType[] = "port_id_t";
-
-// Only clears entities if a P4RT session can be established.
-//
-// P4RT requires a device ID to be pushed over gNMI which is not enforced by
-// this helper function. Given that we can't know the switch's state in all
-// cases where this will be called, we default to best effort for clearing the
-// entities.
-absl::Status TryClearingEntities(
-    thinkit::Switch& thinkit_switch,
-    const pdpi::P4RuntimeSessionOptionalArgs& metadata) {
-  absl::StatusOr<std::unique_ptr<pdpi::P4RuntimeSession>> session =
-      pdpi::P4RuntimeSession::Create(thinkit_switch, metadata);
-  if (!session.ok()) {
-    LOG(WARNING)
-        << "P4RT session could not be established to clear tables. This is "
-           "expected if no gNMI config has been previously pushed: "
-        << session.status();
-    return absl::OkStatus();
-  }
-
-  RETURN_IF_ERROR(pdpi::ClearEntities(**session));
-  RETURN_IF_ERROR(session.value()->Finish());
-  return absl::OkStatus();
-}
-
-// Wrapper around `TestGnoiSystemColdReboot` that ensures we don't ignore fatal
-// failures.
-absl::Status Reboot(thinkit::Switch& thinkit_switch) {
-  if (::testing::Test::HasFatalFailure()) {
-    return gutil::UnknownErrorBuilder()
-           << "skipping switch reboot due to pre-existing, fatal test failure";
-  }
-  TestGnoiSystemColdReboot(thinkit_switch);
-  if (::testing::Test::HasFatalFailure()) {
-    return gutil::UnknownErrorBuilder()
-           << "switch reboot failed with fatal error";
-  }
-  return absl::OkStatus();
-}
-
 absl::StatusOr<std::unique_ptr<pdpi::P4RuntimeSession>>
-CreateP4RuntimeSessionAndOptionallyPushP4Info(
+CreateP4RuntimeSessionAndClearExistingState(
     thinkit::Switch& thinkit_switch,
-    const std::optional<p4::config::v1::P4Info>& p4info,
     const pdpi::P4RuntimeSessionOptionalArgs& metadata) {
   ASSIGN_OR_RETURN(std::unique_ptr<pdpi::P4RuntimeSession> session,
                    pdpi::P4RuntimeSession::Create(thinkit_switch, metadata));
-
-  if (p4info.has_value()) {
-    // Check if P4Info already exists, and if so reboot to workaround PINS
-    // limitations (b/200209778).
-    ASSIGN_OR_RETURN(p4::v1::GetForwardingPipelineConfigResponse response,
-                     pdpi::GetForwardingPipelineConfig(session.get()));
-    ASSIGN_OR_RETURN(std::string p4info_diff,
-                     gutil::ProtoDiff(response.config().p4info(), *p4info));
-    if (response.config().has_p4info() && !p4info_diff.empty()) {
-      LOG(WARNING)
-          << "Rebooting since P4Info reconfiguration is unsupported by PINS, "
-             "but I am asked to push a P4Info with the following diff:\n"
-          << p4info_diff;
-      RETURN_IF_ERROR(session->Finish());
-      RETURN_IF_ERROR(Reboot(thinkit_switch));
-      // Reconnect after reboot.
-      ASSIGN_OR_RETURN(
-          session, pdpi::P4RuntimeSession::Create(thinkit_switch, metadata));
-    }
-
-    // Push P4Info.
-    RETURN_IF_ERROR(pdpi::SetMetadataAndSetForwardingPipelineConfig(
-        session.get(),
-        p4::v1::SetForwardingPipelineConfigRequest::RECONCILE_AND_COMMIT,
-        *p4info));
-  }
-
-  RETURN_IF_ERROR(pdpi::CheckNoEntities(*session));
+  RETURN_IF_ERROR(pdpi::ClearTableEntries(session.get()));
+  RETURN_IF_ERROR(pdpi::CheckNoTableEntries(session.get())).SetPrepend()
+      << "cleared all table entries: ";
   return session;
 }
 
-// Uses the `port_map` to remap any P4runtime ports in `entries`.
-absl::Status RewritePortsInTableEntries(
-    const pdpi::IrP4Info& info, std::vector<pdpi::IrTableEntry>& entries,
-    const absl::flat_hash_map<P4rtPortId, P4rtPortId>& port_map) {
-  p4::config::v1::P4NamedType port_type;
-  port_type.set_name(kPortNamedType);
-  RETURN_IF_ERROR(pdpi::TransformValuesOfType(
-      info, port_type, entries,
-      [&](absl::string_view old_string_port) -> absl::StatusOr<std::string> {
-        ASSIGN_OR_RETURN(P4rtPortId old_port,
-                         P4rtPortId::MakeFromP4rtEncoding(old_string_port));
-        ASSIGN_OR_RETURN(P4rtPortId new_port,
-                         gutil::FindOrStatus(port_map, old_port));
-        return new_port.GetP4rtEncoding();
-      }));
+absl::Status PushGnmiAndWaitForConvergence(thinkit::Switch& thinkit_switch,
+                                           const std::string& gnmi_config,
+                                           absl::Duration gnmi_timeout) {
+  RETURN_IF_ERROR(PushGnmiConfig(thinkit_switch, gnmi_config));
+  return WaitForGnmiPortIdConvergence(thinkit_switch, gnmi_config,
+                                      gnmi_timeout);
+}
 
-  // Watch ports do not have a named type, but we still consider them ports so
-  // we have to deal with them specifically rather than using the generic
-  // rewriting function above.
-  for (pdpi::IrTableEntry& entry : entries) {
-    if (entry.has_action_set()) {
-      for (auto& action : *entry.mutable_action_set()->mutable_actions()) {
-        if (!action.watch_port().empty()) {
-          ASSIGN_OR_RETURN(
-              P4rtPortId old_watch_port,
-              P4rtPortId::MakeFromP4rtEncoding(action.watch_port()));
-          ASSIGN_OR_RETURN(P4rtPortId new_watch_port,
-                           gutil::FindOrStatus(port_map, old_watch_port));
-          *action.mutable_watch_port() = new_watch_port.GetP4rtEncoding();
-        }
-      }
-    }
-  }
-
+absl::Status SetForwardingPipelineConfigAndAssureClearedTables(
+    pdpi::P4RuntimeSession* session, const p4::config::v1::P4Info& p4info) {
+  RETURN_IF_ERROR(pdpi::SetMetadataAndSetForwardingPipelineConfig(
+      session, p4::v1::SetForwardingPipelineConfigRequest::RECONCILE_AND_COMMIT,
+      p4info));
+  RETURN_IF_ERROR(pdpi::CheckNoTableEntries(session)).SetPrepend()
+      << "set a new forwarding pipeline config: ";
   return absl::OkStatus();
 }
 
@@ -161,340 +48,37 @@ absl::Status RewritePortsInTableEntries(
 
 absl::StatusOr<std::unique_ptr<pdpi::P4RuntimeSession>>
 ConfigureSwitchAndReturnP4RuntimeSession(
-    thinkit::Switch& thinkit_switch,
-    const std::optional<absl::string_view>& gnmi_config,
-    const std::optional<p4::config::v1::P4Info>& p4info,
+    thinkit::Switch& thinkit_switch, const std::string& gnmi_config,
+    const p4::config::v1::P4Info& p4info,
     const pdpi::P4RuntimeSessionOptionalArgs& metadata) {
   // Since the gNMI Config push relies on tables being cleared, we construct a
   // P4RuntimeSession and clear the tables first.
-  RETURN_IF_ERROR(TryClearingEntities(thinkit_switch, metadata));
-
-  if (gnmi_config.has_value()) {
-    RETURN_IF_ERROR(PushGnmiConfig(thinkit_switch, *gnmi_config));
-  }
-
-  ASSIGN_OR_RETURN(auto p4rt_session,
-                   CreateP4RuntimeSessionAndOptionallyPushP4Info(
-                       thinkit_switch, p4info, metadata));
-
-  // Ensure that the P4RT port IDs configured on the switch are reflected in the
-  // state before returning.
-  ASSIGN_OR_RETURN(std::unique_ptr<gnmi::gNMI::StubInterface> gnmi_stub,
-                   thinkit_switch.CreateGnmiStub());
-  RETURN_IF_ERROR(
-      WaitForGnmiPortIdConvergence(*gnmi_stub,
-                                   /*gnmi_timeout=*/kGnmiTimeoutDefault));
-  return p4rt_session;
-}
-
-absl::StatusOr<std::pair<std::unique_ptr<pdpi::P4RuntimeSession>,
-                         std::unique_ptr<pdpi::P4RuntimeSession>>>
-ConfigureSwitchPairAndReturnP4RuntimeSessionPair(
-    thinkit::Switch& thinkit_switch1, thinkit::Switch& thinkit_switch2,
-    const std::optional<absl::string_view>& gnmi_config,
-    const std::optional<p4::config::v1::P4Info>& p4info,
-    const pdpi::P4RuntimeSessionOptionalArgs& metadata) {
-  // We configure both switches in parallel, since it may require rebooting the
-  // switch which is costly.
-  using T = absl::StatusOr<std::unique_ptr<pdpi::P4RuntimeSession>>;
-  T session1, session2;
-  {
-    std::future<T> future1 = std::async(std::launch::async, [&] {
-      return ConfigureSwitchAndReturnP4RuntimeSession(
-          thinkit_switch1, gnmi_config, p4info, metadata);
-    });
-    std::future<T> future2 = std::async(std::launch::async, [&] {
-      return ConfigureSwitchAndReturnP4RuntimeSession(
-          thinkit_switch2, gnmi_config, p4info, metadata);
-    });
-    session1 = future1.get();
-    session2 = future2.get();
-  }
-  RETURN_IF_ERROR(session1.status()).SetPrepend()
-      << "failed to configure switch '" << thinkit_switch1.ChassisName()
-      << "': ";
-  RETURN_IF_ERROR(session2.status()).SetPrepend()
-      << "failed to configure switch '" << thinkit_switch2.ChassisName()
-      << "': ";
-  return std::make_pair(std::move(*session1), std::move(*session2));
-}
-
-absl::Status ConfigureSwitchPair(
-    thinkit::Switch& thinkit_switch1, thinkit::Switch& thinkit_switch2,
-    const std::optional<absl::string_view>& gnmi_config,
-    const std::optional<p4::config::v1::P4Info>& p4info,
-    const pdpi::P4RuntimeSessionOptionalArgs& metadata) {
-  return ConfigureSwitchPairAndReturnP4RuntimeSessionPair(
-             thinkit_switch1, thinkit_switch2, std::move(gnmi_config),
-             std::move(p4info), metadata)
-      .status();
-}
-
-absl::Status MirrorSutP4rtPortIdConfigToControlSwitch(
-    thinkit::MirrorTestbed& testbed,
-    absl::Duration config_convergence_timeout_per_switch) {
-  ASSIGN_OR_RETURN(std::unique_ptr<gnmi::gNMI::StubInterface> sut_gnmi_stub,
-                   testbed.Sut().CreateGnmiStub());
-  ASSIGN_OR_RETURN(std::unique_ptr<gnmi::gNMI::StubInterface> control_gnmi_stub,
-                   testbed.ControlSwitch().CreateGnmiStub());
-
-  ASSIGN_OR_RETURN(const pins_test::openconfig::Interfaces sut_interfaces,
-                   pins_test::GetInterfacesAsProto(*sut_gnmi_stub,
-                                                   gnmi::GetRequest::CONFIG));
-  RETURN_IF_ERROR(
-      pins_test::SetInterfaceP4rtIds(*control_gnmi_stub, sut_interfaces));
-
-  // Ensure that the SUT and control switch gNMI state paths have converged to
-  // match their expected configurations.
-  RETURN_IF_ERROR(pins_test::WaitForGnmiPortIdConvergence(
-                      *sut_gnmi_stub, config_convergence_timeout_per_switch))
-          .SetPrepend()
-      << "P4RT port IDs did not converge on SUT within "
-      << config_convergence_timeout_per_switch << ": ";
-  RETURN_IF_ERROR(
-      pins_test::WaitForGnmiPortIdConvergence(
-          *control_gnmi_stub, config_convergence_timeout_per_switch))
-          .SetPrepend()
-      << "P4RT port IDs did not converge on control switch within "
-      << config_convergence_timeout_per_switch << ": ";
-  return absl::OkStatus();
-}
-
-// Reads the enabled interfaces from the switch and waits up to `timeout` until
-// they are all up. Calls `on_failure` prior to returning status if it is not
-// OK.
-absl::Status WaitForEnabledInterfacesToBeUp(
-    thinkit::Switch& thinkit_switch, absl::Duration timeout,
-    std::optional<
-        std::function<void(const openconfig::Interfaces& enabled_interfaces)>>
-        on_failure) {
-  absl::Time start = absl::Now();
-  ASSIGN_OR_RETURN(std::unique_ptr<gnmi::gNMI::StubInterface> gnmi_stub,
-                   thinkit_switch.CreateGnmiStub());
-
-  // Get all enabled interfaces from the config.
-  ASSIGN_OR_RETURN(const pins_test::openconfig::Interfaces enabled_interfaces,
-                   pins_test::GetMatchingInterfacesAsProto(
-                       *gnmi_stub, gnmi::GetRequest::CONFIG,
-                       /*predicate=*/
-                       [](const openconfig::Interfaces::Interface& interface) {
-                         return interface.config().enabled();
-                       },
-                       timeout));
-
-  std::vector<std::string> enabled_interface_names;
-  enabled_interface_names.reserve(enabled_interfaces.interfaces_size());
-  for (const auto& interface : enabled_interfaces.interfaces())
-    enabled_interface_names.push_back(interface.name());
-
-  // Wait for all enabled interfaces to be up.
-  timeout = timeout - (absl::Now() - start);
-  if (on_failure.has_value()) {
-    return pins_test::OnFailure(
-        pins_test::WaitForCondition(pins_test::PortsUp, timeout, thinkit_switch,
-                                    enabled_interface_names,
-                                    /*with_healthz=*/false),
-        /*on_failure=*/[&]() { (*on_failure)(enabled_interfaces); });
-  }
-  return pins_test::WaitForCondition(pins_test::PortsUp, timeout,
-                                     thinkit_switch, enabled_interface_names,
-                                     /*with_healthz=*/false);
-}
-
-// Gets every P4runtime port used in `entries`.
-absl::StatusOr<absl::btree_set<P4rtPortId>> GetPortsUsed(
-    const pdpi::IrP4Info& info, std::vector<pdpi::IrTableEntry> entries) {
-  absl::btree_set<P4rtPortId> ports;
-  p4::config::v1::P4NamedType port_type;
-  port_type.set_name(kPortNamedType);
-  RETURN_IF_ERROR(pdpi::VisitValuesOfType(
-      info, port_type, entries,
-      /*visitor=*/[&](absl::string_view string_port) -> absl::Status {
-        ASSIGN_OR_RETURN(P4rtPortId port,
-                         P4rtPortId::MakeFromP4rtEncoding(string_port));
-        ports.insert(port);
-        return absl::OkStatus();
-      }));
-
-  // Watch ports do not have a named type, but we still consider them ports so
-  // we have to deal with them specifically rather than using the generic
-  // function above.
-  for (pdpi::IrTableEntry& entry : entries) {
-    if (entry.has_action_set()) {
-      for (const auto& action : entry.action_set().actions()) {
-        if (!action.watch_port().empty()) {
-          ASSIGN_OR_RETURN(P4rtPortId port, P4rtPortId::MakeFromP4rtEncoding(
-                                                action.watch_port()));
-          ports.insert(port);
-        }
-      }
-    }
-  }
-
-  return ports;
-}
-
-// Remaps ports in a round-robin fashion, but starts by fixing those that are
-// both used in `entries` and in `ports`.
-absl::Status RewritePortsInTableEntries(
-    const pdpi::IrP4Info& info, absl::Span<const P4rtPortId> new_ports,
-    std::vector<pdpi::IrTableEntry>& entries) {
-  if (new_ports.empty()) {
-    return absl::InvalidArgumentError("`new_ports` may not be empty");
-  }
-
-  // We get the ports used in the original entries so we can preserve any that
-  // exist in both, and then remap them in a round-robin fashion.
-  ASSIGN_OR_RETURN(absl::btree_set<P4rtPortId> ports_used_originally,
-                   GetPortsUsed(info, entries));
-
-  absl::flat_hash_map<P4rtPortId, P4rtPortId> old_to_new_port_id;
-  // Queue of which new port to map an old port to next.
-  std::deque<P4rtPortId> new_port_queue;
-
-  for (const P4rtPortId& new_port : new_ports) {
-    if (ports_used_originally.contains(new_port)) {
-      // Make sure that existing ports are preserved and add them to the back of
-      // the queue for balancing.
-      old_to_new_port_id[new_port] = new_port;
-      new_port_queue.push_back(new_port);
-    } else {
-      new_port_queue.push_front(new_port);
-    }
-  }
-
-  // Map all old ports to new ports.
-  for (const auto& old_port : ports_used_originally) {
-    // If a port is already mapped, we should not remap it.
-    if (old_to_new_port_id.contains(old_port)) continue;
-    P4rtPortId new_port = std::move(new_port_queue.front());
-    new_port_queue.pop_front();
-    new_port_queue.push_back(new_port);
-    old_to_new_port_id[old_port] = new_port;
-  }
-
-  return RewritePortsInTableEntries(info, entries, old_to_new_port_id);
-}
-
-absl::Status RewritePortsInTableEntries(
-    const pdpi::IrP4Info& info, absl::string_view gnmi_config,
-    std::vector<pdpi::IrTableEntry>& entries) {
-  ASSIGN_OR_RETURN(absl::btree_set<std::string> valid_port_ids_set,
-                   GetAllPortIds(gnmi_config));
-
-  if (valid_port_ids_set.empty()) {
-    return absl::InvalidArgumentError(
-        "given gnmi_config had no valid port ids");
-  }
-
-  std::vector<P4rtPortId> new_ports;
-  new_ports.reserve(valid_port_ids_set.size());
-  for (const std::string& port_id : valid_port_ids_set) {
-    ASSIGN_OR_RETURN(new_ports.emplace_back(),
-                     P4rtPortId::MakeFromP4rtEncoding(port_id));
-  }
-
-  return RewritePortsInTableEntries(info, new_ports, entries);
-}
-
-absl::Status RewritePortsInTableEntriesToEnabledEthernetPorts(
-    const pdpi::IrP4Info& info, gnmi::gNMI::StubInterface& gnmi_stub,
-    std::vector<pdpi::IrTableEntry>& entries) {
-  ASSIGN_OR_RETURN(std::vector<P4rtPortId> valid_port_ids,
-                   pins_test::GetMatchingP4rtPortIds(
-                       gnmi_stub, pins_test::IsEnabledEthernetInterface));
-
-  if (valid_port_ids.empty()) {
-    return absl::InvalidArgumentError(
-        "no enabled, ethernet ports were mapped on the switch");
-  }
-
-  return RewritePortsInTableEntries(info, valid_port_ids, entries);
-}
-
-absl::Status ConfigureSwitch(
-    thinkit::Switch& thinkit_switch, const PinsConfigView& config,
-    const pdpi::P4RuntimeSessionOptionalArgs& metadata) {
-  return gutil::StatusBuilder(
-             ConfigureSwitchAndReturnP4RuntimeSession(
-                 thinkit_switch, config.gnmi_config, config.p4info, metadata)
-                 .status())
-             .SetPrepend()
-         << "failed to configure switch '" << thinkit_switch.ChassisName()
-         << "': ";
-}
-
-absl::Status ConfigureSwitchPair(
-    thinkit::Switch& switch1, const PinsConfigView& config1,
-    thinkit::Switch& switch2, const PinsConfigView& config2,
-    const pdpi::P4RuntimeSessionOptionalArgs& metadata) {
-  // We configure both switches in parallel, since it may require rebooting the
-  // switch which is costly.
-  std::future<absl::Status> future1 = std::async(std::launch::async, [&] {
-    return ConfigureSwitch(switch1, config1, metadata);
-  });
-  std::future<absl::Status> future2 = std::async(std::launch::async, [&] {
-    return ConfigureSwitch(switch2, config2, metadata);
-  });
-  absl::Status status = future1.get();
-  status.Update(future2.get());
-  return status;
-}
-
-namespace {
-absl::StatusOr<absl::btree_map<std::string, P4rtPortId>> UpPorts(
-    gnmi::gNMI::StubInterface& gnmi_stub) {
-  ASSIGN_OR_RETURN(const auto interface_id_map,
-                   GetAllInterfaceNameToPortId(gnmi_stub));
   ASSIGN_OR_RETURN(
-      const auto up_interfaces,
-      GetUpInterfacesOverGnmi(gnmi_stub, InterfaceType::kSingleton));
+      std::unique_ptr<pdpi::P4RuntimeSession> session,
+      CreateP4RuntimeSessionAndClearExistingState(thinkit_switch, metadata));
 
-  absl::btree_map<std::string, P4rtPortId> ports;
-  for (const std::string& interface : up_interfaces) {
-    auto lookup = interface_id_map.find(interface);
-    if (lookup == interface_id_map.end()) {
-      return gutil::NotFoundErrorBuilder()
-             << "Interface '"
-             << interface << "' was reported up but has no port id mapping.";
-    }
-    ASSIGN_OR_RETURN(P4rtPortId port_id,
-                     P4rtPortId::MakeFromP4rtEncoding(lookup->second));
-    ports.insert(std::make_pair(interface, std::move(port_id)));
-  }
-  return ports;
-}
-}  // namespace
-
-absl::StatusOr<std::vector<MirroredPort>> MirroredPorts(
-    thinkit::MirrorTestbed& testbed) {
-  ASSIGN_OR_RETURN(auto sut_gnmi_stub, testbed.Sut().CreateGnmiStub());
-  ASSIGN_OR_RETURN(auto control_switch_gnmi_stub,
-                   testbed.ControlSwitch().CreateGnmiStub());
-
-  return MirroredPorts(*sut_gnmi_stub, *control_switch_gnmi_stub);
+  RETURN_IF_ERROR(PushGnmiAndWaitForConvergence(thinkit_switch,
+                                                gnmi_config, /*gnmi_timeout=*/
+                                                absl::Minutes(1)));
+  RETURN_IF_ERROR(
+      SetForwardingPipelineConfigAndAssureClearedTables(session.get(), p4info));
+  return session;
 }
 
-absl::StatusOr<std::vector<MirroredPort>> MirroredPorts(
-    gnmi::gNMI::StubInterface& sut_gnmi_stub,
-    gnmi::gNMI::StubInterface& control_switch_gnmi_stub) {
-  ASSIGN_OR_RETURN(auto sut_ports, UpPorts(sut_gnmi_stub),
-                   _ << "Failed to lookup operational ports from the SUT.");
-
+absl::StatusOr<std::unique_ptr<pdpi::P4RuntimeSession>>
+ConfigureSwitchAndReturnP4RuntimeSessionWithoutP4InfoPush(
+    thinkit::Switch& thinkit_switch, const std::string& gnmi_config,
+    const pdpi::P4RuntimeSessionOptionalArgs& metadata) {
+  // Since the gNMI Config push relies on tables being cleared, we construct a
+  // P4RuntimeSession and clear the tables first.
   ASSIGN_OR_RETURN(
-      auto control_switch_ports, UpPorts(control_switch_gnmi_stub),
-      _ << "Failed to lookup operational ports from the Control Switch.");
-  std::vector<MirroredPort> mirrored_ports;
-  for (const auto& [interface, port] : control_switch_ports) {
-    auto lookup = sut_ports.find(interface);
-    if (lookup == sut_ports.end()) continue;
-    mirrored_ports.push_back({
-        .interface = interface,
-        .sut = lookup->second,
-        .control_switch = port,
-    });
-  }
-  return mirrored_ports;
+      std::unique_ptr<pdpi::P4RuntimeSession> session,
+      CreateP4RuntimeSessionAndClearExistingState(thinkit_switch, metadata));
+
+  RETURN_IF_ERROR(PushGnmiAndWaitForConvergence(thinkit_switch,
+                                                gnmi_config, /*gnmi_timeout=*/
+                                                absl::Minutes(1)));
+  return session;
 }
 
 }  // namespace pins_test

--- a/tests/lib/switch_test_setup_helpers.h
+++ b/tests/lib/switch_test_setup_helpers.h
@@ -1,0 +1,41 @@
+#ifndef PINS_TESTS_LIB_SWITCH_TEST_SETUP_HELPERS_H_
+#define PINS_TESTS_LIB_SWITCH_TEST_SETUP_HELPERS_H_
+
+#include <memory>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4_pdpi/p4_runtime_session.h"
+#include "thinkit/switch.h"
+namespace pins_test {
+
+// Configures the switch and sets up a P4 Runtime Session. If you don't have
+// particular requirements, this is likely the function you want to use.
+// Specifically:
+// * Creates a session.
+// * Clears all tables.
+// * Pushes the given `gnmi_config` and waits for the switch to converge.
+// * Push the given P4Info via RECONCILE_AND_COMMIT.
+absl::StatusOr<std::unique_ptr<pdpi::P4RuntimeSession>>
+ConfigureSwitchAndReturnP4RuntimeSession(
+    thinkit::Switch& thinkit_switch, const std::string& gnmi_config,
+    const p4::config::v1::P4Info& p4info,
+    const pdpi::P4RuntimeSessionOptionalArgs& metadata = {});
+
+// Configures the switch and sets up a P4 Runtime Session without pushing a
+// P4Info. Specifically:
+// * Creates a session.
+// * Clears all tables.
+// * Pushes the given `gnmi_config` and waits for the switch to converge.
+// NOTE: Prefer ConfigureSwitchAndReturnP4RuntimeSession over this function
+// unless you have special requirements for your P4Info push.
+absl::StatusOr<std::unique_ptr<pdpi::P4RuntimeSession>>
+ConfigureSwitchAndReturnP4RuntimeSessionWithoutP4InfoPush(
+    thinkit::Switch& thinkit_switch, const std::string& gnmi_config,
+    const pdpi::P4RuntimeSessionOptionalArgs& metadata = {});
+
+}  // namespace pins_test
+
+#endif  // PINS_TESTS_LIB_SWITCH_TEST_SETUP_HELPERS_H_


### PR DESCRIPTION
PR Description:
Add auxiliary function for switch and P4RT configuration.

Keyword Check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/Google/tools/keyword_checks.sh .
Keyword check Passed.

Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 384 targets (0 packages loaded, 0 targets configured).
INFO: Found 384 targets...
INFO: Elapsed time: 0.617s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 

UT Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 384 targets (0 packages loaded, 0 targets configured).
INFO: Found 252 targets and 132 test targets...
INFO: Elapsed time: 97.986s, Critical Path: 16.62s
INFO: 137 processes: 144 linux-sandbox, 17 local.
INFO: Build completed successfully, 137 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 0.8s
//lib:basic_switch_test                                                  PASSED in 0.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.9s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 0.9s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 0.7s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.9s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.6s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.6s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 9.3s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.7s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.7s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.2s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.7s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.7s
//p4rt_app/tests:action_set_test                                         PASSED in 1.3s
//p4rt_app/tests:api_access_test                                         PASSED in 1.1s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.2s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.8s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.1s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.2s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 6.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.0s
//p4rt_app/tests:packetio_test                                           PASSED in 4.1s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.7s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.8s
//p4rt_app/tests:response_path_test                                      PASSED in 4.9s
//p4rt_app/tests:role_test                                               PASSED in 1.3s
//p4rt_app/tests:state_verification_test                                 PASSED in 3.1s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.9s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 2.5s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.8s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 3.8s
  Stats over 5 runs: max = 3.8s, min = 1.0s, avg = 1.8s, dev = 1.1s

Executed 132 out of 132 tests: 132 tests pass.
INFO: Build completed successfully, 137 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 