### PR TITLE
[P4-PDPI] Workaround bug where we need to split deletes into batches.Remove double references from test program. They are not used anywhere and are not currently supported by fuzzer.build fix

### DIFF
--- a/p4_pdpi/BUILD.bazel
+++ b/p4_pdpi/BUILD.bazel
@@ -369,9 +369,11 @@ cc_library(
         "p4_runtime_session.h",
     ],
     deps = [
+        ":helpers",
         ":ir",
         ":ir_cc_proto",
         ":sequencing",
+        "//gutil:collections",
         "//gutil:status",
         "//gutil:version",
         "//sai_p4/fixed:p4_roles",

--- a/p4_pdpi/p4_runtime_session.cc
+++ b/p4_pdpi/p4_runtime_session.cc
@@ -25,6 +25,7 @@
 #include "absl/functional/any_invocable.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/substitute.h"
@@ -36,9 +37,11 @@
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/util/message_differencer.h"
 #include "grpcpp/create_channel.h"
+#include "gutil/collections.h"
 #include "gutil/status.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/helpers.h"
 #include "p4_pdpi/ir.h"
 #include "p4_pdpi/ir.pb.h"
 #include "p4_pdpi/sequencing.h"
@@ -105,7 +108,7 @@ absl::StatusOr<std::unique_ptr<P4RuntimeSession>> P4RuntimeSession::Create(
     return gutil::InternalErrorBuilder() << "Received device id doesn't match: "
                                          << response.ShortDebugString();
   }
-  // TODO Enable this check once p4rt app supports role.
+  //TODO Enable this check once p4rt app supports role.
   // if (response.arbitration().role().name() != session->role_) {
   //   return gutil::InternalErrorBuilder() << "Received role doesn't match: "
   //                                        << response.ShortDebugString();
@@ -545,6 +548,44 @@ absl::Status CheckNoEntities(P4RuntimeSession& session) {
   return absl::OkStatus();
 }
 
+namespace {
+
+absl::StatusOr<int> GetEntityRank(const pdpi::IrP4Info& info,
+                                  const p4::v1::Entity& entity) {
+  ASSIGN_OR_RETURN(std::string table_name, EntityToTableName(info, entity));
+  return gutil::FindOrStatus(info.dependency_rank_by_table_name(), table_name);
+}
+
+absl::Status SplitSortedUpdatesIntoBatchesAndSend(
+    P4RuntimeSession& session, const pdpi::IrP4Info& info,
+    absl::Span<const p4::v1::Update> updates,
+    std::optional<int> max_batch_size = 5000) {
+  if (max_batch_size.has_value() && *max_batch_size <= 0) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Max batch size must be > 0. Max batch size: " << *max_batch_size;
+  }
+
+  std::vector<WriteRequest> requests;
+  WriteRequest request;
+  std::optional<int> last_rank = std::nullopt;
+  for (const p4::v1::Update& update : updates) {
+    ASSIGN_OR_RETURN(int rank, GetEntityRank(info, update.entity()));
+    // If we have reached a new entity rank or the limit of update size, then
+    // start a new request.
+    if ((last_rank.has_value() && *last_rank != rank) ||
+        (max_batch_size.has_value() &&
+         request.updates_size() > *max_batch_size)) {
+      requests.push_back(std::move(request));
+      request = WriteRequest();
+    }
+    *request.add_updates() = update;
+    last_rank = rank;
+  }
+  requests.push_back(std::move(request));
+  return SetMetadataAndSendPiWriteRequests(&session, requests);
+}
+}  // namespace
+
 absl::Status ClearEntities(P4RuntimeSession& session) {
   // Get P4Info from Switch. It is needed to sequence the delete requests.
   ASSIGN_OR_RETURN(
@@ -570,8 +611,8 @@ absl::Status ClearEntities(P4RuntimeSession& session) {
   RETURN_IF_ERROR(pdpi::StableSortEntities(info, entities));
   absl::c_reverse(entities);
 
-  RETURN_IF_ERROR(
-      SendPiUpdates(&session, CreatePiUpdates(entities, Update::DELETE)))
+  RETURN_IF_ERROR(SplitSortedUpdatesIntoBatchesAndSend(
+      session, info, CreatePiUpdates(entities, Update::DELETE)))
       << "when attempting to delete the following entities: "
       << absl::StrJoin(entities, "\n");
 

--- a/p4_pdpi/p4_runtime_session_mocking.cc
+++ b/p4_pdpi/p4_runtime_session_mocking.cc
@@ -258,13 +258,27 @@ void MockClearEntities(p4::v1::MockP4RuntimeStub& stub, const P4Info& p4info,
     // portion of clearing entities.
     SetNextReadResponse(stub, {table_entity, multicast_entity});
 
-    // Mocks the call to delete the entities that we have created, in reverse
-    // dependency order.
-    EXPECT_CALL(stub, Write(_,
-                            EqualsProto(ConstructDeleteRequest(
-                                metadata, {multicast_entity, table_entity})),
-                            _))
+    // Mocks the calls (multiple due to bug) to delete the entities that we have
+    // created, in reverse dependency order.
+    EXPECT_CALL(
+        stub,
+        Write(_,
+              EqualsProto(ConstructDeleteRequest(metadata, {multicast_entity})),
+              _))
         .Times(1);
+    EXPECT_CALL(
+        stub,
+        Write(_, EqualsProto(ConstructDeleteRequest(metadata, {table_entity})),
+              _))
+        .Times(1);
+
+    // // Mocks the call to delete the entities that we have created, in reverse
+    // // dependency order.
+    // EXPECT_CALL(stub, Write(_,
+    //                         EqualsProto(ConstructDeleteRequest(
+    //                             metadata, {multicast_entity, table_entity})),
+    //                         _))
+    //     .Times(1);
 
     // Mocks a `CheckNoEntities` call, ensuring that the entities are really
     // cleared.

--- a/p4_pdpi/testing/testdata/info.expected
+++ b/p4_pdpi/testing/testdata/info.expected
@@ -1269,7 +1269,6 @@ actions {
     id: 1
     name: "referring_id_1"
     annotations: "@refers_to(one_match_field_table , id)"
-    annotations: "@refers_to(two_match_fields_table , id_1)"
     type_name {
       name: "string_id_t"
     }
@@ -3696,26 +3695,6 @@ tables_by_id {
           }
         }
       }
-      field_references {
-        source {
-          action_field {
-            p4_action_field {
-              action_name: "referring_to_one_match_field_action"
-              action_id: 31920929
-              parameter_name: "referring_id_1"
-              parameter_id: 1
-            }
-          }
-        }
-        destination {
-          match_field {
-            p4_match_field {
-              field_name: "id_1"
-              field_id: 1
-            }
-          }
-        }
-      }
     }
     incoming_references {
       source_table {
@@ -4976,7 +4955,6 @@ tables_by_id {
               id: 1
               name: "referring_id_1"
               annotations: "@refers_to(one_match_field_table , id)"
-              annotations: "@refers_to(two_match_fields_table , id_1)"
               type_name {
                 name: "string_id_t"
               }
@@ -4986,12 +4964,6 @@ tables_by_id {
               table: "one_match_field_table"
               match_field: "id"
               table_id: 46253494
-              match_field_id: 1
-            }
-            references {
-              table: "two_match_fields_table"
-              match_field: "id_1"
-              table_id: 34805412
               match_field_id: 1
             }
           }
@@ -5003,7 +4975,6 @@ tables_by_id {
               id: 1
               name: "referring_id_1"
               annotations: "@refers_to(one_match_field_table , id)"
-              annotations: "@refers_to(two_match_fields_table , id_1)"
               type_name {
                 name: "string_id_t"
               }
@@ -5013,12 +4984,6 @@ tables_by_id {
               table: "one_match_field_table"
               match_field: "id"
               table_id: 46253494
-              match_field_id: 1
-            }
-            references {
-              table: "two_match_fields_table"
-              match_field: "id_1"
-              table_id: 34805412
               match_field_id: 1
             }
           }
@@ -5133,26 +5098,6 @@ tables_by_id {
             p4_match_field {
               field_name: "id_2"
               field_id: 2
-            }
-          }
-        }
-      }
-      field_references {
-        source {
-          action_field {
-            p4_action_field {
-              action_name: "referring_to_one_match_field_action"
-              action_id: 31920929
-              parameter_name: "referring_id_1"
-              parameter_id: 1
-            }
-          }
-        }
-        destination {
-          match_field {
-            p4_match_field {
-              field_name: "id_1"
-              field_id: 1
             }
           }
         }
@@ -7945,7 +7890,6 @@ tables_by_name {
               id: 1
               name: "referring_id_1"
               annotations: "@refers_to(one_match_field_table , id)"
-              annotations: "@refers_to(two_match_fields_table , id_1)"
               type_name {
                 name: "string_id_t"
               }
@@ -7955,12 +7899,6 @@ tables_by_name {
               table: "one_match_field_table"
               match_field: "id"
               table_id: 46253494
-              match_field_id: 1
-            }
-            references {
-              table: "two_match_fields_table"
-              match_field: "id_1"
-              table_id: 34805412
               match_field_id: 1
             }
           }
@@ -7972,7 +7910,6 @@ tables_by_name {
               id: 1
               name: "referring_id_1"
               annotations: "@refers_to(one_match_field_table , id)"
-              annotations: "@refers_to(two_match_fields_table , id_1)"
               type_name {
                 name: "string_id_t"
               }
@@ -7982,12 +7919,6 @@ tables_by_name {
               table: "one_match_field_table"
               match_field: "id"
               table_id: 46253494
-              match_field_id: 1
-            }
-            references {
-              table: "two_match_fields_table"
-              match_field: "id_1"
-              table_id: 34805412
               match_field_id: 1
             }
           }
@@ -8102,26 +8033,6 @@ tables_by_name {
             p4_match_field {
               field_name: "id_2"
               field_id: 2
-            }
-          }
-        }
-      }
-      field_references {
-        source {
-          action_field {
-            p4_action_field {
-              action_name: "referring_to_one_match_field_action"
-              action_id: 31920929
-              parameter_name: "referring_id_1"
-              parameter_id: 1
-            }
-          }
-        }
-        destination {
-          match_field {
-            p4_match_field {
-              field_name: "id_1"
-              field_id: 1
             }
           }
         }
@@ -9255,26 +9166,6 @@ tables_by_name {
           }
         }
       }
-      field_references {
-        source {
-          action_field {
-            p4_action_field {
-              action_name: "referring_to_one_match_field_action"
-              action_id: 31920929
-              parameter_name: "referring_id_1"
-              parameter_id: 1
-            }
-          }
-        }
-        destination {
-          match_field {
-            p4_match_field {
-              field_name: "id_1"
-              field_id: 1
-            }
-          }
-        }
-      }
     }
     incoming_references {
       source_table {
@@ -10364,7 +10255,6 @@ actions_by_id {
           id: 1
           name: "referring_id_1"
           annotations: "@refers_to(one_match_field_table , id)"
-          annotations: "@refers_to(two_match_fields_table , id_1)"
           type_name {
             name: "string_id_t"
           }
@@ -10374,12 +10264,6 @@ actions_by_id {
           table: "one_match_field_table"
           match_field: "id"
           table_id: 46253494
-          match_field_id: 1
-        }
-        references {
-          table: "two_match_fields_table"
-          match_field: "id_1"
-          table_id: 34805412
           match_field_id: 1
         }
       }
@@ -10391,7 +10275,6 @@ actions_by_id {
           id: 1
           name: "referring_id_1"
           annotations: "@refers_to(one_match_field_table , id)"
-          annotations: "@refers_to(two_match_fields_table , id_1)"
           type_name {
             name: "string_id_t"
           }
@@ -10401,12 +10284,6 @@ actions_by_id {
           table: "one_match_field_table"
           match_field: "id"
           table_id: 46253494
-          match_field_id: 1
-        }
-        references {
-          table: "two_match_fields_table"
-          match_field: "id_1"
-          table_id: 34805412
           match_field_id: 1
         }
       }
@@ -10893,7 +10770,6 @@ actions_by_name {
           id: 1
           name: "referring_id_1"
           annotations: "@refers_to(one_match_field_table , id)"
-          annotations: "@refers_to(two_match_fields_table , id_1)"
           type_name {
             name: "string_id_t"
           }
@@ -10903,12 +10779,6 @@ actions_by_name {
           table: "one_match_field_table"
           match_field: "id"
           table_id: 46253494
-          match_field_id: 1
-        }
-        references {
-          table: "two_match_fields_table"
-          match_field: "id_1"
-          table_id: 34805412
           match_field_id: 1
         }
       }
@@ -10920,7 +10790,6 @@ actions_by_name {
           id: 1
           name: "referring_id_1"
           annotations: "@refers_to(one_match_field_table , id)"
-          annotations: "@refers_to(two_match_fields_table , id_1)"
           type_name {
             name: "string_id_t"
           }
@@ -10930,12 +10799,6 @@ actions_by_name {
           table: "one_match_field_table"
           match_field: "id"
           table_id: 46253494
-          match_field_id: 1
-        }
-        references {
-          table: "two_match_fields_table"
-          match_field: "id_1"
-          table_id: 34805412
           match_field_id: 1
         }
       }

--- a/p4_pdpi/testing/testdata/main.p4
+++ b/p4_pdpi/testing/testdata/main.p4
@@ -287,7 +287,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 
   action referring_to_one_match_field_action(@id(1)
   @refers_to(one_match_field_table, id)
-  @refers_to(two_match_fields_table, id_1)
+  // @refers_to(two_match_fields_table, id_1)
                          string_id_t referring_id_1) {}
   // A table whose entries refer to other table entries via action.
   table referring_by_action_table {

--- a/p4_pdpi/testing/testdata/main_p4_pd.expected
+++ b/p4_pdpi/testing/testdata/main_p4_pd.expected
@@ -522,7 +522,6 @@ message OtherGoldenTestFriendlyAction {
 
 message ReferringToOneMatchFieldAction {
   // Refers to 'one_match_field_table.id'.
-  // Refers to 'two_match_fields_table.id_1'.
   string referring_id_1 = 1; // Format::STRING
 }
 

--- a/p4_pdpi/testing/testdata/sequencing.expected
+++ b/p4_pdpi/testing/testdata/sequencing.expected
@@ -2315,6 +2315,18 @@ referenced_by_multicast_replica_table_entry {
 --- Unreachable entries from roots (output):
 referenced_by_multicast_replica_table_entry {
   match {
+    port: "port_1"
+    instance: "0x0031"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+  controller_metadata: "Not Garbage"
+}
+
+referenced_by_multicast_replica_table_entry {
+  match {
     port: "port_12"
     instance: "0x0031"
   }

--- a/p4_pdpi/testing/testdata/sequencing_util.expected
+++ b/p4_pdpi/testing/testdata/sequencing_util.expected
@@ -76,7 +76,6 @@ referring_by_action_table_entry {
 
 -- OUTPUT ----------------------------------------------------------------------
 -- ReferredTableEntries --
-ReferredTableEntry{table_id: 34805412, match_fields and values: [ReferredField{match_field_id: 1,field_value: key-a}]}
 ReferredTableEntry{table_id: 46253494, match_fields and values: [ReferredField{match_field_id: 1,field_value: key-a}]}
 
 =========================================================================


### PR DESCRIPTION
sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/Tools/keyword_checks.sh .
Keyword check Passed.



sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
DEBUG: Rule 'com_github_nelhage_rules_boost' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1619053724 -0700"
DEBUG: Repository com_github_nelhage_rules_boost instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:75:9: in <toplevel>
  /var/vsurya/.cache/bazel/_bazel_vsurya/5fd88bad78ef03829a4685c83637a020/external/com_github_p4lang_p4c/bazel/p4c_deps.bzl:25:23: in p4c_deps
Repository rule git_repository defined at:
  /var/vsurya/.cache/bazel/_bazel_vsurya/5fd88bad78ef03829a4685c83637a020/external/bazel_tools/tools/build_defs/repo/git.bzl:199:33: in <toplevel>
DEBUG: Rule 'sonic_swss_common' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "fbd1f2ef83af06af744491253a66315b8bfe64227e19f0357c2fb560a8da57f0"
DEBUG: Repository sonic_swss_common instantiated at:

p4_pdpi/testing/testdata/main.p4(567): [--Wwarn=unsupported] warning: Target does not support default_action for ingress.golden_test_friendly_wcmp_table (due to action profiles)
  table golden_test_friendly_wcmp_table {
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INFO: Elapsed time: 4.581s, Critical Path: 2.68s
INFO: 22 processes: 4 internal, 18 linux-sandbox.
INFO: Build completed successfully, 22 total actions



/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
DEBUG: Rule 'com_github_nelhage_rules_boost' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1619053724 -0700"
DEBUG: Repository com_github_nelhage_rules_boost instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:75:9: in <toplevel>
  /var/vsurya/.cache/bazel/_bazel_vsurya/5fd88bad78ef03829a4685c83637a020/external/com_github_p4lang_p4c/bazel/p4c_deps.bzl:25:23: in p4c_deps
Repository rule git_repository defined at:
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.2s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s

Executed 21 out of 144 tests: 144 tests pass.
INFO: Build completed successfully, 22 total actions