### PR TITLE
[P4-PDPI] Add built-in Clone Session.Add second action to golden test friendly wcmp table, so that different actions can be used in a set.

### DIFF
--- a/p4_pdpi/built_ins.cc
+++ b/p4_pdpi/built_ins.cc
@@ -25,7 +25,10 @@
 namespace pdpi {
 
 namespace {
+// General string constants.
 constexpr absl::string_view kBuiltInPrefix = "builtin::";
+
+// Multicast group table-related string constants.
 constexpr absl::string_view kMulticastGroupTableString =
     "multicast_group_table";
 constexpr absl::string_view kMulticastGroupIdString = "multicast_group_id";
@@ -33,10 +36,17 @@ constexpr absl::string_view kReplicaString = "replica";
 constexpr absl::string_view kReplicaPortString = "replica.port";
 constexpr absl::string_view kReplicaInstanceString = "replica.instance";
 
+// Clone session table-related string constants.
+constexpr absl::string_view kCloneSessionTableString = "clone_session_table";
+
 }  // namespace
 
 std::string GetMulticastGroupTableName() {
   return absl::StrCat(kBuiltInPrefix, kMulticastGroupTableString);
+}
+
+std::string GetCloneSessionTableName() {
+  return absl::StrCat(kBuiltInPrefix, kCloneSessionTableString);
 }
 
 bool IsBuiltInTable(absl::string_view table_name) {
@@ -94,18 +104,21 @@ absl::StatusOr<IrBuiltInAction> GetBuiltInActionFromBuiltInParameter(
     }
     default: {
       return gutil::InvalidArgumentErrorBuilder()
-             << "Unknown built-in parameter.";
+             << "Unknown built-in parameter: "
+             << IrBuiltInParameter_Name(parameter);
     }
   }
 }
 
 absl::StatusOr<std::string> IrBuiltInTableToString(IrBuiltInTable table) {
   switch (table) {
-    case pdpi::BUILT_IN_TABLE_MULTICAST_GROUP_TABLE: {
+    case pdpi::BUILT_IN_TABLE_MULTICAST_GROUP_TABLE:
       return GetMulticastGroupTableName();
-    }
+    case pdpi::BUILT_IN_TABLE_CLONE_SESSION_TABLE:
+      return GetCloneSessionTableName();
     default: {
-      return gutil::InvalidArgumentErrorBuilder() << "Unknown built-in table.";
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Unknown built-in table: " << IrBuiltInTable_Name(table);
     }
   }
 }
@@ -118,7 +131,8 @@ absl::StatusOr<std::string> IrBuiltInMatchFieldToString(
     }
     default: {
       return gutil::InvalidArgumentErrorBuilder()
-             << "Unknown built-in match field.";
+             << "Unknown built-in match field: "
+             << IrBuiltInMatchField_Name(field);
     }
   }
 }
@@ -129,7 +143,8 @@ absl::StatusOr<std::string> IrBuiltInActionToString(IrBuiltInAction action) {
       return absl::StrCat(kBuiltInPrefix, kReplicaString);
     }
     default: {
-      return gutil::InvalidArgumentErrorBuilder() << "Unknown built-in action.";
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Unknown built-in action: " << IrBuiltInAction_Name(action);
     }
   }
 }
@@ -145,7 +160,8 @@ absl::StatusOr<std::string> IrBuiltInParameterToString(
     }
     default: {
       return gutil::InvalidArgumentErrorBuilder()
-             << "Unknown built-in parameter.";
+             << "Unknown built-in parameter: "
+             << IrBuiltInParameter_Name(parameter);
     }
   }
 }
@@ -153,6 +169,9 @@ absl::StatusOr<std::string> IrBuiltInParameterToString(
 absl::StatusOr<IrBuiltInTable> StringToIrBuiltInTable(absl::string_view table) {
   if (table == GetMulticastGroupTableName()) {
     return pdpi::BUILT_IN_TABLE_MULTICAST_GROUP_TABLE;
+  }
+  if (table == GetCloneSessionTableName()) {
+    return pdpi::BUILT_IN_TABLE_CLONE_SESSION_TABLE;
   }
   return gutil::InvalidArgumentErrorBuilder()
          << "'" << table << "' is not a built-in table.";

--- a/p4_pdpi/built_ins.h
+++ b/p4_pdpi/built_ins.h
@@ -31,6 +31,9 @@ namespace pdpi {
 // Returns the PDPI name for the multicast group table.
 std::string GetMulticastGroupTableName();
 
+// Returns the PDPI name for the clone session table.
+std::string GetCloneSessionTableName();
+
 // Returns true if `table_name` is a known built_in table.
 // Useful for branching on table type.
 bool IsBuiltInTable(absl::string_view table_name);

--- a/p4_pdpi/helpers.cc
+++ b/p4_pdpi/helpers.cc
@@ -22,14 +22,17 @@ absl::StatusOr<std::string> EntityToTableName(const pdpi::IrP4Info& info,
       return table.preamble().alias();
     }
     case p4::v1::Entity::kPacketReplicationEngineEntry: {
-      if (!entity.packet_replication_engine_entry()
-               .has_multicast_group_entry()) {
-        return gutil::InvalidArgumentErrorBuilder()
-               << "Expected a `multicast_group_entry`, but got unexpected "
-                  "packet_replication_engine_entry: "
-               << entity.packet_replication_engine_entry().DebugString();
+      if (entity.packet_replication_engine_entry()
+              .has_multicast_group_entry()) {
+        return GetMulticastGroupTableName();
       }
-      return GetMulticastGroupTableName();
+      if (entity.packet_replication_engine_entry().has_clone_session_entry()) {
+        return GetCloneSessionTableName();
+      }
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Expected a `multicast_group_entry` or `clone_session_entry`, "
+                "but got unexpected packet_replication_engine_entry: "
+             << entity.packet_replication_engine_entry().DebugString();
     }
     default:
       return gutil::InvalidArgumentErrorBuilder()

--- a/p4_pdpi/helpers_test.cc
+++ b/p4_pdpi/helpers_test.cc
@@ -40,10 +40,22 @@ TEST(EntityToTableNameTest, MulticastTableSupported) {
               IsOkAndHolds(multicast_group_table_name));
 }
 
-TEST(EntityToTableNameTest, OtherPacketReplicationEngineUnsupported) {
+TEST(EntityToTableNameTest, CloneSessionTableSupported) {
   p4::v1::Entity entity;
   entity.mutable_packet_replication_engine_entry()
       ->mutable_clone_session_entry();
+
+  ASSERT_OK_AND_ASSIGN(
+      std::string clone_session_table_name,
+      IrBuiltInTableToString(BUILT_IN_TABLE_CLONE_SESSION_TABLE));
+
+  EXPECT_THAT(EntityToTableName(GetTestIrP4Info(), entity),
+              IsOkAndHolds(clone_session_table_name));
+}
+
+TEST(EntityToTableNameTest, EmptyPacketReplicationEngineUnsupported) {
+  p4::v1::Entity entity;
+  entity.mutable_packet_replication_engine_entry();
 
   EXPECT_THAT(EntityToTableName(GetTestIrP4Info(), entity), Not(IsOk()));
 }

--- a/p4_pdpi/ir.proto
+++ b/p4_pdpi/ir.proto
@@ -153,6 +153,9 @@ enum IrBuiltInTable {
   // Corresponds to p4::v1::MulticastGroupEntry
   // String representation in annotations: "builtin::multicast_group_table"
   BUILT_IN_TABLE_MULTICAST_GROUP_TABLE = 1;
+  // Corresponds to p4::v1::CloneSessionEntry
+  // String representation in annotations: "builtin::clone_session_table"
+  BUILT_IN_TABLE_CLONE_SESSION_TABLE = 2;
 }
 
 // Uniquely identifies a table in the scope of a P4 program.

--- a/p4_pdpi/testing/testdata/info.expected
+++ b/p4_pdpi/testing/testdata/info.expected
@@ -1123,6 +1123,10 @@ tables {
     annotations: "@proto_id(1)"
   }
   action_refs {
+    id: 25225410
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
@@ -1311,6 +1315,27 @@ actions {
     id: 31939749
     name: "ingress.golden_test_friendly_action"
     alias: "golden_test_friendly_action"
+  }
+  params {
+    id: 1
+    name: "arg1"
+    type_name {
+      name: "string_id_t"
+    }
+  }
+  params {
+    id: 2
+    name: "arg2"
+    type_name {
+      name: "string_id_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 25225410
+    name: "ingress.other_golden_test_friendly_action"
+    alias: "other_golden_test_friendly_action"
   }
   params {
     id: 1
@@ -3883,6 +3908,72 @@ tables_by_id {
         }
       }
       proto_id: 1
+    }
+    entry_actions {
+      ref {
+        id: 25225410
+        annotations: "@proto_id(2)"
+      }
+      action {
+        preamble {
+          id: 25225410
+          name: "ingress.other_golden_test_friendly_action"
+          alias: "other_golden_test_friendly_action"
+        }
+        params_by_id {
+          key: 1
+          value {
+            param {
+              id: 1
+              name: "arg1"
+              type_name {
+                name: "string_id_t"
+              }
+            }
+            format: STRING
+          }
+        }
+        params_by_id {
+          key: 2
+          value {
+            param {
+              id: 2
+              name: "arg2"
+              type_name {
+                name: "string_id_t"
+              }
+            }
+            format: STRING
+          }
+        }
+        params_by_name {
+          key: "arg1"
+          value {
+            param {
+              id: 1
+              name: "arg1"
+              type_name {
+                name: "string_id_t"
+              }
+            }
+            format: STRING
+          }
+        }
+        params_by_name {
+          key: "arg2"
+          value {
+            param {
+              id: 2
+              name: "arg2"
+              type_name {
+                name: "string_id_t"
+              }
+            }
+            format: STRING
+          }
+        }
+      }
+      proto_id: 2
     }
     default_only_actions {
       ref {
@@ -6711,6 +6802,72 @@ tables_by_name {
         }
       }
       proto_id: 1
+    }
+    entry_actions {
+      ref {
+        id: 25225410
+        annotations: "@proto_id(2)"
+      }
+      action {
+        preamble {
+          id: 25225410
+          name: "ingress.other_golden_test_friendly_action"
+          alias: "other_golden_test_friendly_action"
+        }
+        params_by_id {
+          key: 1
+          value {
+            param {
+              id: 1
+              name: "arg1"
+              type_name {
+                name: "string_id_t"
+              }
+            }
+            format: STRING
+          }
+        }
+        params_by_id {
+          key: 2
+          value {
+            param {
+              id: 2
+              name: "arg2"
+              type_name {
+                name: "string_id_t"
+              }
+            }
+            format: STRING
+          }
+        }
+        params_by_name {
+          key: "arg1"
+          value {
+            param {
+              id: 1
+              name: "arg1"
+              type_name {
+                name: "string_id_t"
+              }
+            }
+            format: STRING
+          }
+        }
+        params_by_name {
+          key: "arg2"
+          value {
+            param {
+              id: 2
+              name: "arg2"
+              type_name {
+                name: "string_id_t"
+              }
+            }
+            format: STRING
+          }
+        }
+      }
+      proto_id: 2
     }
     default_only_actions {
       ref {
@@ -10271,6 +10428,68 @@ actions_by_id {
   }
 }
 actions_by_id {
+  key: 25225410
+  value {
+    preamble {
+      id: 25225410
+      name: "ingress.other_golden_test_friendly_action"
+      alias: "other_golden_test_friendly_action"
+    }
+    params_by_id {
+      key: 1
+      value {
+        param {
+          id: 1
+          name: "arg1"
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+    params_by_id {
+      key: 2
+      value {
+        param {
+          id: 2
+          name: "arg2"
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+    params_by_name {
+      key: "arg1"
+      value {
+        param {
+          id: 1
+          name: "arg1"
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+    params_by_name {
+      key: "arg2"
+      value {
+        param {
+          id: 2
+          name: "arg2"
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+  }
+}
+actions_by_id {
   key: 31920929
   value {
     preamble {
@@ -10672,6 +10891,68 @@ actions_by_name {
       id: 31939749
       name: "ingress.golden_test_friendly_action"
       alias: "golden_test_friendly_action"
+    }
+    params_by_id {
+      key: 1
+      value {
+        param {
+          id: 1
+          name: "arg1"
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+    params_by_id {
+      key: 2
+      value {
+        param {
+          id: 2
+          name: "arg2"
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+    params_by_name {
+      key: "arg1"
+      value {
+        param {
+          id: 1
+          name: "arg1"
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+    params_by_name {
+      key: "arg2"
+      value {
+        param {
+          id: 2
+          name: "arg2"
+          type_name {
+            name: "string_id_t"
+          }
+        }
+        format: STRING
+      }
+    }
+  }
+}
+actions_by_name {
+  key: "other_golden_test_friendly_action"
+  value {
+    preamble {
+      id: 25225410
+      name: "ingress.other_golden_test_friendly_action"
+      alias: "other_golden_test_friendly_action"
     }
     params_by_id {
       key: 1
@@ -11186,6 +11467,12 @@ action_profiles_by_name {
   }
 }
 built_in_tables {
+  key: "builtin::clone_session_table"
+  value {
+    built_in_table: BUILT_IN_TABLE_CLONE_SESSION_TABLE
+  }
+}
+built_in_tables {
   key: "builtin::multicast_group_table"
   value {
     built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
@@ -11308,6 +11595,10 @@ built_in_tables {
       }
     }
   }
+}
+dependency_rank_by_table_name {
+  key: "builtin::clone_session_table"
+  value: 0
 }
 dependency_rank_by_table_name {
   key: "builtin::multicast_group_table"

--- a/p4_pdpi/testing/testdata/main.p4
+++ b/p4_pdpi/testing/testdata/main.p4
@@ -519,7 +519,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         const default_action = NoAction();
   }
 
-  // This action only contains args whose formats are STRING. Values with the 
+  // This action only contains args whose formats are STRING. Values with the
   // STRING format are unchanged when translated from PD to IR/PI making it
   // easy to read values in any representation when golden testing.
   action golden_test_friendly_action(
@@ -528,7 +528,15 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @id(2)
     string_id_t arg2) {}
 
-  // This table only contains fields whose formats are STRING. Values with the 
+  // Same as `golden_test_friendly_action` but with a different name so
+  // `golden_test_friendly_wcmp_table` can use 2 different actions.
+  action other_golden_test_friendly_action(
+    @id(1)
+    string_id_t arg1,
+    @id(2)
+    string_id_t arg2) {}
+
+  // This table only contains fields whose formats are STRING. Values with the
   // STRING format are unchanged when translated from PD to IR/PI making it
   // easy to read values in any representation when golden testing.
   table golden_test_friendly_table {
@@ -560,6 +568,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     actions = {
       @proto_id(1) golden_test_friendly_action;
+      @proto_id(2) other_golden_test_friendly_action;
     }
     implementation = wcmp_group_selector;
   }

--- a/p4_pdpi/testing/testdata/main_p4_pd.expected
+++ b/p4_pdpi/testing/testdata/main_p4_pd.expected
@@ -269,7 +269,10 @@ message GoldenTestFriendlyWcmpTableEntry {
   }
   Match match = 1;
   message Action {
+  oneof action {
+    OtherGoldenTestFriendlyAction other_golden_test_friendly_action = 2;
     GoldenTestFriendlyAction golden_test_friendly_action = 1;
+  }
   }
   message WcmpAction {
     Action action = 1;
@@ -510,6 +513,11 @@ message ReferringToTwoMatchFieldsAction {
   string referring_id_1 = 1; // Format::STRING
   // Refers to 'two_match_fields_table.id_2'.
   string referring_id_2 = 2; // Format::HEX_STRING / 10 bits
+}
+
+message OtherGoldenTestFriendlyAction {
+  string arg1 = 1; // Format::STRING
+  string arg2 = 2; // Format::STRING
 }
 
 message ReferringToOneMatchFieldAction {


### PR DESCRIPTION
/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ./key.sh p4_pdpi/
Keyword check Passed.

 
 
 /sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS  ...
INFO: Analyzed 395 targets (0 packages loaded, 0 targets configured).
INFO: Found 395 targets...
INFO: From Compiling P4 program p4_pdpi/testing/testdata/main.p4:
p4_pdpi/testing/testdata/main.p4(60): [--Wwarn=unused] warning: 'arg1' is unused
action do_thing_1(@id(2) bit<32> arg1, @id(1) bit<32> arg2) {
                                 ^^^^
p4_pdpi/testing/testdata/main.p4(60): [--Wwarn=unused] warning: 'arg2' is unused
action do_thing_1(@id(2) bit<32> arg1, @id(1) bit<32> arg2) {
In file included from p4_pdpi/testing/table_entry_gunit_test.cc:18:
./p4_pdpi/pd.h:268:30: note: declared here
  268 | absl::StatusOr<IrTableEntry> PartialPdTableEntryToIrTableEntry(
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO: From Compiling p4_pdpi/testing/sequencing_test_runner.cc:
p4_pdpi/testing/sequencing_test_runner.cc:1000:3: warning: multi-line comment [-Wcomment]
 1000 |   //   |           \
      |   ^
INFO: Elapsed time: 37.410s, Critical Path: 9.86s
INFO: 43 processes: 7 internal, 36 linux-sandbox.
INFO: Build completed successfully, 43 total actions



/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Analyzed 395 targets (0 packages loaded, 0 targets configured).
INFO: Found 257 targets and 138 test targets...
INFO: Elapsed time: 3.347s, Critical Path: 0.79s
INFO: 19 processes: 31 linux-sandbox.
INFO: Build completed successfully, 19 total actions
//gutil:collections_test                                        (cached) PASSED in 1.1s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s

Executed 18 out of 138 tests: 138 tests pass.
INFO: Build completed successfully, 19 total actions