### PR TITLE
[Comb] Match action coverage test now covers multicast group table.

### DIFF
--- a/p4_pdpi/built_ins.cc
+++ b/p4_pdpi/built_ins.cc
@@ -45,6 +45,10 @@ std::string GetMulticastGroupTableName() {
   return absl::StrCat(kBuiltInPrefix, kMulticastGroupTableString);
 }
 
+std::string GetReplicaActionName() {
+  return absl::StrCat(kBuiltInPrefix, kReplicaString);
+}
+
 std::string GetCloneSessionTableName() {
   return absl::StrCat(kBuiltInPrefix, kCloneSessionTableString);
 }

--- a/p4_pdpi/built_ins.h
+++ b/p4_pdpi/built_ins.h
@@ -34,6 +34,9 @@ std::string GetMulticastGroupTableName();
 // Returns the PDPI name for the clone session table.
 std::string GetCloneSessionTableName();
 
+// Returns the PDPI name for the replica action.
+std::string GetReplicaActionName();
+
 // Returns true if `table_name` is a known built_in table.
 // Useful for branching on table type.
 bool IsBuiltInTable(absl::string_view table_name);


### PR DESCRIPTION
sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/Tools/keyword_checks.sh .
Keyword check Passed.


/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 408 targets (0 packages loaded, 0 targets configured).
INFO: Found 408 targets...
INFO: From Compiling p4_pdpi/ir.cc:
In file included from ./gutil/collections.h:29,
                 from p4_pdpi/ir.cc:44:
p4_pdpi/ir.cc: In function 'absl::lts_20230802::StatusOr<pdpi::IrP4Info> pdpi::CreateIrP4Info(const p4::config::v1::P4Info&)':
p4_pdpi/ir.cc:1486:73: warning: 'absl::lts_20230802::StatusOr<std::vector<pdpi::IrMatchFieldReference> > pdpi::{anonymous}::GetRefersToAnnotations(const p4::config::v1::P4Info&, const google::protobuf::RepeatedPtrField<std::__cxx11::basic_string<char> >&)' is deprecated: Use ParseRefersToAnnotations instead [-Wdeprecated-declarations]
 1486 |           GetRefersToAnnotations(p4_info, ir_param.param().annotations()));
p4_pdpi/ir.cc: In function 'absl::lts_20230802::Status pdpi::{anonymous}::InsertIncomingReferenceInfo(const pdpi::IrTableReference&, pdpi::IrP4Info&)':
p4_pdpi/ir.cc:1403:1: warning: control reaches end of non-void function [-Wreturn-type]
 1403 | }
      | ^
INFO: Elapsed time: 88.148s, Critical Path: 43.00s
INFO: 101 processes: 3 internal, 98 linux-sandbox.
INFO: Build completed successfully, 101 total actions



/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Analyzed 408 targets (0 packages loaded, 0 targets configured).
INFO: Found 261 targets and 147 test targets...
INFO: Elapsed time: 109.329s, Critical Path: 25.82s
INFO: 85 processes: 82 linux-sandbox, 18 local.
INFO: Build completed successfully, 85 total actions
//gutil:collections_test                                        (cached) PASSED in 0.5s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 13.2s
  Stats over 5 runs: max = 13.2s, min = 2.3s, avg = 8.5s, dev = 5.0s

Executed 80 out of 147 tests: 147 tests pass.
INFO: Build completed successfully, 85 total actions
