### PR TITLE
[Thinkit] Make GetGnmiConfig output a valid gNMI Config.

### DIFF
--- a/lib/gnmi/BUILD.bazel
+++ b/lib/gnmi/BUILD.bazel
@@ -37,6 +37,7 @@ cc_library(
         "@com_github_gnmi//proto/gnmi_ext:gnmi_ext_cc_proto",
         "@com_github_gnoi//types:types_cc_proto",
         "@com_github_google_glog//:glog",
+        "@com_github_nlohmann_json//:nlohmann_json",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base:log_severity",
         "@com_google_absl//absl/container:btree",

--- a/lib/gnmi/gnmi_helper.h
+++ b/lib/gnmi/gnmi_helper.h
@@ -145,9 +145,16 @@ absl::StatusOr<gnmi::SetRequest> BuildGnmiSetRequest(
 absl::StatusOr<gnmi::GetRequest> BuildGnmiGetRequest(
     absl::string_view oc_path, gnmi::GetRequest::DataType req_type);
 
-// Parses Get Response to retrieve specific tag value.
+// Parses `response` to retrieve specific tag value, if `match_tag` is given, or
+// the full response otherwise.
+// Uses non-negative `indent` values to pretty-print the GetResponse with
+// `indent` spaces of indentation. `-1` renders a single line of illegible, but
+// correct, JSON.
+// WARNING: Returns InternalError if each notification in the GetResponse does
+// not have exactly 1 update.
 absl::StatusOr<std::string> ParseGnmiGetResponse(
-    const gnmi::GetResponse& response, absl::string_view match_tag = {});
+    const gnmi::GetResponse& response, absl::string_view match_tag = {},
+    int indent = -1);
 
 absl::Status SetGnmiConfigPath(gnmi::gNMI::StubInterface* gnmi_stub,
                                absl::string_view config_path,

--- a/lib/p4rt/p4rt_port.h
+++ b/lib/p4rt/p4rt_port.h
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 
@@ -72,8 +73,12 @@ class P4rtPortId {
   uint32_t p4rt_port_id_ = 0;
 };
 
-// TODO: Remove and update the class to use AbslStringify.
 std::ostream& operator<<(std::ostream& os, const P4rtPortId& p4rt_port_id);
+
+template <typename Sink>
+inline void AbslStringify(Sink& sink, const P4rtPortId& p4rt_port_id) {
+  absl::Format(&sink, "%s", p4rt_port_id.GetP4rtEncoding());
+}
 
 }  // namespace pins_test
 


### PR DESCRIPTION
### Build Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 387 targets (1 packages loaded, 23 targets configured).
INFO: Found 387 targets...
...
INFO: Elapsed time: 63.638s, Critical Path: 24.58s
INFO: 34 processes: 11 internal, 23 linux-sandbox.
INFO: Build completed successfully, 34 total actions

### Test Results:
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 387 targets (0 packages loaded, 289 targets configured).
INFO: Found 252 targets and 135 test targets...
INFO: Elapsed time: 81.632s, Critical Path: 25.83s
INFO: 140 processes: 147 linux-sandbox, 17 local.
INFO: Build completed successfully, 140 total actions
//gutil:collections_test PASSED in 0.5s
//gutil:io_test PASSED in 0.5s
//gutil:proto_matchers_test PASSED in 0.7s
//gutil:proto_ordering_test PASSED in 0.5s
//gutil:proto_test PASSED in 0.5s
//gutil:status_matchers_test PASSED in 0.5s
//gutil:test_artifact_writer_test PASSED in 0.5s
//gutil:testing_test PASSED in 0.5s
//gutil:version_test PASSED in 1.5s
//lib:basic_switch_test PASSED in 0.8s
//lib:ixia_helper_test PASSED in 1.1s
//lib/basic_traffic:basic_p4rt_util_test PASSED in 0.9s
//lib/gnmi:gnmi_helper_test PASSED in 2.8s
//lib/gnoi:gnoi_helper_test PASSED in 0.5s
//lib/p4rt:p4rt_port_test PASSED in 0.6s
//lib/p4rt:p4rt_programming_context_test PASSED in 0.8s
//lib/utils:generic_testbed_utils_test PASSED in 1.2s
//lib/utils:json_utils_test PASSED in 0.5s
//lib/validator:validator_backend_test PASSED in 0.5s
//lib/validator:validator_lib_test PASSED in 25.8s
//p4_fuzzer:constraints_util_integration_test PASSED in 0.9s
//p4_fuzzer:fuzz_util_test PASSED in 1.0s
//p4_fuzzer:fuzzer_showcase_test PASSED in 0.9s
//p4_fuzzer:switch_state_test PASSED in 0.6s
//p4_fuzzer:table_entry_key_test PASSED in 0.1s
//p4_pdpi:built_ins_test PASSED in 0.6s
//p4_pdpi:entity_keys_test PASSED in 0.5s
//p4_pdpi:ir_tools_test PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test PASSED in 0.6s
//p4_pdpi:reference_annotations_test PASSED in 0.9s
//p4_pdpi:sequencing_util_test PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test PASSED in 16.5s
//p4_pdpi/packetlib:packetlib_matchers_test PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test PASSED in 1.1s
//p4_pdpi/string_encodings:bit_string_test PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test PASSED in 0.5s
//p4_pdpi/testing:helper_function_test PASSED in 0.6s
//p4_pdpi/testing:info_test PASSED in 0.3s
//p4_pdpi/testing:info_test_runner PASSED in 0.1s
//p4_pdpi/testing:main_pd_test PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test PASSED in 0.7s
//p4_pdpi/testing:packet_io_test PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner PASSED in 0.3s
//p4_pdpi/testing:rpc_test PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_test PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test_runner PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test PASSED in 1.0s
//p4_pdpi/testing:table_entry_test PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test PASSED in 0.5s
//p4_pdpi/utils:ir_test PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test PASSED in 1.0s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test PASSED in 1.1s
//p4rt_app/event_monitoring:debug_data_dump_events_test PASSED in 1.0s
//p4rt_app/event_monitoring:state_verification_events_test PASSED in 1.1s
//p4rt_app/p4runtime:cpu_queue_translator_test PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test PASSED in 0.7s
//p4rt_app/sonic:app_db_acl_def_table_manager_test PASSED in 0.8s
//p4rt_app/sonic:app_db_manager_test PASSED in 0.9s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test PASSED in 0.8s
//p4rt_app/sonic:hashing_test PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test PASSED in 1.3s
//p4rt_app/sonic:packetio_impl_test PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test PASSED in 0.6s
//p4rt_app/sonic:response_handler_test PASSED in 0.7s
//p4rt_app/sonic:state_verification_test PASSED in 0.7s
//p4rt_app/sonic:vrf_entry_translation_test PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test PASSED in 0.1s
//p4rt_app/tests:acl_table_test PASSED in 1.5s
//p4rt_app/tests:action_set_test PASSED in 1.1s
//p4rt_app/tests:api_access_test PASSED in 1.0s
//p4rt_app/tests:arbitration_test PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test PASSED in 1.6s
//p4rt_app/tests:debug_data_dump_test PASSED in 1.1s
//p4rt_app/tests:fixed_l3_tables_test PASSED in 2.6s
//p4rt_app/tests:forwarding_pipeline_config_test PASSED in 3.9s
//p4rt_app/tests:grpc_behavior_test PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner PASSED in 0.2s
//p4rt_app/tests:p4_programs_test PASSED in 1.6s
//p4rt_app/tests:packetio_test PASSED in 3.7s
//p4rt_app/tests:port_name_and_id_test PASSED in 2.4s
//p4rt_app/tests:resource_limits_test PASSED in 5.6s
//p4rt_app/tests:response_path_test PASSED in 2.9s
//p4rt_app/tests:role_test PASSED in 1.3s
//p4rt_app/tests:state_verification_test PASSED in 1.8s
//p4rt_app/tests:vrf_table_test PASSED in 1.6s
//p4rt_app/tests/lib:app_db_entry_builder_test PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test PASSED in 0.0s
//p4rt_app/utils:table_utility_test PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:sai_p4info_fetcher_test PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test PASSED in 1.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.1s
//sai_p4/instantiations/google/test_tools:test_entries_test PASSED in 1.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test PASSED in 0.8s
//sai_p4/tools:p4info_tools_test PASSED in 0.5s
//sai_p4/tools:packetio_tools_test PASSED in 0.7s
//thinkit:bazel_test_environment_test PASSED in 0.5s
//thinkit:generic_testbed_test PASSED in 1.1s
//thinkit:mock_control_device_test PASSED in 1.0s
//thinkit:mock_generic_testbed_test PASSED in 0.7s
//thinkit:mock_mirror_testbed_test PASSED in 0.6s
//thinkit:mock_ssh_client_test PASSED in 0.0s
//thinkit:mock_switch_test PASSED in 1.0s
//thinkit:mock_test_environment_test PASSED in 0.1s
//thinkit:switch_test PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test PASSED in 13.0s
Stats over 5 runs: max = 13.0s, min = 2.3s, avg = 8.2s, dev = 4.9s

Executed 135 out of 135 tests: 135 tests pass.
INFO: Build completed successfully, 140 total actions
divya@e9e9b2e05579:/sonic/src/sonic-p4rt/sonic-pins$

### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.