### PR TITLE
[P4RT] Adding subscriber_state_table_adapter files.

### DIFF
--- a/p4rt_app/sonic/adapters/BUILD.bazel
+++ b/p4rt_app/sonic/adapters/BUILD.bazel
@@ -214,6 +214,27 @@ cc_test(
 )
 
 cc_library(
+    name = "subscriber_state_table_adapter",
+    srcs = ["subscriber_state_table_adapter.cc"],
+    hdrs = ["subscriber_state_table_adapter.h"],
+    deps = [
+        "@com_github_google_glog//:glog",
+        "@sonic_swss_common//:libswsscommon",
+    ],
+)
+
+cc_library(
+    name = "mock_subscriber_state_table_adapter",
+    testonly = True,
+    hdrs = ["mock_subscriber_state_table_adapter.h"],
+    deps = [
+        ":subscriber_state_table_adapter",
+        "@com_google_googletest//:gtest",
+        "@sonic_swss_common//:common",
+    ],
+)
+
+cc_library(
     name = "warm_boot_state_adapter",
     srcs = ["warm_boot_state_adapter.cc"],
     hdrs = ["warm_boot_state_adapter.h"],

--- a/p4rt_app/sonic/adapters/mock_subscriber_state_table_adapter.h
+++ b/p4rt_app/sonic/adapters/mock_subscriber_state_table_adapter.h
@@ -1,0 +1,39 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef PINS_P4RT_APP_SONIC_ADAPTERS_MOCK_SUBSCRIBER_STATE_TABLE_ADAPTER_H_
+#define PINS_P4RT_APP_SONIC_ADAPTERS_MOCK_SUBSCRIBER_STATE_TABLE_ADAPTER_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "p4rt_app/sonic/adapters/subscriber_state_table_adapter.h"
+#include "swss/rediscommand.h"
+
+namespace p4rt_app {
+namespace sonic {
+
+class MockSubscriberStateTableAdapter : public SubscriberStateTableAdapter {
+ public:
+  MOCK_METHOD(bool, WaitForNotificationAndPop,
+              (std::string & key, std::string &op,
+               std::vector<swss::FieldValueTuple> &values, int64_t timeout_ms),
+              (override));
+};
+
+}  // namespace sonic
+}  // namespace p4rt_app
+
+#endif  // PINS_P4RT_APP_SONIC_ADAPTERS_MOCK_SUBSCRIBER_STATE_TABLE_ADAPTER_H_

--- a/p4rt_app/sonic/adapters/subscriber_state_table_adapter.cc
+++ b/p4rt_app/sonic/adapters/subscriber_state_table_adapter.cc
@@ -1,0 +1,61 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "p4rt_app/sonic/adapters/subscriber_state_table_adapter.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "glog/logging.h"
+#include "swss/dbconnector.h"
+#include "swss/rediscommand.h"
+#include "swss/select.h"
+#include "swss/selectable.h"
+#include "swss/subscriberstatetable.h"
+#include "swss/table.h"
+
+namespace p4rt_app {
+namespace sonic {
+
+SubscriberStateTableAdapter::SubscriberStateTableAdapter(
+    swss::DBConnector *db, const std::string &table_name)
+    : subscriber_state_table_(
+          std::make_unique<swss::SubscriberStateTable>(db, table_name)) {}
+
+bool SubscriberStateTableAdapter::WaitForNotificationAndPop(
+    std::string &key, std::string &op,
+    std::vector<swss::FieldValueTuple> &values, int64_t timeout_ms) {
+  LOG_IF(FATAL, subscriber_state_table_ == nullptr)  // Crash OK
+      << "subscriber_state_table cannot be nullptr.";
+
+  swss::Select s;
+  s.addSelectable(subscriber_state_table_.get());
+  swss::Selectable *sel;
+
+  int error = s.select(&sel, timeout_ms);
+  if (error != swss::Select::OBJECT) {
+    return false;
+  }
+
+  swss::KeyOpFieldsValuesTuple kopfvs;
+  subscriber_state_table_->pop(kopfvs);
+  key = kfvKey(kopfvs);
+  op = kfvOp(kopfvs);
+  values = kfvFieldsValues(kopfvs);
+  return true;
+}
+
+}  // namespace sonic
+}  // namespace p4rt_app

--- a/p4rt_app/sonic/adapters/subscriber_state_table_adapter.h
+++ b/p4rt_app/sonic/adapters/subscriber_state_table_adapter.h
@@ -1,0 +1,53 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef PINS_P4RT_APP_SONIC_ADAPTERS_SUBSCRIBER_STATE_TABLE_ADAPTER_H_
+#define PINS_P4RT_APP_SONIC_ADAPTERS_SUBSCRIBER_STATE_TABLE_ADAPTER_H_
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "swss/dbconnector.h"
+#include "swss/rediscommand.h"
+#include "swss/subscriberstatetable.h"
+
+namespace p4rt_app {
+namespace sonic {
+
+// Acts as a proxy to invoke swss common SubscriberStateTable class methods.
+// This provides the flexibility to define the constructors needed for mocks
+// and fakes.
+class SubscriberStateTableAdapter {
+ public:
+  explicit SubscriberStateTableAdapter(swss::DBConnector *db,
+                                       const std::string &table_name);
+  virtual ~SubscriberStateTableAdapter() = default;
+
+  virtual bool WaitForNotificationAndPop(
+      std::string &key, std::string &op,
+      std::vector<swss::FieldValueTuple> &values, int64_t timeout_ms);
+
+ protected:
+  // Test only constructor used to construct Mock & Fake classes.
+  SubscriberStateTableAdapter() = default;
+
+ private:
+  std::unique_ptr<swss::SubscriberStateTable> subscriber_state_table_;
+};
+
+}  // namespace sonic
+}  // namespace p4rt_app
+
+#endif  // PINS_P4RT_APP_SONIC_ADAPTERS_SUBSCRIBER_STATE_TABLE_ADAPTER_H_


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@529ce8414f42:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 397 targets (243 packages loaded, 19854 targets configured).
INFO: Found 397 targets...
INFO: From Compiling P4 program p4_pdpi/testing/testdata/main.p4:
...
INFO: Elapsed time: 62.794s, Critical Path: 44.16s
INFO: 122 processes: 11 internal, 111 linux-sandbox.
INFO: Build completed successfully, 122 total actions

### Test Results:
divya@529ce8414f42:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 397 targets (0 packages loaded, 292 targets configured).
INFO: Found 259 targets and 138 test targets...
INFO: Elapsed time: 88.065s, Critical Path: 25.94s
INFO: 143 processes: 150 linux-sandbox, 17 local.
INFO: Build completed successfully, 143 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.4s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.7s
//gutil:proto_test                                                       PASSED in 0.4s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:version_test                                                     PASSED in 0.7s
//lib:basic_switch_test                                                  PASSED in 0.7s
//lib:ixia_helper_test                                                   PASSED in 1.0s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 0.8s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 14.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.4s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.7s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.1s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 25.9s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:helpers_test                                                   PASSED in 0.6s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.6s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.5s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.4s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.2s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.2s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.7s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.7s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 2.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.8s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.8s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.1s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.8s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.4s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.8s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.7s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.5s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.6s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.6s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.4s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 0.9s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.0s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.3s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.5s
//p4rt_app/tests:packetio_test                                           PASSED in 3.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.6s
//p4rt_app/tests:response_path_test                                      PASSED in 2.7s
//p4rt_app/tests:role_test                                               PASSED in 1.1s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.7s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.6s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.8s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.3s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.7s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.7s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.6s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.8s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.6s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 22.1s
  Stats over 5 runs: max = 22.1s, min = 11.6s, avg = 14.1s, dev = 4.0s

Executed 138 out of 138 tests: 138 tests pass.
INFO: Build completed successfully, 143 total actions
divya@529ce8414f42:/sonic/src/sonic-p4rt/sonic-pins$ 