### PR TITLE
[P4RT] Support read requests containing packet replication engine entities. Support for reading back entries still needed. add `batch_set()` for TableAdapter.

### DIFF
--- a/p4rt_app/p4rt.cc
+++ b/p4rt_app/p4rt.cc
@@ -34,6 +34,7 @@
 #include "grpcpp/security/authorization_policy_provider.h"
 #include "grpcpp/security/server_credentials.h"
 #include "grpcpp/security/tls_certificate_provider.h"
+#include "grpcpp/security/tls_certificate_verifier.h"
 #include "grpcpp/security/tls_credentials_options.h"
 #include "grpcpp/server.h"
 #include "grpcpp/server_builder.h"

--- a/p4rt_app/p4runtime/p4runtime_impl.cc
+++ b/p4rt_app/p4runtime/p4runtime_impl.cc
@@ -704,7 +704,7 @@ grpc::Status P4RuntimeImpl::Read(
                           "ReadResponse writer cannot be a nullptr.");
     }
 
-    auto response_status = ReadAllTableEntries(
+    auto response_status = ReadAllEntities(
         *request, *ir_p4info_, table_entry_cache_, translate_port_ids_,
         port_translation_map_, *cpu_queue_translator_, p4rt_table_);
     if (!response_status.ok()) {

--- a/p4rt_app/p4runtime/p4runtime_read.cc
+++ b/p4rt_app/p4runtime/p4runtime_read.cc
@@ -113,7 +113,7 @@ absl::Status AppendTableEntryReads(
 
 }  // namespace
 
-absl::StatusOr<p4::v1::ReadResponse> ReadAllTableEntries(
+absl::StatusOr<p4::v1::ReadResponse> ReadAllEntities(
     const p4::v1::ReadRequest& request, const pdpi::IrP4Info& ir_p4_info,
     const absl::flat_hash_map<pdpi::TableEntryKey, p4::v1::TableEntry>&
         table_entry_cache,
@@ -132,6 +132,10 @@ absl::StatusOr<p4::v1::ReadResponse> ReadAllTableEntries(
               port_translation_map, cpu_queue_translator, p4rt_table));
         }
         break;
+      }
+      case p4::v1::Entity::kPacketReplicationEngineEntry: {
+        // TODO: 298489493 - Add support for reading back multicast entries.
+        continue;
       }
       default:
         return gutil::UnimplementedErrorBuilder()

--- a/p4rt_app/p4runtime/p4runtime_read.h
+++ b/p4rt_app/p4runtime/p4runtime_read.h
@@ -29,7 +29,7 @@ namespace p4rt_app {
 
 // Reads all table entries from a cache. For each ACL entry we also fetch
 // counter data from CounterDb.
-absl::StatusOr<p4::v1::ReadResponse> ReadAllTableEntries(
+absl::StatusOr<p4::v1::ReadResponse> ReadAllEntities(
     const p4::v1::ReadRequest& request, const pdpi::IrP4Info& ir_p4_info,
     const absl::flat_hash_map<pdpi::TableEntryKey, p4::v1::TableEntry>&
         table_entry_cache,

--- a/p4rt_app/sonic/adapters/BUILD.bazel
+++ b/p4rt_app/sonic/adapters/BUILD.bazel
@@ -146,6 +146,7 @@ cc_library(
     deps = [
         ":table_adapter",
         "@com_google_googletest//:gtest",
+        "@sonic_swss_common//:libswsscommon",
     ],
 )
 
@@ -159,6 +160,7 @@ cc_library(
         ":table_adapter",
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/strings",
+        "@sonic_swss_common//:libswsscommon",
     ],
 )
 

--- a/p4rt_app/sonic/adapters/fake_table_adapter.cc
+++ b/p4rt_app/sonic/adapters/fake_table_adapter.cc
@@ -20,7 +20,7 @@
 #include "absl/strings/str_cat.h"
 #include "glog/logging.h"
 #include "p4rt_app/sonic/adapters/fake_sonic_db_table.h"
-#include "p4rt_app/sonic/adapters/table_adapter.h"
+#include "swss/table.h"
 
 namespace p4rt_app {
 namespace sonic {
@@ -61,6 +61,13 @@ void FakeTableAdapter::set(
     const std::string& key,
     const std::vector<std::pair<std::string, std::string>>& values) {
   sonic_db_table_->InsertTableEntry(key, values);
+}
+
+void FakeTableAdapter::batch_set(
+    const std::vector<swss::KeyOpFieldsValuesTuple>& values) {
+  for (const swss::KeyOpFieldsValuesTuple& value : values) {
+    sonic_db_table_->InsertTableEntry(kfvKey(value), kfvFieldsValues(value));
+  }
 }
 
 void FakeTableAdapter::del(const std::string& key) {

--- a/p4rt_app/sonic/adapters/fake_table_adapter.h
+++ b/p4rt_app/sonic/adapters/fake_table_adapter.h
@@ -20,6 +20,7 @@
 
 #include "p4rt_app/sonic/adapters/fake_sonic_db_table.h"
 #include "p4rt_app/sonic/adapters/table_adapter.h"
+#include "swss/rediscommand.h"
 
 namespace p4rt_app {
 namespace sonic {
@@ -42,6 +43,9 @@ class FakeTableAdapter final : public TableAdapter {
   void set(
       const std::string& key,
       const std::vector<std::pair<std::string, std::string>>& values) override;
+
+  void batch_set(
+      const std::vector<swss::KeyOpFieldsValuesTuple>& values) override;
 
   void del(const std::string& key) override;
   void batch_del(const std::vector<std::string>& keys) override;

--- a/p4rt_app/sonic/adapters/mock_table_adapter.h
+++ b/p4rt_app/sonic/adapters/mock_table_adapter.h
@@ -20,6 +20,7 @@
 
 #include "gmock/gmock.h"
 #include "p4rt_app/sonic/adapters/table_adapter.h"
+#include "swss/table.h"
 
 namespace p4rt_app {
 namespace sonic {
@@ -38,6 +39,10 @@ class MockTableAdapter : public TableAdapter {
       (const std::string& key,
        (const std::vector<std::pair<std::string, std::string>>& values)),
       (override));
+
+  MOCK_METHOD(void, batch_set,
+              (const std::vector<swss::KeyOpFieldsValuesTuple>& values),
+              (override));
 
   MOCK_METHOD(void, del, (const std::string& key), (override));
 

--- a/p4rt_app/sonic/adapters/table_adapter.cc
+++ b/p4rt_app/sonic/adapters/table_adapter.cc
@@ -52,6 +52,12 @@ void TableAdapter::set(
   table_->set(key, values);
 }
 
+void TableAdapter::batch_set(
+    const std::vector<swss::KeyOpFieldsValuesTuple>& values) {
+  for (const swss::KeyOpFieldsValuesTuple& value : values) {
+    table_->set(kfvKey(value), kfvFieldsValues(value));
+  }
+}
 void TableAdapter::del(const std::string& key) { table_->del(key); }
 
 void TableAdapter::batch_del(const std::vector<std::string>& keys) {

--- a/p4rt_app/sonic/adapters/table_adapter.h
+++ b/p4rt_app/sonic/adapters/table_adapter.h
@@ -32,7 +32,7 @@ namespace sonic {
 //   AppDb:    PORT_TABLE:Ethernet0
 //   StateDb:  PORT_TABLE|Ethernet0
 //
-// Notice how the deliniator for AppDb is ':', but StateDb uses '|' for the same
+// Notice how the delineator for AppDb is ':', but StateDb uses '|' for the same
 // entry. The TableAdapter automatically handles this formatting for us. So if
 // we wanted to read data about Ethernet0 we only need to call:
 //   auto data = table_adapter.get("Ethernet0");
@@ -50,6 +50,8 @@ class TableAdapter {
   virtual void set(
       const std::string& key,
       const std::vector<std::pair<std::string, std::string>>& values);
+  virtual void batch_set(
+      const std::vector<swss::KeyOpFieldsValuesTuple>& values);
 
   virtual void del(const std::string& key);
   virtual void batch_del(const std::vector<std::string>& keys);

--- a/pins_infra_deps.bzl
+++ b/pins_infra_deps.bzl
@@ -51,7 +51,7 @@ def pins_infra_deps():
             url = "https://github.com/abseil/abseil-cpp/archive/20230802.0.tar.gz",
             strip_prefix = "abseil-cpp-20230802.0",
             sha256 = "59d2976af9d6ecf001a81a35749a6e551a335b949d34918cfade07737b9d93c5",
-        )   
+        )
     if not native.existing_rule("com_google_googletest"):
         http_archive(
             name = "com_google_googletest",


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@cfdc38a2acd6:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 388 targets (243 packages loaded, 19831 targets configured).
INFO: Found 388 targets...
INFO: From Compiling p4rt_app/sonic/adapters/table_adapter.cc:
...
INFO: Elapsed time: 241.741s, Critical Path: 51.05s
INFO: 139 processes: 12 internal, 127 linux-sandbox.
INFO: Build completed successfully, 139 total actions

### Test Results:
divya@cfdc38a2acd6:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 388 targets (0 packages loaded, 290 targets configured).
INFO: Found 252 targets and 136 test targets...
INFO: Elapsed time: 83.257s, Critical Path: 25.94s
INFO: 141 processes: 148 linux-sandbox, 17 local.
INFO: Build completed successfully, 141 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.4s
//gutil:status_matchers_test                                             PASSED in 0.4s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.4s
//gutil:version_test                                                     PASSED in 0.7s
//lib:basic_switch_test                                                  PASSED in 0.8s
//lib:ixia_helper_test                                                   PASSED in 1.1s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 0.9s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 14.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.9s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.6s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.4s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.1s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 25.9s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:switch_state_test                                            PASSED in 0.7s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.6s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.0s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.0s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.4s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.4s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.4s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.8s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.4s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.8s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 1.1s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.5s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.6s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.3s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 0.9s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.7s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.3s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.3s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.5s
//p4rt_app/tests:packetio_test                                           PASSED in 3.5s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.2s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.6s
//p4rt_app/tests:response_path_test                                      PASSED in 2.6s
//p4rt_app/tests:role_test                                               PASSED in 1.1s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.7s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.8s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.4s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.2s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.2s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.3s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.7s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.9s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.6s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 12.8s
  Stats over 5 runs: max = 12.8s, min = 0.8s, avg = 7.5s, dev = 5.4s

Executed 136 out of 136 tests: 136 tests pass.
INFO: Build completed successfully, 141 total actions
divya@cfdc38a2acd6:/sonic/src/sonic-p4rt/sonic-pins$ 
