### PR TITLE
[PDPI] : Add a by-dependency-order per-table integer mapping to the IrP4Info proto.

### DIFF
--- a/p4_pdpi/BUILD.bazel
+++ b/p4_pdpi/BUILD.bazel
@@ -133,6 +133,7 @@ cc_library(
     # Disable default arguments internally. Using them in PDPI itself is very likely a bug.
     local_defines = ["PDPI_DISABLE_TRANSLATION_OPTIONS_DEFAULT"],
     deps = [
+        ":helpers",
         ":ir_cc_proto",
         ":sequencing_util",
         "//gutil:collections",
@@ -503,6 +504,36 @@ cc_test(
         "//gutil:status_matchers",
         "@com_google_absl//absl/hash:hash_testing",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "helpers",
+    srcs = ["helpers.cc"],
+    hdrs = ["helpers.h"],
+    deps = [
+        ":built_ins",
+        ":ir_cc_proto",
+        "//gutil:collections",
+        "//gutil:status",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "helpers_test",
+    srcs = ["helpers_test.cc"],
+    deps = [
+        ":built_ins",
+        ":helpers",
+        ":ir_cc_proto",
+        "//gutil:status_matchers",
+        "//p4_pdpi/testing:test_p4info_cc",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/p4_pdpi/built_ins.cc
+++ b/p4_pdpi/built_ins.cc
@@ -32,7 +32,12 @@ constexpr absl::string_view kMulticastGroupIdString = "multicast_group_id";
 constexpr absl::string_view kReplicaString = "replica";
 constexpr absl::string_view kReplicaPortString = "replica.port";
 constexpr absl::string_view kReplicaInstanceString = "replica.instance";
+
 }  // namespace
+
+std::string GetMulticastGroupTableName() {
+  return absl::StrCat(kBuiltInPrefix, kMulticastGroupTableString);
+}
 
 bool IsBuiltInTable(absl::string_view table_name) {
   return StringToIrBuiltInTable(table_name).ok();
@@ -97,7 +102,7 @@ absl::StatusOr<IrBuiltInAction> GetBuiltInActionFromBuiltInParameter(
 absl::StatusOr<std::string> IrBuiltInTableToString(IrBuiltInTable table) {
   switch (table) {
     case pdpi::BUILT_IN_TABLE_MULTICAST_GROUP_TABLE: {
-      return absl::StrCat(kBuiltInPrefix, kMulticastGroupTableString);
+      return GetMulticastGroupTableName();
     }
     default: {
       return gutil::InvalidArgumentErrorBuilder() << "Unknown built-in table.";
@@ -146,7 +151,7 @@ absl::StatusOr<std::string> IrBuiltInParameterToString(
 }
 
 absl::StatusOr<IrBuiltInTable> StringToIrBuiltInTable(absl::string_view table) {
-  if (table == absl::StrCat(kBuiltInPrefix, kMulticastGroupTableString)) {
+  if (table == GetMulticastGroupTableName()) {
     return pdpi::BUILT_IN_TABLE_MULTICAST_GROUP_TABLE;
   }
   return gutil::InvalidArgumentErrorBuilder()

--- a/p4_pdpi/built_ins.h
+++ b/p4_pdpi/built_ins.h
@@ -28,6 +28,9 @@
 
 namespace pdpi {
 
+// Returns the PDPI name for the multicast group table.
+std::string GetMulticastGroupTableName();
+
 // Returns true if `table_name` is a known built_in table.
 // Useful for branching on table type.
 bool IsBuiltInTable(absl::string_view table_name);

--- a/p4_pdpi/helpers.cc
+++ b/p4_pdpi/helpers.cc
@@ -1,0 +1,42 @@
+#include "p4_pdpi/helpers.h"
+
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "gutil/collections.h"
+#include "gutil/status.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/built_ins.h"
+#include "p4_pdpi/ir.pb.h"
+
+namespace pdpi {
+
+absl::StatusOr<std::string> EntityToTableName(const pdpi::IrP4Info& info,
+                                              const p4::v1::Entity& entity) {
+  switch (entity.entity_case()) {
+    case p4::v1::Entity::kTableEntry: {
+      ASSIGN_OR_RETURN(const IrTableDefinition table,
+                       gutil::FindOrStatus(info.tables_by_id(),
+                                           entity.table_entry().table_id()));
+      return table.preamble().alias();
+    }
+    case p4::v1::Entity::kPacketReplicationEngineEntry: {
+      if (!entity.packet_replication_engine_entry()
+               .has_multicast_group_entry()) {
+        return gutil::InvalidArgumentErrorBuilder()
+               << "Expected a `multicast_group_entry`, but got unexpected "
+                  "packet_replication_engine_entry: "
+               << entity.packet_replication_engine_entry().DebugString();
+      }
+      return GetMulticastGroupTableName();
+    }
+    default:
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Expected a `table_entry` or "
+                "`packet_replication_engine_entry`, but got unexpected entity:"
+             << entity.DebugString();
+  }
+}
+
+}  // namespace pdpi

--- a/p4_pdpi/helpers.h
+++ b/p4_pdpi/helpers.h
@@ -1,0 +1,17 @@
+#ifndef PINS_INFRA_P4_PDPI_HELPERS_H_
+#define PINS_INFRA_P4_PDPI_HELPERS_H_
+
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/ir.pb.h"
+
+namespace pdpi {
+
+// Returns the table name associated with the given entity.
+absl::StatusOr<std::string> EntityToTableName(const IrP4Info& info,
+                                              const p4::v1::Entity& entity);
+}  // namespace pdpi
+
+#endif  // PINS_INFRA_P4_PDPI_HELPERS_H_

--- a/p4_pdpi/helpers_test.cc
+++ b/p4_pdpi/helpers_test.cc
@@ -1,0 +1,59 @@
+#include "p4_pdpi/helpers.h"
+
+#include <string>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status_matchers.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/built_ins.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4_pdpi/testing/test_p4info.h"
+
+namespace pdpi {
+namespace {
+
+using gutil::IsOk;
+using gutil::IsOkAndHolds;
+using testing::Not;
+
+TEST(EntityToTableNameTest, StandardTableSupported) {
+  IrP4Info kInfo = GetTestIrP4Info();
+  IrTableDefinition kTestTable = kInfo.tables_by_id().begin()->second;
+  p4::v1::Entity entity;
+  entity.mutable_table_entry()->set_table_id(kTestTable.preamble().id());
+
+  EXPECT_THAT(EntityToTableName(kInfo, entity),
+              IsOkAndHolds(kTestTable.preamble().alias()));
+}
+
+TEST(EntityToTableNameTest, MulticastTableSupported) {
+  p4::v1::Entity entity;
+  entity.mutable_packet_replication_engine_entry()
+      ->mutable_multicast_group_entry();
+
+  ASSERT_OK_AND_ASSIGN(
+      std::string multicast_group_table_name,
+      IrBuiltInTableToString(BUILT_IN_TABLE_MULTICAST_GROUP_TABLE));
+
+  EXPECT_THAT(EntityToTableName(GetTestIrP4Info(), entity),
+              IsOkAndHolds(multicast_group_table_name));
+}
+
+TEST(EntityToTableNameTest, OtherPacketReplicationEngineUnsupported) {
+  p4::v1::Entity entity;
+  entity.mutable_packet_replication_engine_entry()
+      ->mutable_clone_session_entry();
+
+  EXPECT_THAT(EntityToTableName(GetTestIrP4Info(), entity), Not(IsOk()));
+}
+
+TEST(EntityToTableNameTest, OtherEntitiesUnsupported) {
+  p4::v1::Entity entity;
+  entity.mutable_direct_counter_entry();
+
+  EXPECT_THAT(EntityToTableName(GetTestIrP4Info(), entity), Not(IsOk()));
+}
+
+}  // namespace
+}  // namespace pdpi

--- a/p4_pdpi/ir.proto
+++ b/p4_pdpi/ir.proto
@@ -358,6 +358,10 @@ message IrP4Info {
   // Maps built-in table name to definitions. Refer to `IrBuiltInTable` for
   // valid built-in table names.
   map<string, IrBuiltInTableDefinition> built_in_tables = 13;
+  // Maps each table alias to a dependency rank such that if an entry in A can
+  // depend on an entry in B (including transitively), then
+  // dependency_rank_by_table_name[B] > dependency_rank_by_table_name[A].
+  map<string, int32> dependency_rank_by_table_name = 14;
 }
 
 // -- Table entries ------------------------------------------------------------

--- a/p4_pdpi/sequencing.h
+++ b/p4_pdpi/sequencing.h
@@ -57,8 +57,16 @@ absl::StatusOr<std::vector<std::vector<int>>> SequencePiUpdatesInPlace(
 
 // Sorts the table entries such that entries that are depended on come first.
 // That is, two entries x and y where x refers to y will be sorted as [y, x].
+ABSL_DEPRECATED("Prefer StableSortEntities")
 absl::Status SortTableEntries(const IrP4Info& info,
                               std::vector<p4::v1::TableEntry>& entries);
+
+// Stably sorts the entities such that entities that may be depended on come
+// first. That is, two entities x and y where x could refer to y will be sorted
+// as [y, x]. This is done based on the dependency rank remain in the same relative order.
+// Any entities with the same dependency rank remain in the same relative order.
+absl::Status StableSortEntities(const IrP4Info& info,
+                          std::vector<p4::v1::Entity>& entities);
 
 // Returns the subset of Entities in `entities` that is not reachable from any
 // root entity in `entities`, where a root entity is determined by the

--- a/p4_pdpi/testing/testdata/info.expected
+++ b/p4_pdpi/testing/testdata/info.expected
@@ -10803,6 +10803,110 @@ built_in_tables {
     }
   }
 }
+dependency_rank_by_table_name {
+  key: "builtin::multicast_group_table"
+  value: -1
+}
+dependency_rank_by_table_name {
+  key: "byte_count_and_meter_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "constrained_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "count_and_meter_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "exact_and_optional_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "exact_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "golden_test_friendly_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "golden_test_friendly_wcmp_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "id_test_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "lpm1_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "lpm2_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "no_action_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "one_match_field_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "optional_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "packet_count_and_meter_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "referenced_by_multicast_replica_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "referring_by_action_table"
+  value: -1
+}
+dependency_rank_by_table_name {
+  key: "referring_by_match_field_table"
+  value: -1
+}
+dependency_rank_by_table_name {
+  key: "referring_to_referring_by_match_field_table"
+  value: -2
+}
+dependency_rank_by_table_name {
+  key: "refers_to_multicast_by_action_table"
+  value: -2
+}
+dependency_rank_by_table_name {
+  key: "refers_to_multicast_by_match_field_table"
+  value: -2
+}
+dependency_rank_by_table_name {
+  key: "ternary_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "two_match_fields_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "unsupported_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "wcmp2_table"
+  value: 0
+}
+dependency_rank_by_table_name {
+  key: "wcmp_table"
+  value: 0
+}
 
 -- pdpi::RemoveUnsupportedEntities diff ---------------------------
 deleted: tables_by_id[33554435].match_fields_by_id[5]: { match_field { id: 5 name: "unsupported_field" annotations: "@unsupported" bitwidth: 1 match_type: TERNARY } is_unsupported: true }
@@ -10815,3 +10919,6 @@ deleted: tables_by_name[ternary_table].entry_actions[1]: { ref { id: 16777223 an
 deleted: tables_by_name[unsupported_table]: { preamble { id: 33554447 name: "ingress.unsupported_table" alias: "unsupported_table" annotations: "@unsupported" } match_fields_by_id { key: 1 value { match_field { id: 1 name: "ipv6" annotations: "@format(IPV6_ADDRESS)" bitwidth: 128 match_type: EXACT } format: IPV6 } } match_fields_by_id { key: 2 value { match_field { id: 2 name: "ipv4" annotations: "@format(IPV4_ADDRESS)" bitwidth: 32 match_type: EXACT } format: IPV4 } } match_fields_by_name { key: "ipv4" value { match_field { id: 2 name: "ipv4" annotations: "@format(IPV4_ADDRESS)" bitwidth: 32 match_type: EXACT } format: IPV4 } } match_fields_by_name { key: "ipv6" value { match_field { id: 1 name: "ipv6" annotations: "@format(IPV6_ADDRESS)" bitwidth: 128 match_type: EXACT } format: IPV6 } } default_only_actions { ref { id: 21257015 annotations: "@defaultonly" scope: DEFAULT_ONLY } action { preamble { id: 21257015 name: "NoAction" alias: "NoAction" annotations: "@noWarn(\"unused\")" } } } size: 1024 const_default_action { preamble { id: 21257015 name: "NoAction" alias: "NoAction" annotations: "@noWarn(\"unused\")" } } is_unsupported: true }
 deleted: actions_by_id[16777223]: { preamble { id: 16777223 name: "unsupported_action" alias: "unsupported_action" annotations: "@unsupported" } is_unsupported: true }
 deleted: actions_by_name[unsupported_action]: { preamble { id: 16777223 name: "unsupported_action" alias: "unsupported_action" annotations: "@unsupported" } is_unsupported: true }
+
+
+DO NOT SUBMIT: P4Info still contains unsupported entities after call to `pdpi::RemoveUnsupportedEntities`

--- a/p4_pdpi/testing/testdata/sequencing.expected
+++ b/p4_pdpi/testing/testdata/sequencing.expected
@@ -1203,6 +1203,492 @@ updates {
 }
 
 =========================================================================
+SortTest: Empty input
+=========================================================================
+
+--- PD entries (input):
+<empty>
+
+--- Sorted entities (output):
+<empty>
+
+=========================================================================
+SortTest: EntryWithOneKey{key-a} -> EntryThatRefersTo{key-a}
+=========================================================================
+
+--- PD entries (input):
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_one_match_field_action {
+      referring_id_1: "key-a"
+    }
+  }
+}
+
+one_match_field_table_entry {
+  match {
+    id: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+--- Sorted entities (output):
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_one_match_field_action {
+      referring_id_1: "key-a"
+    }
+  }
+}
+
+one_match_field_table_entry {
+  match {
+    id: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+=========================================================================
+SortTest: EntryWithOneKey{key-a} -> EntryThatRefersTo{key-a, 0x002}
+=========================================================================
+
+--- PD entries (input):
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_two_match_fields_action {
+      referring_id_1: "key-a"
+      referring_id_2: "0x002"
+    }
+  }
+}
+
+one_match_field_table_entry {
+  match {
+    id: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+--- Sorted entities (output):
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_two_match_fields_action {
+      referring_id_1: "key-a"
+      referring_id_2: "0x002"
+    }
+  }
+}
+
+one_match_field_table_entry {
+  match {
+    id: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+=========================================================================
+SortTest: EntryWithTwoKeys{key-a, 0x002} -> EntryThatRefersTo{key-a, 0x002}
+=========================================================================
+
+--- PD entries (input):
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_two_match_fields_action {
+      referring_id_1: "key-a"
+      referring_id_2: "0x002"
+    }
+  }
+}
+
+two_match_fields_table_entry {
+  match {
+    id_1: "key-a"
+    id_2: "0x002"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+--- Sorted entities (output):
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_two_match_fields_action {
+      referring_id_1: "key-a"
+      referring_id_2: "0x002"
+    }
+  }
+}
+
+two_match_fields_table_entry {
+  match {
+    id_1: "key-a"
+    id_2: "0x002"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+=========================================================================
+SortTest: EntryThatRefersTo{key-a, 0x002} -> EntryWithTwoKeys{key-c, 0x004}
+=========================================================================
+
+--- PD entries (input):
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_two_match_fields_action {
+      referring_id_1: "key-a"
+      referring_id_2: "0x002"
+    }
+  }
+}
+
+two_match_fields_table_entry {
+  match {
+    id_1: "key-c"
+    id_2: "0x004"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+--- Sorted entities (output):
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_two_match_fields_action {
+      referring_id_1: "key-a"
+      referring_id_2: "0x002"
+    }
+  }
+}
+
+two_match_fields_table_entry {
+  match {
+    id_1: "key-c"
+    id_2: "0x004"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+=========================================================================
+SortTest: Entries at same rank should maintain the original order.
+=========================================================================
+
+--- PD entries (input):
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_two_match_fields_action {
+      referring_id_1: "key-a"
+      referring_id_2: "0x002"
+    }
+  }
+}
+
+packet_count_and_meter_table_entry {
+  match {
+    ipv4 {
+      value: "16.36.50.0"
+      prefix_length: 24
+    }
+  }
+  action {
+    packet_count_and_meter {
+    }
+  }
+}
+
+--- Sorted entities (output):
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_two_match_fields_action {
+      referring_id_1: "key-a"
+      referring_id_2: "0x002"
+    }
+  }
+}
+
+packet_count_and_meter_table_entry {
+  match {
+    ipv4 {
+      value: "16.36.50.0"
+      prefix_length: 24
+    }
+  }
+  action {
+    packet_count_and_meter {
+    }
+  }
+}
+
+=========================================================================
+SortTest: EntryWithOneKey{key-a} -> EntryThatRefersTo{key-a} , another entry
+=========================================================================
+
+--- PD entries (input):
+lpm2_table_entry {
+  match {
+    ipv6 {
+      value: "ffff::abcd:0:0"
+      prefix_length: 96
+    }
+  }
+  action {
+    NoAction {
+    }
+  }
+}
+
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_one_match_field_action {
+      referring_id_1: "key-a"
+    }
+  }
+}
+
+one_match_field_table_entry {
+  match {
+    id: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+--- Sorted entities (output):
+lpm2_table_entry {
+  match {
+    ipv6 {
+      value: "ffff::abcd:0:0"
+      prefix_length: 96
+    }
+  }
+  action {
+    NoAction {
+    }
+  }
+}
+
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_one_match_field_action {
+      referring_id_1: "key-a"
+    }
+  }
+}
+
+one_match_field_table_entry {
+  match {
+    id: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+=========================================================================
+SortTest: EntryWithOneKey{key-a} -> EntryThatRefersTo{key-a} ,EntryWithOneKey{key-b} -> EntryThatRefersTo{key-b}
+=========================================================================
+
+--- PD entries (input):
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_one_match_field_action {
+      referring_id_1: "key-a"
+    }
+  }
+}
+
+one_match_field_table_entry {
+  match {
+    id: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_two_match_fields_action {
+      referring_id_1: "key-a"
+      referring_id_2: "0x002"
+    }
+  }
+}
+
+two_match_fields_table_entry {
+  match {
+    id_1: "key-c"
+    id_2: "0x004"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+--- Sorted entities (output):
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_one_match_field_action {
+      referring_id_1: "key-a"
+    }
+  }
+}
+
+one_match_field_table_entry {
+  match {
+    id: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_two_match_fields_action {
+      referring_id_1: "key-a"
+      referring_id_2: "0x002"
+    }
+  }
+}
+
+two_match_fields_table_entry {
+  match {
+    id_1: "key-c"
+    id_2: "0x004"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+=========================================================================
+SortTest: two_match_fields_table_entry -> referring_by_match_field_table_entry
+=========================================================================
+
+--- PD entries (input):
+referring_by_match_field_table_entry {
+  match {
+    referring_id_1: "key-a"
+    referring_id_2: "0x001"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+two_match_fields_table_entry {
+  match {
+    id_1: "key-a"
+    id_2: "0x001"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+--- Sorted entities (output):
+referring_by_match_field_table_entry {
+  match {
+    referring_id_1: "key-a"
+    referring_id_2: "0x001"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+two_match_fields_table_entry {
+  match {
+    id_1: "key-a"
+    id_2: "0x001"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+=========================================================================
 GetEntriesUnreachableFromRootsTest: Empty input generates no garbage.
 =========================================================================
 

--- a/p4_pdpi/testing/testdata/sequencing.expected
+++ b/p4_pdpi/testing/testdata/sequencing.expected
@@ -1239,6 +1239,16 @@ one_match_field_table_entry {
 }
 
 --- Sorted entities (output):
+one_match_field_table_entry {
+  match {
+    id: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
 referring_by_action_table_entry {
   match {
     val: "0x001"
@@ -1246,16 +1256,6 @@ referring_by_action_table_entry {
   action {
     referring_to_one_match_field_action {
       referring_id_1: "key-a"
-    }
-  }
-}
-
-one_match_field_table_entry {
-  match {
-    id: "key-a"
-  }
-  action {
-    do_thing_4 {
     }
   }
 }
@@ -1288,6 +1288,16 @@ one_match_field_table_entry {
 }
 
 --- Sorted entities (output):
+one_match_field_table_entry {
+  match {
+    id: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
 referring_by_action_table_entry {
   match {
     val: "0x001"
@@ -1296,16 +1306,6 @@ referring_by_action_table_entry {
     referring_to_two_match_fields_action {
       referring_id_1: "key-a"
       referring_id_2: "0x002"
-    }
-  }
-}
-
-one_match_field_table_entry {
-  match {
-    id: "key-a"
-  }
-  action {
-    do_thing_4 {
     }
   }
 }
@@ -1339,6 +1339,17 @@ two_match_fields_table_entry {
 }
 
 --- Sorted entities (output):
+two_match_fields_table_entry {
+  match {
+    id_1: "key-a"
+    id_2: "0x002"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
 referring_by_action_table_entry {
   match {
     val: "0x001"
@@ -1347,17 +1358,6 @@ referring_by_action_table_entry {
     referring_to_two_match_fields_action {
       referring_id_1: "key-a"
       referring_id_2: "0x002"
-    }
-  }
-}
-
-two_match_fields_table_entry {
-  match {
-    id_1: "key-a"
-    id_2: "0x002"
-  }
-  action {
-    do_thing_4 {
     }
   }
 }
@@ -1391,6 +1391,17 @@ two_match_fields_table_entry {
 }
 
 --- Sorted entities (output):
+two_match_fields_table_entry {
+  match {
+    id_1: "key-c"
+    id_2: "0x004"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
 referring_by_action_table_entry {
   match {
     val: "0x001"
@@ -1399,17 +1410,6 @@ referring_by_action_table_entry {
     referring_to_two_match_fields_action {
       referring_id_1: "key-a"
       referring_id_2: "0x002"
-    }
-  }
-}
-
-two_match_fields_table_entry {
-  match {
-    id_1: "key-c"
-    id_2: "0x004"
-  }
-  action {
-    do_thing_4 {
     }
   }
 }
@@ -1445,18 +1445,6 @@ packet_count_and_meter_table_entry {
 }
 
 --- Sorted entities (output):
-referring_by_action_table_entry {
-  match {
-    val: "0x001"
-  }
-  action {
-    referring_to_two_match_fields_action {
-      referring_id_1: "key-a"
-      referring_id_2: "0x002"
-    }
-  }
-}
-
 packet_count_and_meter_table_entry {
   match {
     ipv4 {
@@ -1466,6 +1454,18 @@ packet_count_and_meter_table_entry {
   }
   action {
     packet_count_and_meter {
+    }
+  }
+}
+
+referring_by_action_table_entry {
+  match {
+    val: "0x001"
+  }
+  action {
+    referring_to_two_match_fields_action {
+      referring_id_1: "key-a"
+      referring_id_2: "0x002"
     }
   }
 }
@@ -1523,6 +1523,16 @@ lpm2_table_entry {
   }
 }
 
+one_match_field_table_entry {
+  match {
+    id: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
 referring_by_action_table_entry {
   match {
     val: "0x001"
@@ -1530,16 +1540,6 @@ referring_by_action_table_entry {
   action {
     referring_to_one_match_field_action {
       referring_id_1: "key-a"
-    }
-  }
-}
-
-one_match_field_table_entry {
-  match {
-    id: "key-a"
-  }
-  action {
-    do_thing_4 {
     }
   }
 }
@@ -1594,6 +1594,27 @@ two_match_fields_table_entry {
 }
 
 --- Sorted entities (output):
+one_match_field_table_entry {
+  match {
+    id: "key-a"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
+two_match_fields_table_entry {
+  match {
+    id_1: "key-c"
+    id_2: "0x004"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+}
+
 referring_by_action_table_entry {
   match {
     val: "0x001"
@@ -1601,16 +1622,6 @@ referring_by_action_table_entry {
   action {
     referring_to_one_match_field_action {
       referring_id_1: "key-a"
-    }
-  }
-}
-
-one_match_field_table_entry {
-  match {
-    id: "key-a"
-  }
-  action {
-    do_thing_4 {
     }
   }
 }
@@ -1623,17 +1634,6 @@ referring_by_action_table_entry {
     referring_to_two_match_fields_action {
       referring_id_1: "key-a"
       referring_id_2: "0x002"
-    }
-  }
-}
-
-two_match_fields_table_entry {
-  match {
-    id_1: "key-c"
-    id_2: "0x004"
-  }
-  action {
-    do_thing_4 {
     }
   }
 }
@@ -1666,10 +1666,10 @@ two_match_fields_table_entry {
 }
 
 --- Sorted entities (output):
-referring_by_match_field_table_entry {
+two_match_fields_table_entry {
   match {
-    referring_id_1: "key-a"
-    referring_id_2: "0x001"
+    id_1: "key-a"
+    id_2: "0x001"
   }
   action {
     do_thing_4 {
@@ -1677,10 +1677,10 @@ referring_by_match_field_table_entry {
   }
 }
 
-two_match_fields_table_entry {
+referring_by_match_field_table_entry {
   match {
-    id_1: "key-a"
-    id_2: "0x001"
+    referring_id_1: "key-a"
+    referring_id_2: "0x001"
   }
   action {
     do_thing_4 {


### PR DESCRIPTION
/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ./key.sh p4_pdpi/
Keyword check Passed.

 
 /sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS  ...
INFO: Build options --copt, --cxxopt, --host_copt, and 1 more have changed, discarding analysis cache.
INFO: Analyzed 394 targets (235 packages loaded, 19846 targets configured).
INFO: Found 394 targets...
INFO: From Compiling libs/graph/src/read_graphviz_new.cpp:
In file included from external/boost/boost/smart_ptr/detail/sp_thread_sleep.hpp:22,
                 from external/boost/boost/smart_ptr/detail/yield_k.hpp:23,
                 from external/boost/boost/smart_ptr/detail/spinlock_gcc_atomic.hpp:14,
                 from external/boost/boost/smart_ptr/detail/spinlock.hpp:42,
                 from external/boost/boost/smart_ptr/detail/spinlock_pool.hpp:25,
      |                     ~~~^~~~~~~~~~~
INFO: From Compiling p4_pdpi/testing/sequencing_test_runner.cc:
p4_pdpi/testing/sequencing_test_runner.cc:1000:3: warning: multi-line comment [-Wcomment]
 1000 |   //   |           \
      |   ^
INFO: Elapsed time: 3118.982s, Critical Path: 87.73s
INFO: 4485 processes: 1 internal, 4484 linux-sandbox.
INFO: Build completed successfully, 4485 total actions


/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Analyzed 394 targets (0 packages loaded, 0 targets configured).
INFO: Found 256 targets and 138 test targets...
INFO: Elapsed time: 1.042s, Critical Path: 0.23s
INFO: 3 processes: 4 linux-sandbox.
INFO: Build completed successfully, 3 total actions
//gutil:collections_test                                        (cached) PASSED in 1.1s
//gutil:io_test                                                 (cached) PASSED in 1.0s
//p4_pdpi/testing:info_test                                              PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.2s

Executed 2 out of 138 tests: 138 tests pass.
INFO: Build completed successfully, 3 total actions