### PR TITLE
[Comb] Move utilities to common libraries & Add provision to pass in ingress and egress ports.

### DIFF
--- a/lib/gnmi/gnmi_helper.cc
+++ b/lib/gnmi/gnmi_helper.cc
@@ -1016,4 +1016,70 @@ GetInterfaceToLaneSpeedMap(gnmi::gNMI::StubInterface& gnmi_stub) {
   return interface_to_lane_speed;
 }
 
+absl::Status SetPortSpeedInBitsPerSecond(const std::string& port_speed,
+                                         const std::string& interface_name,
+                                         gnmi::gNMI::StubInterface& gnmi_stub) {
+  std::string ops_config_path =
+      absl::StrCat("interfaces/interface[name=", interface_name,
+                   "]/ethernet/config/port-speed");
+  std::string ops_val =
+      absl::StrCat("{\"openconfig-if-ethernet:port-speed\":", port_speed, "}");
+
+  RETURN_IF_ERROR(pins_test::SetGnmiConfigPath(&gnmi_stub, ops_config_path,
+                                               GnmiSetType::kUpdate, ops_val));
+
+  return absl::OkStatus();
+}
+
+absl::StatusOr<int64_t> GetPortSpeedInBitsPerSecond(
+    const std::string& interface_name, gnmi::gNMI::StubInterface& gnmi_stub) {
+  // Map keyed on openconfig speed string to value in bits per second.
+  // http://ops.openconfig.net/branches/models/master/docs/openconfig-interfaces.html#mod-openconfig-if-ethernet
+  const auto kPortSpeedTable =
+      absl::flat_hash_map<absl::string_view, uint64_t>({
+          {"openconfig-if-ethernet:SPEED_100GB", 100000000000},
+          {"openconfig-if-ethernet:SPEED_200GB", 200000000000},
+          {"openconfig-if-ethernet:SPEED_400GB", 400000000000},
+      });
+  std::string speed_state_path =
+      absl::StrCat("interfaces/interface[name=", interface_name,
+                   "]/ethernet/state/port-speed");
+
+  std::string parse_str = "openconfig-if-ethernet:port-speed";
+  ASSIGN_OR_RETURN(
+      std::string response,
+      GetGnmiStatePathInfo(&gnmi_stub, speed_state_path, parse_str));
+
+  auto speed = kPortSpeedTable.find(StripQuotes(response));
+  if (speed == kPortSpeedTable.end()) {
+    return absl::NotFoundError(response);
+  }
+  return speed->second;
+}
+
+absl::Status SetPortMtu(int port_mtu, const std::string& interface_name,
+                        gnmi::gNMI::StubInterface& gnmi_stub) {
+  std::string config_path = absl::StrCat(
+      "interfaces/interface[name=", interface_name, "]/config/mtu");
+  std::string value = absl::StrCat("{\"config:mtu\":", port_mtu, "}");
+
+  RETURN_IF_ERROR(pins_test::SetGnmiConfigPath(&gnmi_stub, config_path,
+                                               GnmiSetType::kUpdate, value));
+
+  return absl::OkStatus();
+}
+
+absl::StatusOr<bool> CheckLinkUp(const std::string& interface_name,
+                                 gnmi::gNMI::StubInterface& gnmi_stub) {
+  std::string oper_status_state_path = absl::StrCat(
+      "interfaces/interface[name=", interface_name, "]/state/oper-status");
+
+  std::string parse_str = "openconfig-interfaces:oper-status";
+  ASSIGN_OR_RETURN(
+      std::string ops_response,
+      GetGnmiStatePathInfo(&gnmi_stub, oper_status_state_path, parse_str));
+
+  return ops_response == "\"UP\"";
+}
+
 }  // namespace pins_test

--- a/lib/gnmi/gnmi_helper.h
+++ b/lib/gnmi/gnmi_helper.h
@@ -270,5 +270,25 @@ GetTransceiverToEthernetPmdMap(gnmi::gNMI::StubInterface& gnmi_stub);
 absl::StatusOr<absl::flat_hash_map<std::string, int>>
 GetInterfaceToLaneSpeedMap(gnmi::gNMI::StubInterface& gnmi_stub);
 
+// Check if switch port link is up.
+absl::StatusOr<bool> CheckLinkUp(const std::string& interface_name,
+                                 gnmi::gNMI::StubInterface& gnmi_stub);
+// Set port speed using gNMI.
+absl::Status SetPortSpeedInBitsPerSecond(const std::string& port_speed,
+                                         const std::string& interface_name,
+                                         gnmi::gNMI::StubInterface& gnmi_stub);
+
+// Get configured port speed.
+absl::StatusOr<int64_t> GetPortSpeedInBitsPerSecond(
+    const std::string& interface_name, gnmi::gNMI::StubInterface& gnmi_stub);
+
+// Set port MTU using gNMI.
+absl::Status SetPortMtu(int port_mtu, const std::string& interface_name,
+                        gnmi::gNMI::StubInterface& gnmi_stub);
+
+// Set a port in loopback mode.
+absl::Status SetPortLoopbackMode(bool port_loopback,
+                                 absl::string_view interface_name,
+                                 gnmi::gNMI::StubInterface& gnmi_stub);
 }  // namespace pins_test
 #endif  // PINS_LIB_GNMI_GNMI_HELPER_H_

--- a/lib/ixia_helper.h
+++ b/lib/ixia_helper.h
@@ -38,6 +38,16 @@ struct IxiaPortInfo {
   std::string port;
 };
 
+// Structure represents a link between SUT and Ixia.
+// This is represented by Ixia interface name and the SUT's gNMI interface
+// name.
+struct IxiaLink {
+  std::string ixia_interface;
+  std::string sut_interface;
+  // Speed of the SUT interface in bits/second.
+  int64_t sut_interface_bits_per_second = 0;
+};
+
 // ExtractHref - Extract the href path from the Ixia response provided as
 // input.  Returns either the href string or an error.
 absl::StatusOr<std::string> ExtractHref(thinkit::HttpResponse &resp);
@@ -309,6 +319,21 @@ inline double BytesPerSecondReceived(const TrafficItemStats &stats) {
 // Return Unavailable error if the stats are not ready yet.
 absl::StatusOr<TrafficStats> ParseTrafficItemStats(absl::string_view raw_stats);
 
+// Go over the connections and return vector of connections
+// whose links are up.
+absl::StatusOr<std::vector<IxiaLink>> GetReadyIxiaLinks(
+    thinkit::GenericTestbed &generic_testbed,
+    gnmi::gNMI::StubInterface &gnmi_stub);
+
+// Returns Ixia link information for requested `port` on switch connected to
+// Ixia. Returns failure status if Ixia link information is not found.
+absl::StatusOr<IxiaLink> GetIxiaLink(thinkit::GenericTestbed &generic_testbed,
+                                     gnmi::gNMI::StubInterface &gnmi_stub,
+                                     const std::string &switch_port);
+
+// Connects to Ixia on the given testbed and returns a string handle identifying
+// the connection (aka "topology ref").
+absl::StatusOr<std::string> ConnectToIxia(thinkit::GenericTestbed &testbed);
 }  // namespace pins_test::ixia
 
 #endif  // PINS_THINKIT_IXIA_INTERFACE_H_


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 385 targets (0 packages loaded, 0 targets configured).
INFO: Found 385 targets...
...
INFO: Elapsed time: 101.438s, Critical Path: 28.15s
INFO: 24 processes: 3 internal, 21 linux-sandbox.
INFO: Build completed successfully, 24 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 385 targets (0 packages loaded, 287 targets configured).
INFO: Found 252 targets and 133 test targets...
INFO: Elapsed time: 67.797s, Critical Path: 16.35s
INFO: 138 processes: 145 linux-sandbox, 17 local.
INFO: Build completed successfully, 138 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.7s
//gutil:proto_ordering_test                                              PASSED in 0.6s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.6s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 0.8s
//lib:basic_switch_test                                                  PASSED in 0.8s
//lib:ixia_helper_test                                                   PASSED in 0.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.9s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 0.9s
//lib/utils:json_utils_test                                              PASSED in 0.6s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 0.8s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.8s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.9s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.7s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.6s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.3s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.2s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.5s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 2.7s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 1.0s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.7s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.6s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.7s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.2s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 1.0s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.8s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.8s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 1.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.5s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 4.0s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.7s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.6s
//p4rt_app/tests:packetio_test                                           PASSED in 3.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.4s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.7s
//p4rt_app/tests:response_path_test                                      PASSED in 2.8s
//p4rt_app/tests:role_test                                               PASSED in 1.2s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.8s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.6s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.0s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.2s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.7s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.2s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.9s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 11.8s
  Stats over 5 runs: max = 11.8s, min = 1.0s, avg = 3.2s, dev = 4.3s

Executed 133 out of 133 tests: 133 tests pass.
INFO: Build completed successfully, 138 total actions
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ 