### PR TITLE
[Comb] Adds `StreamableStatusOr` utility and removed `absl::StatusOr` `operator<<` overloads.

### DIFF
--- a/p4_pdpi/packetlib/BUILD.bazel
+++ b/p4_pdpi/packetlib/BUILD.bazel
@@ -105,6 +105,7 @@ cc_test(
         ":packetlib",
         ":packetlib_cc_proto",
         "//gutil:proto",
+        "//gutil:status",
         "//gutil:testing",
         "//p4_pdpi/string_encodings:readable_byte_string",
         "@com_google_absl//absl/status",

--- a/p4_pdpi/packetlib/packetlib_test_runner.cc
+++ b/p4_pdpi/packetlib/packetlib_test_runner.cc
@@ -24,6 +24,7 @@
 #include "absl/strings/str_cat.h"
 #include "google/protobuf/util/message_differencer.h"
 #include "gutil/proto.h"
+#include "gutil/status.h"
 #include "gutil/testing.h"
 #include "p4_pdpi/packetlib/packetlib.h"
 #include "p4_pdpi/packetlib/packetlib.pb.h"
@@ -55,13 +56,6 @@ const std::string StatusToStableString(const absl::Status& status) {
     absl::StrAppend(&status_message, ": ", status.message());
   }
   return status_message;
-}
-
-// Pretty prints `StatusOr<T>`, assuming a pretty printer for `T` exists.
-template <class T>
-std::ostream& operator<<(std::ostream& os, const absl::StatusOr<T>& statusor) {
-  if (statusor.ok()) return os << *statusor;
-  return os << StatusToStableString(statusor.status());
 }
 
 // Parses packet from bytes, and if it succeeds, re-serializes the parsed packet
@@ -183,8 +177,9 @@ void RunProtoPacketTest(
   if (bytes != bytes_from_proto) {
     std::cout << "BUG: The two overloads of the Serialize function return "
                  "different results:\n- Serialize(Packet): "
-              << bytes
-              << "\n- Serialize(absl::string_view): " << bytes_from_proto;
+              << gutil::StreamableStatusOr(bytes)
+              << "\n- Serialize(absl::string_view): "
+              << gutil::StreamableStatusOr(bytes_from_proto);
   }
   if (!bytes.ok()) return;
 


### PR DESCRIPTION
sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/Tools/keyword_checks.sh .
Keyword check Passed.



sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 408 targets (150 packages loaded, 18986 targets configured).
INFO: Found 408 targets...
INFO: From Compiling p4_pdpi/netaddr/mac_address.cc:
In file included from ./p4_pdpi/netaddr/network_address.h:28,
                 from ./p4_pdpi/netaddr/ipv6_address.h:23,
                 from ./p4_pdpi/netaddr/mac_address.h:22,
                 from p4_pdpi/netaddr/mac_address.cc:14:
./p4_pdpi/string_encodings/hex_string.h: In instantiation of 'std::string pdpi::BitsetToHexString(const std::bitset<_Nb>&) [with long unsigned int num_bits = 64; std::string = std::__cxx11::basic_string<char>]':
p4_pdpi/netaddr/mac_address.cc:103:78:   required from here
p4rt_app/scripts/p4rt_route_measurement_test.cc:198:58: warning: comparison of integer expressions of different signedness: 'absl::lts_20230802::container_internal::btree_container<absl::lts_20230802::container_internal::btree<absl::lts_20230802::container_internal::set_params<long unsigned int, std::less<long unsigned int>, std::allocator<long unsigned int>, 256, false> > >::size_type' {aka 'long unsigned int'} and 'int' [-Wsign-compare]
  198 |     for (T i = min_value; i < max_value && result.size() < size; i++) {
      |                                            ~~~~~~~~~~~~~~^~~~~~
INFO: Elapsed time: 1042.833s, Critical Path: 61.74s
INFO: 309 processes: 13 internal, 296 linux-sandbox.
INFO: Build completed successfully, 309 total actions



/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Analyzed 408 targets (0 packages loaded, 0 targets configured).
INFO: Found 261 targets and 147 test targets...
INFO: Elapsed time: 63.455s, Critical Path: 6.67s
INFO: 34 processes: 17 linux-sandbox, 18 local.
INFO: Build completed successfully, 34 total actions
//gutil:collections_test                                        (cached) PASSED in 0.5s
/p4rt_app/tests:state_verification_test                                 PASSED in 2.2s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.1s

Executed 33 out of 147 tests: 147 tests pass.
INFO: Build completed successfully, 34 total actions
