### PR TITLE
[Thinkit] Add in mfg-name and serial-no for future use-cases, No-Op & Make SetInterfaceP4rtIds ignore already correct interfaces.

### DIFF
--- a/lib/gnmi/gnmi_helper.h
+++ b/lib/gnmi/gnmi_helper.h
@@ -77,11 +77,15 @@ struct OpenConfigInterfaceDescription {
 struct TransceiverPart {
   std::string vendor;
   std::string part_number;
+  std::string manufacturer_name;
+  std::string serial_number;
   std::string rev;
 
   bool operator==(const TransceiverPart& other) const {
-    return std::tie(vendor, part_number) ==
-           std::tie(other.vendor, other.part_number);
+    return std::tie(vendor, part_number, manufacturer_name, serial_number,
+                    rev) == std::tie(other.vendor, other.part_number,
+                                     other.manufacturer_name,
+                                     other.serial_number, other.rev);
   }
 };
 
@@ -276,8 +280,9 @@ absl::Status MapP4rtIdsToMatchingInterfaces(
     absl::Duration timeout = absl::Seconds(60));
 
 // Uses `gnmi_stub` to set the P4RT IDs of `interfaces`, deleting any of those
-// P4RT IDs previously mapped on the switch a P4RT ID can't be mapped to
-// multiple interfaces.
+// P4RT IDs previously mapped on the switch since a P4RT ID can't be mapped to
+// multiple interfaces. Any existing interface that already maps its desired
+// P4RT ID is untouched.
 absl::Status SetInterfaceP4rtIds(gnmi::gNMI::StubInterface& gnmi_stub,
                                  const openconfig::Interfaces& interfaces);
 

--- a/lib/gnmi/gnmi_helper_test.cc
+++ b/lib/gnmi/gnmi_helper_test.cc
@@ -51,6 +51,7 @@ using ::gutil::IsOk;
 using ::gutil::IsOkAndHolds;
 using ::gutil::StatusIs;
 using ::testing::_;
+using ::testing::AllOf;
 using ::testing::ContainerEq;
 using ::testing::DoAll;
 using ::testing::ElementsAre;
@@ -1890,6 +1891,8 @@ TEST(TransceiverPartInformation, WorksProperly) {
               "empty": false,
               "openconfig-platform-ext:vendor-name": "Vendor",
               "part-no": "123",
+              "mfg-name": "manufactuer",
+              "serial-no": "serial",
               "firmware-version": "ab"
             }
           }
@@ -1901,8 +1904,11 @@ TEST(TransceiverPartInformation, WorksProperly) {
       .WillRepeatedly(
           DoAll(SetArgPointee<2>(response), Return(grpc::Status::OK)));
   absl::flat_hash_map<std::string, TransceiverPart> expected_map{
-      {"Ethernet1",
-       TransceiverPart{.vendor = "Vendor", .part_number = "123", .rev = "ab"}}};
+      {"Ethernet1", TransceiverPart{.vendor = "Vendor",
+                                    .part_number = "123",
+                                    .manufacturer_name = "manufactuer",
+                                    .serial_number = "serial",
+                                    .rev = "ab"}}};
   EXPECT_THAT(GetTransceiverPartInformation(mock_stub),
               IsOkAndHolds(UnorderedPointwise(Eq(), expected_map)));
 }


### PR DESCRIPTION
### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 387 targets (243 packages loaded, 19829 targets configured).
INFO: Found 387 targets...
INFO: From Compiling lib/gnmi/gnmi_helper.cc:
...
INFO: Elapsed time: 53.250s, Critical Path: 22.66s
INFO: 23 processes: 3 internal, 20 linux-sandbox.
INFO: Build completed successfully, 23 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 387 targets (0 packages loaded, 289 targets configured).
INFO: Found 252 targets and 135 test targets...
INFO: Elapsed time: 87.249s, Critical Path: 25.80s
INFO: 140 processes: 147 linux-sandbox, 17 local.
INFO: Build completed successfully, 140 total actions
//gutil:collections_test PASSED in 0.5s
//gutil:io_test PASSED in 0.5s
//gutil:proto_matchers_test PASSED in 0.8s
//gutil:proto_ordering_test PASSED in 0.5s
//gutil:proto_test PASSED in 0.5s
//gutil:status_matchers_test PASSED in 0.5s
//gutil:test_artifact_writer_test PASSED in 0.5s
//gutil:testing_test PASSED in 0.5s
//gutil:version_test PASSED in 0.8s
//lib:basic_switch_test PASSED in 1.0s
//lib:ixia_helper_test PASSED in 1.3s
//lib/basic_traffic:basic_p4rt_util_test PASSED in 0.9s
//lib/gnmi:gnmi_helper_test PASSED in 2.8s
//lib/gnoi:gnoi_helper_test PASSED in 0.5s
//lib/p4rt:p4rt_port_test PASSED in 0.6s
//lib/p4rt:p4rt_programming_context_test PASSED in 0.8s
//lib/utils:generic_testbed_utils_test PASSED in 1.2s
//lib/utils:json_utils_test PASSED in 0.5s
//lib/validator:validator_backend_test PASSED in 0.5s
//lib/validator:validator_lib_test PASSED in 25.8s
//p4_fuzzer:constraints_util_integration_test PASSED in 0.7s
//p4_fuzzer:fuzz_util_test PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test PASSED in 0.7s
//p4_fuzzer:switch_state_test PASSED in 0.6s
//p4_fuzzer:table_entry_key_test PASSED in 0.1s
//p4_pdpi:built_ins_test PASSED in 0.5s
//p4_pdpi:entity_keys_test PASSED in 0.5s
//p4_pdpi:ir_tools_test PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test PASSED in 0.6s
//p4_pdpi:reference_annotations_test PASSED in 0.7s
//p4_pdpi:sequencing_util_test PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test PASSED in 0.6s
//p4_pdpi/netaddr:ipv6_address_test PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test PASSED in 16.3s
//p4_pdpi/packetlib:packetlib_matchers_test PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_test PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_test_runner PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test PASSED in 2.7s
//p4_pdpi/string_encodings:bit_string_test PASSED in 0.6s
//p4_pdpi/string_encodings:byte_string_test PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test PASSED in 0.6s
//p4_pdpi/testing:helper_function_test PASSED in 0.6s
//p4_pdpi/testing:info_test PASSED in 0.3s
//p4_pdpi/testing:info_test_runner PASSED in 0.1s
//p4_pdpi/testing:main_pd_test PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test PASSED in 0.6s
//p4_pdpi/testing:packet_io_test PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner PASSED in 0.1s
//p4_pdpi/testing:rpc_test PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_test PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test PASSED in 0.9s
//p4_pdpi/testing:table_entry_test PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test PASSED in 0.5s
//p4_pdpi/utils:ir_test PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test PASSED in 1.0s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test PASSED in 1.2s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test PASSED in 1.3s
//p4rt_app/p4runtime:p4info_verification_schema_test PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test PASSED in 2.0s
//p4rt_app/p4runtime:packetio_helpers_test PASSED in 1.0s
//p4rt_app/p4runtime:resource_utilization_test PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test PASSED in 0.8s
//p4rt_app/sonic:app_db_manager_test PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test PASSED in 0.7s
//p4rt_app/sonic:hashing_test PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test PASSED in 0.6s
//p4rt_app/sonic:response_handler_test PASSED in 0.7s
//p4rt_app/sonic:state_verification_test PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test PASSED in 0.0s
//p4rt_app/tests:acl_table_test PASSED in 1.4s
//p4rt_app/tests:action_set_test PASSED in 1.1s
//p4rt_app/tests:api_access_test PASSED in 1.0s
//p4rt_app/tests:arbitration_test PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test PASSED in 1.6s
//p4rt_app/tests:debug_data_dump_test PASSED in 1.1s
//p4rt_app/tests:fixed_l3_tables_test PASSED in 2.6s
//p4rt_app/tests:forwarding_pipeline_config_test PASSED in 3.9s
//p4rt_app/tests:grpc_behavior_test PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test PASSED in 0.4s
//p4rt_app/tests:p4_constraints_test_runner PASSED in 0.2s
//p4rt_app/tests:p4_programs_test PASSED in 1.6s
//p4rt_app/tests:packetio_test PASSED in 3.7s
//p4rt_app/tests:port_name_and_id_test PASSED in 2.4s
//p4rt_app/tests:resource_limits_test PASSED in 4.6s
//p4rt_app/tests:response_path_test PASSED in 2.8s
//p4rt_app/tests:role_test PASSED in 1.2s
//p4rt_app/tests:state_verification_test PASSED in 1.8s
//p4rt_app/tests:vrf_table_test PASSED in 1.6s
//p4rt_app/tests/lib:app_db_entry_builder_test PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test PASSED in 0.1s
//p4rt_app/utils:table_utility_test PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test PASSED in 0.9s
//sai_p4/instantiations/google:sai_p4info_test PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.8s
//sai_p4/instantiations/google/test_tools:test_entries_test PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test PASSED in 0.8s
//sai_p4/tools:p4info_tools_test PASSED in 1.0s
//sai_p4/tools:packetio_tools_test PASSED in 0.7s
//thinkit:bazel_test_environment_test PASSED in 0.5s
//thinkit:generic_testbed_test PASSED in 0.9s
//thinkit:mock_control_device_test PASSED in 0.7s
//thinkit:mock_generic_testbed_test PASSED in 0.7s
//thinkit:mock_mirror_testbed_test PASSED in 0.7s
//thinkit:mock_ssh_client_test PASSED in 0.0s
//thinkit:mock_switch_test PASSED in 0.7s
//thinkit:mock_test_environment_test PASSED in 0.1s
//thinkit:switch_test PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test PASSED in 24.9s
Stats over 5 runs: max = 24.9s, min = 1.0s, avg = 13.2s, dev = 7.6s

Executed 135 out of 135 tests: 135 tests pass.
INFO: Build completed successfully, 140 total actions
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$

### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.