### PR TITLE
[Thinkit] Improve timing robustness of unit tests. Improve error messages for WaitForCondition.E xtend with a function to get a mapping from all interfaces enabled in the config to their p4rt ports.

### DIFF
--- a/lib/gnmi/BUILD.bazel
+++ b/lib/gnmi/BUILD.bazel
@@ -25,6 +25,8 @@ cc_library(
     srcs = ["gnmi_helper.cc"],
     hdrs = ["gnmi_helper.h"],
     deps = [
+        ":openconfig_cc_proto",
+        "//gutil:proto",
         "//gutil:status",
         "//p4_pdpi:p4_runtime_session",
         "//thinkit:switch",

--- a/lib/gnmi/gnmi_helper.h
+++ b/lib/gnmi/gnmi_helper.h
@@ -204,6 +204,12 @@ GetAllInterfaceNameToPortId(absl::string_view gnmi_config);
 absl::StatusOr<absl::flat_hash_map<std::string, std::string>>
 GetAllInterfaceNameToPortId(gnmi::gNMI::StubInterface& stub);
 
+// Reads the gNMI config from the switch and returns a map of all enabled
+// interfaces to their p4rt port id.
+absl::StatusOr<absl::flat_hash_map<std::string, std::string>>
+GetAllEnabledInterfaceNameToPortId(gnmi::gNMI::StubInterface& stub,
+                                   absl::Duration timeout = absl::Seconds(60));
+
 // Returns the ordered set of all port ids mapped by the given gNMI config.
 absl::StatusOr<absl::btree_set<std::string>> GetAllPortIds(
     absl::string_view gnmi_config);


### PR DESCRIPTION
PR Description:
Improve timing robustness of unit tests.
Improve error messages for WaitForCondition.E
xtend with a function to get a mapping from all interfaces enabled in the config to their p4rt ports.

Keyword Check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/Google/tools/keyword_checks.sh .
Keyword check Passed.

Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 385 targets (1 packages loaded, 23 targets configured).
INFO: Found 385 targets...
INFO: Elapsed time: 1.107s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 

UT Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 385 targets (0 packages loaded, 287 targets configured).
INFO: Found 252 targets and 133 test targets...
INFO: Elapsed time: 119.597s, Critical Path: 16.41s
INFO: 138 processes: 145 linux-sandbox, 17 local.
INFO: Build completed successfully, 138 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.6s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.8s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 6.8s
//lib:basic_switch_test                                                  PASSED in 0.8s
//lib:ixia_helper_test                                                   PASSED in 0.9s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.6s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 0.9s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 0.7s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.9s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.4s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 9.4s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 2.7s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.2s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 1.1s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 1.1s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 1.0s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.7s
//p4rt_app/tests:action_set_test                                         PASSED in 1.3s
//p4rt_app/tests:api_access_test                                         PASSED in 1.1s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.8s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.2s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 6.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.3s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.3s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.0s
//p4rt_app/tests:packetio_test                                           PASSED in 4.1s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.1s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.9s
//p4rt_app/tests:response_path_test                                      PASSED in 3.5s
//p4rt_app/tests:role_test                                               PASSED in 1.4s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.5s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.8s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.6s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 2.9s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.7s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.8s
//thinkit:bazel_test_environment_test                                    PASSED in 0.7s
//thinkit:generic_testbed_test                                           PASSED in 0.8s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.0s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 12.9s
  Stats over 5 runs: max = 12.9s, min = 0.9s, avg = 7.6s, dev = 5.4s

Executed 133 out of 133 tests: 133 tests pass.
INFO: Build completed successfully, 138 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$