### PR TITLE
[Thinkit] Adding p4rt port test file.

### DIFF
--- a/lib/p4rt/BUILD.bazel
+++ b/lib/p4rt/BUILD.bazel
@@ -18,20 +18,6 @@ package(
 )
 
 cc_library(
-    name = "p4rt_port",
-    srcs = ["p4rt_port.cc"],
-    hdrs = ["p4rt_port.h"],
-    deps = [
-        "//p4_pdpi/string_encodings:decimal_string",
-        "@com_google_absl//absl/status",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/strings:str_format",
-        "@com_google_absl//absl/types:span",
-    ],
-)
-
-cc_library(
     name = "packet_listener",
     testonly = 1,
     srcs = ["packet_listener.cc"],
@@ -81,6 +67,30 @@ cc_test(
         "//p4_pdpi:p4_runtime_session",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
         "@com_google_absl//absl/status",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "p4rt_port",
+    srcs = ["p4rt_port.cc"],
+    hdrs = ["p4rt_port.h"],
+    deps = [
+        "//p4_pdpi/string_encodings:decimal_string",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_test(
+    name = "p4rt_port_test",
+    srcs = ["p4rt_port_test.cc"],
+    deps = [
+        ":p4rt_port",
+        "//gutil:status_matchers",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/lib/p4rt/p4rt_port_test.cc
+++ b/lib/p4rt/p4rt_port_test.cc
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "lib/p4rt/p4rt_port.h"
+
+#include <cstdint>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status_matchers.h"
+
+namespace pins_test {
+namespace {
+
+using ::gutil::IsOk;
+using ::gutil::IsOkAndHolds;
+using ::testing::Eq;
+using ::testing::Not;
+
+TEST(P4rtPortId, RoundtripsFromInt) {
+  constexpr int kP4rtPortIdInt = 42;
+  const std::string kP4rtPortIdString = "42";
+  P4rtPortId port_id = P4rtPortId::MakeFromOpenConfigEncoding(kP4rtPortIdInt);
+  EXPECT_EQ(port_id.GetOpenConfigEncoding(), kP4rtPortIdInt);
+  EXPECT_EQ(port_id.GetP4rtEncoding(), kP4rtPortIdString);
+  EXPECT_THAT(P4rtPortId::MakeFromP4rtEncoding(port_id.GetP4rtEncoding()),
+              IsOkAndHolds(Eq(port_id)));
+}
+
+TEST(P4rtPortId, RoundtripsFromString) {
+  constexpr int kP4rtPortIdInt = 42;
+  const std::string kP4rtPortIdString = "42";
+  ASSERT_OK_AND_ASSIGN(P4rtPortId port_id,
+                       P4rtPortId::MakeFromP4rtEncoding(kP4rtPortIdString));
+  EXPECT_EQ(port_id.GetOpenConfigEncoding(), kP4rtPortIdInt);
+  EXPECT_EQ(port_id.GetP4rtEncoding(), kP4rtPortIdString);
+  EXPECT_EQ(
+      P4rtPortId::MakeFromOpenConfigEncoding(port_id.GetOpenConfigEncoding()),
+      port_id);
+}
+
+TEST(P4rtPortId, PointwiseIntEquivalence) {
+  const std::vector<uint32_t> kP4rtPortIdIntSpan = {42, 3, 500};
+  std::vector<P4rtPortId> port_ids_from_vector_function =
+      P4rtPortId::MakeVectorFromOpenConfigEncodings(kP4rtPortIdIntSpan);
+  std::vector<P4rtPortId> port_ids_from_single_function;
+  for (uint32_t port_id : kP4rtPortIdIntSpan) {
+    port_ids_from_single_function.push_back(
+        P4rtPortId::MakeFromOpenConfigEncoding(port_id));
+  }
+  EXPECT_EQ(port_ids_from_vector_function, port_ids_from_single_function);
+}
+
+TEST(P4rtPortId, PointwiseStringEquivalence) {
+  const std::vector<std::string> kP4rtPortIdStringSpan = {"42", "3", "500"};
+  ASSERT_OK_AND_ASSIGN(
+      std::vector<P4rtPortId> port_ids_from_vector_function,
+      P4rtPortId::MakeVectorFromP4rtEncodings(kP4rtPortIdStringSpan));
+  std::vector<P4rtPortId> port_ids_from_single_function;
+  for (absl::string_view port_id_string : kP4rtPortIdStringSpan) {
+    ASSERT_OK_AND_ASSIGN(P4rtPortId port_id,
+                         P4rtPortId::MakeFromP4rtEncoding(port_id_string));
+    port_ids_from_single_function.push_back(port_id);
+  }
+  EXPECT_EQ(port_ids_from_vector_function, port_ids_from_single_function);
+}
+
+TEST(P4rtPortId, InvalidFromString) {
+  EXPECT_THAT(P4rtPortId::MakeFromP4rtEncoding("not a decimal string"),
+              Not(IsOk()));
+  EXPECT_THAT(P4rtPortId::MakeFromP4rtEncoding("-1"), Not(IsOk()));
+  EXPECT_THAT(P4rtPortId::MakeFromP4rtEncoding("99999999999999999999999999999"),
+              Not(IsOk()));
+}
+
+TEST(P4rtPortId, Comparisons) {
+  P4rtPortId port_id_big = P4rtPortId::MakeFromOpenConfigEncoding(42);
+  P4rtPortId port_id_medium = P4rtPortId::MakeFromOpenConfigEncoding(21);
+  P4rtPortId port_id_small = P4rtPortId::MakeFromOpenConfigEncoding(1);
+  EXPECT_LT(port_id_small, port_id_medium);
+  EXPECT_LT(port_id_medium, port_id_big);
+}
+
+}  // namespace
+}  // namespace pins_test


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 386 targets (0 packages loaded, 0 targets configured).
INFO: Found 386 targets...
INFO: From Compiling lib/basic_traffic/basic_traffic.cc:
...
INFO: Elapsed time: 22.059s, Critical Path: 19.72s
INFO: 13 processes: 3 internal, 10 linux-sandbox.
INFO: Build completed successfully, 13 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 386 targets (0 packages loaded, 288 targets configured).
INFO: Found 252 targets and 134 test targets...
INFO: Elapsed time: 85.544s, Critical Path: 22.26s
INFO: 139 processes: 146 linux-sandbox, 17 local.
INFO: Build completed successfully, 139 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 1.3s
//gutil:proto_matchers_test                                              PASSED in 1.3s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.6s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 0.7s
//lib:basic_switch_test                                                  PASSED in 0.8s
//lib:ixia_helper_test                                                   PASSED in 0.9s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.0s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 0.8s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:switch_state_test                                            PASSED in 0.8s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.6s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.4s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.0s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.9s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 1.5s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 1.2s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.9s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.8s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.5s
//p4rt_app/tests:action_set_test                                         PASSED in 1.2s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.2s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.7s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.1s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 4.0s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.9s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.6s
//p4rt_app/tests:packetio_test                                           PASSED in 3.7s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.4s
//p4rt_app/tests:resource_limits_test                                    PASSED in 2.8s
//p4rt_app/tests:response_path_test                                      PASSED in 2.8s
//p4rt_app/tests:role_test                                               PASSED in 1.2s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.8s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.6s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.2s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.4s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 1.4s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 22.2s
  Stats over 5 runs: max = 22.2s, min = 3.5s, avg = 14.2s, dev = 7.2s

Executed 134 out of 134 tests: 134 tests pass.
INFO: Build completed successfully, 139 total actions
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ 