### PR TITLE
[P4RT] Add warm-boot adapter in P4RT.

### DIFF
--- a/p4rt_app/BUILD.bazel
+++ b/p4rt_app/BUILD.bazel
@@ -56,6 +56,7 @@ cc_binary(
         "//p4rt_app/sonic/adapters:producer_state_table_adapter",
         "//p4rt_app/sonic/adapters:system_call_adapter",
         "//p4rt_app/sonic/adapters:table_adapter",
+        "//p4rt_app/sonic/adapters:warm_boot_state_adapter",
         "@sonic_swss_common//:libswsscommon",
     ],
 )

--- a/p4rt_app/p4runtime/BUILD.bazel
+++ b/p4rt_app/p4runtime/BUILD.bazel
@@ -151,6 +151,7 @@ cc_library(
         "//p4rt_app/sonic:response_handler",
         "//p4rt_app/sonic:state_verification",
         "//p4rt_app/sonic:vrf_entry_translation",
+        "//p4rt_app/sonic/adapters:warm_boot_state_adapter",
         "//p4rt_app/utils:event_data_tracker",
         "//p4rt_app/utils:status_utility",
         "//p4rt_app/utils:table_utility",

--- a/p4rt_app/sonic/adapters/BUILD.bazel
+++ b/p4rt_app/sonic/adapters/BUILD.bazel
@@ -165,6 +165,17 @@ cc_library(
 )
 
 cc_library(
+    name = "fake_warm_boot_state_adapter",
+    testonly = True,
+    srcs = ["fake_warm_boot_state_adapter.cc"],
+    hdrs = ["fake_warm_boot_state_adapter.h"],
+    deps = [
+        ":warm_boot_state_adapter",
+        "@sonic_swss_common//:libswsscommon",
+    ],
+)
+
+cc_library(
     name = "fake_sonic_db_table",
     testonly = True,
     srcs = ["fake_sonic_db_table.cc"],
@@ -189,5 +200,33 @@ cc_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "fake_warm_boot_state_adapter_test",
+    srcs = ["fake_warm_boot_state_adapter_test.cc"],
+    deps = [
+        ":fake_warm_boot_state_adapter",
+        "@com_google_googletest//:gtest_main",
+        "@sonic_swss_common//:libswsscommon",
+    ],
+)
+
+cc_library(
+    name = "warm_boot_state_adapter",
+    srcs = ["warm_boot_state_adapter.cc"],
+    hdrs = ["warm_boot_state_adapter.h"],
+    deps = ["@sonic_swss_common//:libswsscommon"],
+)
+
+cc_library(
+    name = "mock_warm_boot_state_adapter",
+    testonly = True,
+    hdrs = ["mock_warm_boot_state_adapter.h"],
+    deps = [
+        ":warm_boot_state_adapter",
+        "@com_google_googletest//:gtest",
+        "@sonic_swss_common//:common",
     ],
 )

--- a/p4rt_app/sonic/adapters/fake_warm_boot_state_adapter.cc
+++ b/p4rt_app/sonic/adapters/fake_warm_boot_state_adapter.cc
@@ -1,0 +1,39 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "p4rt_app/sonic/adapters/fake_warm_boot_state_adapter.h"
+
+#include "swss/warm_restart.h"
+
+namespace p4rt_app {
+namespace sonic {
+
+FakeWarmBootStateAdapter::FakeWarmBootStateAdapter() {}
+
+swss::WarmStart::WarmStartState FakeWarmBootStateAdapter::GetWarmBootState() {
+  return state_;
+}
+
+void FakeWarmBootStateAdapter::SetWarmBootState(
+    swss::WarmStart::WarmStartState state) {
+  state_ = state;
+}
+
+bool FakeWarmBootStateAdapter::IsWarmStart() { return is_warm_start_; }
+
+void FakeWarmBootStateAdapter::SetWarmStart(bool is_warm_start) {
+  is_warm_start_ = is_warm_start;
+}
+
+}  // namespace sonic
+}  // namespace p4rt_app

--- a/p4rt_app/sonic/adapters/fake_warm_boot_state_adapter.h
+++ b/p4rt_app/sonic/adapters/fake_warm_boot_state_adapter.h
@@ -1,0 +1,39 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef PINS_P4RT_APP_SONIC_ADAPTERS_FAKE_WARM_BOOT_STATE_ADAPTER_H_
+#define PINS_P4RT_APP_SONIC_ADAPTERS_FAKE_WARM_BOOT_STATE_ADAPTER_H_
+
+#include "p4rt_app/sonic/adapters/warm_boot_state_adapter.h"
+
+namespace p4rt_app {
+namespace sonic {
+
+class FakeWarmBootStateAdapter final : public WarmBootStateAdapter {
+ public:
+  explicit FakeWarmBootStateAdapter();
+  swss::WarmStart::WarmStartState GetWarmBootState() override;
+  void SetWarmBootState(swss::WarmStart::WarmStartState state) override;
+  bool IsWarmStart(void) override;
+  void SetWarmStart(bool is_warm_start);
+
+ private:
+  swss::WarmStart::WarmStartState state_ =
+      swss::WarmStart::WarmStartState::WSUNKNOWN;
+  bool is_warm_start_ = false;
+};
+
+}  // namespace sonic
+}  // namespace p4rt_app
+
+#endif  // PINS_P4RT_APP_SONIC_ADAPTERS_FAKE_WARM_BOOT_STATE_ADAPTER_H_

--- a/p4rt_app/sonic/adapters/fake_warm_boot_state_adapter_test.cc
+++ b/p4rt_app/sonic/adapters/fake_warm_boot_state_adapter_test.cc
@@ -1,0 +1,49 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "p4rt_app/sonic/adapters/fake_warm_boot_state_adapter.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "swss/warm_restart.h"
+
+namespace p4rt_app {
+namespace sonic {
+namespace {
+
+TEST(FakeWarmBootStateAdapterTest, GetWarmBootStateDefault) {
+  FakeWarmBootStateAdapter adapter;
+  EXPECT_THAT(adapter.GetWarmBootState(),
+              swss::WarmStart::WarmStartState::WSUNKNOWN);
+}
+
+TEST(FakeWarmBootStateAdapterTest, SetWarmBootState) {
+  FakeWarmBootStateAdapter adapter;
+  swss::WarmStart::WarmStartState state =
+      swss::WarmStart::WarmStartState::INITIALIZED;
+  adapter.SetWarmBootState(state);
+  EXPECT_THAT(adapter.GetWarmBootState(), state);
+}
+
+TEST(FakeWarmBootStateAdapterTest, SetWarmStart) {
+  FakeWarmBootStateAdapter adapter;
+  EXPECT_THAT(adapter.IsWarmStart(), false);
+  adapter.SetWarmStart(true);
+  EXPECT_THAT(adapter.IsWarmStart(), true);
+  adapter.SetWarmStart(false);
+  EXPECT_THAT(adapter.IsWarmStart(), false);
+}
+
+}  // namespace
+}  // namespace sonic
+}  // namespace p4rt_app

--- a/p4rt_app/sonic/adapters/mock_warm_boot_state_adapter.h
+++ b/p4rt_app/sonic/adapters/mock_warm_boot_state_adapter.h
@@ -1,0 +1,36 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef PINS_P4RT_APP_SONIC_ADAPTERS_MOCK_WARM_BOOT_STATE_ADAPTER_H_
+#define PINS_P4RT_APP_SONIC_ADAPTERS_MOCK_WARM_BOOT_STATE_ADAPTER_H_
+
+#include "gmock/gmock.h"
+#include "p4rt_app/sonic/adapters/warm_boot_state_adapter.h"
+#include "swss/warm_restart.h"
+
+namespace p4rt_app {
+namespace sonic {
+
+class MockWarmBootStateAdapter : public WarmBootStateAdapter {
+ public:
+  MOCK_METHOD(swss::WarmStart::WarmStartState, GetWarmBootState, (),
+              (override));
+  MOCK_METHOD(void, SetWarmBootState, (swss::WarmStart::WarmStartState state),
+              (override));
+  MOCK_METHOD(bool, IsWarmStart, (), (override));
+};
+
+}  // namespace sonic
+}  // namespace p4rt_app
+
+#endif  // PINS_P4RT_APP_SONIC_ADAPTERS_MOCK_WARM_BOOT_STATE_ADAPTER_H_

--- a/p4rt_app/sonic/adapters/warm_boot_state_adapter.cc
+++ b/p4rt_app/sonic/adapters/warm_boot_state_adapter.cc
@@ -1,0 +1,40 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "p4rt_app/sonic/adapters/warm_boot_state_adapter.h"
+
+#include "swss/warm_restart.h"
+
+namespace p4rt_app {
+namespace sonic {
+
+WarmBootStateAdapter::WarmBootStateAdapter() {}
+
+swss::WarmStart::WarmStartState WarmBootStateAdapter::GetWarmBootState() {
+  swss::WarmStart::WarmStartState state;
+  swss::WarmStart::getWarmStartState("p4rt", state);
+
+  return state;
+}
+
+void WarmBootStateAdapter::SetWarmBootState(
+    swss::WarmStart::WarmStartState state) {
+  swss::WarmStart::setWarmStartState("p4rt", state);
+}
+
+bool WarmBootStateAdapter::IsWarmStart() {
+  return swss::WarmStart::isWarmStart();
+}
+
+}  // namespace sonic
+}  // namespace p4rt_app

--- a/p4rt_app/sonic/adapters/warm_boot_state_adapter.h
+++ b/p4rt_app/sonic/adapters/warm_boot_state_adapter.h
@@ -1,0 +1,37 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef PINS_P4RT_APP_SONIC_ADAPTERS_WARM_BOOT_STATE_ADAPTER_H_
+#define PINS_P4RT_APP_SONIC_ADAPTERS_WARM_BOOT_STATE_ADAPTER_H_
+
+#include "swss/warm_restart.h"
+
+namespace p4rt_app {
+namespace sonic {
+// Acts as a proxy to invoke swss common swss::WarmStart class methods.
+// This provides the flexibility to define the constructors needed for mocks
+// and fakes.
+class WarmBootStateAdapter {
+ public:
+  explicit WarmBootStateAdapter();
+  virtual ~WarmBootStateAdapter() = default;
+
+  virtual swss::WarmStart::WarmStartState GetWarmBootState();
+  virtual void SetWarmBootState(swss::WarmStart::WarmStartState state);
+  virtual bool IsWarmStart(void);
+};
+
+}  // namespace sonic
+}  // namespace p4rt_app
+
+#endif  // PINS_P4RT_APP_SONIC_ADAPTERS_WARM_BOOT_STATE_ADAPTER_H_

--- a/p4rt_app/tests/BUILD.bazel
+++ b/p4rt_app/tests/BUILD.bazel
@@ -396,6 +396,7 @@ cc_test(
         "//p4rt_app/p4runtime:p4runtime_impl",
         "//p4rt_app/sonic:fake_packetio_interface",
         "//p4rt_app/sonic:redis_connections",
+        "//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter",
         "@com_github_google_glog//:glog",
         "@com_github_grpc_grpc//:grpc++_public_hdrs",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",

--- a/p4rt_app/tests/grpc_behavior_test.cc
+++ b/p4rt_app/tests/grpc_behavior_test.cc
@@ -26,6 +26,7 @@
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
 #include "p4rt_app/p4runtime/p4runtime_impl.h"
+#include "p4rt_app/sonic/adapters/fake_warm_boot_state_adapter.h"
 #include "p4rt_app/sonic/fake_packetio_interface.h"
 #include "p4rt_app/sonic/redis_connections.h"
 //TODO(PINS): Add fake Component/System state Translator
@@ -63,7 +64,8 @@ P4RuntimeImpl DummyP4RuntimeImpl() {
       std::move(dummy_p4rt_table), std::move(dummy_vrf_table),
       std::move(dummy_hash_table), std::move(dummy_switch_table),
       std::move(dummy_port_table), std::move(dummy_host_stats_table),
-      std::move(packet_io),
+      std::make_unique<p4rt_app::sonic::FakeWarmBootStateAdapter>(),
+      std::move(packet_io), 
       //TODO(PINS): To add component_state_helper, system_state_helper and netdev_translator.
       //component_state_helper, system_state_helper, netdev_translator,
       P4RuntimeImplOptions{});

--- a/p4rt_app/tests/lib/BUILD.bazel
+++ b/p4rt_app/tests/lib/BUILD.bazel
@@ -73,6 +73,7 @@ cc_library(
         "//p4rt_app/sonic/adapters:fake_producer_state_table_adapter",
         "//p4rt_app/sonic/adapters:fake_sonic_db_table",
         "//p4rt_app/sonic/adapters:fake_table_adapter",
+        "//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter",
         "@com_github_google_glog//:glog",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/memory",

--- a/p4rt_app/tests/lib/p4runtime_grpc_service.cc
+++ b/p4rt_app/tests/lib/p4runtime_grpc_service.cc
@@ -31,6 +31,7 @@
 #include "p4rt_app/sonic/adapters/fake_producer_state_table_adapter.h"
 #include "p4rt_app/sonic/adapters/fake_sonic_db_table.h"
 #include "p4rt_app/sonic/adapters/fake_table_adapter.h"
+#include "p4rt_app/sonic/adapters/fake_warm_boot_state_adapter.h"
 #include "p4rt_app/sonic/fake_packetio_interface.h"
 #include "p4rt_app/sonic/redis_connections.h"
 //TODO(PINS): Add Component/System state Translator
@@ -144,7 +145,9 @@ P4RuntimeGrpcService::P4RuntimeGrpcService(const P4RuntimeImplOptions& options)
   p4runtime_server_ = absl::make_unique<P4RuntimeImpl>(
       std::move(p4rt_table), std::move(vrf_table), std::move(hash_table),
       std::move(switch_table), std::move(port_table),
-      std::move(host_stats_table), std::move(fake_packetio_interface),
+      std::move(host_stats_table),
+      std::make_unique<p4rt_app::sonic::FakeWarmBootStateAdapter>(),
+      std::move(fake_packetio_interface),
      // TODO(PINS): To add fake component_state_helper, system_state_helper and netdev_translator.
      // fake_component_state_helper_, fake_system_state_helper_, fake_netdev_translator_, 
       options);
@@ -221,6 +224,11 @@ sonic::FakeSonicDbTable& P4RuntimeGrpcService::GetP4rtStateDbTable() {
 
 sonic::FakeSonicDbTable& P4RuntimeGrpcService::GetHostStatsStateDbTable() {
   return fake_host_stats_table_;
+}
+
+sonic::FakeWarmBootStateAdapter&
+P4RuntimeGrpcService::GetWarmBootStateAdapter() {
+  return fake_warm_boot_state_adapter_;
 }
 
 sonic::FakePacketIoInterface& P4RuntimeGrpcService::GetFakePacketIoInterface() {

--- a/p4rt_app/tests/lib/p4runtime_grpc_service.h
+++ b/p4rt_app/tests/lib/p4runtime_grpc_service.h
@@ -19,6 +19,7 @@
 #include "grpcpp/server.h"
 #include "p4rt_app/p4runtime/p4runtime_impl.h"
 #include "p4rt_app/sonic/adapters/fake_sonic_db_table.h"
+#include "p4rt_app/sonic/adapters/fake_warm_boot_state_adapter.h"
 #include "p4rt_app/sonic/fake_packetio_interface.h"
 //TODO(PINS):
 // #include "swss/fakes/fake_component_state_helper.h"
@@ -56,6 +57,9 @@ class P4RuntimeGrpcService {
   sonic::FakeSonicDbTable& GetP4rtStateDbTable();
   sonic::FakeSonicDbTable& GetHostStatsStateDbTable();
 
+  // Accessor for WarmBootStateAdapter.
+  sonic::FakeWarmBootStateAdapter& GetWarmBootStateAdapter();
+
   // Accessor for PacketIO interface.
   sonic::FakePacketIoInterface& GetFakePacketIoInterface();
 
@@ -86,6 +90,9 @@ class P4RuntimeGrpcService {
 
   // Faked StateDb tables.
   sonic::FakeSonicDbTable fake_host_stats_table_;
+
+  // Faked warm-boot state.
+  sonic::FakeWarmBootStateAdapter fake_warm_boot_state_adapter_;
 
   // Faked PacketIO interface.
   sonic::FakePacketIoInterface* fake_packetio_interface_;  // No ownership.


### PR DESCRIPTION
### Build Results:
divya@cfdc38a2acd6:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 392 targets (0 packages loaded, 0 targets configured).
INFO: Found 392 targets...
INFO: Elapsed time: 59.944s, Critical Path: 30.66s
INFO: 23 processes: 2 internal, 21 linux-sandbox.
INFO: Build completed successfully, 23 total actions

### Test Results:
divya@cfdc38a2acd6:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 392 targets (0 packages loaded, 44 targets configured).
INFO: Found 255 targets and 137 test targets...
INFO: Elapsed time: 95.550s, Critical Path: 25.75s
INFO: 142 processes: 149 linux-sandbox, 17 local.
INFO: Build completed successfully, 142 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.4s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.4s
//gutil:test_artifact_writer_test                                        PASSED in 0.6s
//gutil:testing_test                                                     PASSED in 0.4s
//gutil:version_test                                                     PASSED in 0.7s
//lib:basic_switch_test                                                  PASSED in 0.8s
//lib:ixia_helper_test                                                   PASSED in 1.1s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 0.8s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 14.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.4s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.4s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.1s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.4s
//lib/validator:validator_lib_test                                       PASSED in 25.7s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.5s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.6s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.5s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.4s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.6s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.4s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.2s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.1s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.4s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.0s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.4s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.8s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.8s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.8s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.4s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.8s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.7s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.5s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.6s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.3s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 0.9s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.0s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.7s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.3s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.5s
//p4rt_app/tests:packetio_test                                           PASSED in 3.5s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.2s
//p4rt_app/tests:resource_limits_test                                    PASSED in 2.6s
//p4rt_app/tests:response_path_test                                      PASSED in 2.6s
//p4rt_app/tests:role_test                                               PASSED in 1.1s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.7s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.6s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.0s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.7s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.6s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.8s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.6s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 22.1s
  Stats over 5 runs: max = 22.1s, min = 0.9s, avg = 12.2s, dev = 9.2s

Executed 137 out of 137 tests: 137 tests pass.
INFO: Build completed successfully, 142 total actions
divya@cfdc38a2acd6:/sonic/src/sonic-p4rt/sonic-pins$ 

### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.