### PR TITLE
[Comb] Add syslog sink to be used with GLOG.

### DIFF
--- a/gutil/BUILD.bazel
+++ b/gutil/BUILD.bazel
@@ -316,3 +316,10 @@ cc_test(
         "@com_google_absl//absl/strings",
     ],
 )
+
+cc_library(
+    name = "syslog_sink",
+    srcs = ["syslog_sink.cc"],
+    hdrs = ["syslog_sink.h"],
+    deps = ["@com_github_google_glog//:glog"],
+)

--- a/gutil/syslog_sink.cc
+++ b/gutil/syslog_sink.cc
@@ -1,0 +1,62 @@
+#include "gutil/syslog_sink.h"
+
+#include <sys/syscall.h>
+#include <sys/syslog.h>
+#include <sys/time.h>
+
+#include <array>
+
+#include "glog/logging.h"
+
+namespace gutil {
+namespace {
+
+// GLOG severity uses integers in the range [0-3]:
+//   https://github.com/google/glog/blob/master/src/glog/log_severity.h
+constexpr std::array<int, 4> kGlogSeverityToSyslog = {
+    LOG_INFO,
+    LOG_WARNING,
+    LOG_ERR,
+    LOG_EMERG,
+};
+constexpr std::array<char, 4> kGlogSeverityLetter = {
+    'I',
+    'W',
+    'E',
+    'F',
+};
+
+}  // namespace
+
+SyslogSink::SyslogSink(const char* process_name) {
+  openlog(process_name, LOG_NDELAY, LOG_USER);
+  google::AddLogSink(this);
+}
+
+SyslogSink::~SyslogSink() {
+  google::RemoveLogSink(this);
+  closelog();
+}
+
+void SyslogSink::send(google::LogSeverity severity, const char* full_filename,
+                      const char* base_filename, int line,
+                      const google::LogMessageTime& logmsgtime,
+                      const char* message, size_t message_len) {
+  // Create a timestamp with micosecond resolution.
+  struct timeval tv;
+  struct timezone tz;
+  struct tm time;
+  gettimeofday(&tv, &tz);
+  localtime_r(&tv.tv_sec, &time);
+
+  // Output format:
+  //   I0104 23:00:59.123456    71 filename.cc:100] Your Message Here!
+  syslog(kGlogSeverityToSyslog[severity],
+         "%c%02d%02d %02d:%02d:%02d.%06ld %5ld %s:%d] %.*s",
+         kGlogSeverityLetter[severity], 1 + time.tm_mon, time.tm_mday,
+         time.tm_hour, time.tm_min, time.tm_sec, static_cast<long>(tv.tv_usec),
+         syscall(SYS_gettid), base_filename, line,
+         static_cast<int>(message_len), message);
+}
+
+}  // namespace gutil

--- a/gutil/syslog_sink.h
+++ b/gutil/syslog_sink.h
@@ -1,0 +1,34 @@
+#ifndef PINS_GUTIL_SYSLOG_SINK_H_
+#define PINS_GUTIL_SYSLOG_SINK_H_
+
+#include <cstddef>
+
+#include "glog/logging.h"
+
+namespace gutil {
+
+// When constructed SyslogSink will automatically register with GLOG and begin
+// forwarding all LOG() messages to syslog. In the dtor we unregister with GLOG
+// so the SyslogSink should outlive the program. These messages are treated as
+// user-level (i.e. a LOG_USER facility), and serverities are mapped as follows:
+//   LOG(INFO)    -> LOG_INFO
+//   LOG(WARNING) -> LOG_WARNING
+//   LOG(ERROR)   -> LOG_ERR
+//   LOG(FATAL)   -> LOG_EMERG
+//
+// The syslog message will be formatted similar to a GLOG message with a
+// microsecond timestamp.
+class SyslogSink : google::LogSink {
+ public:
+  SyslogSink(const char* process_name);
+  ~SyslogSink();
+
+  void send(google::LogSeverity severity, const char* full_filename,
+            const char* base_filename, int line,
+            const google::LogMessageTime& logmsgtime, const char* message,
+            size_t message_len) override;
+};
+
+}  // namespace gutil
+
+#endif  // PINS_GUTIL_SYSLOG_SINK_H_

--- a/p4rt_app/BUILD.bazel
+++ b/p4rt_app/BUILD.bazel
@@ -40,6 +40,7 @@ cc_binary(
         "@com_google_absl//absl/time",
         "@com_github_grpc_grpc//:grpc++_public_hdrs",
         "//gutil:status",
+        "//gutil:syslog_sink",
         "//p4rt_app/event_monitoring:app_state_db_port_table_event",
         "//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event",
         "//p4rt_app/event_monitoring:config_db_cpu_queue_table_event",

--- a/p4rt_app/p4rt.cc
+++ b/p4rt_app/p4rt.cc
@@ -40,6 +40,7 @@
 #include "grpcpp/server.h"
 #include "grpcpp/server_builder.h"
 #include "gutil/status.h"
+#include "gutil/syslog_sink.h"
 #include "p4rt_app/event_monitoring/app_state_db_port_table_event.h"
 #include "p4rt_app/event_monitoring/app_state_db_send_to_ingress_port_table_event.h"
 #include "p4rt_app/event_monitoring/config_db_cpu_queue_table_event.h"
@@ -364,6 +365,7 @@ void ConfigDbEventLoop(P4RuntimeImpl* p4runtime_server,
 }  // namespace p4rt_app
 
 int main(int argc, char** argv) {
+  gutil::SyslogSink syslog_sink("p4rt");
   google::InitGoogleLogging(argv[0]);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@529ce8414f42:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
DEBUG: Rule 'com_github_nelhage_rules_boost' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1619053724 -0700"
DEBUG: Repository com_github_nelhage_rules_boost instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:75:9: in <toplevel>
  /var/divya/.cache/bazel/_bazel_divya/5fd88bad78ef03829a4685c83637a020/external/com_github_p4lang_p4c/bazel/p4c_deps.bzl:25:23: in p4c_deps
Repository rule git_repository defined at:
  /var/divya/.cache/bazel/_bazel_divya/5fd88bad78ef03829a4685c83637a020/external/bazel_tools/tools/build_defs/repo/git.bzl:199:33: in <toplevel>
INFO: Analyzed 393 targets (0 packages loaded, 24 targets configured).
INFO: Found 393 targets...
...
INFO: Elapsed time: 2211.877s, Critical Path: 85.07s
INFO: 9069 processes: 2681 internal, 6388 linux-sandbox.
INFO: Build completed successfully, 9069 total actions

### Test Results:
divya@529ce8414f42:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
DEBUG: Rule 'com_github_nelhage_rules_boost' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1619053724 -0700"
DEBUG: Repository com_github_nelhage_rules_boost instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:75:9: in <toplevel>
  /var/divya/.cache/bazel/_bazel_divya/5fd88bad78ef03829a4685c83637a020/external/com_github_p4lang_p4c/bazel/p4c_deps.bzl:25:23: in p4c_deps
Repository rule git_repository defined at:
  /var/divya/.cache/bazel/_bazel_divya/5fd88bad78ef03829a4685c83637a020/external/bazel_tools/tools/build_defs/repo/git.bzl:199:33: in <toplevel>
INFO: Analyzed 393 targets (1 packages loaded, 333 targets configured).
INFO: Found 256 targets and 137 test targets...
INFO: Elapsed time: 94.381s, Critical Path: 25.75s
INFO: 142 processes: 149 linux-sandbox, 17 local.
INFO: Build completed successfully, 142 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.8s
//gutil:proto_ordering_test                                              PASSED in 0.7s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.6s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.4s
//gutil:version_test                                                     PASSED in 0.8s
//lib:basic_switch_test                                                  PASSED in 0.7s
//lib:ixia_helper_test                                                   PASSED in 1.0s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 0.9s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 14.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.4s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 1.0s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.1s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 25.7s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.7s
//p4_fuzzer:switch_state_test                                            PASSED in 0.7s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.7s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.3s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.7s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 2.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.4s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.1s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.8s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.0s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.4s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.8s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 2.4s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 2.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.3s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 0.9s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.0s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.7s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.3s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.4s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.5s
//p4rt_app/tests:packetio_test                                           PASSED in 3.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 2.7s
//p4rt_app/tests:response_path_test                                      PASSED in 2.7s
//p4rt_app/tests:role_test                                               PASSED in 1.1s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.7s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.6s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.8s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.3s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.3s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.7s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.8s
//thinkit:mock_control_device_test                                       PASSED in 0.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 21.8s
  Stats over 5 runs: max = 21.8s, min = 2.2s, avg = 12.1s, dev = 6.2s

Executed 137 out of 137 tests: 137 tests pass.
INFO: Build completed successfully, 142 total actions

