### PR TITLE
[Comb] gNMI port mtu tests

### DIFF
--- a/lib/basic_traffic/basic_traffic.cc
+++ b/lib/basic_traffic/basic_traffic.cc
@@ -307,7 +307,7 @@ absl::StatusOr<std::vector<TrafficStatistic>> SendTraffic(
     while (absl::Now() - traffic_start_time < duration) {
       for (const auto& [key, packet] : packets_to_send) {
         RETURN_IF_ERROR(testbed.ControlDevice().SendPacket(
-            packet.control_interface, packet.serialized_packet));
+            packet.control_interface, packet.serialized_packet, std::nullopt));
         sent_packets[key]++;
         absl::SleepFor(absl::Seconds(1) / options.packets_per_second);
       }

--- a/lib/pins_control_device.cc
+++ b/lib/pins_control_device.cc
@@ -163,22 +163,23 @@ PinsControlDevice::CollectPackets(thinkit::PacketCallback callback) {
       });
 }
 
-absl::Status PinsControlDevice::SendPacket(absl::string_view interface,
-                                           absl::string_view packet) {
+absl::Status PinsControlDevice::SendPacket(
+    absl::string_view interface, absl::string_view packet,
+    std::optional<absl::Duration> packet_delay) {
   if (control_session_ == nullptr) {
     return absl::InternalError(
         "No P4RuntimeSession exists; Likely failed to establish another "
         "P4RuntimeSession.");
   }
-  return gpins::InjectEgressPacket(
-      interface_name_to_port_id_[interface], std::string(packet), ir_p4_info_,
-      control_session_.get(), /*packet_delay=*/std::nullopt);
+  return gpins::InjectEgressPacket(interface_name_to_port_id_[interface],
+                                   std::string(packet), ir_p4_info_,
+                                   control_session_.get(), packet_delay);
 }
 
 absl::Status PinsControlDevice::SendPackets(
     absl::string_view interface, absl::Span<const std::string> packets) {
   for (absl::string_view packet : packets) {
-    RETURN_IF_ERROR(SendPacket(interface, packet));
+    RETURN_IF_ERROR(SendPacket(interface, packet, std::nullopt));
   }
   return absl::OkStatus();
 }

--- a/lib/pins_control_device.h
+++ b/lib/pins_control_device.h
@@ -16,6 +16,7 @@
 #define PINS_LIB_PINS_CONTROL_DEVICE_H_
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "absl/container/flat_hash_map.h"
@@ -23,6 +24,7 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "diag/diag.grpc.pb.h"
 #include "p4_pdpi/p4_runtime_session.h"
@@ -56,8 +58,8 @@ class PinsControlDevice : public thinkit::ControlDevice {
   absl::StatusOr<std::unique_ptr<thinkit::PacketGenerationFinalizer>>
   CollectPackets(thinkit::PacketCallback callback) override;
 
-  absl::Status SendPacket(absl::string_view interface,
-                          absl::string_view packet) override;
+  absl::Status SendPacket(absl::string_view interface, absl::string_view packet,
+                          std::optional<absl::Duration> packet_delay) override;
 
   bool SupportsSendPacket() const override { return true; }
 

--- a/thinkit/BUILD.bazel
+++ b/thinkit/BUILD.bazel
@@ -315,6 +315,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",
     ],
 )

--- a/thinkit/control_device.h
+++ b/thinkit/control_device.h
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -24,6 +25,7 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "diag/diag.grpc.pb.h"
 #include "diag/diag.pb.h"
@@ -63,10 +65,16 @@ class ControlDevice {
   virtual absl::StatusOr<std::unique_ptr<thinkit::PacketGenerationFinalizer>>
   CollectPackets(PacketCallback callback) = 0;
 
+  absl::Status SendPacket(absl::string_view interface,
+                          absl::string_view packet) {
+    return SendPacket(interface, packet, std::nullopt);
+  }
+
   // Sends a `packet` raw byte string out of the control device’s
-  // `interface`.
-  virtual absl::Status SendPacket(absl::string_view interface,
-                                  absl::string_view packet) = 0;
+  // `interface`. Rate limits packet is packet_delay is specified.
+  virtual absl::Status SendPacket(
+      absl::string_view interface, absl::string_view packet,
+      std::optional<absl::Duration> packet_delay) = 0;
 
   // Check whether the ControlDevice implementation supports SendPacket - not
   // all control devices support it.

--- a/thinkit/mock_control_device.h
+++ b/thinkit/mock_control_device.h
@@ -38,7 +38,8 @@ class MockControlDevice : public ControlDevice {
       absl::StatusOr<std::unique_ptr<thinkit::PacketGenerationFinalizer>>,
       CollectPackets, (PacketCallback callback), (override));
   MOCK_METHOD(absl::Status, SendPacket,
-              (absl::string_view interface, absl::string_view packet),
+              (absl::string_view interface, absl::string_view packet,
+               std::optional<absl::Duration> packet_delay),
               (override));
   MOCK_METHOD(bool, SupportsSendPacket, (), (const, override));
   MOCK_METHOD(absl::Status, SendPackets,


### PR DESCRIPTION
PR Description:
gNMI port mtu tests

Keyword Check:
bibhuprasad@eonms7vm1:~/Sonic_06_06_2024/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/Google/tools/keyword_checks.sh .
Keyword check Passed.

Build Results:
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 387 targets (0 packages loaded, 0 targets configured).
INFO: Found 387 targets...
INFO: Elapsed time: 1.067s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 

UT Results: 
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 387 targets (0 packages loaded, 33 targets configured).
INFO: Found 252 targets and 135 test targets...
INFO: Elapsed time: 128.101s, Critical Path: 25.83s
INFO: 140 processes: 147 linux-sandbox, 17 local.
INFO: Build completed successfully, 140 total actions
//gutil:collections_test                                                 PASSED in 0.6s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.6s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 0.9s
//lib:basic_switch_test                                                  PASSED in 0.8s
//lib:ixia_helper_test                                                   PASSED in 1.1s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 0.9s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.2s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 25.8s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.9s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.1s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.3s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.0s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.6s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.5s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.7s
//p4rt_app/tests:action_set_test                                         PASSED in 1.3s
//p4rt_app/tests:api_access_test                                         PASSED in 2.2s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.0s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.2s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 5.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.3s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.0s
//p4rt_app/tests:packetio_test                                           PASSED in 4.0s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.4s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.8s
//p4rt_app/tests:response_path_test                                      PASSED in 3.8s
//p4rt_app/tests:role_test                                               PASSED in 1.3s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.2s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.8s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.6s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.3s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.8s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.6s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 21.9s
  Stats over 5 runs: max = 21.9s, min = 1.0s, avg = 9.6s, dev = 7.6s

Executed 135 out of 135 tests: 135 tests pass.
INFO: Build completed successfully, 140 total actions
bibhuprasad@bb37b62b1ae4:/sonic/src/sonic-p4rt/sonic-pins$ 
