### PR TITLE
[P4-PDPI] Add references library to help handle p4 table entry dependencies.

### DIFF
--- a/p4_pdpi/BUILD.bazel
+++ b/p4_pdpi/BUILD.bazel
@@ -18,6 +18,39 @@ package(
 )
 
 cc_library(
+    name = "references",
+    srcs = ["references.cc"],
+    hdrs = ["references.h"],
+    # Disable default arguments internally. Using them in PDPI itself is very likely a bug.
+    local_defines = ["PDPI_DISABLE_TRANSLATION_OPTIONS_DEFAULT"],
+    deps = [
+        ":ir_cc_proto",
+        ":reference_annotations",
+        "//gutil:proto",
+        "//gutil:status",
+        "//p4_pdpi/string_encodings:byte_string",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/container:btree",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)
+
+cc_test(
+    name = "references_test",
+    srcs = ["references_test.cc"],
+    deps = [
+        "references",
+        "@com_google_absl//absl/hash:hash_testing",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "built_ins",
     srcs = [
         "built_ins.cc",
@@ -59,7 +92,6 @@ cc_library(
         ":built_ins",
         ":ir_cc_proto",
         "//gutil:collections",
-        "//gutil:proto",
         "//gutil:status",
         "//p4_pdpi/internal:ordered_map",
         "//p4_pdpi/utils:annotation_parser",

--- a/p4_pdpi/references.cc
+++ b/p4_pdpi/references.cc
@@ -1,0 +1,600 @@
+#include "p4_pdpi/references.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/container/btree_set.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gutil/proto.h"
+#include "gutil/status.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4_pdpi/reference_annotations.h"
+#include "p4_pdpi/string_encodings/byte_string.h"
+
+namespace pdpi {
+namespace {
+
+// Used to store a set of ConcreteFieldReferences, that partially represents a
+// ConcreteTableReference, coming from an action or the match fields. Partial
+// references are combined to form full references, more details below.
+using PartialConcreteTableReference = absl::btree_set<ConcreteFieldReference>;
+
+// Inherited from v1model , see `standard_metadata_t.mcast_grp`.
+// https://github.com/p4lang/p4c/blob/main/p4include/v1model.p4
+constexpr int kMulticastGroupIdWidth = 16;
+// Inherited from v1model, see `standard_metadata_t.egress_rid`.
+// https://github.com/p4lang/p4c/blob/main/p4include/v1model.p4
+constexpr int kMulticastReplicaInstanceWidth = 16;
+
+// -- Match Field Value Getters ------------------------------------------------
+
+// Returns value of `field` in `entry`. Returns error if `entry` does not
+// contain `field` or `field does not have type EXACT.
+absl::StatusOr<std::string> GetMatchFieldValue(
+    const IrP4MatchField& field, const p4::v1::TableEntry& entry) {
+  for (const auto& match_field : entry.match()) {
+    if (match_field.field_id() == field.field_id()) {
+      switch (match_field.field_match_type_case()) {
+        case ::p4::v1::FieldMatch::kExact: {
+          return match_field.exact().value();
+        }
+        default: {
+          ASSIGN_OR_RETURN(
+              std::string type,
+              gutil::GetOneOfFieldName(match_field, "field_match_type"));
+          return gutil::UnimplementedErrorBuilder()
+                 << "Only match field type EXACT is supported in references. "
+                    "Match field '"
+                 << field.field_name() << "' has type '" << type << "'.";
+        }
+      }
+    }
+  }
+  return gutil::InvalidArgumentErrorBuilder()
+         << "Entry is missing match field " << field.field_name();
+}
+
+// Returns value of `field` in `entry`. Returns error if `field` is not a
+// multicast group entry match field.
+absl::StatusOr<std::string> GetMatchFieldValue(
+    const IrBuiltInMatchField& field,
+    const p4::v1::MulticastGroupEntry& entry) {
+  switch (field) {
+    case IrBuiltInMatchField::BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID: {
+      // Built-in field multicast group id is an int in PI representation, but
+      // user-defined fields involved in references encode the field as a
+      // bytestring, so it is converted for the sake of equality testing.
+      return BitsetToP4RuntimeByteString<kMulticastGroupIdWidth>(
+          entry.multicast_group_id());
+    }
+    default: {
+      return gutil::InternalErrorBuilder()
+             << "Built-in field " << IrBuiltInMatchField_Name(field)
+             << " is not a multicast group entry match field.";
+    }
+  }
+}
+
+// Returns value of `field` in `entry`. Returns error if `field` contains an
+// `IrActionField` or is empty.
+absl::StatusOr<std::string> GetMatchFieldValue(const IrMatchField& field,
+                                               const p4::v1::Entity& entry) {
+  switch (field.match_field_case()) {
+    case IrMatchField::kP4MatchField: {
+      return GetMatchFieldValue(field.p4_match_field(), entry.table_entry());
+    }
+    case IrMatchField::kBuiltInMatchField: {
+      return GetMatchFieldValue(
+          field.built_in_match_field(),
+          entry.packet_replication_engine_entry().multicast_group_entry());
+    }
+    case IrField::FIELD_NOT_SET: {
+      return gutil::InvalidArgumentErrorBuilder()
+             << "IrMatchField field oneof not set.";
+    }
+  }
+}
+
+// -- Action Param Value Getters -----------------------------------------------
+
+// Returns value of `field` in `entry`. Returns error if `entry` does not
+// contain `field` or `field does not have type EXACT.
+absl::StatusOr<std::string> GetActionFieldValue(const IrP4ActionField& field,
+                                                const p4::v1::Action& action) {
+  for (const auto& param : action.params()) {
+    if (param.param_id() == field.parameter_id()) {
+      return param.value();
+    }
+  }
+  return gutil::InvalidArgumentErrorBuilder()
+         << "Action " << field.action_name() << " is missing parameter "
+         << field.parameter_name();
+}
+
+// Returns value of `field` in `entry`. Returns error if `field` is not a
+// multicast group entry match field.
+absl::StatusOr<std::string> GetActionFieldValue(
+    const IrBuiltInActionField& field, const p4::v1::Replica& replica) {
+  switch (field.parameter()) {
+    case IrBuiltInParameter::BUILT_IN_PARAMETER_REPLICA_PORT: {
+      return replica.port();
+      break;
+    }
+    case IrBuiltInParameter::BUILT_IN_PARAMETER_REPLICA_INSTANCE: {
+      // Built-in field instance is an int in PI representation, but
+      // user-defined fields involved in references encode the field as a
+      // bytestring, so it is converted for the sake of equality testing.
+      return BitsetToP4RuntimeByteString<kMulticastReplicaInstanceWidth>(
+          replica.instance());
+    }
+    default: {
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Unknown IrBuiltInActionField " << field.DebugString();
+    }
+  }
+}
+
+// -- Reference Field Type -----------------------------------------------------
+
+// Enum representing the type of reference from an `IrField` in a source entry
+// to an `IrField` in a destination entry. These reference types dictate how
+// ConcreteFieldReferences should be merged together to form
+// ConcreteTableReferences.
+//
+// NOTE: There is currently no practical use case for kMatchFieldToActionParam
+// and kActionParamToActionParam references. In order to avoid unnecessary
+// implementation, they are unsupported and excluded from the enum. That being
+// said, it would not be an impossible task to imagine how they would be
+// supported. We leave this as an exercise for the reader.
+enum class FieldReferenceType {
+  kMatchFieldToMatchField,
+  kActionParamToMatchField,
+};
+
+// Returns `FieldReferenceType` of a reference from `source` to `destination`.
+// Returns error if the type of reference is not supported.
+absl::StatusOr<FieldReferenceType> GetReferenceType(
+    const IrField& source, const IrField& destination) {
+  if (source.has_match_field() && destination.has_match_field()) {
+    return FieldReferenceType::kMatchFieldToMatchField;
+  } else if (source.has_action_field() && destination.has_match_field()) {
+    return FieldReferenceType::kActionParamToMatchField;
+  }
+
+  return gutil::UnimplementedErrorBuilder()
+         << "Unsupported field reference from IrField "
+         << gutil::PrintShortTextProto(source) << " to IrField "
+         << gutil::PrintShortTextProto(destination);
+}
+
+// -- Validation function ------------------------------------------------------
+
+absl::Status ValidateEntityBelongsToTable(const p4::v1::Entity& entity,
+                                          const IrTable& table) {
+  switch (entity.entity_case()) {
+    case p4::v1::Entity::kTableEntry: {
+      if (!table.has_p4_table()) {
+        return gutil::InvalidArgumentErrorBuilder()
+               << "Entity contained a table entry but IrTable was not an "
+                  "IrP4Table. IrTable: "
+               << table.DebugString();
+      }
+      if (entity.table_entry().table_id() != table.p4_table().table_id()) {
+        return gutil::InvalidArgumentErrorBuilder()
+               << "Provided table entry had id "
+               << entity.table_entry().table_id() << " but IrP4Table had id "
+               << table.p4_table().table_id();
+      }
+      return absl::OkStatus();
+    }
+    case p4::v1::Entity::kPacketReplicationEngineEntry: {
+      if (!entity.packet_replication_engine_entry()
+               .has_multicast_group_entry()) {
+        return gutil::UnimplementedErrorBuilder()
+               << "Only packet replication engine entries of type "
+                  "multicast are supported. Entity: "
+               << entity.DebugString();
+      }
+      if (!table.has_built_in_table()) {
+        return gutil::InvalidArgumentErrorBuilder()
+               << "Entity contained built-in table but IrTable was "
+                  "not a IrBuiltInTable. IrTable: "
+               << table.DebugString();
+      }
+      if (table.built_in_table() != BUILT_IN_TABLE_MULTICAST_GROUP_TABLE) {
+        return gutil::InvalidArgumentErrorBuilder()
+               << "Entity contained multicast group entry but IrBuiltInTable "
+                  "was not BUILT_IN_TABLE_MULTICAST_GROUP_ENTRY. IrTable: "
+               << table.DebugString();
+      }
+      return absl::OkStatus();
+    }
+    default: {
+      ASSIGN_OR_RETURN(std::string type,
+                       gutil::GetOneOfFieldName(entity, "entity"));
+      return gutil::UnimplementedErrorBuilder()
+             << "Cannot create reference entries for unsupported entity type: "
+             << type << ". Entity: " << entity.DebugString();
+    }
+  }
+}
+
+absl::StatusOr<PartialConcreteTableReference> GetPartialReferenceFromAction(
+    std::vector<const IrTableReference::FieldReference*>
+        action_field_to_match_field_references,
+    const p4::v1::Action& action) {
+  PartialConcreteTableReference result;
+  for (const auto& reference : action_field_to_match_field_references) {
+    ASSIGN_OR_RETURN(std::string source_name,
+                     GetNameOfField(reference->source()));
+    ASSIGN_OR_RETURN(std::string destination_name,
+                     GetNameOfField(reference->destination()));
+    ASSIGN_OR_RETURN(
+        std::string param_value,
+        GetActionFieldValue(
+            reference->source().action_field().p4_action_field(), action));
+
+    result.insert(ConcreteFieldReference{
+        .source_field = std::move(source_name),
+        .destination_field = std::move(destination_name),
+        .value = std::move(param_value),
+    });
+  }
+  return result;
+}
+
+absl::StatusOr<PartialConcreteTableReference> GetPartialReferenceFromReplica(
+    std::vector<const IrTableReference::FieldReference*>
+        replica_field_to_match_field_references,
+    const p4::v1::Replica& replica) {
+  PartialConcreteTableReference partial_reference;
+  for (const auto& reference : replica_field_to_match_field_references) {
+    ASSIGN_OR_RETURN(std::string source_name,
+                     GetNameOfField(reference->source()));
+    ASSIGN_OR_RETURN(std::string destination_name,
+                     GetNameOfField(reference->destination()));
+
+    ASSIGN_OR_RETURN(
+        std::string param_value,
+        GetActionFieldValue(
+            reference->source().action_field().built_in_action_field(),
+            replica));
+
+    partial_reference.insert(ConcreteFieldReference{
+        .source_field = std::move(source_name),
+        .destination_field = std::move(destination_name),
+        .value = std::move(param_value),
+    });
+  }
+  return partial_reference;
+}
+
+}  // namespace
+
+absl::StatusOr<absl::flat_hash_set<ConcreteTableReference>>
+OutgoingConcreteTableReferences(const IrTableReference& reference_info,
+                                const ::p4::v1::Entity& entity) {
+  RETURN_IF_ERROR(
+      ValidateEntityBelongsToTable(entity, reference_info.source_table()));
+
+  // The set of outgoing ConcreteTableReferences is created by taking the union
+  // of each action partial reference with the match field partial reference.
+  // If there are no action partial reference, then the match field partial
+  // reference alone will form a single ConcreteTableReference.
+
+  // STEP 1: Group references by match field or source action.
+  std::vector<const IrTableReference::FieldReference*>
+      match_field_to_match_field_references;
+  absl::flat_hash_map<int, std::vector<const IrTableReference::FieldReference*>>
+      action_field_to_match_field_references_by_action_id;
+  // Built-in actions do not have an action id so references from a built-in
+  // action are explicitly stored in separate containers.
+  std::vector<const IrTableReference::FieldReference*>
+      built_in_replica_field_to_match_field_references;
+  for (const auto& field_reference : reference_info.field_references()) {
+    ASSIGN_OR_RETURN(FieldReferenceType reference_type,
+                     GetReferenceType(field_reference.source(),
+                                      field_reference.destination()));
+    switch (reference_type) {
+      case FieldReferenceType::kMatchFieldToMatchField: {
+        match_field_to_match_field_references.push_back(&field_reference);
+        break;
+      }
+      case FieldReferenceType::kActionParamToMatchField: {
+        if (field_reference.source().action_field().has_p4_action_field()) {
+          action_field_to_match_field_references_by_action_id
+              [field_reference.source()
+                   .action_field()
+                   .p4_action_field()
+                   .action_id()]
+                  .push_back(&field_reference);
+        } else {
+          built_in_replica_field_to_match_field_references.push_back(
+              &field_reference);
+        }
+        break;
+      }
+    }
+  }
+
+  // STEP 2: Get partial references for each action.
+  std::vector<PartialConcreteTableReference> action_partial_references;
+  switch (entity.entity_case()) {
+    case p4::v1::Entity::kTableEntry: {
+      const p4::v1::TableEntry& entry = entity.table_entry();
+      switch (entry.action().type_case()) {
+        case p4::v1::TableAction::kAction: {
+          ASSIGN_OR_RETURN(
+              action_partial_references.emplace_back(),
+              GetPartialReferenceFromAction(
+                  action_field_to_match_field_references_by_action_id
+                      [entry.action().action().action_id()],
+                  entry.action().action()));
+          break;
+        }
+        case p4::v1::TableAction::kActionProfileActionSet: {
+          for (const auto& action : entry.action()
+                                        .action_profile_action_set()
+                                        .action_profile_actions()) {
+            ASSIGN_OR_RETURN(
+                action_partial_references.emplace_back(),
+                GetPartialReferenceFromAction(
+                    action_field_to_match_field_references_by_action_id
+                        [action.action().action_id()],
+                    action.action()));
+          }
+          break;
+        }
+        default: {
+          return gutil::InvalidArgumentErrorBuilder()
+                 << "Unknown TableAction " << entry.action().DebugString();
+        }
+      }
+      break;
+    }
+    case p4::v1::Entity::kPacketReplicationEngineEntry: {
+      const p4::v1::MulticastGroupEntry& entry =
+          entity.packet_replication_engine_entry().multicast_group_entry();
+      for (const auto& replica : entry.replicas()) {
+        ASSIGN_OR_RETURN(
+            action_partial_references.emplace_back(),
+            GetPartialReferenceFromReplica(
+                built_in_replica_field_to_match_field_references, replica));
+      }
+      break;
+    }
+    default: {
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Unknown Entity " << entity.DebugString();
+    }
+  }
+
+  // Step 3: Get partial reference for the match fields.
+  PartialConcreteTableReference match_field_partial_reference;
+  for (const auto& match_field_reference :
+       match_field_to_match_field_references) {
+    ASSIGN_OR_RETURN(std::string source_name,
+                     GetNameOfField(match_field_reference->source()));
+    ASSIGN_OR_RETURN(std::string destination_name,
+                     GetNameOfField(match_field_reference->destination()));
+    ASSIGN_OR_RETURN(
+        std::string match_field_value,
+        GetMatchFieldValue(match_field_reference->source().match_field(),
+                           entity));
+    match_field_partial_reference.insert(ConcreteFieldReference{
+        .source_field = std::move(source_name),
+        .destination_field = std::move(destination_name),
+        .value = std::move(match_field_value),
+    });
+  }
+
+  // Step 4: Combine partial concrete table references from actions and match
+  // fields.
+  ASSIGN_OR_RETURN(std::string source_table_name,
+                   GetNameOfTable(reference_info.source_table()));
+  ASSIGN_OR_RETURN(std::string destination_table_name,
+                   GetNameOfTable(reference_info.destination_table()));
+
+  absl::flat_hash_set<ConcreteTableReference> result;
+  // If `entity` only refers to another table via match fields, it should only
+  // have a single ConcreteTableReference.
+  if (action_partial_references.empty() &&
+      !match_field_partial_reference.empty()) {
+    result.insert(ConcreteTableReference{
+        .source_table = source_table_name,
+        .destination_table = destination_table_name,
+        .fields = std::move(match_field_partial_reference),
+    });
+  } else {
+    // Union the partial references from actions (if any) with the partial
+    // reference from match fields (if any).
+    for (auto& partial_reference : action_partial_references) {
+      partial_reference.insert(match_field_partial_reference.begin(),
+                               match_field_partial_reference.end());
+
+      // Don't create empty references.
+      if (partial_reference.empty()) continue;
+
+      result.insert(ConcreteTableReference{
+          .source_table = source_table_name,
+          .destination_table = destination_table_name,
+          .fields = std::move(partial_reference),
+      });
+    }
+  }
+  return result;
+}
+
+absl::StatusOr<absl::flat_hash_set<ConcreteTableReference>>
+PossibleIncomingConcreteTableReferences(const IrTableReference& reference_info,
+                                        const ::p4::v1::Entity& entity) {
+  RETURN_IF_ERROR(
+      ValidateEntityBelongsToTable(entity, reference_info.destination_table()));
+
+  // The set of possible incoming ConcreteTableReferences is created by taking
+  // the union of each partial reference coming from an action with the partial
+  // reference coming from match fields. In addition, the partial
+  // reference coming from match fields also creates its own reference since
+  // referencing entities may contain no action.
+
+  // STEP 1: Group references by match field or source action.
+  std::vector<const IrTableReference::FieldReference*>
+      match_field_to_match_field_references;
+  absl::flat_hash_map<std::string,
+                      std::vector<const IrTableReference::FieldReference*>>
+      action_field_to_match_field_references_by_action_name;
+  // NOTE: We do not need a container specific for built-in actions because we
+  // are not accessing the actions in `entity`. We are only stating that a match
+  // field is being referenced by some action, and action names are sufficient
+  // for that purpose, which both built-ins and user-defined support.
+
+  for (const auto& field_reference : reference_info.field_references()) {
+    ASSIGN_OR_RETURN(FieldReferenceType reference_type,
+                     GetReferenceType(field_reference.source(),
+                                      field_reference.destination()));
+    switch (reference_type) {
+      case FieldReferenceType::kMatchFieldToMatchField: {
+        match_field_to_match_field_references.push_back(&field_reference);
+        break;
+      }
+      case FieldReferenceType::kActionParamToMatchField: {
+        ASSIGN_OR_RETURN(
+            std::string action_name,
+            GetNameOfAction(field_reference.source().action_field()));
+        action_field_to_match_field_references_by_action_name[action_name]
+            .push_back(&field_reference);
+        break;
+      }
+    }
+  }
+
+  // STEP 2: Get partial reference for each possible source action.
+  std::vector<PartialConcreteTableReference> action_partial_references;
+  for (const auto& [action_name, references] :
+       action_field_to_match_field_references_by_action_name) {
+    PartialConcreteTableReference partial_reference;
+    for (const auto& reference : references) {
+      ASSIGN_OR_RETURN(std::string source_name,
+                       GetNameOfField(reference->source()));
+      ASSIGN_OR_RETURN(std::string destination_name,
+                       GetNameOfField(reference->destination()));
+      ASSIGN_OR_RETURN(
+          std::string match_field_value,
+          GetMatchFieldValue(reference->destination().match_field(), entity));
+      partial_reference.insert(ConcreteFieldReference{
+          .source_field = source_name,
+          .destination_field = destination_name,
+          .value = match_field_value,
+      });
+    }
+    action_partial_references.push_back(std::move(partial_reference));
+  }
+
+  // Step 3: Get partial reference for the match fields.
+  PartialConcreteTableReference match_field_partial_reference;
+  for (const auto& match_field_reference :
+       match_field_to_match_field_references) {
+    ASSIGN_OR_RETURN(std::string source_name,
+                     GetNameOfField(match_field_reference->source()));
+    ASSIGN_OR_RETURN(std::string destination_name,
+                     GetNameOfField(match_field_reference->destination()));
+    ASSIGN_OR_RETURN(
+        std::string match_field_value,
+        GetMatchFieldValue(match_field_reference->destination().match_field(),
+                           entity));
+    match_field_partial_reference.insert(ConcreteFieldReference{
+        .source_field = source_name,
+        .destination_field = destination_name,
+        .value = match_field_value,
+    });
+  }
+
+  // Step 4: Combine partial concrete table references from actions and match
+  // fields.
+  ASSIGN_OR_RETURN(std::string source_table_name,
+                   GetNameOfTable(reference_info.source_table()));
+  ASSIGN_OR_RETURN(std::string destination_table_name,
+                   GetNameOfTable(reference_info.destination_table()));
+
+  absl::flat_hash_set<ConcreteTableReference> result;
+  // If `entity` is only referenced by another table via match fields, it should
+  // a single ConcreteTableReference accounting for this.
+  if (!match_field_partial_reference.empty()) {
+    result.insert(ConcreteTableReference{
+        .source_table = source_table_name,
+        .destination_table = destination_table_name,
+        .fields = match_field_partial_reference,
+    });
+  }
+
+  // Union the partial references from actions (if any) with the partial
+  // reference from match fields (if any).
+  for (auto& partial_reference : action_partial_references) {
+    partial_reference.insert(match_field_partial_reference.begin(),
+                             match_field_partial_reference.end());
+
+    // Don't create empty references.
+    if (partial_reference.empty()) continue;
+
+    result.insert(ConcreteTableReference{
+        .source_table = source_table_name,
+        .destination_table = destination_table_name,
+        .fields = std::move(partial_reference),
+    });
+  }
+
+  return result;
+}
+
+// ConcreteFieldReference operators
+bool operator==(const ConcreteFieldReference& lhs,
+                const ConcreteFieldReference& rhs) {
+  return lhs.source_field == rhs.source_field &&
+         lhs.destination_field == rhs.destination_field &&
+         lhs.value == rhs.value;
+}
+bool operator!=(const ConcreteFieldReference& lhs,
+                const ConcreteFieldReference& rhs) {
+  return !(lhs == rhs);
+}
+bool operator<(const ConcreteFieldReference& lhs,
+               const ConcreteFieldReference& rhs) {
+  if (lhs.source_field != rhs.source_field) {
+    return lhs.source_field < rhs.source_field;
+  }
+  if (lhs.destination_field != rhs.destination_field) {
+    return lhs.destination_field < rhs.destination_field;
+  }
+  return lhs.value < rhs.value;
+}
+
+// ConcreteTableReference operators
+bool operator==(const ConcreteTableReference& lhs,
+                const ConcreteTableReference& rhs) {
+  return lhs.source_table == rhs.source_table &&
+         lhs.destination_table == rhs.destination_table &&
+         lhs.fields == rhs.fields;
+}
+
+bool operator!=(const ConcreteTableReference& lhs,
+                const ConcreteTableReference& rhs) {
+  return !(lhs == rhs);
+}
+
+bool operator<(const ConcreteTableReference& lhs,
+               const ConcreteTableReference& rhs) {
+  if (lhs.source_table != rhs.source_table) {
+    return lhs.source_table < rhs.source_table;
+  }
+  if (lhs.destination_table != rhs.destination_table) {
+    return lhs.destination_table < rhs.destination_table;
+  }
+  return lhs.fields < rhs.fields;
+}
+
+}  // namespace pdpi

--- a/p4_pdpi/references.h
+++ b/p4_pdpi/references.h
@@ -1,0 +1,152 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PINS_P4_PDPI_REFERENCES_H_
+#define PINS_P4_PDPI_REFERENCES_H_
+
+#include <algorithm>
+#include <string>
+#include <utility>
+
+#include "absl/container/btree_set.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/ir.pb.h"
+
+namespace pdpi {
+
+// Corresponds to a concrete instance of `IrTableReference::FieldReference` in
+// ir.proto where a value is provided for the reference.
+struct ConcreteFieldReference {
+  // String representation of `source` in `FieldReference`.
+  std::string source_field;
+  // String representation of `destination` in `FieldReference`.
+  std::string destination_field;
+  std::string value;
+};
+
+// Corresponds to a concrete instance of `IrTableReference` in ir.proto where an
+// entry's values are provided for the reference. This allows us to check
+// dependencies in the following way:
+//  - We have a table entry from `source_table` S
+//  - We have a table entry from `destination_table` D
+//  - S produces a set of Concrete Table Entry References (STER)
+//  - D can be referenced by a set of Concrete Table Entry References (DTER)
+//  - If the intersection of STER and DTER is not empty, then S depends on D
+struct ConcreteTableReference {
+  std::string source_table;
+  std::string destination_table;
+  absl::btree_set<ConcreteFieldReference> fields;
+};
+
+// Returns ConcreteTableReferences from `entity` to `destination_table` in
+// `reference_info`. Returns error if:
+//  - `entity` is not a table entry or multicast group entry
+//  - `entity` does not belong to `source_table` in `reference_info`
+//  - `entity` is missing one or more match fields/action parameters associated
+//    with `field_references` in `reference_info`
+//  - `reference_info` contains an unknown/unsupported built_in table/field
+//  - there is an unsupported reference type (i.e.action param-to-action param)
+//
+// ASSUMPTIONS about `reference_info`:
+//  - All source fields present in `reference_info` are fields that `entity` can
+//    have.
+// If these assumptions are not met, concrete table references may not be
+// considered valid. Ideally `reference_info` should come from an IR p4 info
+// created using `CreateIrP4Info` which respects these assumptions.
+absl::StatusOr<absl::flat_hash_set<ConcreteTableReference>>
+OutgoingConcreteTableReferences(const IrTableReference& reference_info,
+                                const ::p4::v1::Entity& entity);
+
+// Returns all possible concrete table references from some entry in
+// `source_table` in `reference_info` to `entity`. Returns error if:
+//  - `entity` is not a table entry or multicast group entry
+//  - `entity` does not belong to `destination_table` in `reference_info`
+//  - `entity` is missing one or more match fields associated with
+//    `field_references` in `reference_info`
+//  - `reference_info` contains an unknown/unsupported built_in table/field
+//  - there is an unsupported reference type (i.e.action param-to-action param)
+//
+// ASSUMPTIONS about `reference_info`:
+//  - All destination fields present in `reference_info` are fields that an
+//    entry from the destination table can have.
+// If these assumptions are not met, reference entries may not be considered
+// valid. Ideally `reference_info` should come from an ir p4 info created using
+// `CreateIrP4Info` which respects these assumptions.
+absl::StatusOr<absl::flat_hash_set<ConcreteTableReference>>
+PossibleIncomingConcreteTableReferences(const IrTableReference& reference_info,
+                                        const ::p4::v1::Entity& entity);
+
+// Reference Field operators.
+bool operator==(const ConcreteFieldReference& lhs,
+                const ConcreteFieldReference& rhs);
+bool operator!=(const ConcreteFieldReference& lhs,
+                const ConcreteFieldReference& rhs);
+bool operator<(const ConcreteFieldReference& lhs,
+               const ConcreteFieldReference& rhs);
+
+// Reference Entry operators.
+bool operator==(const ConcreteTableReference& lhs,
+                const ConcreteTableReference& rhs);
+bool operator!=(const ConcreteTableReference& lhs,
+                const ConcreteTableReference& rhs);
+bool operator<(const ConcreteTableReference& lhs,
+               const ConcreteTableReference& rhs);
+
+// -- END OF PUBLIC INTERFACE -- implementation details follow -----------------
+
+template <typename Sink>
+void AbslStringify(Sink& sink, const ConcreteFieldReference& field) {
+  absl::Format(
+      &sink,
+      "ConcreteFieldReference{ source field: '%v', destination field: '%v', "
+      "value: '%v' }",
+      field.source_field, field.destination_field, field.value);
+}
+template <typename H>
+H AbslHashValue(H h, const ConcreteFieldReference& field) {
+  return H::combine(std::move(h), field.source_field, field.destination_field,
+                    field.value);
+}
+template <typename Sink>
+void AbslStringify(Sink& sink, const ConcreteTableReference& entry) {
+  std::string string_entry = "ConcreteTableReference{\n";
+  absl::StrAppend(&string_entry, std::string(2, ' '), "source table: '",
+                  entry.source_table, "'\n");
+  absl::StrAppend(&string_entry, std::string(2, ' '), "destination table: '",
+                  entry.destination_table, "'\n");
+  absl::StrAppend(&string_entry, std::string(2, ' '), "fields: {\n");
+  for (const ConcreteFieldReference& field : entry.fields) {
+    absl::StrAppend(&string_entry, std::string(4, ' '), field, ",\n");
+  }
+  absl::StrAppend(&string_entry, std::string(2, ' '), "}\n");
+  absl::StrAppend(&string_entry, "}\n");
+  absl::Format(&sink, "%v", string_entry);
+}
+template <typename H>
+H AbslHashValue(H h, const ConcreteTableReference& entry) {
+  h = H::combine(std::move(h), entry.source_table, entry.destination_table);
+  for (const ConcreteFieldReference& field : entry.fields) {
+    h = H::combine(std::move(h), field.source_field, field.destination_field,
+                   field.value);
+  }
+  return h;
+}
+
+}  // namespace pdpi
+
+#endif  // PINS_P4_PDPI_REFERENCE_UTIL_H_

--- a/p4_pdpi/references_test.cc
+++ b/p4_pdpi/references_test.cc
@@ -1,0 +1,309 @@
+#include "p4_pdpi/references.h"
+
+#include "absl/hash/hash_testing.h"
+#include "gtest/gtest.h"
+namespace pdpi {
+namespace {
+
+// -- Concrete Reference Field Test --------------------------------------------
+
+TEST(ConcreteFieldReferenceTest, FieldsWithSrcNameDiffAreNotEqual) {
+  EXPECT_NE((ConcreteFieldReference{
+                .source_field = "Src1",
+                .destination_field = "Dst",
+                .value = "v",
+            }),
+            (ConcreteFieldReference{
+                .source_field = "Src2",
+                .destination_field = "Dst",
+                .value = "v",
+            }));
+}
+
+TEST(ConcreteFieldReferenceTest, FieldsWithDstNameDiffAreNotEqual) {
+  EXPECT_NE((ConcreteFieldReference{
+                .source_field = "Src",
+                .destination_field = "Dst1",
+                .value = "v",
+            }),
+            (ConcreteFieldReference{
+                .source_field = "Src",
+                .destination_field = "Dst2",
+                .value = "v",
+            }));
+}
+
+TEST(ConcreteFieldReferenceTest, FieldsWithValueDiffAreNotEqual) {
+  EXPECT_NE((ConcreteFieldReference{
+                .source_field = "Src",
+                .destination_field = "Dst",
+                .value = "v1",
+            }),
+            (ConcreteFieldReference{
+                .source_field = "Src",
+                .destination_field = "Dst",
+                .value = "v2",
+            }));
+}
+
+TEST(ConcreteFieldReferenceTest, IdenticalFieldsAreEqual) {
+  EXPECT_EQ((ConcreteFieldReference{
+                .source_field = "Src",
+                .destination_field = "Dst",
+                .value = "v",
+            }),
+            (ConcreteFieldReference{
+                .source_field = "Src",
+                .destination_field = "Dst",
+                .value = "v",
+            }));
+}
+
+// The hash value check is provided by VerifyTypeImplementsAbslHashCorrectly
+// that checks `ReferenceField`s that are equal have the same hash values and
+// `ReferenceField`s that are not equal have different hash values.
+TEST(ConcreteFieldReferenceTest, HashingTest) {
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly({
+      (ConcreteFieldReference{
+          .source_field = "Src",
+          .destination_field = "Dst",
+          .value = "v",
+      }),
+      (ConcreteFieldReference{
+          .source_field = "Src1",
+          .destination_field = "Dst",
+          .value = "v",
+      }),
+      (ConcreteFieldReference{
+          .source_field = "Src",
+          .destination_field = "Dst1",
+          .value = "v",
+      }),
+      (ConcreteFieldReference{
+          .source_field = "Src",
+          .destination_field = "Dst",
+          .value = "v1",
+      }),
+      (ConcreteFieldReference{
+          .source_field = "Src",
+          .destination_field = "Dst",
+          .value = "v",
+      }),
+  }));
+}
+
+// -- Concrete Reference Entry Test --------------------------------------------
+
+TEST(ConcreteTableReferenceTest, EntriesWithSrcNameDiffAreNotEqual) {
+  EXPECT_NE((ConcreteTableReference{
+                .source_table = "Src1",
+                .destination_table = "Dst",
+            }),
+            (ConcreteTableReference{
+                .source_table = "Src2",
+                .destination_table = "Dst",
+            }));
+}
+
+TEST(ConcreteTableReferenceTest, EntriesWithDstNameDiffAreNotEqual) {
+  EXPECT_NE((ConcreteTableReference{
+                .source_table = "Src",
+                .destination_table = "Dst1",
+            }),
+            (ConcreteTableReference{
+                .source_table = "Src",
+                .destination_table = "Dst2",
+            }));
+}
+
+TEST(ConcreteTableReferenceTest, EntriesWithFieldsDiffAreNotEqual) {
+  EXPECT_NE((ConcreteTableReference{.source_table = "Src",
+                                    .destination_table = "Dst",
+                                    .fields =
+                                        {
+                                            ConcreteFieldReference{
+                                                .source_field = "Src1",
+                                                .destination_field = "Dst1",
+                                                .value = "v1",
+                                            },
+                                        }}),
+            (ConcreteTableReference{.source_table = "Src",
+                                    .destination_table = "Dst",
+                                    .fields = {
+                                        ConcreteFieldReference{
+                                            .source_field = "Src2",
+                                            .destination_field = "Dst2",
+                                            .value = "v2",
+                                        },
+                                    }}));
+}
+
+TEST(ConcreteTableReferenceTest, IdenticalEntriesAreEqual) {
+  EXPECT_EQ((ConcreteTableReference{.source_table = "Src",
+                                    .destination_table = "Dst",
+                                    .fields =
+                                        {
+                                            ConcreteFieldReference{
+                                                .source_field = "Src1",
+                                                .destination_field = "Dst1",
+                                                .value = "v1",
+                                            },
+                                        }}),
+            (ConcreteTableReference{.source_table = "Src",
+                                    .destination_table = "Dst",
+                                    .fields = {
+                                        ConcreteFieldReference{
+                                            .source_field = "Src1",
+                                            .destination_field = "Dst1",
+                                            .value = "v1",
+                                        },
+                                    }}));
+}
+
+TEST(ConcreteTableReferenceTest, EntriesWithSameFieldsInDiffOrderAreEqual) {
+  EXPECT_EQ((ConcreteTableReference{.source_table = "Src",
+                                    .destination_table = "Dst",
+                                    .fields =
+                                        {
+                                            ConcreteFieldReference{
+                                                .source_field = "Src2",
+                                                .destination_field = "Dst2",
+                                                .value = "v2",
+                                            },
+                                            ConcreteFieldReference{
+                                                .source_field = "Src1",
+                                                .destination_field = "Dst1",
+                                                .value = "v1",
+                                            },
+                                        }}),
+            (ConcreteTableReference{.source_table = "Src",
+                                    .destination_table = "Dst",
+                                    .fields = {
+                                        ConcreteFieldReference{
+                                            .source_field = "Src1",
+                                            .destination_field = "Dst1",
+                                            .value = "v1",
+                                        },
+                                        ConcreteFieldReference{
+                                            .source_field = "Src2",
+                                            .destination_field = "Dst2",
+                                            .value = "v2",
+                                        },
+                                    }}));
+}
+
+TEST(ConcreteTableReferenceTest, EntriesWithSubsetFieldsAreNotEqual) {
+  EXPECT_NE((ConcreteTableReference{.source_table = "Src",
+                                    .destination_table = "Dst",
+                                    .fields =
+                                        {
+                                            ConcreteFieldReference{
+                                                .source_field = "Src1",
+                                                .destination_field = "Dst1",
+                                                .value = "v1",
+                                            },
+                                        }}),
+            (ConcreteTableReference{.source_table = "Src",
+                                    .destination_table = "Dst",
+                                    .fields = {
+                                        ConcreteFieldReference{
+                                            .source_field = "Src1",
+                                            .destination_field = "Dst1",
+                                            .value = "v1",
+                                        },
+                                        ConcreteFieldReference{
+                                            .source_field = "Src2",
+                                            .destination_field = "Dst2",
+                                            .value = "v2",
+                                        },
+                                    }}));
+}
+
+// The hash value check is provided by VerifyTypeImplementsAbslHashCorrectly
+// that checks `ReferenceField`s that are equal have the same hash values and
+// `ReferenceField`s that are not equal have different hash values.
+TEST(ConcreteTableReferenceTest, HashingTest) {
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
+      {(ConcreteTableReference{.source_table = "Src",
+                               .destination_table = "Dst",
+                               .fields =
+                                   {
+                                       ConcreteFieldReference{
+                                           .source_field = "Src1",
+                                           .destination_field = "Dst1",
+                                           .value = "v1",
+                                       },
+                                   }}),
+       (ConcreteTableReference{.source_table = "Src",
+                               .destination_table = "Dst",
+                               .fields =
+                                   {
+                                       ConcreteFieldReference{
+                                           .source_field = "Src2",
+                                           .destination_field = "Dst2",
+                                           .value = "v1",
+                                       },
+                                   }}),
+       (ConcreteTableReference{.source_table = "Src",
+                               .destination_table = "Dst",
+                               .fields =
+                                   {
+                                       ConcreteFieldReference{
+                                           .source_field = "Src1",
+                                           .destination_field = "Dst1",
+                                           .value = "v1",
+                                       },
+                                       ConcreteFieldReference{
+                                           .source_field = "Src2",
+                                           .destination_field = "Dst2",
+                                           .value = "v1",
+                                       },
+                                   }}),
+       (ConcreteTableReference{.source_table = "Src",
+                               .destination_table = "Dst",
+                               .fields =
+                                   {
+                                       ConcreteFieldReference{
+                                           .source_field = "Src2",
+                                           .destination_field = "Dst2",
+                                           .value = "v1",
+                                       },
+                                       ConcreteFieldReference{
+                                           .source_field = "Src1",
+                                           .destination_field = "Dst1",
+                                           .value = "v1",
+                                       },
+                                   }}),
+       (ConcreteTableReference{.source_table = "OtherSrc",
+                               .destination_table = "Dst",
+                               .fields =
+                                   {
+                                       ConcreteFieldReference{
+                                           .source_field = "Src2",
+                                           .destination_field = "Dst2",
+                                           .value = "v1",
+                                       },
+                                       ConcreteFieldReference{
+                                           .source_field = "Src1",
+                                           .destination_field = "Dst1",
+                                           .value = "v1",
+                                       },
+                                   }}),
+       (ConcreteTableReference{.source_table = "Src",
+                               .destination_table = "OtherDst",
+                               .fields = {
+                                   ConcreteFieldReference{
+                                       .source_field = "Src2",
+                                       .destination_field = "Dst2",
+                                       .value = "v1",
+                                   },
+                                   ConcreteFieldReference{
+                                       .source_field = "Src1",
+                                       .destination_field = "Dst1",
+                                       .value = "v1",
+                                   },
+                               }})}));
+}
+
+}  // namespace
+}  // namespace pdpi

--- a/p4_pdpi/testing/BUILD.bazel
+++ b/p4_pdpi/testing/BUILD.bazel
@@ -212,6 +212,36 @@ cmd_diff_test(
     tools = [":sequencing_util_test_runner"],
 )
 
+cc_test(
+    name = "references_test_runner",
+    srcs = ["references_test_runner.cc"],
+    linkstatic = True,
+    deps = [
+        ":main_p4_pd_cc_proto",
+        ":test_helper",
+        ":test_p4info_cc",
+        "//gutil:proto",
+        "//gutil:status",
+        "//gutil:testing",
+        "//p4_pdpi:ir_cc_proto",
+        "//p4_pdpi:pd",
+        "//p4_pdpi:references",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/container:btree",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cmd_diff_test(
+    name = "references_test",
+    actual_cmd = "$(execpath :references_test_runner) ",
+    expected = "//p4_pdpi/testing/testdata:references.expected",
+    tools = [":references_test_runner"],
+)
+
 # go/golden-test-with-coverage
 cc_test(
     name = "info_test_runner",

--- a/p4_pdpi/testing/references_test_runner.cc
+++ b/p4_pdpi/testing/references_test_runner.cc
@@ -1,0 +1,1498 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "absl/container/btree_set.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "gutil/proto.h"
+#include "gutil/status.h"
+#include "gutil/testing.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4_pdpi/pd.h"
+#include "p4_pdpi/references.h"
+#include "p4_pdpi/testing/main_p4_pd.pb.h"
+#include "p4_pdpi/testing/test_helper.h"
+#include "p4_pdpi/testing/test_p4info.h"
+
+namespace pdpi {
+namespace {
+
+constexpr absl::string_view kInputBanner =
+    "-- INPUT --------------------------------------------------------------\n";
+const absl::string_view kOutputBanner =
+    "-- OUTPUT -------------------------------------------------------------\n";
+
+struct ConcreteTableReferenceTestCase {
+  // PD representation of PI entity used to generate outgoing/possible-incoming
+  // table references. Valid entities must meet the following requirements:
+  // - Entity must be valid for main.p4 program.
+  // - Must belong to `reference_info.source_table` when creating outgoing
+  // references.
+  // - Must belong to `reference_info.destination_table` when creating possible
+  // incoming references.
+  pdpi::TableEntry entity;
+  // Reference information used to to create table references from `entity`.
+  IrTableReference reference_info;
+  // Description of test case.
+  std::string description;
+};
+
+std::vector<ConcreteTableReferenceTestCase>
+OutgoingConcreteTableReferencesTestCases() {
+  std::vector<ConcreteTableReferenceTestCase> test_cases;
+
+  pdpi::TableEntry p4_entry = gutil::ParseProtoOrDie<pdpi::TableEntry>(
+      R"pb(golden_test_friendly_table_entry {
+             match { key1: "key-a" key2: "key-b" }
+             action {
+               golden_test_friendly_action { arg1: "arg1" arg2: "arg2" }
+             }
+           })pb");
+
+  pdpi::TableEntry p4_group_entry_with_multiple_actions =
+      gutil::ParseProtoOrDie<pdpi::TableEntry>(
+          R"pb(golden_test_friendly_wcmp_table_entry {
+                 match { key1: "key-a" key2: "key-b" }
+                 wcmp_actions {
+                   action {
+                     golden_test_friendly_action {
+                       arg1: "act1-arg1"
+                       arg2: "act1-arg2"
+                     }
+                   }
+                   weight: 1
+                 }
+                 wcmp_actions {
+                   action {
+                     golden_test_friendly_action {
+                       arg1: "act2-arg1"
+                       arg2: "act2-arg2"
+                     }
+                   }
+                   weight: 2
+                 }
+                 wcmp_actions {
+                   action {
+                     other_golden_test_friendly_action {
+                       arg1: "act3-arg1"
+                       arg2: "act3-arg2"
+                     }
+                   }
+                   weight: 3
+                 }
+               })pb");
+
+  pdpi::TableEntry built_in_entry_with_multiple_actions =
+      gutil::ParseProtoOrDie<pdpi::TableEntry>(R"pb(
+        multicast_group_table_entry {
+          match { multicast_group_id: "0x0037" }
+          action {
+            replicate {
+              replicas { port: "port_1" instance: "0x0031" }
+              replicas { port: "port_2" instance: "0x0032" }
+            }
+          }
+        }
+      )pb");
+
+  // Error test cases.
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "wrong_table" table_id: 7 } }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+      )pb"),
+      .description = "Fails if entity does not belong to source table",
+  });
+  // NOTE: Similar errors are encountered for the following:
+  // P4MatchField-Refers-To-P4ActionField
+  // P4MatchField-Refers-To-BuiltInActionField
+  // BuiltInMatchField-Refers-To-P4ActionField
+  // BuiltInMatchField-Refers-To-BuiltInActionField
+  // P4ActionField-Refers-To-P4ActionField
+  // P4ActionField-Refers-To-BuiltInActionField
+  // BuiltInActionField-Refers-To-P4ActionField
+  // BuiltInField-Refers-To-BuiltInActionField
+  // Only the first is tested to avoid redundancy.
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table {
+          p4_table {
+            table_name: "golden_test_friendly_table"
+            table_id: 50151603
+          }
+        }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+          destination {
+            action_field {
+              p4_action_field {
+                action_name: "other_action"
+                parameter_name: "other_arg"
+              }
+            }
+          }
+        }
+      )pb"),
+      .description = "Fails for unsupported reference type (i.e. "
+                     "P4MatchField-Refers-To-P4ActionField)",
+  });
+
+  // Fundamental test cases testing single field relationships.
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table {
+          p4_table {
+            table_name: "golden_test_friendly_table"
+            table_id: 50151603
+          }
+        }
+        destination_table { p4_table { table_name: "other_table" } }
+      )pb"),
+      .description = "No field references creates no concrete references",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table {
+          p4_table {
+            table_name: "golden_test_friendly_table"
+            table_id: 50151603
+          }
+        }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+      )pb"),
+      .description =
+          "P4MatchField-Refers-To-P4MatchField reference creates a single "
+          "concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table {
+          p4_table {
+            table_name: "golden_test_friendly_table"
+            table_id: 50151603
+          }
+        }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+      )pb"),
+      .description =
+          "P4MatchField-Refers-To-BuiltInMatchField reference creates a "
+          "single concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry_with_multiple_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+      )pb"),
+      .description =
+          "BuiltInMatchField-Refers-To-P4MatchField reference creates a "
+          "single concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry_with_multiple_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE }
+        destination_table {
+          built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+        }
+        field_references {
+          source {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+      )pb"),
+      .description =
+          "BuiltInMatchField-Refers-To-BuiltInMatchField reference creates "
+          "a single concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_group_entry_with_multiple_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table {
+          p4_table {
+            table_name: "golden_test_friendly_wcmp_table"
+            table_id: 37604604
+          }
+        }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "golden_test_friendly_action"
+                action_id: 31939749
+                parameter_name: "arg1"
+                parameter_id: 1
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+      )pb"),
+      .description = "P4ActionField-Refers-To-P4MatchField reference creates a "
+                     "concrete reference for every instance of the action.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_group_entry_with_multiple_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table {
+          p4_table {
+            table_name: "golden_test_friendly_wcmp_table"
+            table_id: 37604604
+          }
+        }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "golden_test_friendly_action"
+                action_id: 31939749
+                parameter_name: "arg1"
+                parameter_id: 1
+              }
+            }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+      )pb"),
+      .description =
+          "P4ActionField-Refers-To-BuiltInMatchField reference creates a "
+          "concrete reference for every instance of the action.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry_with_multiple_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            action_field {
+              built_in_action_field {
+                action: BUILT_IN_ACTION_REPLICA
+                parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+      )pb"),
+      .description =
+          "BuiltInActionField-Refers-To-P4MatchField reference creates a "
+          "concrete reference for every instance of the action.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry_with_multiple_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            action_field {
+              built_in_action_field {
+                action: BUILT_IN_ACTION_REPLICA
+                parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+              }
+            }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+      )pb"),
+      .description =
+          "BuiltInActionField-Refers-To-BuiltInMatchField reference creates a "
+          "concrete reference for every instance of the action.",
+  });
+
+  // NOTE: For all following test cases, output is similar whether destination
+  // field is P4-defined or built-in so only the first is used to avoid
+  // redundancy.
+  // Composite test cases testing multi-field relationships
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table {
+          p4_table {
+            table_name: "golden_test_friendly_table"
+            table_id: 50151603
+          }
+        }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "key2" field_id: 2 } }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+      )pb"),
+      .description =
+          "Multi P4MatchField-Refers-To-MatchField references create a "
+          "single concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_group_entry_with_multiple_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table {
+          p4_table {
+            table_name: "golden_test_friendly_wcmp_table"
+            table_id: 37604604
+          }
+        }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "golden_test_friendly_action"
+                action_id: 31939749
+                parameter_name: "arg1"
+                parameter_id: 1
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "golden_test_friendly_action"
+                action_id: 31939749
+                parameter_name: "arg2"
+                parameter_id: 2
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+      )pb"),
+      .description =
+          "Multi P4ActionField-Refers-To-MatchField references for the "
+          "same action create a concrete reference containing all "
+          "fields for every instance of the action.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_group_entry_with_multiple_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table {
+          p4_table {
+            table_name: "golden_test_friendly_wcmp_table"
+            table_id: 37604604
+          }
+        }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "golden_test_friendly_action"
+                action_id: 31939749
+                parameter_name: "arg1"
+                parameter_id: 1
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "other_golden_test_friendly_action"
+                action_id: 25225410
+                parameter_name: "arg2"
+                parameter_id: 2
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+      )pb"),
+      .description =
+          "Multi P4ActionField-Refers-To-MatchField references for the "
+          "different "
+          "actions create a concrete reference containing respective fields "
+          "for every instance of the respective action.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_group_entry_with_multiple_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table {
+          p4_table {
+            table_name: "golden_test_friendly_wcmp_table"
+            table_id: 37604604
+          }
+        }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "golden_test_friendly_action"
+                action_id: 31939749
+                parameter_name: "arg1"
+                parameter_id: 1
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+      )pb"),
+      .description =
+          "P4MatchField-Refers-To-MatchField + "
+          "P4ActionField-Refers-To-MatchField references "
+          "create a concrete reference for every action (including action with "
+          "no reference info).",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry_with_multiple_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              built_in_action_field {
+                action: BUILT_IN_ACTION_REPLICA
+                parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "some_other_field" } }
+          }
+        }
+      )pb"),
+      .description =
+          "BuiltInMatchField-Refers-To-MatchField + "
+          "BuiltInActionField-Refers-To-MatchField references create a "
+          "concrete reference for every instance of the action.",
+  });
+
+  // Test cases on entries with no actions.
+  pdpi::TableEntry p4_group_entry_with_no_actions =
+      gutil::ParseProtoOrDie<pdpi::TableEntry>(
+          R"pb(golden_test_friendly_wcmp_table_entry {
+                 match { key1: "key-a" key2: "key-b" }
+               })pb");
+
+  pdpi::TableEntry built_in_entry_with_no_actions =
+      gutil::ParseProtoOrDie<pdpi::TableEntry>(R"pb(
+        multicast_group_table_entry {
+          match { multicast_group_id: "0x0037" }
+          action { replicate {} }
+        }
+      )pb");
+
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_group_entry_with_no_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table {
+          p4_table {
+            table_name: "golden_test_friendly_wcmp_table"
+            table_id: 37604604
+          }
+        }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "golden_test_friendly_action"
+                action_id: 31939749
+                parameter_name: "arg1"
+                parameter_id: 1
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+      )pb"),
+      .description =
+          "P4MatchField-Refers-To-MatchField + "
+          "P4ActionField-Refers-To-MatchField references "
+          "create a single concrete reference for match fields when no actions "
+          "are present",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry_with_no_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              built_in_action_field {
+                action: BUILT_IN_ACTION_REPLICA
+                parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "some_other_field" } }
+          }
+        }
+      )pb"),
+      .description =
+          "BuiltInMatchField-Refers-To-MatchField + "
+          "BuiltInActionField-Refers-To-MatchField "
+          "references create a single concrete reference for match fields when "
+          "no actions are present",
+  });
+
+  // Test cases on entries with duplicate references.
+  pdpi::TableEntry p4_group_entry_duplicate_info =
+      gutil::ParseProtoOrDie<pdpi::TableEntry>(
+          R"pb(golden_test_friendly_wcmp_table_entry {
+                 match { key1: "key-a" key2: "key-b" }
+                 wcmp_actions {
+                   action {
+                     golden_test_friendly_action {
+                       arg1: "arg-dupe"
+                       arg2: "act1-arg2"
+                     }
+                   }
+                   weight: 1
+                 }
+                 wcmp_actions {
+                   action {
+                     golden_test_friendly_action {
+                       arg1: "arg-dupe"
+                       arg2: "act2-arg2"
+                     }
+                   }
+                   weight: 2
+                 }
+               })pb");
+
+  pdpi::TableEntry built_in_entry_with_duplicate_info =
+      gutil::ParseProtoOrDie<pdpi::TableEntry>(R"pb(
+        multicast_group_table_entry {
+          match { multicast_group_id: "0x0037" }
+          action {
+            replicate {
+              replicas { port: "port_dupe" instance: "0x0031" }
+              replicas { port: "port_dupe" instance: "0x0032" }
+            }
+          }
+        }
+      )pb");
+
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_group_entry_duplicate_info,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table {
+          p4_table {
+            table_name: "golden_test_friendly_wcmp_table"
+            table_id: 37604604
+          }
+        }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "golden_test_friendly_action"
+                action_id: 31939749
+                parameter_name: "arg1"
+                parameter_id: 1
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+      )pb"),
+      .description = "A single reference is created for P4 actions with "
+                     "duplicate referring values.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry_with_duplicate_info,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              built_in_action_field {
+                action: BUILT_IN_ACTION_REPLICA
+                parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "some_other_field" } }
+          }
+        }
+      )pb"),
+      .description = "A single reference is created for built-in actions with "
+                     "duplicate referring values.",
+  });
+
+  return test_cases;
+}  // NOLINT(readability/fn_size)
+
+std::vector<ConcreteTableReferenceTestCase>
+PossibleIncomingConcreteTableReferencesTestCases() {
+  std::vector<ConcreteTableReferenceTestCase> test_cases;
+
+  pdpi::TableEntry p4_entry = gutil::ParseProtoOrDie<pdpi::TableEntry>(
+      R"pb(golden_test_friendly_table_entry {
+             match { key1: "key-a" key2: "key-b" }
+             action {
+               golden_test_friendly_action { arg1: "arg1" arg2: "arg2" }
+             }
+           })pb");
+
+  pdpi::TableEntry built_in_entry =
+      gutil::ParseProtoOrDie<pdpi::TableEntry>(R"pb(
+        multicast_group_table_entry {
+          match { multicast_group_id: "0x0037" }
+          action { replicate { replicas { port: "port" instance: "0x0031" } } }
+        }
+      )pb");
+
+  // Error test cases
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table { p4_table { table_name: "wrong_table" table_id: 7 } }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+        }
+      )pb"),
+      .description = "Fails if entity does not belong to destination table",
+  });
+  // NOTE: Similar errors are encountered for the following:
+  // P4ActionField-Referenced-By-P4MatchField
+  // P4ActionField-Referenced-By-BuiltInMatchField
+  // BuiltInActionField-Referenced-By-P4MatchField
+  // BuiltInActionField-Referenced-By-BuiltInMatchField
+  // P4ActionField-Referenced-By-P4ActionField
+  // P4ActionField-Referenced-By-BuiltInActionField
+  // BuiltInActionField-Referenced-By-P4ActionField
+  // BuiltInActionField-Referenced-By-BuiltInField
+  // Only the first is tested to avoid redundancy.
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          p4_table {
+            table_name: "golden_test_friendly_table"
+            table_id: 50151603
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "other_action"
+                parameter_name: "other_arg"
+              }
+            }
+          }
+          destination {
+            action_field {
+              p4_action_field {
+                action_name: "golden_test_friendly_action"
+                action_id: 31939749
+                parameter_name: "arg1"
+                parameter_id: 1
+              }
+            }
+          }
+        }
+      )pb"),
+      .description = "Fails for unsupported reference type (i.e. "
+                     "Action-Referenced-By-Action)",
+  });
+
+  // Fundamental test cases testing single field relationships.
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          p4_table {
+            table_name: "golden_test_friendly_table"
+            table_id: 50151603
+          }
+        }
+      )pb"),
+      .description = "No field references creates no concrete references",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          p4_table {
+            table_name: "golden_test_friendly_table"
+            table_id: 50151603
+          }
+        }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+        }
+      )pb"),
+      .description =
+          "P4MatchField-Referenced-By-P4MatchField reference creates a single "
+          "concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          p4_table {
+            table_name: "golden_test_friendly_table"
+            table_id: 50151603
+          }
+        }
+        field_references {
+          source {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+
+        }
+      )pb"),
+      .description =
+          "P4MatchField-Referenced-By-BuiltInField reference creates a "
+          "single concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+        }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+      )pb"),
+      .description =
+          "BuiltInMatchField-Referenced-By-P4MatchField reference creates a "
+          "single concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE }
+        destination_table {
+          built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+        }
+        field_references {
+          source {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+      )pb"),
+      .description =
+          "BuiltInMatchField-Referenced-By-BuiltInMatchField reference creates "
+          "a single concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          p4_table {
+            table_name: "golden_test_friendly_table"
+            table_id: 50151603
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "some_action"
+                parameter_name: "some_arg"
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+        }
+      )pb"),
+      .description = "P4MatchField-To-P4ActionField reference creates a single "
+                     "concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          p4_table {
+            table_name: "golden_test_friendly_table"
+            table_id: 50151603
+          }
+        }
+        field_references {
+          source {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+        }
+      )pb"),
+      .description =
+          "P4MatchField-Referenced-By-BuiltInActionField reference creates a "
+          "single concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "some_action"
+                parameter_name: "some_arg"
+              }
+            }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+      )pb"),
+      .description =
+          "BuiltInMatchField-Referenced-By-P4ActionField reference creates a "
+          "single concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE }
+        destination_table {
+          built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+        }
+        field_references {
+          source {
+            action_field {
+              built_in_action_field {
+                action: BUILT_IN_ACTION_REPLICA
+                parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+              }
+            }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+      )pb"),
+      .description = "BuiltInMatchField-Referenced-By-BuiltInActionField "
+                     "reference creates a single"
+                     "concrete reference.",
+  });
+
+  // NOTE: For all following test cases, output is similar whether source field
+  // is P4-defined or built-in so only the first is used to avoid redundancy.
+  // Composite test cases testing multi-field relationships
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          p4_table {
+            table_name: "golden_test_friendly_table"
+            table_id: 50151603
+          }
+        }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+        }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "some_other_field" } }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "key2" field_id: 2 } }
+          }
+        }
+      )pb"),
+      .description =
+          "Multi P4MatchField-Referenced-By-MatchField references create a "
+          "single concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          p4_table {
+            table_name: "golden_test_friendly_table"
+            table_id: 50151603
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field { action_name: "action" parameter_name: "arg1" }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field { action_name: "action" parameter_name: "arg2" }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "key2" field_id: 2 } }
+          }
+        }
+      )pb"),
+      .description =
+          "Multi P4MatchField-Referenced-By-ActionField references from the "
+          "same action create a single concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          p4_table {
+            table_name: "golden_test_friendly_table"
+            table_id: 50151603
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field { action_name: "action" parameter_name: "arg1" }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "other_action"
+                parameter_name: "arg2"
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "key2" field_id: 2 } }
+          }
+        }
+      )pb"),
+      .description = "Multi P4MatchField-Referenced-By-ActionField references "
+                     "from different "
+                     "actions create a concrete reference for every action.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = p4_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          p4_table {
+            table_name: "golden_test_friendly_table"
+            table_id: 50151603
+          }
+        }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field { action_name: "action" parameter_name: "arg1" }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "key1" field_id: 1 } }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "other_action"
+                parameter_name: "arg2"
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "key2" field_id: 2 } }
+          }
+        }
+      )pb"),
+      .description =
+          "P4MatchField-Referenced-By-MatchField + Multi "
+          "P4MatchField-Referenced-By-ActionField "
+          "references from different actions create a concrete reference for "
+          "every action plus an additional reference for match field only.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+        }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "some_other_field" } }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+      )pb"),
+      .description =
+          "Multi BuiltInMatchField-Referenced-By-MatchField references create "
+          "a single concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field { action_name: "action" parameter_name: "arg1" }
+            }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field { action_name: "action" parameter_name: "arg2" }
+            }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+      )pb"),
+      .description =
+          "Multi BuiltInMatchField-Referenced-By-ActionField references from "
+          "the same action create a single concrete reference.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field { action_name: "action" parameter_name: "arg1" }
+            }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "other_action"
+                parameter_name: "arg2"
+              }
+            }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+      )pb"),
+      .description = "Multi BuiltInMatchField-Referenced-By-ActionField "
+                     "references from different "
+                     "actions create a concrete reference for every action.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { p4_table { table_name: "other_table" } }
+        destination_table {
+          built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+        }
+        field_references {
+          source {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field { action_name: "action" parameter_name: "arg1" }
+            }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+        field_references {
+          source {
+            action_field {
+              p4_action_field {
+                action_name: "other_action"
+                parameter_name: "arg2"
+              }
+            }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+      )pb"),
+      .description =
+          "BuiltInMatchField-Referenced-By-MatchField + Multi "
+          "BuiltInMatchField-Referenced-By-ActionField references from "
+          "different actions "
+          "create a concrete reference for every action plus an additional "
+          "reference for match field only.",
+  });
+
+  return test_cases;
+}  // NOLINT(readability/fn_size)
+
+absl::Status OutgoingConcreteTableReferencesTest() {
+  for (const auto& test_case : OutgoingConcreteTableReferencesTestCases()) {
+    std::cout << TestHeader(absl::StrCat("OutgoingConcreteTableReferences: ",
+                                         test_case.description))
+              << "\n";
+    std::cout << kInputBanner << "-- PD table entry --\n";
+    std::cout << gutil::PrintTextProto(test_case.entity) << "\n";
+    std::cout << "-- ReferenceInfo --\n";
+    std::cout << gutil::PrintTextProto(test_case.reference_info) << "\n";
+
+    ASSIGN_OR_RETURN(
+        const p4::v1::Entity pi_entity,
+        PdTableEntryToPiEntity(GetTestIrP4Info(), test_case.entity));
+
+    absl::StatusOr<absl::flat_hash_set<ConcreteTableReference>>
+        reference_entries = OutgoingConcreteTableReferences(
+            test_case.reference_info, pi_entity);
+
+    std::cout << kOutputBanner;
+    if (!reference_entries.ok()) {
+      std::cout << gutil::StableStatusToString(reference_entries.status())
+                << "\n";
+    } else if (reference_entries->empty()) {
+      std::cout << "<empty>\n\n";
+    } else {
+      // Sorted for golden file stability
+      absl::btree_set<ConcreteTableReference> reference_entries_sorted(
+          reference_entries->begin(), reference_entries->end());
+      std::cout << "-- ReferenceEntries --\n"
+                << absl::StrJoin(reference_entries_sorted, "") << "\n";
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status PossibleIncomingConcreteTableReferencesTest() {
+  for (const auto& test_case :
+       PossibleIncomingConcreteTableReferencesTestCases()) {
+    std::cout << TestHeader(
+                     absl::StrCat("PossibleIncomingConcreteTableReferences: ",
+                                  test_case.description))
+              << "\n";
+
+    std::cout << kInputBanner << "-- PD table entry --\n";
+    std::cout << gutil::PrintTextProto(test_case.entity) << "\n";
+    std::cout << "-- ReferenceInfo --\n";
+    std::cout << gutil::PrintTextProto(test_case.reference_info) << "\n";
+
+    ASSIGN_OR_RETURN(
+        const p4::v1::Entity pi_entity,
+        PdTableEntryToPiEntity(GetTestIrP4Info(), test_case.entity));
+
+    absl::StatusOr<absl::flat_hash_set<ConcreteTableReference>>
+        reference_entries = PossibleIncomingConcreteTableReferences(
+            test_case.reference_info, pi_entity);
+
+    std::cout << kOutputBanner;
+    if (!reference_entries.ok()) {
+      std::cout << gutil::StableStatusToString(reference_entries.status())
+                << "\n";
+    } else if (reference_entries->empty()) {
+      std::cout << "<empty>\n\n";
+    } else {
+      // Sorted for golden file stability
+      absl::btree_set<ConcreteTableReference> reference_entries_sorted(
+          reference_entries->begin(), reference_entries->end());
+      std::cout << "-- ReferenceEntries --\n"
+                << absl::StrJoin(reference_entries_sorted, "") << "\n";
+    }
+  }
+  return absl::OkStatus();
+}
+
+void main(int argc, char** argv) {
+  if (absl::Status test = OutgoingConcreteTableReferencesTest(); !test.ok()) {
+    std::cout << "OutgoingConcreteTableReferencesTest failed.\n" << test;
+  }
+
+  if (absl::Status test = PossibleIncomingConcreteTableReferencesTest();
+      !test.ok()) {
+    std::cout << "PossibleIncomingConcreteTableReferencesTest failed.\n"
+              << test;
+  }
+}
+
+}  // namespace
+}  // namespace pdpi
+
+int main(int argc, char** argv) { pdpi::main(argc, argv); }

--- a/p4_pdpi/testing/testdata/references.expected
+++ b/p4_pdpi/testing/testdata/references.expected
@@ -1,0 +1,2701 @@
+=========================================================================
+OutgoingConcreteTableReferences: Fails if entity does not belong to source table
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "wrong_table"
+    table_id: 7
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+INVALID_ARGUMENT: Provided table entry had id 50151603 but IrP4Table had id 7
+
+=========================================================================
+OutgoingConcreteTableReferences: Fails for unsupported reference type (i.e. P4MatchField-Refers-To-P4ActionField)
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "golden_test_friendly_table"
+    table_id: 50151603
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+  destination {
+    action_field {
+      p4_action_field {
+        action_name: "other_action"
+        parameter_name: "other_arg"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+UNIMPLEMENTED: Unsupported field reference from IrField match_field { p4_match_field { field_name: "key1" field_id: 1 } } to IrField action_field { p4_action_field { action_name: "other_action" parameter_name: "other_arg" } }
+
+=========================================================================
+OutgoingConcreteTableReferences: No field references creates no concrete references
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "golden_test_friendly_table"
+    table_id: 50151603
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+<empty>
+
+=========================================================================
+OutgoingConcreteTableReferences: P4MatchField-Refers-To-P4MatchField reference creates a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "golden_test_friendly_table"
+    table_id: 50151603
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'golden_test_friendly_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'key1', destination field: 'other_field', value: 'key-a' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: P4MatchField-Refers-To-BuiltInMatchField reference creates a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "golden_test_friendly_table"
+    table_id: 50151603
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'golden_test_friendly_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'key1', destination field: 'multicast_group_id', value: 'key-a' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: BuiltInMatchField-Refers-To-P4MatchField reference creates a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port_1"
+        instance: "0x0031"
+      }
+      replicas {
+        port: "port_2"
+        instance: "0x0032"
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'multicast_group_id', destination field: 'other_field', value: '7' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: BuiltInMatchField-Refers-To-BuiltInMatchField reference creates a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port_1"
+        instance: "0x0031"
+      }
+      replicas {
+        port: "port_2"
+        instance: "0x0032"
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+destination_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+field_references {
+  source {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'builtin::multicast_group_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'multicast_group_id', destination field: 'multicast_group_id', value: '7' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: P4ActionField-Refers-To-P4MatchField reference creates a concrete reference for every instance of the action.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_wcmp_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  wcmp_actions {
+    action {
+      golden_test_friendly_action {
+        arg1: "act1-arg1"
+        arg2: "act1-arg2"
+      }
+    }
+    weight: 1
+  }
+  wcmp_actions {
+    action {
+      golden_test_friendly_action {
+        arg1: "act2-arg1"
+        arg2: "act2-arg2"
+      }
+    }
+    weight: 2
+  }
+  wcmp_actions {
+    action {
+      other_golden_test_friendly_action {
+        arg1: "act3-arg1"
+        arg2: "act3-arg2"
+      }
+    }
+    weight: 3
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "golden_test_friendly_wcmp_table"
+    table_id: 37604604
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "golden_test_friendly_action"
+        action_id: 31939749
+        parameter_name: "arg1"
+        parameter_id: 1
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'golden_test_friendly_wcmp_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'golden_test_friendly_action.arg1', destination field: 'other_field', value: 'act1-arg1' },
+  }
+}
+ConcreteTableReference{
+  source table: 'golden_test_friendly_wcmp_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'golden_test_friendly_action.arg1', destination field: 'other_field', value: 'act2-arg1' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: P4ActionField-Refers-To-BuiltInMatchField reference creates a concrete reference for every instance of the action.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_wcmp_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  wcmp_actions {
+    action {
+      golden_test_friendly_action {
+        arg1: "act1-arg1"
+        arg2: "act1-arg2"
+      }
+    }
+    weight: 1
+  }
+  wcmp_actions {
+    action {
+      golden_test_friendly_action {
+        arg1: "act2-arg1"
+        arg2: "act2-arg2"
+      }
+    }
+    weight: 2
+  }
+  wcmp_actions {
+    action {
+      other_golden_test_friendly_action {
+        arg1: "act3-arg1"
+        arg2: "act3-arg2"
+      }
+    }
+    weight: 3
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "golden_test_friendly_wcmp_table"
+    table_id: 37604604
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "golden_test_friendly_action"
+        action_id: 31939749
+        parameter_name: "arg1"
+        parameter_id: 1
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'golden_test_friendly_wcmp_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'golden_test_friendly_action.arg1', destination field: 'multicast_group_id', value: 'act1-arg1' },
+  }
+}
+ConcreteTableReference{
+  source table: 'golden_test_friendly_wcmp_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'golden_test_friendly_action.arg1', destination field: 'multicast_group_id', value: 'act2-arg1' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: BuiltInActionField-Refers-To-P4MatchField reference creates a concrete reference for every instance of the action.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port_1"
+        instance: "0x0031"
+      }
+      replicas {
+        port: "port_2"
+        instance: "0x0032"
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    action_field {
+      built_in_action_field {
+        action: BUILT_IN_ACTION_REPLICA
+        parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'other_field', value: 'port_1' },
+  }
+}
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'other_field', value: 'port_2' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: BuiltInActionField-Refers-To-BuiltInMatchField reference creates a concrete reference for every instance of the action.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port_1"
+        instance: "0x0031"
+      }
+      replicas {
+        port: "port_2"
+        instance: "0x0032"
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    action_field {
+      built_in_action_field {
+        action: BUILT_IN_ACTION_REPLICA
+        parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'multicast_group_id', value: 'port_1' },
+  }
+}
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'multicast_group_id', value: 'port_2' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: Multi P4MatchField-Refers-To-MatchField references create a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "golden_test_friendly_table"
+    table_id: 50151603
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "key2"
+        field_id: 2
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'golden_test_friendly_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'key1', destination field: 'other_field', value: 'key-a' },
+    ConcreteFieldReference{ source field: 'key2', destination field: 'other_field', value: 'key-b' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: Multi P4ActionField-Refers-To-MatchField references for the same action create a concrete reference containing all fields for every instance of the action.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_wcmp_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  wcmp_actions {
+    action {
+      golden_test_friendly_action {
+        arg1: "act1-arg1"
+        arg2: "act1-arg2"
+      }
+    }
+    weight: 1
+  }
+  wcmp_actions {
+    action {
+      golden_test_friendly_action {
+        arg1: "act2-arg1"
+        arg2: "act2-arg2"
+      }
+    }
+    weight: 2
+  }
+  wcmp_actions {
+    action {
+      other_golden_test_friendly_action {
+        arg1: "act3-arg1"
+        arg2: "act3-arg2"
+      }
+    }
+    weight: 3
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "golden_test_friendly_wcmp_table"
+    table_id: 37604604
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "golden_test_friendly_action"
+        action_id: 31939749
+        parameter_name: "arg1"
+        parameter_id: 1
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "golden_test_friendly_action"
+        action_id: 31939749
+        parameter_name: "arg2"
+        parameter_id: 2
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'golden_test_friendly_wcmp_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'golden_test_friendly_action.arg1', destination field: 'other_field', value: 'act1-arg1' },
+    ConcreteFieldReference{ source field: 'golden_test_friendly_action.arg2', destination field: 'other_field', value: 'act1-arg2' },
+  }
+}
+ConcreteTableReference{
+  source table: 'golden_test_friendly_wcmp_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'golden_test_friendly_action.arg1', destination field: 'other_field', value: 'act2-arg1' },
+    ConcreteFieldReference{ source field: 'golden_test_friendly_action.arg2', destination field: 'other_field', value: 'act2-arg2' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: Multi P4ActionField-Refers-To-MatchField references for the different actions create a concrete reference containing respective fields for every instance of the respective action.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_wcmp_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  wcmp_actions {
+    action {
+      golden_test_friendly_action {
+        arg1: "act1-arg1"
+        arg2: "act1-arg2"
+      }
+    }
+    weight: 1
+  }
+  wcmp_actions {
+    action {
+      golden_test_friendly_action {
+        arg1: "act2-arg1"
+        arg2: "act2-arg2"
+      }
+    }
+    weight: 2
+  }
+  wcmp_actions {
+    action {
+      other_golden_test_friendly_action {
+        arg1: "act3-arg1"
+        arg2: "act3-arg2"
+      }
+    }
+    weight: 3
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "golden_test_friendly_wcmp_table"
+    table_id: 37604604
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "golden_test_friendly_action"
+        action_id: 31939749
+        parameter_name: "arg1"
+        parameter_id: 1
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "other_golden_test_friendly_action"
+        action_id: 25225410
+        parameter_name: "arg2"
+        parameter_id: 2
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'golden_test_friendly_wcmp_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'golden_test_friendly_action.arg1', destination field: 'other_field', value: 'act1-arg1' },
+  }
+}
+ConcreteTableReference{
+  source table: 'golden_test_friendly_wcmp_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'golden_test_friendly_action.arg1', destination field: 'other_field', value: 'act2-arg1' },
+  }
+}
+ConcreteTableReference{
+  source table: 'golden_test_friendly_wcmp_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'other_golden_test_friendly_action.arg2', destination field: 'other_field', value: 'act3-arg2' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: P4MatchField-Refers-To-MatchField + P4ActionField-Refers-To-MatchField references create a concrete reference for every action (including action with no reference info).
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_wcmp_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  wcmp_actions {
+    action {
+      golden_test_friendly_action {
+        arg1: "act1-arg1"
+        arg2: "act1-arg2"
+      }
+    }
+    weight: 1
+  }
+  wcmp_actions {
+    action {
+      golden_test_friendly_action {
+        arg1: "act2-arg1"
+        arg2: "act2-arg2"
+      }
+    }
+    weight: 2
+  }
+  wcmp_actions {
+    action {
+      other_golden_test_friendly_action {
+        arg1: "act3-arg1"
+        arg2: "act3-arg2"
+      }
+    }
+    weight: 3
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "golden_test_friendly_wcmp_table"
+    table_id: 37604604
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "golden_test_friendly_action"
+        action_id: 31939749
+        parameter_name: "arg1"
+        parameter_id: 1
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'golden_test_friendly_wcmp_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'golden_test_friendly_action.arg1', destination field: 'other_field', value: 'act1-arg1' },
+    ConcreteFieldReference{ source field: 'key1', destination field: 'other_field', value: 'key-a' },
+  }
+}
+ConcreteTableReference{
+  source table: 'golden_test_friendly_wcmp_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'golden_test_friendly_action.arg1', destination field: 'other_field', value: 'act2-arg1' },
+    ConcreteFieldReference{ source field: 'key1', destination field: 'other_field', value: 'key-a' },
+  }
+}
+ConcreteTableReference{
+  source table: 'golden_test_friendly_wcmp_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'key1', destination field: 'other_field', value: 'key-a' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: BuiltInMatchField-Refers-To-MatchField + BuiltInActionField-Refers-To-MatchField references create a concrete reference for every instance of the action.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port_1"
+        instance: "0x0031"
+      }
+      replicas {
+        port: "port_2"
+        instance: "0x0032"
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      built_in_action_field {
+        action: BUILT_IN_ACTION_REPLICA
+        parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "some_other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'multicast_group_id', destination field: 'other_field', value: '7' },
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'some_other_field', value: 'port_1' },
+  }
+}
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'multicast_group_id', destination field: 'other_field', value: '7' },
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'some_other_field', value: 'port_2' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: P4MatchField-Refers-To-MatchField + P4ActionField-Refers-To-MatchField references create a single concrete reference for match fields when no actions are present
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_wcmp_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "golden_test_friendly_wcmp_table"
+    table_id: 37604604
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "golden_test_friendly_action"
+        action_id: 31939749
+        parameter_name: "arg1"
+        parameter_id: 1
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'golden_test_friendly_wcmp_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'key1', destination field: 'other_field', value: 'key-a' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: BuiltInMatchField-Refers-To-MatchField + BuiltInActionField-Refers-To-MatchField references create a single concrete reference for match fields when no actions are present
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      built_in_action_field {
+        action: BUILT_IN_ACTION_REPLICA
+        parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "some_other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'multicast_group_id', destination field: 'other_field', value: '7' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: A single reference is created for P4 actions with duplicate referring values.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_wcmp_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  wcmp_actions {
+    action {
+      golden_test_friendly_action {
+        arg1: "arg-dupe"
+        arg2: "act1-arg2"
+      }
+    }
+    weight: 1
+  }
+  wcmp_actions {
+    action {
+      golden_test_friendly_action {
+        arg1: "arg-dupe"
+        arg2: "act2-arg2"
+      }
+    }
+    weight: 2
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "golden_test_friendly_wcmp_table"
+    table_id: 37604604
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "golden_test_friendly_action"
+        action_id: 31939749
+        parameter_name: "arg1"
+        parameter_id: 1
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'golden_test_friendly_wcmp_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'golden_test_friendly_action.arg1', destination field: 'other_field', value: 'arg-dupe' },
+    ConcreteFieldReference{ source field: 'key1', destination field: 'other_field', value: 'key-a' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: A single reference is created for built-in actions with duplicate referring values.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port_dupe"
+        instance: "0x0031"
+      }
+      replicas {
+        port: "port_dupe"
+        instance: "0x0032"
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      built_in_action_field {
+        action: BUILT_IN_ACTION_REPLICA
+        parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "some_other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'multicast_group_id', destination field: 'other_field', value: '7' },
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'some_other_field', value: 'port_dupe' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: Fails if entity does not belong to destination table
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "wrong_table"
+    table_id: 7
+  }
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+INVALID_ARGUMENT: Provided table entry had id 50151603 but IrP4Table had id 7
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: Fails for unsupported reference type (i.e. Action-Referenced-By-Action)
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "golden_test_friendly_table"
+    table_id: 50151603
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "other_action"
+        parameter_name: "other_arg"
+      }
+    }
+  }
+  destination {
+    action_field {
+      p4_action_field {
+        action_name: "golden_test_friendly_action"
+        action_id: 31939749
+        parameter_name: "arg1"
+        parameter_id: 1
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+UNIMPLEMENTED: Unsupported field reference from IrField action_field { p4_action_field { action_name: "other_action" parameter_name: "other_arg" } } to IrField action_field { p4_action_field { action_name: "golden_test_friendly_action" action_id: 31939749 parameter_name: "arg1" parameter_id: 1 } }
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: No field references creates no concrete references
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "golden_test_friendly_table"
+    table_id: 50151603
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+<empty>
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: P4MatchField-Referenced-By-P4MatchField reference creates a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "golden_test_friendly_table"
+    table_id: 50151603
+  }
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'golden_test_friendly_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'other_field', destination field: 'key1', value: 'key-a' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: P4MatchField-Referenced-By-BuiltInField reference creates a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "golden_test_friendly_table"
+    table_id: 50151603
+  }
+}
+field_references {
+  source {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'golden_test_friendly_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'multicast_group_id', destination field: 'key1', value: 'key-a' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: BuiltInMatchField-Referenced-By-P4MatchField reference creates a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port"
+        instance: "0x0031"
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'builtin::multicast_group_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'other_field', destination field: 'multicast_group_id', value: '7' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: BuiltInMatchField-Referenced-By-BuiltInMatchField reference creates a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port"
+        instance: "0x0031"
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+destination_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+field_references {
+  source {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'builtin::multicast_group_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'multicast_group_id', destination field: 'multicast_group_id', value: '7' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: P4MatchField-To-P4ActionField reference creates a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "golden_test_friendly_table"
+    table_id: 50151603
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "some_action"
+        parameter_name: "some_arg"
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'golden_test_friendly_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'some_action.some_arg', destination field: 'key1', value: 'key-a' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: P4MatchField-Referenced-By-BuiltInActionField reference creates a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "golden_test_friendly_table"
+    table_id: 50151603
+  }
+}
+field_references {
+  source {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'golden_test_friendly_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'multicast_group_id', destination field: 'key1', value: 'key-a' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: BuiltInMatchField-Referenced-By-P4ActionField reference creates a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port"
+        instance: "0x0031"
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "some_action"
+        parameter_name: "some_arg"
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'builtin::multicast_group_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'some_action.some_arg', destination field: 'multicast_group_id', value: '7' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: BuiltInMatchField-Referenced-By-BuiltInActionField reference creates a singleconcrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port"
+        instance: "0x0031"
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+destination_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+field_references {
+  source {
+    action_field {
+      built_in_action_field {
+        action: BUILT_IN_ACTION_REPLICA
+        parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'builtin::multicast_group_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'multicast_group_id', value: '7' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: Multi P4MatchField-Referenced-By-MatchField references create a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "golden_test_friendly_table"
+    table_id: 50151603
+  }
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "some_other_field"
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "key2"
+        field_id: 2
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'golden_test_friendly_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'other_field', destination field: 'key1', value: 'key-a' },
+    ConcreteFieldReference{ source field: 'some_other_field', destination field: 'key2', value: 'key-b' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: Multi P4MatchField-Referenced-By-ActionField references from the same action create a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "golden_test_friendly_table"
+    table_id: 50151603
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "action"
+        parameter_name: "arg1"
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "action"
+        parameter_name: "arg2"
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "key2"
+        field_id: 2
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'golden_test_friendly_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'action.arg1', destination field: 'key1', value: 'key-a' },
+    ConcreteFieldReference{ source field: 'action.arg2', destination field: 'key2', value: 'key-b' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: Multi P4MatchField-Referenced-By-ActionField references from different actions create a concrete reference for every action.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "golden_test_friendly_table"
+    table_id: 50151603
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "action"
+        parameter_name: "arg1"
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "other_action"
+        parameter_name: "arg2"
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "key2"
+        field_id: 2
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'golden_test_friendly_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'action.arg1', destination field: 'key1', value: 'key-a' },
+  }
+}
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'golden_test_friendly_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'other_action.arg2', destination field: 'key2', value: 'key-b' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: P4MatchField-Referenced-By-MatchField + Multi P4MatchField-Referenced-By-ActionField references from different actions create a concrete reference for every action plus an additional reference for match field only.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+golden_test_friendly_table_entry {
+  match {
+    key1: "key-a"
+    key2: "key-b"
+  }
+  action {
+    golden_test_friendly_action {
+      arg1: "arg1"
+      arg2: "arg2"
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  p4_table {
+    table_name: "golden_test_friendly_table"
+    table_id: 50151603
+  }
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "action"
+        parameter_name: "arg1"
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "key1"
+        field_id: 1
+      }
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "other_action"
+        parameter_name: "arg2"
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "key2"
+        field_id: 2
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'golden_test_friendly_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'action.arg1', destination field: 'key1', value: 'key-a' },
+    ConcreteFieldReference{ source field: 'other_field', destination field: 'key1', value: 'key-a' },
+  }
+}
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'golden_test_friendly_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'other_action.arg2', destination field: 'key2', value: 'key-b' },
+    ConcreteFieldReference{ source field: 'other_field', destination field: 'key1', value: 'key-a' },
+  }
+}
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'golden_test_friendly_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'other_field', destination field: 'key1', value: 'key-a' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: Multi BuiltInMatchField-Referenced-By-MatchField references create a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port"
+        instance: "0x0031"
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "some_other_field"
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'builtin::multicast_group_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'other_field', destination field: 'multicast_group_id', value: '7' },
+    ConcreteFieldReference{ source field: 'some_other_field', destination field: 'multicast_group_id', value: '7' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: Multi BuiltInMatchField-Referenced-By-ActionField references from the same action create a single concrete reference.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port"
+        instance: "0x0031"
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "action"
+        parameter_name: "arg1"
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "action"
+        parameter_name: "arg2"
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'builtin::multicast_group_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'action.arg1', destination field: 'multicast_group_id', value: '7' },
+    ConcreteFieldReference{ source field: 'action.arg2', destination field: 'multicast_group_id', value: '7' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: Multi BuiltInMatchField-Referenced-By-ActionField references from different actions create a concrete reference for every action.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port"
+        instance: "0x0031"
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "action"
+        parameter_name: "arg1"
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "other_action"
+        parameter_name: "arg2"
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'builtin::multicast_group_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'action.arg1', destination field: 'multicast_group_id', value: '7' },
+  }
+}
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'builtin::multicast_group_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'other_action.arg2', destination field: 'multicast_group_id', value: '7' },
+  }
+}
+
+=========================================================================
+PossibleIncomingConcreteTableReferences: BuiltInMatchField-Referenced-By-MatchField + Multi BuiltInMatchField-Referenced-By-ActionField references from different actions create a concrete reference for every action plus an additional reference for match field only.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port"
+        instance: "0x0031"
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+destination_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+field_references {
+  source {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "action"
+        parameter_name: "arg1"
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+field_references {
+  source {
+    action_field {
+      p4_action_field {
+        action_name: "other_action"
+        parameter_name: "arg2"
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'builtin::multicast_group_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'action.arg1', destination field: 'multicast_group_id', value: '7' },
+    ConcreteFieldReference{ source field: 'other_field', destination field: 'multicast_group_id', value: '7' },
+  }
+}
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'builtin::multicast_group_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'other_action.arg2', destination field: 'multicast_group_id', value: '7' },
+    ConcreteFieldReference{ source field: 'other_field', destination field: 'multicast_group_id', value: '7' },
+  }
+}
+ConcreteTableReference{
+  source table: 'other_table'
+  destination table: 'builtin::multicast_group_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'other_field', destination field: 'multicast_group_id', value: '7' },
+  }
+}


### PR DESCRIPTION
sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.


/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS  ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 401 targets (243 packages loaded, 19863 targets configured).
INFO: Found 401 targets...
INFO: From Compiling sai_p4/instantiations/google/test_tools/test_entries.cc:
In file included from ./gutil/proto.h:26,
                 from sai_p4/instantiations/google/test_tools/test_entries.cc:30:
sai_p4/instantiations/google/test_tools/test_entries.cc: In function 'absl::lts_20230802::StatusOr<std::vector<p4::v1::TableEntry> > sai::MakePiEntriesForwardingIpPacketsToGivenPort(absl::lts_20230802::string_view, const pdpi::IrP4Info&)':
sai_p4/instantiations/google/test_tools/test_entries.cc:144:75: warning: 'absl::lts_20230802::StatusOr<sai::TableEntries> sai::MakePdEntriesForwardingIpPacketsToGivenPort(absl::lts_20230802::string_view)' is deprecated: Use EntryBuilder().AddEntriesForwardingIpPacketsToGivenPort(`egress_port`).GetDedupedPiEntities(`ir_p4info`) instead. [-Wdeprecated-declarations]
In file included from ./p4_pdpi/pdgenlib.h:25,
                 from p4_pdpi/pdgenlib.cc:15:
bazel-out/k8-fastbuild/bin/p4_pdpi/ir.pb.h:14031:1: note: declared here
14031 | IrActionDefinition_IrActionParamDefinition::references() const {
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO: Elapsed time: 661.784s, Critical Path: 27.19s
INFO: 150 processes: 6 internal, 144 linux-sandbox.
INFO: Build completed successfully, 150 total actions



sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Analyzed 401 targets (0 packages loaded, 0 targets configured).
INFO: Found 260 targets and 141 test targets...
INFO: Elapsed time: 3.029s, Critical Path: 0.80s
INFO: 4 processes: 5 linux-sandbox.
INFO: Build completed successfully, 4 total actions
//gutil:collections_test                                        (cached) PASSED in 1.1s
//p4_pdpi/testing:references_test                                        PASSED in 0.3s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
Executed 3 out of 141 tests: 141 tests pass.
INFO: Build completed successfully, 4 total actions