### PR TITLE
[Comb] Make neighbor_id an IPv6 address and update tunnels to refer to it properly. Adding basic_p4rt_util_test to basic_traffic.

### DIFF
--- a/lib/basic_traffic/BUILD.bazel
+++ b/lib/basic_traffic/BUILD.bazel
@@ -42,6 +42,22 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "basic_p4rt_util_test",
+    srcs = ["basic_p4rt_util_test.cc"],
+    deps = [
+        ":basic_p4rt_util",
+        "//gutil:proto_matchers",
+        "//gutil:status_matchers",
+        "//p4_pdpi:p4_runtime_session",
+        "//sai_p4/instantiations/google:instantiations",
+        "//sai_p4/instantiations/google:sai_p4info_cc",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/status",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "basic_traffic",
     srcs = ["basic_traffic.cc"],

--- a/lib/basic_traffic/basic_p4rt_util.cc
+++ b/lib/basic_traffic/basic_p4rt_util.cc
@@ -116,14 +116,14 @@ absl::Status ProgramIPv4Route(
                 neighbor_table_entry {
                   match {
                     router_interface_id: "traffic-router-interface-$0"
-                    neighbor_id: "$1"
+                    neighbor_id: "fe80::21a:11ff:fe17:0080"
                   }
                   action { set_dst_mac { dst_mac: "00:1A:11:17:00:80" } }
                 }
               }
             }
           )pb",
-          port_id, PortIdToIP(port_id))));
+          port_id)));
   RETURN_IF_ERROR(
       WritePdWriteRequest(write_request, ir_p4info, neighbor_request))
       << "Error writing neighbor entry request.";
@@ -140,14 +140,14 @@ absl::Status ProgramIPv4Route(
                   action {
                     set_ip_nexthop {
                       router_interface_id: "traffic-router-interface-$0"
-                      neighbor_id: "$1"
+                      neighbor_id: "fe80::21a:11ff:fe17:0080"
                     }
                   }
                 }
               }
             }
           )pb",
-          port_id, PortIdToIP(port_id))));
+          port_id)));
   RETURN_IF_ERROR(
       WritePdWriteRequest(write_request, ir_p4info, nexthop_request))
       << "Error writing nexthop entry request.";

--- a/lib/basic_traffic/basic_p4rt_util_test.cc
+++ b/lib/basic_traffic/basic_p4rt_util_test.cc
@@ -1,0 +1,237 @@
+// Copyright (c) 2024, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lib/basic_traffic/basic_p4rt_util.h"
+
+#include "absl/status/status.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/proto_matchers.h"
+#include "gutil/status_matchers.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/p4_runtime_session.h"
+#include "sai_p4/instantiations/google/instantiations.h"
+#include "sai_p4/instantiations/google/sai_p4info.h"
+
+namespace pins_test::basic_traffic {
+namespace {
+
+using ::gutil::EqualsProto;
+using ::testing::_;
+using ::testing::MockFunction;
+using ::testing::Return;
+
+TEST(BasicTraffic, ProgramDefaultVrf) {
+  MockFunction<absl::Status(pdpi::P4RuntimeSession*, p4::v1::WriteRequest&)>
+      mock_write_request;
+  EXPECT_CALL(
+      mock_write_request,
+      Call(_, EqualsProto(R"pb(updates {
+                                 type: INSERT
+                                 entity {
+                                   table_entry {
+                                     table_id: 33554506
+                                     match {
+                                       field_id: 1
+                                       exact { value: "traffic-vrf" }
+                                     }
+                                     action { action { action_id: 24742814 } }
+                                   }
+                                 }
+                               })pb")))
+      .WillOnce(Return(absl::OkStatus()));
+  EXPECT_CALL(mock_write_request,
+              Call(_, EqualsProto(R"pb(
+                     updates {
+                       type: INSERT
+                       entity {
+                         table_entry {
+                           table_id: 33554689
+                           action {
+                             action {
+                               action_id: 16777472
+                               params { param_id: 1 value: "traffic-vrf" }
+                             }
+                           }
+                           priority: 1132
+                         }
+                       }
+                     }
+                   )pb")))
+      .WillOnce(Return(absl::OkStatus()));
+  EXPECT_OK(ProgramTrafficVrf(
+      /*session=*/nullptr, sai::GetIrP4Info(sai::Instantiation::kMiddleblock),
+      mock_write_request.AsStdFunction()));
+}
+
+TEST(BasicTraffic, ProgramRouterInterface) {
+  MockFunction<absl::Status(pdpi::P4RuntimeSession*, p4::v1::WriteRequest&)>
+      mock_write_request;
+  EXPECT_CALL(mock_write_request,
+              Call(_, EqualsProto(R"pb(
+                     updates {
+                       type: INSERT
+                       entity {
+                         table_entry {
+                           table_id: 33554497
+                           match {
+                             field_id: 1
+                             exact { value: "traffic-router-interface-5" }
+                           }
+                           action {
+                             action {
+                               action_id: 16777218
+                               params { param_id: 1 value: "5" }
+                               params { param_id: 2 value: "\005" }
+                             }
+                           }
+                         }
+                       }
+                     }
+                   )pb")))
+      .WillOnce(Return(absl::OkStatus()));
+  EXPECT_OK(
+      ProgramRouterInterface(/*session=*/nullptr, /*port_id=*/5,
+                             sai::GetIrP4Info(sai::Instantiation::kMiddleblock),
+                             mock_write_request.AsStdFunction()));
+}
+
+TEST(BasicTraffic, ProgramIPv4Route) {
+  MockFunction<absl::Status(pdpi::P4RuntimeSession*, p4::v1::WriteRequest&)>
+      mock_write_request;
+  // Neighbor entry.
+  EXPECT_CALL(
+      mock_write_request,
+      Call(
+          _, EqualsProto(R"pb(
+            updates {
+              type: INSERT
+              entity {
+                table_entry {
+                  table_id: 33554496
+                  match {
+                    field_id: 1
+                    exact { value: "traffic-router-interface-5" }
+                  }
+                  match {
+                    field_id: 2
+                    exact {
+                      value: "\376\200\000\000\000\000\000\000\002\032\021\377\376\027\000\200"
+                    }
+                  }
+                  action {
+                    action {
+                      action_id: 16777217
+                      params { param_id: 1 value: "\032\021\027\000\200" }
+                    }
+                  }
+                }
+              }
+            }
+          )pb")))
+      .WillOnce(Return(absl::OkStatus()));
+
+  // Nexthop entry.
+  EXPECT_CALL(
+      mock_write_request,
+      Call(
+          _, EqualsProto(R"pb(
+            updates {
+              type: INSERT
+              entity {
+                table_entry {
+                  table_id: 33554498
+                  match {
+                    field_id: 1
+                    exact { value: "traffic-nexthop-5" }
+                  }
+                  action {
+                    action {
+                      action_id: 16777236
+                      params { param_id: 1 value: "traffic-router-interface-5" }
+                      params {
+                        param_id: 2
+                        value: "\376\200\000\000\000\000\000\000\002\032\021\377\376\027\000\200"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          )pb")))
+      .WillOnce(Return(absl::OkStatus()));
+
+  // IPv4 table entry.
+  EXPECT_CALL(mock_write_request,
+              Call(_, EqualsProto(R"pb(
+                     updates {
+                       type: INSERT
+                       entity {
+                         table_entry {
+                           table_id: 33554500
+                           match {
+                             field_id: 1
+                             exact { value: "traffic-vrf" }
+                           }
+                           match {
+                             field_id: 2
+                             lpm { value: "\x0a\x00\x00\x05" prefix_len: 32 }
+                           }
+                           action {
+                             action {
+                               action_id: 16777221
+                               params { param_id: 1 value: "traffic-nexthop-5" }
+                             }
+                           }
+                         }
+                       }
+                     }
+                   )pb")))
+      .WillOnce(Return(absl::OkStatus()));
+  EXPECT_OK(ProgramIPv4Route(/*session=*/nullptr, /*port_id=*/5,
+                             sai::GetIrP4Info(sai::Instantiation::kMiddleblock),
+                             mock_write_request.AsStdFunction()));
+}
+
+TEST(BasicTraffic, ProgramL3AdmitTableEntry) {
+  MockFunction<absl::Status(pdpi::P4RuntimeSession*, p4::v1::WriteRequest&)>
+      mock_write_request;
+  EXPECT_CALL(
+      mock_write_request,
+      Call(_, EqualsProto(R"pb(
+             updates {
+               type: INSERT
+               entity {
+                 table_entry {
+                   table_id: 33554503
+                   match {
+                     field_id: 1
+                     ternary { value: "\000" mask: "\001\000\000\000\000\000" }
+                   }
+                   action { action { action_id: 16777224 } }
+                   priority: 1
+                   metadata: "Experimental_type: VARIOUS_L3ADMIT_PUNTFLOW"
+                 }
+               }
+             }
+           )pb")))
+      .WillOnce(Return(absl::OkStatus()));
+
+  EXPECT_OK(ProgramL3AdmitTableEntry(
+      /*session=*/nullptr, sai::GetIrP4Info(sai::Instantiation::kMiddleblock),
+      mock_write_request.AsStdFunction()));
+}
+
+}  // namespace
+}  // namespace pins_test::basic_traffic


### PR DESCRIPTION
PR Description:
Make neighbor_id an IPv6 address and update tunnels to refer to it properly. Adding basic_p4rt_util_test to basic_traffic.

Keyword Check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/Google/tools/keyword_checks.sh .
Keyword check Passed.

Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 386 targets (0 packages loaded, 0 targets configured).
INFO: Found 386 targets...
INFO: Elapsed time: 0.629s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 

UT Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 386 targets (0 packages loaded, 1 target configured).
INFO: Found 252 targets and 134 test targets...
INFO: Elapsed time: 100.437s, Critical Path: 16.49s
INFO: 139 processes: 146 linux-sandbox, 17 local.
INFO: Build completed successfully, 139 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.7s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 4.4s
//lib:basic_switch_test                                                  PASSED in 0.9s
//lib:ixia_helper_test                                                   PASSED in 0.8s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 0.9s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 0.9s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 0.8s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.9s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.6s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.5s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.9s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 3.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.0s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.1s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 1.0s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.7s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.8s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.5s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.8s
//p4rt_app/tests:action_set_test                                         PASSED in 1.3s
//p4rt_app/tests:api_access_test                                         PASSED in 2.2s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.3s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.1s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.2s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.7s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 6.1s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.3s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.0s
//p4rt_app/tests:packetio_test                                           PASSED in 4.1s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.1s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.8s
//p4rt_app/tests:response_path_test                                      PASSED in 3.7s
//p4rt_app/tests:role_test                                               PASSED in 1.3s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.3s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.1s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.2s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 12.0s
  Stats over 5 runs: max = 12.0s, min = 0.9s, avg = 3.7s, dev = 4.2s

Executed 134 out of 134 tests: 134 tests pass.
INFO: Build completed successfully, 139 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 
