### PR TITLE
[P4RT] Update `mirror_session_table` to support new action `mirror_with_vlan_tag_and_ipfix_encapsulation`, Remove non-programmable action parameters from `mirror_with_vlan_tag_and_ipfix_encapsulation` action, Fix P4RT table schema, modify action name for ipv6_tunnel_termination_table & Add `l2_multicast_passthrough` action to supported actions.

### DIFF
--- a/p4rt_app/p4runtime/p4info_verification_schema.pb.txt
+++ b/p4rt_app/p4runtime/p4info_verification_schema.pb.txt
@@ -83,6 +83,30 @@ tables {
     parameters { name: "tos" bitwidth: 8 }
     parameters { name: "ttl" bitwidth: 8 }
   }
+  actions {
+    name: "mirror_with_vlan_tag_and_ipfix_encapsulation"
+    parameters { name: "monitor_port" format: STRING }
+    parameters { name: "monitor_failover_port" format: STRING }
+    parameters { name: "mirror_encap_src_mac" format: MAC }
+    parameters { name: "mirror_encap_dst_mac" format: MAC }
+    parameters {
+      name: "mirror_encap_vlan_id"
+      format: HEX_STRING
+      bitwidth: 16
+    }
+    parameters { name: "mirror_encap_dst_ip" format: IPV6 }
+    parameters { name: "mirror_encap_src_ip" format: IPV6 }
+    parameters {
+      name: "mirror_encap_udp_src_port"
+      format: HEX_STRING
+      bitwidth: 16
+    }
+    parameters {
+      name: "mirror_encap_udp_dst_port"
+      format: HEX_STRING
+      bitwidth: 16
+    }
+  }
 }
 tables {
   name: "multicast_router_interface_table"
@@ -97,6 +121,7 @@ tables {
     name: "set_multicast_src_mac"
     parameters { name: "src_mac" format: MAC }
   }
+  actions { name: "l2_multicast_passthrough" }
 }
 tables {
   name: "neighbor_table"
@@ -130,10 +155,10 @@ tables {
     name: "set_ip_nexthop_and_disable_rewrites"
     parameters { name: "router_interface_id" format: STRING }
     parameters { name: "neighbor_id" format: IPV6 }
-    parameters { name: "disable_decrement_ttl" bitwidth: 1}
-    parameters { name: "disable_src_mac_rewrite" bitwidth: 1}
-    parameters { name: "disable_dst_mac_rewrite" bitwidth: 1}
-    parameters { name: "disable_vlan_rewrite" bitwidth: 1}
+    parameters { name: "disable_decrement_ttl" bitwidth: 1 }
+    parameters { name: "disable_src_mac_rewrite" bitwidth: 1 }
+    parameters { name: "disable_dst_mac_rewrite" bitwidth: 1 }
+    parameters { name: "disable_vlan_rewrite" bitwidth: 1 }
   }
 }
 tables {
@@ -171,10 +196,8 @@ tables {
 tables {
   name: "ipv6_tunnel_termination_table"
   match_fields { name: "dst_ipv6" format: IPV6 type: TERNARY }
-  actions {
-    name: "mark_for_tunnel_decap_and_set_vrf"
-    parameters { name: "vrf_id" format: STRING }
-  }
+  match_fields { name: "src_ipv6" format: IPV6 type: TERNARY }
+  actions { name: "tunnel_decap" }
 }
 tables {
   name: "disable_vlan_checks_table"


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@cfdc38a2acd6:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 392 targets (0 packages loaded, 291 targets configured).
INFO: Found 392 targets...
INFO: Elapsed time: 2.033s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### Test Results:
divya@cfdc38a2acd6:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 392 targets (0 packages loaded, 0 targets configured).
INFO: Found 255 targets and 137 test targets...
INFO: Elapsed time: 90.535s, Critical Path: 25.72s
INFO: 142 processes: 149 linux-sandbox, 17 local.
INFO: Build completed successfully, 142 total actions
//gutil:collections_test                                                 PASSED in 0.4s
//gutil:io_test                                                          PASSED in 0.4s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 0.7s
//lib:basic_switch_test                                                  PASSED in 0.8s
//lib:ixia_helper_test                                                   PASSED in 1.1s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 0.8s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 14.9s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.4s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.4s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.7s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.2s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 25.7s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.6s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.0s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.2s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.4s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.7s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.5s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.3s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 0.9s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.0s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.3s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.5s
//p4rt_app/tests:packetio_test                                           PASSED in 3.5s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 2.7s
//p4rt_app/tests:response_path_test                                      PASSED in 2.7s
//p4rt_app/tests:role_test                                               PASSED in 1.1s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.7s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.6s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.6s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.8s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 0.9s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.7s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.6s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 23.2s
  Stats over 5 runs: max = 23.2s, min = 2.2s, avg = 10.4s, dev = 7.5s

Executed 137 out of 137 tests: 137 tests pass.
INFO: Build completed successfully, 142 total actions
divya@cfdc38a2acd6:/sonic/src/sonic-p4rt/sonic-pins$