### PR TITLE
[Comb] Tunnel table prog measurement tests.

### DIFF
--- a/p4rt_app/scripts/BUILD.bazel
+++ b/p4rt_app/scripts/BUILD.bazel
@@ -48,6 +48,7 @@ cc_binary(
         "//p4_pdpi/netaddr:mac_address",
         "//sai_p4/instantiations/google:instantiations",
         "//sai_p4/instantiations/google:sai_p4info_cc",
+        "//sai_p4/instantiations/google:sai_pd_cc_proto",
         "//tests/lib:p4rt_fixed_table_programming_helper",
         "@com_github_gflags_gflags//:gflags",
         "@com_github_google_glog//:glog",

--- a/p4rt_app/scripts/p4rt_route_measurement_test.cc
+++ b/p4rt_app/scripts/p4rt_route_measurement_test.cc
@@ -14,11 +14,9 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <fstream>
 #include <iostream>
 #include <memory>
 #include <random>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -37,6 +35,7 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
+#include "absl/strings/substitute.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "gflags/gflags.h"
@@ -57,6 +56,7 @@
 #include "p4_pdpi/p4_runtime_session.h"
 #include "sai_p4/instantiations/google/instantiations.h"
 #include "sai_p4/instantiations/google/sai_p4info.h"
+#include "sai_p4/instantiations/google/sai_pd.pb.h"
 #include "tests/lib/p4rt_fixed_table_programming_helper.h"
 
 // The test can be run over a unix socket or TCP connection. In general (i.e.
@@ -96,6 +96,7 @@ DEFINE_string(port_ids, "1", "A comma separated list of usable ports.");
 DEFINE_int32(vrfs, 64, "The number of VRFs to install.");
 DEFINE_int32(rifs, 64, "The number of router interfaces to install.");
 DEFINE_int32(next_hops, 512, "The number of next-hop entries to install.");
+DEFINE_int32(encaps, 512, "The number of tunnel encap entries to install.");
 
 // A run will automatically generate `number_batches` write requests each with
 // `batch_size` updates (i.e. number_batches x batch_size total flows). Runtime
@@ -104,6 +105,7 @@ DEFINE_int32(number_batches, 10,
              "Total number of gRPC write calls made to the switch.");
 DEFINE_int32(batch_size, 100,
              "Total number of table entries in each gRPC write.");
+DEFINE_bool(cleanup, true, "Delete all programmed flows at end of test.");
 
 // Users should select the specific test they want to run.  Because the tested
 // tables don't overlap users can run multiple, and they will happen
@@ -113,6 +115,7 @@ DEFINE_int32(batch_size, 100,
 DEFINE_bool(run_ipv4, false, "Run IPv4 route latency tests.");
 DEFINE_bool(run_ipv6, false, "Run IPv6 route latency tests.");
 DEFINE_bool(run_wcmp, false, "Run IPv4 route latency tests.");
+DEFINE_bool(run_encap, false, "Run Tunnel encap latency tests.");
 
 // Extra configs that affect WCMP batch sizes and flows.
 DEFINE_int32(wcmp_members_per_group, 2,
@@ -166,24 +169,33 @@ std::seed_seq GetSeedSeq() {
   return std::seed_seq(seq.begin(), seq.end());
 }
 
+// Generated a random set of unique value in the range [min_value, max_value)
 // To make runs reproducible we intentionally return a absl::btree_set.
 template <typename T>
-absl::StatusOr<absl::btree_set<T>> RandomSetOfValues(absl::BitGen& bitgen,
-                                                     const T& min_value,
-                                                     const T& max_value,
-                                                     int size) {
+absl::StatusOr<absl::btree_set<T>> RandomSetOfUniqueValues(absl::BitGen& bitgen,
+                                                           const T& min_value,
+                                                           const T& max_value,
+                                                           int size) {
+  if ((max_value - min_value) < size) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Interval is not enough to generate ", size,
+        " unique values in the range [", min_value, ",", max_value, ")"));
+  }
+
   // We use the max strikes count to prevent infinite loops.
-  const int max_strikes = 2 * size;
+  const int max_strikes = 4 * size;
   int strikes = 0;
 
   absl::btree_set<T> result;
-  while (result.size() < size) {
+  while (result.size() < size && strikes < max_strikes) {
     if (!result.insert(absl::Uniform<T>(bitgen, min_value, max_value)).second) {
       strikes++;
     }
-    if (strikes > max_strikes) {
-      return absl::UnknownError(
-          absl::StrCat("Could not generate ", size, " random values."));
+  }
+  // Try to fill the missing entries.
+  if (strikes >= max_strikes) {
+    for (T i = min_value; i < max_value && result.size() < size; i++) {
+      result.insert(i);
     }
   }
   return result;
@@ -275,9 +287,10 @@ struct P4WriteRequests {
 
 // Sanity checks that we are generating the correct number of batch requests,
 // and each request has the correct number of entries.
-absl::Status VerifyP4WriteReuqestSizes(const P4WriteRequests& requests,
+absl::Status VerifyP4WriteRequestSizes(const P4WriteRequests& requests,
                                        uint32_t expected_batches,
-                                       uint32_t expected_requests_per_batch) {
+                                       uint32_t expected_requests_per_batch,
+                                       bool modify_supported = true) {
   if (requests.inserts.size() != expected_batches) {
     return absl::UnknownError(absl::StrFormat(
         "Failed to generate enough insert batches: want=%d got=%d",
@@ -293,18 +306,21 @@ absl::Status VerifyP4WriteReuqestSizes(const P4WriteRequests& requests,
     }
   }
 
-  if (requests.modifies.size() != expected_batches) {
-    return absl::UnknownError(absl::StrFormat(
-        "Failed to generate enough modify batches: want=%d got=%d",
-        expected_batches, requests.modifies.size()));
-  }
-  for (int i = 0; i < requests.modifies.size(); ++i) {
-    int got = requests.modifies[i].updates_size();
-    if (got != expected_requests_per_batch) {
-      return absl::UnknownError(
-          absl::StrFormat("Failed to generate enough modify requests in batch "
-                          "%d: want=%d got=%d",
-                          i, expected_requests_per_batch, got));
+  if (modify_supported) {
+    if (requests.modifies.size() != expected_batches) {
+      return absl::UnknownError(absl::StrFormat(
+          "Failed to generate enough modify batches: want=%d got=%d",
+          expected_batches, requests.modifies.size()));
+    }
+
+    for (int i = 0; i < requests.modifies.size(); ++i) {
+      int got = requests.modifies[i].updates_size();
+      if (got != expected_requests_per_batch) {
+        return absl::UnknownError(absl::StrFormat(
+            "Failed to generate enough modify requests in batch "
+            "%d: want=%d got=%d",
+            i, expected_requests_per_batch, got));
+      }
     }
   }
 
@@ -372,7 +388,9 @@ class P4rtRouteTest : public testing::Test {
   void TearDown() override {
     // Remove table entries that were created.
     if (p4rt_session_ != nullptr) {
-      ASSERT_OK(pdpi::ClearTableEntries(p4rt_session_.get()));
+      if (FLAGS_cleanup) {
+        ASSERT_OK(pdpi::ClearTableEntries(p4rt_session_.get()));
+      }
     }
   }
 
@@ -427,6 +445,8 @@ struct RouteEntryInfo {
   // needed.
   absl::flat_hash_map<std::string, std::string> port_by_rif_name;
   absl::flat_hash_map<std::string, std::string> port_by_next_hop_name;
+  // Used for matching the router interface in the tunnel and neighbor tables.
+  absl::btree_map<std::string, std::string> neighbor_to_router_interface_name;
 };
 
 absl::StatusOr<std::vector<int32_t>> ParsePortIds(
@@ -451,9 +471,9 @@ absl::StatusOr<std::vector<int32_t>> ParsePortIds(
 absl::Status GenerateRandomVrfs(absl::BitGen& bitgen, RouteEntryInfo& routes,
                                 const pdpi::IrP4Info& ir_p4info,
                                 int32_t count) {
-  ASSIGN_OR_RETURN(auto vrfs,
-                   RandomSetOfValues<int16_t>(bitgen, /*min_value=*/1,
-                                              /*max_value=*/0x00FF, count));
+  ASSIGN_OR_RETURN(
+      auto vrfs, RandomSetOfUniqueValues<int16_t>(bitgen, /*min_value=*/1,
+                                                  /*max_value=*/0x0100, count));
   for (const auto& vrf : vrfs) {
     std::string name = absl::StrCat("vrf-", vrf);
     ASSIGN_OR_RETURN(
@@ -471,10 +491,10 @@ absl::Status GenerateRandomRIFs(absl::BitGen& bitgen, RouteEntryInfo& routes,
         "Port IDs need to be created before RIFs");
   }
 
-  ASSIGN_OR_RETURN(
-      auto addresses,
-      RandomSetOfValues<int64_t>(bitgen, /*min_value=*/0,
-                                 /*max_value=*/0x00'FF'FF'FF'FF'FF, count));
+  ASSIGN_OR_RETURN(auto addresses,
+                   RandomSetOfUniqueValues<int64_t>(
+                       bitgen, /*min_value=*/0,
+                       /*max_value=*/0x00'FF'FF'FF'FF'FF, count));
   for (const auto& address : addresses) {
     netaddr::MacAddress mac(0x10'00'00'00'00'00 + address);
     std::string rif_name = absl::StrCat("rif-", mac.ToString());
@@ -497,10 +517,10 @@ absl::Status GenerateRandomNextHops(absl::BitGen& bitgen,
   ASSIGN_OR_RETURN(std::vector<std::string> rifs,
                    GetKeys(routes.router_interfaces_by_name),
                    _ << "RIFs need to be created before next hops");
-  ASSIGN_OR_RETURN(
-      auto addresses,
-      RandomSetOfValues<int64_t>(bitgen, /*min_value=*/0,
-                                 /*max_value=*/0x00'FF'FF'FF'FF'FF, count));
+  ASSIGN_OR_RETURN(auto addresses,
+                   RandomSetOfUniqueValues<int64_t>(
+                       bitgen, /*min_value=*/0,
+                       /*max_value=*/0x00'FF'FF'FF'FF'FF, count));
   for (const auto& address : addresses) {
     netaddr::MacAddress mac(0x20'00'00'00'00'00 + address);
     std::string neighbor_name = mac.ToLinkLocalIpv6Address().ToString();
@@ -526,6 +546,49 @@ absl::Status GenerateRandomNextHops(absl::BitGen& bitgen,
   return absl::OkStatus();
 }
 
+absl::StatusOr<P4WriteRequests> ComputeEncapNeighbors(
+    absl::BitGen& bitgen, RouteEntryInfo& route_entry,
+    const pdpi::IrP4Info& ir_p4info, int batch_count, int32_t encap_count) {
+  ASSIGN_OR_RETURN(std::vector<std::string> rifs,
+                   GetKeys(route_entry.router_interfaces_by_name),
+                   _ << "RIFs need to be created before next hops");
+  ASSIGN_OR_RETURN(auto addresses,
+                   RandomSetOfUniqueValues<int64_t>(
+                       bitgen, /*min_value=*/0,
+                       /*max_value=*/0x00'FF'FF'FF'FF'FF, encap_count),
+                   _ << "Failed to get " << encap_count << " of addrs");
+  P4WriteRequests requests;
+
+  for (const auto& address : addresses) {
+    if (requests.inserts.empty() ||
+        requests.inserts.back().updates_size() == encap_count / batch_count) {
+      requests.inserts.push_back(p4::v1::WriteRequest{});
+      requests.modifies.push_back(p4::v1::WriteRequest{});
+      requests.deletes.push_back(p4::v1::WriteRequest{});
+    }
+
+    netaddr::MacAddress mac(0x20'00'00'00'00'00 + address);
+    std::string neighbor_name = mac.ToLinkLocalIpv6Address().ToString();
+    std::string nexthop_name = absl::StrCat("nh-", mac.ToString());
+    std::string rif = rifs[absl::Uniform<size_t>(bitgen, 0, rifs.size())];
+
+    ASSIGN_OR_RETURN(
+        route_entry.neighbors_by_name[neighbor_name],
+        gpins::NeighborTableUpdate(ir_p4info, p4::v1::Update::INSERT, rif,
+                                   neighbor_name, mac.ToString()));
+    *requests.inserts.back().add_updates() =
+        route_entry.neighbors_by_name[neighbor_name];
+    route_entry.neighbor_to_router_interface_name[neighbor_name] = rif;
+
+    // DELETE the entry.
+    ASSIGN_OR_RETURN(
+        *requests.deletes.back().add_updates(),
+        gpins::NeighborTableUpdate(ir_p4info, p4::v1::Update::DELETE, rif,
+                                   neighbor_name, mac.ToString()));
+  }
+  return requests;
+}
+
 absl::StatusOr<P4WriteRequests> ComputeIpv4WriteRequests(
     absl::BitGen& bitgen, const RouteEntryInfo& routes,
     const pdpi::IrP4Info& ir_p4info, uint32_t number_batches,
@@ -536,9 +599,9 @@ absl::StatusOr<P4WriteRequests> ComputeIpv4WriteRequests(
                    GetKeys(routes.next_hops_by_name),
                    _ << "Next hops need to be created before IPv4");
   ASSIGN_OR_RETURN(auto addresses,
-                   RandomSetOfValues<int32_t>(bitgen, /*min_value=*/0x0100'0000,
-                                              /*max_value=*/0x1FFF'FFFF,
-                                              number_batches * batch_size));
+                   RandomSetOfUniqueValues<int32_t>(
+                       bitgen, /*min_value=*/0x0100'0000,
+                       /*max_value=*/0x1FFF'FFFF, number_batches * batch_size));
 
   P4WriteRequests requests;
   for (const int32_t address : addresses) {
@@ -592,7 +655,7 @@ absl::StatusOr<P4WriteRequests> ComputeIpv4WriteRequests(
   }
 
   RETURN_IF_ERROR(
-      VerifyP4WriteReuqestSizes(requests, number_batches, batch_size));
+      VerifyP4WriteRequestSizes(requests, number_batches, batch_size));
   return requests;
 }
 
@@ -629,9 +692,9 @@ absl::StatusOr<std::vector<gpins::WcmpAction>> ComputeWcmpGroupAction(
   std::vector<gpins::WcmpAction> actions(members_per_group);
 
   // Get a random set of next hops, but don't allow duplicates.
-  ASSIGN_OR_RETURN(
-      auto nexthop_indices,
-      RandomSetOfValues<size_t>(bitgen, 0, nexthops.size(), members_per_group));
+  ASSIGN_OR_RETURN(auto nexthop_indices,
+                   RandomSetOfUniqueValues<size_t>(bitgen, 0, nexthops.size(),
+                                                   members_per_group));
 
   int action_num = 0;
   for (const auto& nexthop : nexthop_indices) {
@@ -657,9 +720,8 @@ absl::StatusOr<std::vector<gpins::WcmpAction>> ComputeWcmpGroupAction(
 absl::StatusOr<P4WriteRequests> ComputeWcmpWriteRequests(
     absl::BitGen& bitgen, const RouteEntryInfo& routes,
     const pdpi::IrP4Info& ir_p4info, uint32_t number_batches,
-    uint32_t batch_size, int members_per_group, int total_group_weight) {
-  // If both these flags are false then modify will have no affect. Report a
-  // warning incase of user error.
+    uint32_t batch_size, int members_per_group, bool randomize_weights,
+    int total_group_weight) {
   bool change_weights_on_modify = FLAGS_wcmp_update_weights_when_modifying;
   bool change_nexthops_on_modify = FLAGS_wcmp_update_nexthops_when_modifying;
   if (!change_weights_on_modify && !change_nexthops_on_modify) {
@@ -683,16 +745,22 @@ absl::StatusOr<P4WriteRequests> ComputeWcmpWriteRequests(
     for (int entry_num = 0; entry_num < batch_size; ++entry_num) {
       std::string group_name = absl::StrCat("group-", ++group_id);
 
-      // The initial INSERT request with randomly assigned weights.
+      // The initial INSERT request.
       ASSIGN_OR_RETURN(
           std::vector<gpins::WcmpAction> actions,
           ComputeWcmpGroupAction(bitgen, members_per_group, set_watch_port,
                                  nexthops, routes.port_by_next_hop_name));
-      std::vector<int> weights =
-          RandmizeWeights(bitgen, actions.size(), total_group_weight);
+
+      std::vector<int> weights;
+      if (randomize_weights) {
+        weights = RandmizeWeights(bitgen, actions.size(), total_group_weight);
+      } else {
+        weights = std::vector<int>(members_per_group, 1);
+      }
       for (size_t i = 0; i < actions.size(); ++i) {
         actions[i].weight = weights[i];
       }
+
       ASSIGN_OR_RETURN(
           *requests.inserts[batch_num].add_updates(),
           gpins::WcmpGroupTableUpdate(ir_p4info, p4::v1::Update::INSERT,
@@ -739,7 +807,7 @@ absl::StatusOr<P4WriteRequests> ComputeWcmpWriteRequests(
   RETURN_IF_ERROR(VerifyP4WcmpWriteSizes(requests.modifies, expected_members,
                                          expected_weight));
   RETURN_IF_ERROR(
-      VerifyP4WriteReuqestSizes(requests, number_batches, batch_size));
+      VerifyP4WriteRequestSizes(requests, number_batches, batch_size));
   return requests;
 }
 
@@ -754,9 +822,9 @@ absl::StatusOr<P4WriteRequests> ComputeIpv6WriteRequests(
                    _ << "Next hops need to be created before IPv6");
   ASSIGN_OR_RETURN(
       auto addresses,
-      RandomSetOfValues<int64_t>(bitgen, /*min_value=*/0x0000'0000'0000'0001,
-                                 /*max_value=*/0x1FFF'FFFF'FFFF'FFFF,
-                                 number_batches * batch_size));
+      RandomSetOfUniqueValues<int64_t>(
+          bitgen, /*min_value=*/0x0000'0000'0000'0001,
+          /*max_value=*/0x1FFF'FFFF'FFFF'FFFF, number_batches * batch_size));
 
   P4WriteRequests requests;
   for (const int64_t address : addresses) {
@@ -810,7 +878,82 @@ absl::StatusOr<P4WriteRequests> ComputeIpv6WriteRequests(
   }
 
   RETURN_IF_ERROR(
-      VerifyP4WriteReuqestSizes(requests, number_batches, batch_size));
+      VerifyP4WriteRequestSizes(requests, number_batches, batch_size));
+  return requests;
+}
+
+// Encap tunnel needs the following objects and is referenced by nexthop.
+// Nexthop group -> Nexthop tunnel -> Tunnel -> Neighbor, RouterInterface
+absl::StatusOr<P4WriteRequests> ComputeEncapWriteRequests(
+    absl::BitGen& bitgen, RouteEntryInfo& route_entry,
+    const pdpi::IrP4Info& ir_p4info, int num_batches, uint32_t num_encaps) {
+  if (route_entry.neighbors_by_name.size() != num_encaps) {
+    return absl::InvalidArgumentError(
+        absl::Substitute("Not enough neighbors, required $0, got $1",
+                         num_encaps, route_entry.neighbors_by_name.size()));
+  }
+
+  ASSIGN_OR_RETURN(std::vector<std::string> neighbors,
+                   GetKeys(route_entry.neighbors_by_name),
+                   _ << "Neighbors need to be created before Tunnel encap");
+  ASSIGN_OR_RETURN(auto addresses,
+                   RandomSetOfUniqueValues<int64_t>(
+                       bitgen, /*min_value=*/0x0000'0000'0000'0001,
+                       /*max_value=*/0x1FFF'FFFF'FFFF'FFFF, num_encaps),
+                   _ << "Failed to get " << num_encaps
+                     << " addresses for encap write requests");
+
+  int batch_size = num_encaps / num_batches;
+  int neighbor_index = 0;
+  int count = 0;
+  P4WriteRequests requests;
+  for (const int64_t address : addresses) {
+    if (count == 0 || count == batch_size) {
+      count = 0;
+      requests.inserts.push_back(p4::v1::WriteRequest{});
+      requests.modifies.push_back(p4::v1::WriteRequest{});
+      requests.deletes.push_back(p4::v1::WriteRequest{});
+    }
+
+    // The initial INSERT request.
+    netaddr::Ipv6Address src_ip6(absl::MakeUint128(address, /*low=*/0));
+    std::string neighbor = neighbors[neighbor_index++];
+
+    std::string router_interface_id =
+        route_entry.neighbor_to_router_interface_name.at(neighbor);
+    std::string tunnel_name = absl::StrCat("tunnel-", neighbor);
+    std::string nexthop_name = absl::StrCat("nh-", tunnel_name);
+
+    ASSIGN_OR_RETURN(*requests.inserts.back().add_updates(),
+                     gpins::TunnelTableUpdate(
+                         ir_p4info, p4::v1::Update::INSERT, tunnel_name,
+                         neighbor, src_ip6.ToString(), router_interface_id));
+
+    ASSIGN_OR_RETURN(
+        route_entry.next_hops_by_name[nexthop_name],
+        gpins::NexthopTunnelTableUpdate(ir_p4info, p4::v1::Update::INSERT,
+                                        nexthop_name, tunnel_name));
+    *requests.inserts.back().add_updates() =
+        route_entry.next_hops_by_name[nexthop_name];
+
+    // MODIFY not supported for Tunnels.
+
+    // DELETE the entry.
+    ASSIGN_OR_RETURN(
+        *requests.deletes.back().add_updates(),
+        gpins::NexthopTunnelTableUpdate(ir_p4info, p4::v1::Update::DELETE,
+                                        nexthop_name, tunnel_name));
+
+    ASSIGN_OR_RETURN(*requests.deletes.back().add_updates(),
+                     gpins::TunnelTableUpdate(
+                         ir_p4info, p4::v1::Update::DELETE, tunnel_name,
+                         neighbor, src_ip6.ToString(), router_interface_id));
+
+    count++;
+  }
+
+  RETURN_IF_ERROR(VerifyP4WriteRequestSizes(
+      requests, num_batches, batch_size * 2, /*modify_supported=*/false));
   return requests;
 }
 
@@ -821,15 +964,19 @@ TEST_F(P4rtRouteTest, MeasureWriteLatency) {
   int32_t number_of_vrfs = FLAGS_vrfs;
   int32_t number_of_rifs = FLAGS_rifs;
   int32_t number_of_nexthops = FLAGS_next_hops;
+  int32_t number_of_encaps = FLAGS_encaps;
 
   // Randomly generate the routes that will be used by these tests.
   absl::BitGen bitgen(GetSeedSeq());
   RouteEntryInfo routes;
   ASSERT_OK_AND_ASSIGN(routes.port_ids, ParsePortIds(available_port_ids));
-  ASSERT_OK(GenerateRandomVrfs(bitgen, routes, ir_p4info_, number_of_vrfs));
   ASSERT_OK(GenerateRandomRIFs(bitgen, routes, ir_p4info_, number_of_rifs));
-  ASSERT_OK(
-      GenerateRandomNextHops(bitgen, routes, ir_p4info_, number_of_nexthops));
+  ASSERT_OK(GenerateRandomVrfs(bitgen, routes, ir_p4info_, number_of_vrfs));
+  // Tunnel nexthops are created differently later.
+  if (!FLAGS_run_encap) {
+    ASSERT_OK(
+        GenerateRandomNextHops(bitgen, routes, ir_p4info_, number_of_nexthops));
+  }
 
   // Install the route entries that are needed by the IPv4 flows.
   std::vector<p4::v1::WriteRequest> premeasurement_requests;
@@ -856,21 +1003,22 @@ TEST_F(P4rtRouteTest, MeasureWriteLatency) {
                          SendBatchRequest(requests.inserts));
     ASSERT_OK_AND_ASSIGN(absl::Duration modify_time,
                          SendBatchRequest(requests.modifies));
-    ASSERT_OK_AND_ASSIGN(absl::Duration delete_time,
-                         SendBatchRequest(requests.deletes));
 
     // Write the results to stdout so that the callers can parse the output.
     int64_t total_entries = number_of_batches * requests_per_batch;
-    std::cout
-        << absl::StreamFormat(
-               "ipv4_requests=%d ipv4_entry_total=%lld "
-               "ipv4_insert_time=%lld(msecs) ipv4_modify_time=%lld(msecs) "
-               "ipv4_delete_time=%lld(msecs)",
-               number_of_batches, total_entries,
-               absl::ToInt64Milliseconds(insert_time),
-               absl::ToInt64Milliseconds(modify_time),
-               absl::ToInt64Milliseconds(delete_time))
-        << std::endl;
+    std::cout << absl::StreamFormat(
+        "ipv4_requests=%d ipv4_entry_total=%lld "
+        "ipv4_insert_time=%lld(msecs) ipv4_modify_time=%lld(msecs) ",
+        number_of_batches, total_entries,
+        absl::ToInt64Milliseconds(insert_time),
+        absl::ToInt64Milliseconds(modify_time));
+    if (FLAGS_cleanup) {
+      ASSERT_OK_AND_ASSIGN(absl::Duration delete_time,
+                           SendBatchRequest(requests.deletes));
+      std::cout << absl::StreamFormat("ipv4_delete_time=%lld(msecs) ",
+                                      absl::ToInt64Milliseconds(delete_time));
+    }
+    std::cout << std::endl;
 
     // TODO: remove once we migrate the Perfkit dashboard to the
     // new tags.
@@ -890,57 +1038,116 @@ TEST_F(P4rtRouteTest, MeasureWriteLatency) {
                          SendBatchRequest(requests.inserts));
     ASSERT_OK_AND_ASSIGN(absl::Duration modify_time,
                          SendBatchRequest(requests.modifies));
-    ASSERT_OK_AND_ASSIGN(absl::Duration delete_time,
-                         SendBatchRequest(requests.deletes));
 
     // Write the results to stdout so that the callers can parse the output.
     int64_t total_entries = number_of_batches * requests_per_batch;
-    std::cout
-        << absl::StreamFormat(
-               "ipv6_requests=%d ipv6_entry_total=%lld "
-               "ipv6_insert_time=%lld(msecs) ipv6_modify_time=%lld(msecs) "
-               "ipv6_delete_time=%lld(msecs)",
-               number_of_batches, total_entries,
-               absl::ToInt64Milliseconds(insert_time),
-               absl::ToInt64Milliseconds(modify_time),
-               absl::ToInt64Milliseconds(delete_time))
-        << std::endl;
+    std::cout << absl::StreamFormat(
+        "ipv6_requests=%d ipv6_entry_total=%lld "
+        "ipv6_insert_time=%lld(msecs) ipv6_modify_time=%lld(msecs) ",
+        number_of_batches, total_entries,
+        absl::ToInt64Milliseconds(insert_time),
+        absl::ToInt64Milliseconds(modify_time));
+    if (FLAGS_cleanup) {
+      ASSERT_OK_AND_ASSIGN(absl::Duration delete_time,
+                           SendBatchRequest(requests.deletes));
+      std::cout << absl::StreamFormat("ipv6_delete_time=%lld(msecs) ",
+                                      absl::ToInt64Milliseconds(delete_time));
+    }
+    std::cout << std::endl;
   }
 
+  int members_per_group = FLAGS_wcmp_members_per_group;
+  int total_group_weight = FLAGS_wcmp_total_group_weight;
   if (FLAGS_run_wcmp) {
-    int members_per_group = FLAGS_wcmp_members_per_group;
-    int total_group_weight = FLAGS_wcmp_total_group_weight;
-
     // Pre-compute all the WCMP requests so they can be sent as quickly as
     // possible to the switch under test.
     ASSERT_OK_AND_ASSIGN(
         P4WriteRequests requests,
-        ComputeWcmpWriteRequests(bitgen, routes, ir_p4info_, number_of_batches,
-                                 requests_per_batch, members_per_group,
-                                 total_group_weight));
+        ComputeWcmpWriteRequests(
+            bitgen, routes, ir_p4info_, number_of_batches, requests_per_batch,
+            members_per_group, /*randomize_weights=*/true, total_group_weight));
     UpdateRequestMetadata(requests);
     ASSERT_OK_AND_ASSIGN(absl::Duration insert_time,
                          SendBatchRequest(requests.inserts));
     ASSERT_OK_AND_ASSIGN(absl::Duration modify_time,
                          SendBatchRequest(requests.modifies));
-    ASSERT_OK_AND_ASSIGN(absl::Duration delete_time,
-                         SendBatchRequest(requests.deletes));
 
     // Write the results to stdout so that callers can parse the output.
     int64_t total_groups = number_of_batches * requests_per_batch;
     int64_t total_members = total_groups * members_per_group;
     int64_t total_weight = total_groups * total_group_weight;
-    std::cout
-        << absl::StreamFormat(
-               "wcmp_requests=%d wcmp_groups_total=%lld "
-               "wcmp_members_total=%lld wcmp_weight_total=%lld "
-               "wcmp_insert_time=%lld(msecs) wcmp_modify_time=%lld(msecs) "
-               "wcmp_delete_time=%lld(msecs)",
-               number_of_batches, total_groups, total_members, total_weight,
-               absl::ToInt64Milliseconds(insert_time),
-               absl::ToInt64Milliseconds(modify_time),
-               absl::ToInt64Milliseconds(delete_time))
-        << std::endl;
+    std::cout << absl::StreamFormat(
+        "wcmp_requests=%d wcmp_groups_total=%lld "
+        "wcmp_members_total=%lld wcmp_weight_total=%lld "
+        "wcmp_insert_time=%lld(msecs) wcmp_modify_time=%lld(msecs) ",
+        number_of_batches, total_groups, total_members, total_weight,
+        absl::ToInt64Milliseconds(insert_time),
+        absl::ToInt64Milliseconds(modify_time));
+    if (FLAGS_cleanup) {
+      ASSERT_OK_AND_ASSIGN(absl::Duration delete_time,
+                           SendBatchRequest(requests.deletes));
+      std::cout << absl::StreamFormat("wcmp_delete_time=%lld(msecs) ",
+                                      absl::ToInt64Milliseconds(delete_time));
+    }
+    std::cout << std::endl;
+  }
+
+  if (FLAGS_run_encap) {
+    int total_tunnels =
+        number_of_batches * requests_per_batch * members_per_group;
+
+    ASSERT_OK_AND_ASSIGN(
+        P4WriteRequests encap_neighbor_requests,
+        ComputeEncapNeighbors(bitgen, routes, ir_p4info_, number_of_batches,
+                              number_of_encaps));
+    UpdateRequestMetadata(encap_neighbor_requests);
+    ASSERT_OK_AND_ASSIGN(absl::Duration encap_neighbor_insert_time,
+                         SendBatchRequest(encap_neighbor_requests.inserts));
+
+    // Pre-compute all the Tunnel encap requests so they can be sent as quickly
+    // as possible to the switch under test.
+    ASSERT_OK_AND_ASSIGN(
+        P4WriteRequests encap_requests,
+        ComputeEncapWriteRequests(bitgen, routes, ir_p4info_, number_of_batches,
+                                  number_of_encaps));
+    UpdateRequestMetadata(encap_requests);
+    ASSERT_OK_AND_ASSIGN(absl::Duration encap_insert_time,
+                         SendBatchRequest(encap_requests.inserts));
+
+    ASSERT_OK_AND_ASSIGN(P4WriteRequests wcmp_requests,
+                         ComputeWcmpWriteRequests(
+                             bitgen, routes, ir_p4info_, number_of_batches,
+                             requests_per_batch, members_per_group,
+                             /*randomize_weights=*/false, total_group_weight));
+    UpdateRequestMetadata(wcmp_requests);
+    ASSERT_OK_AND_ASSIGN(absl::Duration wcmp_insert_time,
+                         SendBatchRequest(wcmp_requests.inserts));
+
+    int64_t total_groups = number_of_batches * requests_per_batch;
+    std::cout << absl::StreamFormat(
+        "encap_entry_total=%d wcmp_total_groups=%lld "
+        "encap_insert_time=%lld(msecs) wcmp_insert_time=%lld(msecs) ",
+        total_tunnels, total_groups,
+        absl::ToInt64Milliseconds(encap_insert_time) +
+            absl::ToInt64Milliseconds(encap_neighbor_insert_time),
+        absl::ToInt64Milliseconds(wcmp_insert_time));
+    if (FLAGS_cleanup) {
+      ASSERT_OK_AND_ASSIGN(absl::Duration wcmp_delete_time,
+                           SendBatchRequest(wcmp_requests.deletes));
+
+      ASSERT_OK_AND_ASSIGN(absl::Duration encap_delete_time,
+                           SendBatchRequest(encap_requests.deletes));
+
+      ASSERT_OK_AND_ASSIGN(absl::Duration encap_neighbor_delete_time,
+                           SendBatchRequest(encap_neighbor_requests.deletes));
+      // Write the results to stdout so that callers can parse the output.
+      std::cout << absl::StreamFormat(
+          "encap_delete_time=%lld(msecs) wcmp_delete_time=%lld(msecs) ",
+          absl::ToInt64Milliseconds(encap_delete_time) +
+              absl::ToInt64Milliseconds(encap_neighbor_delete_time),
+          absl::ToInt64Milliseconds(wcmp_delete_time));
+    }
+    std::cout << std::endl;
   }
 }
 

--- a/tests/lib/p4rt_fixed_table_programming_helper.cc
+++ b/tests/lib/p4rt_fixed_table_programming_helper.cc
@@ -202,6 +202,36 @@ absl::StatusOr<p4::v1::Update> NexthopTableUpdate(
   return pdpi::IrUpdateToPi(ir_p4_info, ir_update);
 }
 
+absl::StatusOr<p4::v1::Update> NexthopTunnelTableUpdate(
+    const pdpi::IrP4Info& ir_p4_info, p4::v1::Update::Type type,
+    absl::string_view nexthop_id, absl::string_view tunnel_id) {
+  pdpi::IrUpdate ir_update;
+  RETURN_IF_ERROR(gutil::ReadProtoFromString(
+      absl::Substitute(R"pb(
+                         type: $0
+                         entity {
+                           table_entry {
+                             table_name: "nexthop_table"
+                             matches {
+                               name: "nexthop_id"
+                               exact { str: "$1" }
+                             }
+                             action {
+                               name: "set_p2p_tunnel_encap_nexthop"
+                               params {
+                                 name: "tunnel_id"
+                                 value { str: "$2" }
+                               }
+                             }
+                           }
+                         }
+                       )pb",
+                       type, nexthop_id, tunnel_id),
+      &ir_update))
+      << "invalid pdpi::IrUpdate string.";
+  return pdpi::IrUpdateToPi(ir_p4_info, ir_update);
+}
+
 absl::StatusOr<p4::v1::Update> TunnelTableUpdate(
     const pdpi::IrP4Info& ir_p4_info, p4::v1::Update::Type type,
     absl::string_view tunnel_id, absl::string_view encap_dst_ip,

--- a/tests/lib/p4rt_fixed_table_programming_helper.h
+++ b/tests/lib/p4rt_fixed_table_programming_helper.h
@@ -44,6 +44,10 @@ absl::StatusOr<p4::v1::Update> TunnelTableUpdate(
     absl::string_view tunnel_id, absl::string_view encap_dst_ip,
     absl::string_view encap_src_ip, absl::string_view router_interface_id);
 
+absl::StatusOr<p4::v1::Update> NexthopTunnelTableUpdate(
+    const pdpi::IrP4Info& ir_p4_info, p4::v1::Update::Type type,
+    absl::string_view nexthop_id, absl::string_view tunnel_id);
+
 absl::StatusOr<p4::v1::Update> VrfTableUpdate(const pdpi::IrP4Info& ir_p4_info,
                                               p4::v1::Update::Type type,
                                               absl::string_view vrf_id);

--- a/tests/lib/p4rt_fixed_table_programming_helper.h
+++ b/tests/lib/p4rt_fixed_table_programming_helper.h
@@ -39,6 +39,11 @@ absl::StatusOr<p4::v1::Update> NexthopTableUpdate(
     absl::string_view nexthop_id, absl::string_view router_interface_id,
     absl::string_view neighbor_id);
 
+absl::StatusOr<p4::v1::Update> TunnelTableUpdate(
+    const pdpi::IrP4Info& ir_p4_info, p4::v1::Update::Type type,
+    absl::string_view tunnel_id, absl::string_view encap_dst_ip,
+    absl::string_view encap_src_ip, absl::string_view router_interface_id);
+
 absl::StatusOr<p4::v1::Update> VrfTableUpdate(const pdpi::IrP4Info& ir_p4_info,
                                               p4::v1::Update::Type type,
                                               absl::string_view vrf_id);


### PR DESCRIPTION
### Build Results:
divya@529ce8414f42:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 392 targets (1 packages loaded, 19 targets configured).
INFO: Found 392 targets...
INFO: From Compiling p4rt_app/scripts/p4rt_route_measurement_test.cc:
...
INFO: Elapsed time: 41.811s, Critical Path: 41.11s
INFO: 10 processes: 3 internal, 7 linux-sandbox.
INFO: Build completed successfully, 10 total actions

### Test Results:
divya@529ce8414f42:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 392 targets (0 packages loaded, 0 targets configured).
INFO: Found 255 targets and 137 test targets...
INFO: Elapsed time: 81.945s, Critical Path: 25.75s
INFO: 142 processes: 149 linux-sandbox, 17 local.
INFO: Build completed successfully, 142 total actions
//gutil:collections_test PASSED in 0.5s
//gutil:io_test PASSED in 0.4s
//gutil:proto_matchers_test PASSED in 0.6s
//gutil:proto_ordering_test PASSED in 0.5s
//gutil:proto_test PASSED in 0.4s
//gutil:status_matchers_test PASSED in 0.4s
//gutil:test_artifact_writer_test PASSED in 0.5s
//gutil:testing_test PASSED in 0.5s
//gutil:version_test PASSED in 1.0s
//lib:basic_switch_test PASSED in 0.7s
//lib:ixia_helper_test PASSED in 1.1s
//lib/basic_traffic:basic_p4rt_util_test PASSED in 0.8s
//lib/basic_traffic:basic_traffic_test PASSED in 15.0s
//lib/gnmi:gnmi_helper_test PASSED in 2.8s
//lib/gnoi:gnoi_helper_test PASSED in 0.5s
//lib/p4rt:p4rt_port_test PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test PASSED in 0.7s
//lib/utils:generic_testbed_utils_test PASSED in 1.1s
//lib/utils:json_utils_test PASSED in 0.5s
//lib/validator:validator_backend_test PASSED in 0.5s
//lib/validator:validator_lib_test PASSED in 25.7s
//p4_fuzzer:constraints_util_integration_test PASSED in 0.7s
//p4_fuzzer:fuzz_util_test PASSED in 0.8s
//p4_fuzzer:fuzzer_showcase_test PASSED in 1.0s
//p4_fuzzer:switch_state_test PASSED in 0.6s
//p4_fuzzer:table_entry_key_test PASSED in 0.1s
//p4_pdpi:built_ins_test PASSED in 0.5s
//p4_pdpi:entity_keys_test PASSED in 0.5s
//p4_pdpi:ir_tools_test PASSED in 0.6s
//p4_pdpi:p4_runtime_matchers_test PASSED in 0.6s
//p4_pdpi:reference_annotations_test PASSED in 0.6s
//p4_pdpi:sequencing_util_test PASSED in 0.5s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test PASSED in 0.4s
//p4_pdpi/netaddr:ipv6_address_test PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test PASSED in 16.4s
//p4_pdpi/packetlib:packetlib_matchers_test PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test PASSED in 2.1s
//p4_pdpi/string_encodings:bit_string_test PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test PASSED in 0.4s
//p4_pdpi/string_encodings:decimal_string_test PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test PASSED in 0.5s
//p4_pdpi/testing:helper_function_test PASSED in 0.6s
//p4_pdpi/testing:info_test PASSED in 0.1s
//p4_pdpi/testing:info_test_runner PASSED in 0.1s
//p4_pdpi/testing:main_pd_test PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test PASSED in 0.6s
//p4_pdpi/testing:packet_io_test PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner PASSED in 0.1s
//p4_pdpi/testing:rpc_test PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_test PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test PASSED in 0.7s
//p4_pdpi/testing:table_entry_test PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test PASSED in 0.5s
//p4_pdpi/utils:ir_test PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test PASSED in 0.8s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.8s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test PASSED in 0.8s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test PASSED in 0.8s
//p4rt_app/event_monitoring:debug_data_dump_events_test PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test PASSED in 1.0s
//p4rt_app/p4runtime:cpu_queue_translator_test PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test PASSED in 0.8s
//p4rt_app/p4runtime:packetio_helpers_test PASSED in 0.8s
//p4rt_app/p4runtime:resource_utilization_test PASSED in 0.7s
//p4rt_app/sonic:app_db_acl_def_table_manager_test PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test PASSED in 0.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test PASSED in 0.7s
//p4rt_app/sonic:hashing_test PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test PASSED in 0.5s
//p4rt_app/sonic:packetio_port_test PASSED in 0.5s
//p4rt_app/sonic:response_handler_test PASSED in 0.7s
//p4rt_app/sonic:state_verification_test PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test PASSED in 0.6s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test PASSED in 0.0s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test PASSED in 0.0s
//p4rt_app/tests:acl_table_test PASSED in 1.3s
//p4rt_app/tests:action_set_test PASSED in 1.1s
//p4rt_app/tests:api_access_test PASSED in 0.9s
//p4rt_app/tests:arbitration_test PASSED in 1.0s
//p4rt_app/tests:cpu_queue_name_and_id_test PASSED in 1.5s
//p4rt_app/tests:debug_data_dump_test PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test PASSED in 3.8s
//p4rt_app/tests:grpc_behavior_test PASSED in 5.3s
//p4rt_app/tests:p4_constraints_test PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner PASSED in 0.2s
//p4rt_app/tests:p4_programs_test PASSED in 1.5s
//p4rt_app/tests:packetio_test PASSED in 3.6s
//p4rt_app/tests:port_name_and_id_test PASSED in 2.3s
//p4rt_app/tests:resource_limits_test PASSED in 2.7s
//p4rt_app/tests:response_path_test PASSED in 2.7s
//p4rt_app/tests:role_test PASSED in 1.1s
//p4rt_app/tests:state_verification_test PASSED in 1.7s
//p4rt_app/tests:vrf_table_test PASSED in 1.5s
//p4rt_app/tests/lib:app_db_entry_builder_test PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test PASSED in 0.0s
//p4rt_app/utils:table_utility_test PASSED in 0.6s
//sai_p4/instantiations/google:clos_stage_test PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.6s
//sai_p4/instantiations/google/test_tools:test_entries_test PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test PASSED in 0.7s
//sai_p4/tools:p4info_tools_test PASSED in 0.5s
//sai_p4/tools:packetio_tools_test PASSED in 0.6s
//thinkit:bazel_test_environment_test PASSED in 0.5s
//thinkit:generic_testbed_test PASSED in 0.9s
//thinkit:mock_control_device_test PASSED in 0.5s
//thinkit:mock_generic_testbed_test PASSED in 0.6s
//thinkit:mock_mirror_testbed_test PASSED in 0.6s
//thinkit:mock_ssh_client_test PASSED in 0.0s
//thinkit:mock_switch_test PASSED in 0.6s
//thinkit:mock_test_environment_test PASSED in 0.1s
//thinkit:switch_test PASSED in 0.6s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test PASSED in 12.6s
Stats over 5 runs: max = 12.6s, min = 0.9s, avg = 4.1s, dev = 4.4s

Executed 137 out of 137 tests: 137 tests pass.
INFO: Build completed successfully, 142 total actions
divya@529ce8414f42:/sonic/src/sonic-p4rt/sonic-pins$

### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.