### PR TITLE
[P4RT] Use consistent 16-bit hex strings for `multicast_group_id` and `multicast_replica_instance`.

### DIFF
--- a/p4rt_app/sonic/app_db_to_pdpi_ir_translator.cc
+++ b/p4rt_app/sonic/app_db_to_pdpi_ir_translator.cc
@@ -590,7 +590,8 @@ absl::StatusOr<pdpi::IrTableEntry> AppDbKeyAndValuesToIrTableEntry(
 
 std::string IrMulticastGroupEntryToAppDbKey(
     const pdpi::IrMulticastGroupEntry &entry) {
-  return absl::StrCat("0x", absl::Hex(entry.multicast_group_id()));
+  return absl::StrCat("0x",
+                      absl::Hex(entry.multicast_group_id(), absl::kZeroPad4));
 }
 
 }  // namespace sonic

--- a/p4rt_app/sonic/app_db_to_pdpi_ir_translator_test.cc
+++ b/p4rt_app/sonic/app_db_to_pdpi_ir_translator_test.cc
@@ -474,7 +474,7 @@ TEST(TranslateAppDbToPdpiTest, MulticastGroupEntrySuccess) {
       )pb",
       &entry));
 
-  EXPECT_EQ(IrMulticastGroupEntryToAppDbKey(entry), "0x11");
+  EXPECT_EQ(IrMulticastGroupEntryToAppDbKey(entry), "0x0011");
 }
 
 }  // namespace

--- a/p4rt_app/sonic/packet_replication_entry_translation.cc
+++ b/p4rt_app/sonic/packet_replication_entry_translation.cc
@@ -78,7 +78,7 @@ std::string CreateEntryForInsert(
     nlohmann::json json;
     json["multicast_replica_port"] = replica.port();
     json["multicast_replica_instance"] =
-        absl::StrCat("0x", absl::Hex(replica.instance()));
+        absl::StrCat("0x", absl::Hex(replica.instance(), absl::kZeroPad4));
     json_array.push_back(json);
   }
   kfvFieldsValues(key_value).push_back(

--- a/p4rt_app/sonic/packet_replication_entry_translation_test.cc
+++ b/p4rt_app/sonic/packet_replication_entry_translation_test.cc
@@ -95,17 +95,17 @@ TEST_F(PacketReplicationEntryTranslationTest, InsertPacketReplicationEntry) {
 
   // Expected RedisDB entry.
   const std::string json_array =
-      R"j([{"multicast_replica_instance":"0x1",)j"
+      R"j([{"multicast_replica_instance":"0x0001",)j"
       R"j("multicast_replica_port":"Ethernet1/1/1"},)j"
-      R"j({"multicast_replica_instance":"0x1",)j"
+      R"j({"multicast_replica_instance":"0x0001",)j"
       R"j("multicast_replica_port":"Ethernet3/1/1"},)j"
-      R"j({"multicast_replica_instance":"0x1",)j"
+      R"j({"multicast_replica_instance":"0x0001",)j"
       R"j("multicast_replica_port":"Ethernet5/1/1"}])j";
 
   const std::vector<std::pair<std::string, std::string>> kfv_values = {
       std::make_pair("replicas", json_array),
   };
-  const std::string expected_key = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::string expected_key = "REPLICATION_IP_MULTICAST_TABLE:0x0001";
   const std::vector<swss::KeyOpFieldsValuesTuple> expected_key_value = {
       std::make_tuple(expected_key, "SET", kfv_values)};
 
@@ -128,15 +128,15 @@ TEST_F(PacketReplicationEntryTranslationTest, ModifyPacketReplicationEntry) {
 
   // Expected RedisDB entry.
   const std::string json_array =
-      R"j([{"multicast_replica_instance":"0x1",)j"
+      R"j([{"multicast_replica_instance":"0x0001",)j"
       R"j("multicast_replica_port":"Ethernet1/1/1"},)j"
-      R"j({"multicast_replica_instance":"0x1",)j"
+      R"j({"multicast_replica_instance":"0x0001",)j"
       R"j("multicast_replica_port":"Ethernet3/1/1"}])j";
 
   const std::vector<std::pair<std::string, std::string>> kfv_values = {
       std::make_pair("replicas", json_array),
   };
-  const std::string expected_key = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::string expected_key = "REPLICATION_IP_MULTICAST_TABLE:0x0001";
   const std::vector<swss::KeyOpFieldsValuesTuple> expected_key_value = {
       std::make_tuple(expected_key, "SET", kfv_values)};
 
@@ -159,9 +159,10 @@ TEST_F(PacketReplicationEntryTranslationTest, DeletePacketReplicationEntry) {
 
   // Expected RedisDB entry.
   const std::vector<std::pair<std::string, std::string>> empty_values;
-  const std::string expected_key = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::string expected_key = "REPLICATION_IP_MULTICAST_TABLE:0x0001";
   const std::vector<swss::KeyOpFieldsValuesTuple> expected_key_value = {
-      std::make_tuple("REPLICATION_IP_MULTICAST_TABLE:0x1", "DEL", empty_values)};
+      std::make_tuple("REPLICATION_IP_MULTICAST_TABLE:0x0001", "DEL",
+                      empty_values)};
 
   std::vector<swss::KeyOpFieldsValuesTuple> kfvs;
   ASSERT_THAT(CreatePacketReplicationTableUpdateForAppDb(
@@ -182,7 +183,8 @@ TEST_F(PacketReplicationEntryTranslationTest, UnspecifiedOperationFails) {
   // Expected RedisDB entry.
   const std::vector<std::pair<std::string, std::string>> empty_values;
   const std::vector<swss::KeyOpFieldsValuesTuple> expected_key_value = {
-      std::make_tuple("REPLICATION_IP_MULTICAST_TABLE:0x1", "SET", empty_values)};
+      std::make_tuple("REPLICATION_IP_MULTICAST_TABLE:0x0001", "SET",
+                      empty_values)};
 
   std::vector<swss::KeyOpFieldsValuesTuple> kfvs;
   EXPECT_THAT(
@@ -207,19 +209,19 @@ TEST_F(PacketReplicationEntryTranslationTest,
 TEST_F(PacketReplicationEntryTranslationTest,
        GetAllAppDbPacketReplicationTableEntries) {
   const std::string json_array1 =
-      R"j([{"multicast_replica_instance":"0x1",)j"
+      R"j([{"multicast_replica_instance":"0x0001",)j"
       R"j("multicast_replica_port":"Ethernet1/1/1"},)j"
-      R"j({"multicast_replica_instance":"0x1",)j"
+      R"j({"multicast_replica_instance":"0x0001",)j"
       R"j("multicast_replica_port":"Ethernet3/1/1"}])j";
-  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x0001";
   const std::vector<std::pair<std::string, std::string>> kfv_values1 = {
       std::make_pair("replicas", json_array1),
   };
 
   const std::string json_array2 =
-      R"j([{"multicast_replica_instance":"0x1",)j"
+      R"j([{"multicast_replica_instance":"0x0001",)j"
       R"j("multicast_replica_port":"Ethernet1/1/1"}])j";
-  const std::string app_db_key2 = "REPLICATION_IP_MULTICAST_TABLE:0x2";
+  const std::string app_db_key2 = "REPLICATION_IP_MULTICAST_TABLE:0x0002";
   const std::vector<std::pair<std::string, std::string>> kfv_values2 = {
       std::make_pair("replicas", json_array2),
   };
@@ -270,9 +272,9 @@ TEST_F(PacketReplicationEntryTranslationTest, InvalidInstance) {
   const std::string json_array1 =
       R"j([{"multicast_replica_instance":"0xZZ",)j"
       R"j("multicast_replica_port":"Ethernet1/1/1"},)j"
-      R"j({"multicast_replica_instance":"0x1",)j"
+      R"j({"multicast_replica_instance":"0x0001",)j"
       R"j("multicast_replica_port":"Ethernet3/1/1"}])j";
-  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x0001";
   const std::vector<std::pair<std::string, std::string>> kfv_values1 = {
       std::make_pair("replicas", json_array1),
   };
@@ -286,8 +288,9 @@ TEST_F(PacketReplicationEntryTranslationTest, InvalidInstance) {
 }
 
 TEST_F(PacketReplicationEntryTranslationTest, MissingMulticastReplicaPort) {
-  const std::string json_array1 = R"j([{"multicast_replica_instance":"0x1"}])j";
-  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::string json_array1 =
+      R"j([{"multicast_replica_instance":"0x0001"}])j";
+  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x0001";
   const std::vector<std::pair<std::string, std::string>> kfv_values1 = {
       std::make_pair("replicas", json_array1),
   };
@@ -303,7 +306,7 @@ TEST_F(PacketReplicationEntryTranslationTest, MissingMulticastReplicaPort) {
 TEST_F(PacketReplicationEntryTranslationTest, MissingMulticastReplicaInstance) {
   const std::string json_array1 =
       R"j([{"multicast_replica_port":"Ethernet1/1/1"}])j";
-  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x0001";
   const std::vector<std::pair<std::string, std::string>> kfv_values1 = {
       std::make_pair("replicas", json_array1),
   };

--- a/p4rt_app/sonic/state_verification_test.cc
+++ b/p4rt_app/sonic/state_verification_test.cc
@@ -274,7 +274,7 @@ TEST_F(StateVerificationPacketReplicationTest,
            })pb",
       &ir_entity));
 
-  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x0001";
 
   EXPECT_EQ(
       VerifyP4rtTableWithCacheEntities(mock_app_db, {ir_entity}, ir_p4_info)
@@ -284,11 +284,11 @@ TEST_F(StateVerificationPacketReplicationTest,
 
 TEST_F(StateVerificationPacketReplicationTest, VerifyPacketReplicationSuccess) {
   const std::string json_array1 =
-      R"j([{"multicast_replica_instance":"0x1",)j"
+      R"j([{"multicast_replica_instance":"0x0001",)j"
       R"j("multicast_replica_port":"Ethernet1/1/1"},)j"
-      R"j({"multicast_replica_instance":"0x1",)j"
+      R"j({"multicast_replica_instance":"0x0001",)j"
       R"j("multicast_replica_port":"Ethernet1/1/3"}])j";
-  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x0001";
   const std::vector<std::pair<std::string, std::string>> kfv_values1 = {
       std::make_pair("replicas", json_array1),
   };
@@ -316,9 +316,9 @@ TEST_F(StateVerificationPacketReplicationTest, VerifyPacketReplicationSuccess) {
 
 TEST_F(StateVerificationPacketReplicationTest, VerifyPacketReplicationFails) {
   const std::string json_array1 =
-      R"j([{"multicast_replica_instance":"0x1",)j"
+      R"j([{"multicast_replica_instance":"0x0001",)j"
       R"j("multicast_replica_port":"Ethernet1/1/1"}])j";
-  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const std::string app_db_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x0001";
   const std::vector<std::pair<std::string, std::string>> kfv_values1 = {
       std::make_pair("replicas", json_array1),
   };

--- a/p4rt_app/tests/forwarding_pipeline_config_test.cc
+++ b/p4rt_app/tests/forwarding_pipeline_config_test.cc
@@ -350,15 +350,15 @@ TEST_F(CommitTest, LoadsLastSavedConfig) {
   ASSERT_OK(
       p4rt_service_->GetP4rtServer().AddPortTranslation("Ethernet3/1/1", "2"));
   const std::string json_array =
-      R"j([{"multicast_replica_instance":"0x1",)j"
+      R"j([{"multicast_replica_instance":"0x0001",)j"
       R"j("multicast_replica_port":"Ethernet1/1/1"},)j"
-      R"j({"multicast_replica_instance":"0x1",)j"
+      R"j({"multicast_replica_instance":"0x0001",)j"
       R"j("multicast_replica_port":"Ethernet3/1/1"}])j";
   const std::vector<std::pair<std::string, std::string>> kfv_values = {
       std::make_pair("replicas", json_array),
   };
   p4rt_service_->GetP4rtAppDbTable().InsertTableEntry(
-      "REPLICATION_IP_MULTICAST_TABLE:0x1", kfv_values);
+      "REPLICATION_IP_MULTICAST_TABLE:0x0001", kfv_values);
 
   // Then we'll load the saved config with the COMMIT action.
   SetForwardingPipelineConfigRequest load_request = GetBasicForwardingRequest();

--- a/p4rt_app/tests/packet_replication_table_test.cc
+++ b/p4rt_app/tests/packet_replication_table_test.cc
@@ -67,7 +67,7 @@ TEST_F(PacketReplicationTableTest, InsertReadAndDeleteEntry) {
   EXPECT_OK(
       pdpi::SetMetadataAndSendPiWriteRequest(p4rt_session_.get(), request));
 
-  const auto expected_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const auto expected_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x0001";
 
   ASSERT_OK(p4rt_service_.GetP4rtAppDbTable().ReadTableEntry(expected_key1))
       << "Unable to read entry for " << expected_key1;
@@ -140,7 +140,7 @@ TEST_F(PacketReplicationTableTest, InsertRequestFails) {
                              })pb",
                            ir_p4_info_));
 
-  const auto expected_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x11";
+  const auto expected_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x0011";
 
   // Assume the Orchagent fails with an invalid parameter.
   p4rt_service_.GetP4rtAppDbTable().SetResponseForKey(
@@ -204,7 +204,7 @@ TEST_F(PacketReplicationTableTest, DeleteRequestFails) {
                              })pb",
                            ir_p4_info_));
 
-  const auto expected_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const auto expected_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x0001";
 
   // First we insert the entry because a delete isn't allowed on non-existing
   // table entries.
@@ -251,7 +251,7 @@ TEST_F(PacketReplicationTableTest, ModifySuccess) {
                              })pb",
                            ir_p4_info_));
 
-  const auto expected_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x1";
+  const auto expected_key1 = "REPLICATION_IP_MULTICAST_TABLE:0x0001";
 
   // First, insert an entry.
   EXPECT_OK(


### PR DESCRIPTION
### Keyword Check:
divya@eonms3vm12:~/new_code/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_checks.sh .
Keyword check Passed.

### Build Results:
divya@a17da3ffc51c:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 408 targets (0 packages loaded, 29 targets configured).
INFO: Found 408 targets...
...
INFO: Elapsed time: 2248.676s, Critical Path: 92.81s
INFO: 9139 processes: 2723 internal, 6416 linux-sandbox.
INFO: Build completed successfully, 9139 total actions

### Test Results:
divya@a17da3ffc51c:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
DEBUG: Rule 'com_github_nelhage_rules_boost' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1619053724 -0700"
DEBUG: Repository com_github_nelhage_rules_boost instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:75:9: in <toplevel>
  /var/divya/.cache/bazel/_bazel_divya/5fd88bad78ef03829a4685c83637a020/external/com_github_p4lang_p4c/bazel/p4c_deps.bzl:25:23: in p4c_deps
Repository rule git_repository defined at:
  /var/divya/.cache/bazel/_bazel_divya/5fd88bad78ef03829a4685c83637a020/external/bazel_tools/tools/build_defs/repo/git.bzl:199:33: in <toplevel>
INFO: Analyzed 408 targets (1 packages loaded, 343 targets configured).
INFO: Found 261 targets and 147 test targets...
INFO: Elapsed time: 100.315s, Critical Path: 25.78s
INFO: 152 processes: 162 linux-sandbox, 18 local.
INFO: Build completed successfully, 152 total actions
//gutil:collections_test                                                 PASSED in 0.7s
//gutil:io_test                                                          PASSED in 1.3s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.6s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.7s
//gutil:test_artifact_writer_test                                        PASSED in 0.6s
//gutil:testing_test                                                     PASSED in 0.4s
//gutil:version_test                                                     PASSED in 1.4s
//lib:basic_switch_test                                                  PASSED in 1.0s
//lib:ixia_helper_test                                                   PASSED in 1.1s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 0.9s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 16.9s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.2s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 25.8s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.8s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:oracle_util_test                                             PASSED in 0.7s
//p4_fuzzer:switch_state_test                                            PASSED in 0.8s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_properties_test                                             PASSED in 0.5s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 0.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:names_test                                                     PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:references_test                                                PASSED in 0.6s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.5s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.6s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 17.1s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 3.4s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.6s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 2.6s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.6s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.1s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.3s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.5s
//p4_pdpi/testing:references_test                                        PASSED in 0.1s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.3s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.5s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.3s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 1.0s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.4s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.6s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.7s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.0s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.0s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 1.0s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.8s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.7s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.9s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.9s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.4s
//p4rt_app/tests:action_set_test                                         PASSED in 1.1s
//p4rt_app/tests:api_access_test                                         PASSED in 0.9s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.0s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 1.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 3.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.3s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.3s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.2s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.6s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 1.7s
//p4rt_app/tests:packetio_test                                           PASSED in 3.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 2.9s
//p4rt_app/tests:response_path_test                                      PASSED in 2.8s
//p4rt_app/tests:role_test                                               PASSED in 1.2s
//p4rt_app/tests:state_verification_test                                 PASSED in 1.7s
//p4rt_app/tests:vrf_table_test                                          PASSED in 1.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.5s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.3s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.4s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 2.1s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.7s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.9s
//thinkit:bazel_test_environment_test                                    PASSED in 0.6s
//thinkit:generic_testbed_test                                           PASSED in 1.0s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 15.5s
  Stats over 5 runs: max = 15.5s, min = 1.3s, avg = 6.9s, dev = 5.9s

Executed 147 out of 147 tests: 147 tests pass.
INFO: Build completed successfully, 152 total actions
divya@a17da3ffc51c:/sonic/src/sonic-p4rt/sonic-pins$ 
divya@a17da3ffc51c:/sonic/src/sonic-p4rt/sonic-pins$ 
divya@a17da3ffc51c:/sonic/src/sonic-p4rt/sonic-pins$ 
divya@a17da3ffc51c:/sonic/src/sonic-p4rt/sonic-pins$ 
