### PR TITLE
[Thinkit] Add a util function to append sFlow-related config in gNMI config & Support parsing multiple key value in gNMI path.

### DIFF
--- a/lib/gnmi/BUILD.bazel
+++ b/lib/gnmi/BUILD.bazel
@@ -29,6 +29,7 @@ cc_library(
         "//gutil:collections",
         "//gutil:proto",
         "//gutil:status",
+        "//lib/utils:json_utils",
         "//p4_pdpi:p4_runtime_session",
         "//thinkit:switch",
         "@com_github_gnmi//proto/gnmi:gnmi_cc_proto",

--- a/lib/gnmi/gnmi_helper.h
+++ b/lib/gnmi/gnmi_helper.h
@@ -342,5 +342,16 @@ absl::Status SetPortMtu(int port_mtu, const std::string& interface_name,
 absl::Status SetPortLoopbackMode(bool port_loopback,
                                  absl::string_view interface_name,
                                  gnmi::gNMI::StubInterface& gnmi_stub);
+
+// Appends sFlow config to `gnmi_config` and returns modified config if success.
+// The modified config would sort collector IPs and interface names by string
+// order. This function would return original `gnmi_config` if sFlow config is
+// already present in `gnmi_config`. Returns an FailedPreconditionError if
+// `agent_addr_ipv6` or `sflow_enabled_interfaces` is empty.
+absl::StatusOr<std::string> AppendSflowConfigIfNotPresent(
+    absl::string_view gnmi_config, absl::string_view agent_addr_ipv6,
+    const absl::flat_hash_map<std::string, int>& collector_address_to_port,
+    const absl::flat_hash_set<std::string>& sflow_enabled_interfaces,
+    const int sampling_rate, const int sampling_header_size);
 }  // namespace pins_test
 #endif  // PINS_LIB_GNMI_GNMI_HELPER_H_

--- a/lib/gnmi/gnmi_helper_test.cc
+++ b/lib/gnmi/gnmi_helper_test.cc
@@ -296,6 +296,24 @@ TEST(OCStringToPath, OCStringToPathTestCase2) {
       )pb"));
 }
 
+TEST(OCStringToPath, OCStringToPathMultipleKeyTestCase) {
+  EXPECT_THAT(ConvertOCStringToPath(
+                  "/sampling/sflow/collectors/"
+                  "collector[address=127.0.0.1][port=6343]/state/address"),
+              EqualsProto(R"pb(
+                elem { name: "sampling" }
+                elem { name: "sflow" }
+                elem { name: "collectors" }
+                elem {
+                  name: "collector"
+                  key { key: "address" value: "127.0.0.1" }
+                  key { key: "port" value: "6343" }
+                }
+                elem { name: "state" }
+                elem { name: "address" }
+              )pb"));
+}
+
 TEST(OCStringToPath, OCStringToPathTestCase3) {
   EXPECT_THAT(
       ConvertOCStringToPath(
@@ -2151,6 +2169,171 @@ TEST(BreakoutModeMatchTest, LocalFileTestDataTest) {
                                 BreakoutSpeed::k400GB}),
       IsOkAndHolds(10));
 }
-  
+
+TEST(SflowconfigTest, AppendSflowConfigSuccess) {
+  const std::string kOpenConfig = R"({
+    "openconfig-interfaces:interfaces":{
+      "interface":[
+        {
+          "name":"bond0",
+          "state":{"oper-status":"UP","openconfig-p4rt:id":1}
+        }
+      ]
+    }
+  })";
+  const std::string kSflowConfig = R"({
+    "openconfig-interfaces:interfaces":{
+      "interface":[
+        {
+          "name":"bond0",
+          "state":{"oper-status":"UP","openconfig-p4rt:id":1}
+        }
+      ]
+    },
+     "openconfig-sampling:sampling" : {
+        "openconfig-sampling-sflow:sflow" : {
+           "collectors" : {
+              "collector" : [
+                 {
+                    "address" : "2001:4860:f802::be",
+                    "config" : {
+                       "address" : "2001:4860:f802::be",
+                       "port" : 6343
+                    },
+                    "port" : 6343
+                 }
+              ]
+           },
+           "config" : {
+              "agent-id-ipv6" : "8002:12::aab0",
+              "enabled" : true,
+              "polling-interval" : 0,
+              "sample-size" : 128
+           },
+           "interfaces" : {
+              "interface" : [
+                 {
+                    "config" : {
+                       "enabled" : true,
+                       "name" : "Ethernet1",
+                       "ingress-sampling-rate" : 1000
+                    },
+                    "name" : "Ethernet1"
+                 },
+                 {
+                    "config" : {
+                       "enabled" : true,
+                       "name" : "Ethernet2",
+                       "ingress-sampling-rate" : 1000
+                    },
+                    "name" : "Ethernet2"
+                 }
+             ]
+           }
+        }
+     }
+  })";
+  ASSERT_OK_AND_ASSIGN(
+      auto json_str,
+      AppendSflowConfigIfNotPresent(
+          kOpenConfig,
+          /*agent_addr_ipv6=*/"8002:12::aab0",
+          /*collector_address_to_port=*/{{"2001:4860:f802::be", 6343}},
+          /*sflow_enabled_interfaces=*/{"Ethernet1", "Ethernet2"},
+          /*sampling_rate=*/1000,
+          /*sampling_header_size=*/128));
+  ASSERT_EQ(::nlohmann::json::parse(json_str),
+            ::nlohmann::json::parse(kSflowConfig));
+}
+
+TEST(SflowconfigTest, AppendSflowConfigNoopIfPresent) {
+  const std::string kGnmiConfig = R"({
+    "openconfig-interfaces:interfaces":{
+      "interface":[
+        {
+          "name":"bond0",
+          "state":{"oper-status":"UP","openconfig-p4rt:id":1}
+        }
+      ]
+    },
+     "openconfig-sampling:sampling" : {
+        "openconfig-sampling-sflow:sflow" : {
+           "collectors" : {
+              "collector" : [
+                 {
+                    "address" : "2001:4860:f802::be",
+                    "config" : {
+                       "address" : "2001:4860:f802::be",
+                       "port" : 6343
+                    },
+                    "port" : 6343
+                 }
+              ]
+           },
+           "config" : {
+              "agent-id-ipv6" : "8002:12::aab0",
+              "enabled" : true,
+              "polling-interval" : 0,
+              "sample-size" : 128
+           },
+           "interfaces" : {
+              "interface" : [
+                 {
+                    "config" : {
+                       "enabled" : true,
+                       "name" : "Ethernet1",
+                       "ingress-sampling-rate" : 1000
+                    },
+                    "name" : "Ethernet1"
+                 },
+                 {
+                    "config" : {
+                       "enabled" : true,
+                       "name" : "Ethernet2",
+                       "ingress-sampling-rate" : 1000
+                    },
+                    "name" : "Ethernet2"
+                 }
+             ]
+           }
+        }
+     }
+  })";
+  ASSERT_OK_AND_ASSIGN(
+      auto json_str,
+      AppendSflowConfigIfNotPresent(
+          kGnmiConfig,
+          /*agent_addr_ipv6=*/"8002:12::aab0",
+          /*collector_address_to_port=*/{{"12:34:56::78", 6343}},
+          /*sflow_enabled_interfaces=*/{"Ethernet3", "Ethernet4"},
+          /*sampling_rate=*/100,
+          /*sampling_header_size=*/12));
+  ASSERT_EQ(::nlohmann::json::parse(json_str),
+            ::nlohmann::json::parse(kGnmiConfig));
+}
+
+TEST(SflowconfigTest, AppendSflowConfigWrongParameterFail) {
+  EXPECT_THAT(
+      AppendSflowConfigIfNotPresent(
+          /*gnmi_config=*/"",
+          /*agent_addr_ipv6=*/"",
+          /*collector_address_to_port=*/{{"2001:4860:f802::be", 6343}},
+          /*sflow_enabled_interfaces=*/{"Ethernet1", "Ethernet2"},
+          /*sampling_rate=*/1000,
+          /*sampling_header_size=*/128),
+      StatusIs(absl::StatusCode::kFailedPrecondition,
+               HasSubstr("loopback_address parameter cannot be empty.")));
+  EXPECT_THAT(
+      AppendSflowConfigIfNotPresent(
+          /*gnmi_config=*/"",
+          /*agent_addr_ipv6=*/"8002:12::aab0",
+          /*collector_address_to_port=*/{{"2001:4860:f802::be", 6343}},
+          /*sflow_enabled_interfaces=*/{},
+          /*sampling_rate=*/1000,
+          /*sampling_header_size=*/128),
+      StatusIs(
+          absl::StatusCode::kFailedPrecondition,
+          HasSubstr("sflow_enabled_interfaces parameter cannot be empty.")));
+}
 }  // namespace
 }  // namespace pins_test


### PR DESCRIPTION
### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 387 targets (243 packages loaded, 19829 targets configured).
INFO: Found 387 targets...
INFO: From Compiling lib/gnmi/gnmi_helper.cc:
...
INFO: Elapsed time: 86.616s, Critical Path: 24.60s
INFO: 56 processes: 17 internal, 39 linux-sandbox.
INFO: Build completed successfully, 56 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 387 targets (0 packages loaded, 289 targets configured).
INFO: Found 252 targets and 135 test targets...
INFO: Elapsed time: 87.249s, Critical Path: 25.80s
INFO: 140 processes: 147 linux-sandbox, 17 local.
INFO: Build completed successfully, 140 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.8s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 0.8s
//lib:basic_switch_test                                                  PASSED in 1.0s
//lib:ixia_helper_test                                                   PASSED in 1.3s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 0.9s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.6s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.2s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 25.8s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.7s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.6s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.3s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 2.7s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.6s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.6s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.9s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.0s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.2s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 1.3s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.0s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 1.0s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.8s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.4s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.1s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.4s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.6s
//p4rt_app/tests:packetio_test                                           PASSED in 3.7s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.4s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.6s
//p4rt_app/tests:response_path_test                                      PASSED in 2.8s
//p4rt_app/tests:role_test                                               PASSED in 1.2s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.8s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.6s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.9s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.8s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.0s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.7s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 24.9s
  Stats over 5 runs: max = 24.9s, min = 1.0s, avg = 13.2s, dev = 7.6s

Executed 135 out of 135 tests: 135 tests pass.
INFO: Build completed successfully, 140 total actions
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ 

### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.