### PR TITLE
[P4_Fuzzer] Fix oracle_util_test.

### DIFF
--- a/p4_fuzzer/BUILD.bazel
+++ b/p4_fuzzer/BUILD.bazel
@@ -182,6 +182,28 @@ cc_library(
 )
 
 cc_test(
+    name = "oracle_util_test",
+    srcs = ["oracle_util_test.cc"],
+    deps = [
+        ":oracle_util",
+        "//gutil:collections",
+        "//gutil:status",
+        "//gutil:status_matchers",
+        "//gutil:testing",
+        "//p4_pdpi:ir",
+        "//p4_pdpi:ir_cc_proto",
+        "//p4_pdpi:pd",
+        "//p4_pdpi/netaddr:ipv4_address",
+        "//sai_p4/instantiations/google:sai_p4info_cc",
+        "//sai_p4/instantiations/google:sai_pd_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "fuzzer_showcase_test",
     srcs = [
         "fuzzer_showcase_test.cc",

--- a/p4_fuzzer/oracle_util_test.cc
+++ b/p4_fuzzer/oracle_util_test.cc
@@ -3,190 +3,61 @@
 #include <utility>
 
 #include "absl/status/status.h"
-#include "devtools/build/runtime/get_runfiles_dir.h"
-#include "file/base/helpers.h"
-#include "file/base/options.h"
+#include "absl/strings/str_cat.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "gutil/collections.h"
 #include "gutil/status.h"
-#include "net/google::protobuf/contrib/parse_proto/parse_text_proto.h"
-#include "platforms/networking/orion/core/sfe/sfe.pb.h"
-#include "util/task/canonical_errors.h"
+#include "gutil/status_matchers.h"
+#include "gutil/testing.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/ir.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4_pdpi/netaddr/ipv4_address.h"
+#include "p4_pdpi/pd.h"
+#include "sai_p4/instantiations/google/sai_p4info.h"
+#include "sai_p4/instantiations/google/sai_pd.pb.h"
 
-namespace switchstack {
-namespace testing {
-namespace hercules {
+namespace p4_fuzzer {
 namespace {
 
 using ::absl::StatusCode;
-using ::google::protobuf::contrib::parse_proto::ParseTextProtoOrDie;
-using ::orion::core::sfe::P4Entity;
-using ::orion::core::sfe::P4Update;
-using ::orion::p4::test::PdToPiUpdate;
+using ::p4::v1::TableEntry;
 using ::p4::v1::Update;
 using ::p4::v1::WriteRequest;
-using ::testing::Not;
-using ::testing::status::IsOk;
 
-constexpr char kDecapFlow[] = R"(
-type: INSERT
-entity {
-  flow_entry {
-    priority: 900
-    table_entry {
-      decap_table_entry {
-        match {
-          hdr_ethernet_ether_type {
-            mask: 0xffff
-            value: 2048
-          }
-          hdr_ipv4_base_src_addr {
-            mask: 4294967295
-            value: 1869573999
-          }
-          hdr_ipv4_base_dst_addr {
-            mask: 4294967295
-            value: 170408329
-          }
-        }
-        action {
-          ip_decap {
-          }
-        }
-      }
-    }
-  }
-}
-)";
-
-util::Status CheckWellformed(P4Update pd) {
-  ASSIGN_OR_RETURN(Update pi, PdToPiUpdate(pd));
-  return IsWellformedUpdate(pi);
+int AclIngressTableSize() {
+  auto table = gutil::FindOrStatus(
+      sai::GetIrP4Info(sai::Instantiation::kMiddleblock).tables_by_name(),
+      "acl_ingress_table");
+  CHECK(table.ok());  // Crash ok
+  return table->size();
 }
 
-TEST(OracleUtilTest, IsWellformedUpdate) {
-  // Starting with PD because it's easier to read and write.
-  P4Update pd = ParseTextProtoOrDie(kDecapFlow);
-
-  // Regular update is fine
-  EXPECT_OK(CheckWellformed(pd));
-
-  // Wrong eth type (but still matching on IPv4 fields)
-  pd.mutable_entity()
-      ->mutable_flow_entry()
-      ->mutable_table_entry()
-      ->mutable_decap_table_entry()
-      ->mutable_match()
-      ->mutable_hdr_ethernet_ether_type()
-      ->set_value(1234);
-  EXPECT_THAT(CheckWellformed(pd), Not(IsOk()));
-
-  // Missing eth_type (but still matching on IPv4 fields)
-  pd.mutable_entity()
-      ->mutable_flow_entry()
-      ->mutable_table_entry()
-      ->mutable_decap_table_entry()
-      ->mutable_match()
-      ->clear_hdr_ethernet_ether_type();
-  EXPECT_THAT(CheckWellformed(pd), Not(IsOk()));
-}
-
-TEST(OracleUtilTest, IsWellformedLackOfPriority) {
-  P4Update pd = ParseTextProtoOrDie(R"(
-    type: INSERT
-    entity {
-      flow_entry {
-        priority: 0
-        cookie: 9223372036855300096
-        table_entry {
-          punt_table_entry {
-            match {
-              hdr_ethernet_ether_type { mask: 65535 value: 34525 }
-              hdr_ipv6_base_dst_addr {
-                mask: "\377\377\377\377\377\377\377\377\000\000\000\000\000\000\000\000"
-                value: "&\007\370\260\321\001P\004\000\000\000\000\000\000\000\000"
-              }
-            }
-            action { set_queue_and_send_to_cpu { queue_id: 2 } }
-          }
-        }
-        meter_config { cir: 28672 cburst: 57344 pir: 28672 pburst: 57344 }
-      }
-    }
-  )");
-
-  // Priority cannot be 0 if there are ternary matches
-  EXPECT_THAT(CheckWellformed(pd), Not(IsOk()));
-}
-
-constexpr char kVrfClassifierFlow[] = R"(
-flow_entry {
-  priority: 1134
-  cookie: 9223372036854841344
-  table_entry {
-    vrf_classifier_table_entry {
-      match {
-        hdr_ethernet_ether_type {
-          mask: 65535
-          value: 2048
-        }
-        standard_metadata_ingress_port {
-          mask: 4294967295
-          value: 1025
-        }
-      }
-      action {
-        set_vrf {
-          vrf_id: 117
-        }
-      }
-    }
-  }
-}
-)";
-
-SwitchState EmptyState() { return {}; }
-
-// Add a flow to a state.
-void AddFlow(const P4Entity& flow, SwitchState* state) {
-  P4Update update;
-  update.set_type(orion::core::sfe::P4Update::INSERT);
-  *update.mutable_entity() = flow;
-  CHECK_OK(state->ApplyUpdate(PdToPiUpdate(update).value()));
-}
-
-// Get a VRF classifier flow (n can be varied to get different flows).
-P4Entity GetVrfClassifierFlow(int n) {
-  P4Entity flow = ParseTextProtoOrDie(kVrfClassifierFlow);
-  flow.mutable_flow_entry()
-      ->mutable_table_entry()
-      ->mutable_vrf_classifier_table_entry()
-      ->mutable_match()
-      ->mutable_hdr_ethernet_ether_type()
-      ->set_value(n);
-  return flow;
+SwitchState EmptyState() {
+  return SwitchState(sai::GetIrP4Info(sai::Instantiation::kMiddleblock));
 }
 
 // An update and it's corresponding status.
-struct PdUpdateStatus {
-  P4Update update;
+struct UpdateStatus {
+  p4::v1::Update update;
   StatusCode status;
 };
 
 // Checks whether the update+state combo is plausible or not
-util::Status Check(const std::vector<PdUpdateStatus>& updates,
+absl::Status Check(const std::vector<UpdateStatus>& updates,
                    const SwitchState& state, bool valid) {
   WriteRequest request;
-  std::vector<::p4::v1::Error> statuses;
-  for (const auto& update : updates) {
-    ASSIGN_OR_RETURN(Update pi, PdToPiUpdate(update.update));
-    *request.add_updates() = pi;
-    ::p4::v1::Error status;
-    status.set_canonical_code(static_cast<int32>(update.status));
-    statuses.push_back(status);
+  std::vector<p4::v1::Error> statuses;
+  for (const auto& [update, status] : updates) {
+    *request.add_updates() = update;
+    p4::v1::Error p4_error;
+    p4_error.set_canonical_code(static_cast<int32_t>(status));
+    statuses.push_back(p4_error);
   }
   absl::optional<std::vector<std::string>> oracle =
-      WriteRequestOracle(request, statuses, state);
+      WriteRequestOracle(sai::GetIrP4Info(sai::Instantiation::kMiddleblock),
+                         request, statuses, state);
   if (valid) {
     if (oracle.has_value()) {
       std::string explanation = absl::StrCat(
@@ -196,112 +67,39 @@ util::Status Check(const std::vector<PdUpdateStatus>& updates,
       for (const auto& error : oracle.value()) {
         explanation += absl::StrCat("\n", error);
       }
-      return util::InvalidArgumentError(explanation);
+      return gutil::InvalidArgumentErrorBuilder() << explanation;
     }
   } else {
     if (!oracle.has_value()) {
-      return util::InvalidArgumentError(
-          "Expected the write request and statuses to not be a valid "
-          "combination, "
-          "but they are according to the oracle.");
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Expected the write request and statuses to not be a valid "
+                "combination, "
+                "but they are according to the oracle.";
     }
   }
-  return util::OkStatus();
+  return absl::OkStatus();
 }
 
-PdUpdateStatus MakeInsert(const P4Entity& entity, StatusCode status) {
-  P4Update update;
-  update.set_type(orion::core::sfe::P4Update::INSERT);
-  *update.mutable_entity() = entity;
+UpdateStatus MakeInsert(const TableEntry& table_entry, StatusCode status) {
+  p4::v1::Update update;
+  update.set_type(p4::v1::Update::INSERT);
+  *update.mutable_entity()->mutable_table_entry() = table_entry;
   return {update, status};
 }
 
-PdUpdateStatus MakeDelete(const P4Entity& entity, StatusCode status) {
-  P4Update update;
-  update.set_type(orion::core::sfe::P4Update::DELETE);
-  *update.mutable_entity() = entity;
+UpdateStatus MakeDelete(const TableEntry& table_entry, StatusCode status) {
+  p4::v1::Update update;
+  update.set_type(p4::v1::Update::DELETE);
+  *update.mutable_entity()->mutable_table_entry() = table_entry;
   return {update, status};
 }
 
-TEST(OracleUtilTest, BatchInsertDelete) {
-  P4Entity flow = ParseTextProtoOrDie(kVrfClassifierFlow);
-
-  // Insert/delete is fine in either order.
-  EXPECT_OK(Check(
-      {MakeInsert(flow, StatusCode::kOk), MakeDelete(flow, StatusCode::kOk)},
-      EmptyState(), /*valid=*/true));
-  EXPECT_OK(Check(
-      {MakeDelete(flow, StatusCode::kOk), MakeInsert(flow, StatusCode::kOk)},
-      EmptyState(), /*valid=*/true));
-
-  // It is also fine for the delete to fail (in either order).
-  EXPECT_OK(Check({MakeDelete(flow, StatusCode::kNotFound),
-                   MakeInsert(flow, StatusCode::kOk)},
-                  EmptyState(), /*valid=*/true));
-  EXPECT_OK(Check({MakeInsert(flow, StatusCode::kOk),
-                   MakeDelete(flow, StatusCode::kNotFound)},
-                  EmptyState(), /*valid=*/true));
-}
-
-TEST(OracleUtilTest, BatchDoubleInsert) {
-  P4Entity flow = ParseTextProtoOrDie(kVrfClassifierFlow);
-
-  // Double insert is not okay.
-  EXPECT_OK(Check(
-      {MakeInsert(flow, StatusCode::kOk), MakeInsert(flow, StatusCode::kOk)},
-      EmptyState(), /*valid=*/false));
-
-  // If one is rejected, it's fine.
-  EXPECT_OK(Check({MakeInsert(flow, StatusCode::kAlreadyExists),
-                   MakeInsert(flow, StatusCode::kOk)},
-                  EmptyState(), /*valid=*/true));
-  EXPECT_OK(Check({MakeInsert(flow, StatusCode::kOk),
-                   MakeInsert(flow, StatusCode::kAlreadyExists)},
-                  EmptyState(), /*valid=*/true));
-}
-
-TEST(OracleUtilTest, BatchResources) {
-  // Create a state that's full.
-  SwitchState full;
-  for (int i = 1; i <= 512; i++) {
-    AddFlow(GetVrfClassifierFlow(i), &full);
-  }
-
-  P4Entity new_flow = GetVrfClassifierFlow(513);
-
-  // Inserting into full table is okay.
-  EXPECT_OK(
-      Check({MakeInsert(new_flow, StatusCode::kOk)}, full, /*valid=*/true));
-
-  // Resource exhasted is okay too.
-  EXPECT_OK(Check({MakeInsert(new_flow, StatusCode::kResourceExhausted)}, full,
-                  /*valid=*/true));
-}
-
-TEST(OracleUtilTest, BatchResourcesAlmostFull) {
-  // Create a state that's almost full (1 entry remaining).
-  SwitchState almost_full;
-  for (int i = 1; i <= 511; i++) {
-    AddFlow(GetVrfClassifierFlow(i), &almost_full);
-  }
-
-  P4Entity new_flow1 = GetVrfClassifierFlow(513);
-  P4Entity new_flow2 = GetVrfClassifierFlow(514);
-
-  // Resource exhasted is not okay.
-  EXPECT_OK(Check({MakeInsert(new_flow1, StatusCode::kResourceExhausted)},
-                  almost_full, /*valid=*/false));
-
-  // Inserting two flows, one of them can fail.
-  EXPECT_OK(Check({MakeInsert(new_flow1, StatusCode::kOk),
-                   MakeInsert(new_flow2, StatusCode::kResourceExhausted)},
-                  almost_full, /*valid=*/true));
-  EXPECT_OK(Check({MakeInsert(new_flow1, StatusCode::kResourceExhausted),
-                   MakeInsert(new_flow2, StatusCode::kOk)},
-                  almost_full, /*valid=*/true));
+// Add a table entry to a state.
+void AddTableEntry(const TableEntry& table_entry, SwitchState* state) {
+  auto status =
+      state->ApplyUpdate(MakeInsert(table_entry, absl::StatusCode::kOk).update);
+  CHECK(status.ok());
 }
 
 }  // namespace
-}  // namespace hercules
-}  // namespace testing
-}  // namespace switchstack
+}  // namespace p4_fuzzer


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@3c5359ef48c4:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...                        
INFO: Analyzed 398 targets (0 packages loaded, 293 targets configured).
INFO: Found 398 targets...
...
INFO: Elapsed time: 305.328s, Critical Path: 68.48s
INFO: 896 processes: 375 internal, 504 linux-sandbox, 17 local.
INFO: Build completed successfully, 896 total actions

### Test Results:
divya@3c5359ef48c4:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 398 targets (0 packages loaded, 0 targets configured).
INFO: Found 259 targets and 139 test targets...
INFO: Elapsed time: 92.586s, Critical Path: 25.74s
INFO: 144 processes: 151 linux-sandbox, 17 local.
INFO: Build completed successfully, 144 total actions
//gutil:collections_test                                                 PASSED in 0.4s
//gutil:io_test                                                          PASSED in 0.4s
//gutil:proto_matchers_test                                              PASSED in 0.5s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.7s
//gutil:status_matchers_test                                             PASSED in 0.4s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 1.3s
//gutil:version_test                                                     PASSED in 1.6s
//lib:basic_switch_test                                                  PASSED in 0.7s
//lib:ixia_helper_test                                                   PASSED in 1.0s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 0.9s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 14.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.4s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.4s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.7s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.1s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 25.7s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:oracle_util_test                                             PASSED in 0.6s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:helpers_test                                                   PASSED in 0.6s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.5s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.6s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.5s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.4s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.3s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.1s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.4s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.4s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 2.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.4s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.5s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.8s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.8s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.0s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.8s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.8s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.6s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.5s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.4s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 0.9s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.0s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.3s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.5s
//p4rt_app/tests:packetio_test                                           PASSED in 3.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 2.7s
//p4rt_app/tests:response_path_test                                      PASSED in 2.7s
//p4rt_app/tests:role_test                                               PASSED in 1.1s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.7s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.6s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.4s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.8s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 0.9s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.7s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.8s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.6s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 24.3s
  Stats over 5 runs: max = 24.3s, min = 0.9s, avg = 12.4s, dev = 7.4s

Executed 139 out of 139 tests: 139 tests pass.
INFO: Build completed successfully, 144 total actions