### PR TITLE
[P4-Symbolic] Adding bmv2 files in p4_symbolic

### DIFF
--- a/p4_symbolic/bmv2/BUILD.bazel
+++ b/p4_symbolic/bmv2/BUILD.bazel
@@ -1,0 +1,102 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test", "diff_test")
+load("//p4_pdpi:pdgen.bzl", "p4_pd_proto")
+load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
+load("//p4_symbolic/bmv2:test.bzl", "bmv2_protobuf_parsing_test")
+
+package(licenses = ["notice"])
+
+cc_proto_library(
+    name = "bmv2_cc_proto",
+    visibility = ["//p4_symbolic:__subpackages__"],
+    deps = [":bmv2_proto"],
+)
+
+proto_library(
+    name = "bmv2_proto",
+    srcs = [
+        "bmv2.proto",
+    ],
+    visibility = ["//p4_symbolic:__subpackages__"],
+    deps = [
+        "@com_google_protobuf//:struct_proto",
+    ],
+)
+
+cc_library(
+    name = "bmv2",
+    srcs = [
+        "bmv2.cc",
+    ],
+    hdrs = [
+        "bmv2.h",
+    ],
+    visibility = ["//p4_symbolic:__subpackages__"],
+    deps = [
+        ":bmv2_cc_proto",
+        "//gutil:status",
+        "//p4_symbolic/util",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_binary(
+    name = "test",
+    srcs = ["test.cc"],
+    deps = [
+        ":bmv2",
+        "//gutil:status",
+        "//p4_symbolic/util",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/flags:usage",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+py_binary(
+    name = "test_sdiff",
+    srcs = ["test_sdiff.py"],
+    python_version = "PY3",
+)
+
+# Test rules: one per program in //p4-samples
+bmv2_protobuf_parsing_test(
+    name = "port_table",
+    golden_file = "expected/table.pb.txt",
+    p4_program = "//p4_symbolic/testdata:port-table/table.p4",
+)
+
+bmv2_protobuf_parsing_test(
+    name = "ipv4_routing",
+    golden_file = "expected/basic.pb.txt",
+    p4_program = "//p4_symbolic/testdata:ipv4-routing/basic.p4",
+)
+
+bmv2_protobuf_parsing_test(
+    name = "port_hardcoded",
+    golden_file = "expected/hardcoded.pb.txt",
+    p4_program = "//p4_symbolic/testdata:hardcoded/hardcoded.p4",
+)
+
+bmv2_protobuf_parsing_test(
+    name = "reflector",
+    golden_file = "expected/reflector.pb.txt",
+    p4_program = "//p4_symbolic/testdata:reflector/reflector.p4",
+)

--- a/p4_symbolic/bmv2/bmv2.cc
+++ b/p4_symbolic/bmv2/bmv2.cc
@@ -17,25 +17,22 @@
 #include <string>
 
 #include "google/protobuf/util/json_util.h"
-#include "gutil/io.h"
 #include "gutil/status.h"
+#include "p4_symbolic/util/io.h"
 
 namespace p4_symbolic {
 namespace bmv2 {
 
 absl::StatusOr<P4Program> ParseBmv2JsonFile(const std::string &json_path) {
-  ASSIGN_OR_RETURN(std::string json, gutil::ReadFile(json_path));
-  return ParseBmv2JsonString(json);
-}
+  ASSIGN_OR_RETURN(std::string file_content, util::ReadFile(json_path));
 
-absl::StatusOr<P4Program> ParseBmv2JsonString(const std::string &json_string) {
   P4Program output;
   google::protobuf::util::JsonParseOptions options;
   options.ignore_unknown_fields = true;
 
   RETURN_IF_ERROR(
       gutil::ToAbslStatus(google::protobuf::util::JsonStringToMessage(
-          json_string, &output, options)));
+          file_content, &output, options)));
 
   return output;
 }

--- a/p4_symbolic/bmv2/expected/basic.pb.txt
+++ b/p4_symbolic/bmv2/expected/basic.pb.txt
@@ -391,6 +391,23 @@ parsers {
   init_state: "start"
   parse_states {
     name: "start"
+    parser_ops {
+      op: extract
+      parameters {
+        fields {
+          key: "type"
+          value {
+            string_value: "regular"
+          }
+        }
+        fields {
+          key: "value"
+          value {
+            string_value: "ethernet"
+          }
+        }
+      }
+    }
     transitions {
       value: "0x0800"
       type: hexstr
@@ -398,10 +415,38 @@ parsers {
     }
     transitions {
     }
+    transition_key {
+      type: field
+      value {
+        values {
+          string_value: "ethernet"
+        }
+        values {
+          string_value: "etherType"
+        }
+      }
+    }
   }
   parse_states {
     name: "parse_ipv4"
     id: 1
+    parser_ops {
+      op: extract
+      parameters {
+        fields {
+          key: "type"
+          value {
+            string_value: "regular"
+          }
+        }
+        fields {
+          key: "value"
+          value {
+            string_value: "ipv4"
+          }
+        }
+      }
+    }
     transitions {
     }
   }
@@ -413,6 +458,8 @@ deparsers {
     column: 8
     source_fragment: "MyDeparser"
   }
+  order: "ethernet"
+  order: "ipv4"
 }
 actions {
   name: "NoAction"
@@ -1062,5 +1109,61 @@ pipelines {
     line: 138
     column: 8
     source_fragment: "MyEgress"
+  }
+}
+errors {
+  values {
+    string_value: "NoError"
+  }
+  values {
+    number_value: 0
+  }
+}
+errors {
+  values {
+    string_value: "PacketTooShort"
+  }
+  values {
+    number_value: 1
+  }
+}
+errors {
+  values {
+    string_value: "NoMatch"
+  }
+  values {
+    number_value: 2
+  }
+}
+errors {
+  values {
+    string_value: "StackOutOfBounds"
+  }
+  values {
+    number_value: 3
+  }
+}
+errors {
+  values {
+    string_value: "HeaderTooShort"
+  }
+  values {
+    number_value: 4
+  }
+}
+errors {
+  values {
+    string_value: "ParserTimeout"
+  }
+  values {
+    number_value: 5
+  }
+}
+errors {
+  values {
+    string_value: "ParserInvalidArgument"
+  }
+  values {
+    number_value: 6
   }
 }

--- a/p4_symbolic/bmv2/expected/hardcoded.pb.txt
+++ b/p4_symbolic/bmv2/expected/hardcoded.pb.txt
@@ -522,3 +522,59 @@ pipelines {
     source_fragment: "UselessEgress"
   }
 }
+errors {
+  values {
+    string_value: "NoError"
+  }
+  values {
+    number_value: 0
+  }
+}
+errors {
+  values {
+    string_value: "PacketTooShort"
+  }
+  values {
+    number_value: 1
+  }
+}
+errors {
+  values {
+    string_value: "NoMatch"
+  }
+  values {
+    number_value: 2
+  }
+}
+errors {
+  values {
+    string_value: "StackOutOfBounds"
+  }
+  values {
+    number_value: 3
+  }
+}
+errors {
+  values {
+    string_value: "HeaderTooShort"
+  }
+  values {
+    number_value: 4
+  }
+}
+errors {
+  values {
+    string_value: "ParserTimeout"
+  }
+  values {
+    number_value: 5
+  }
+}
+errors {
+  values {
+    string_value: "ParserInvalidArgument"
+  }
+  values {
+    number_value: 6
+  }
+}

--- a/p4_symbolic/bmv2/expected/reflector.pb.txt
+++ b/p4_symbolic/bmv2/expected/reflector.pb.txt
@@ -350,3 +350,59 @@ pipelines {
     source_fragment: "UselessEgress"
   }
 }
+errors {
+  values {
+    string_value: "NoError"
+  }
+  values {
+    number_value: 0
+  }
+}
+errors {
+  values {
+    string_value: "PacketTooShort"
+  }
+  values {
+    number_value: 1
+  }
+}
+errors {
+  values {
+    string_value: "NoMatch"
+  }
+  values {
+    number_value: 2
+  }
+}
+errors {
+  values {
+    string_value: "StackOutOfBounds"
+  }
+  values {
+    number_value: 3
+  }
+}
+errors {
+  values {
+    string_value: "HeaderTooShort"
+  }
+  values {
+    number_value: 4
+  }
+}
+errors {
+  values {
+    string_value: "ParserTimeout"
+  }
+  values {
+    number_value: 5
+  }
+}
+errors {
+  values {
+    string_value: "ParserInvalidArgument"
+  }
+  values {
+    number_value: 6
+  }
+}

--- a/p4_symbolic/bmv2/expected/table.pb.txt
+++ b/p4_symbolic/bmv2/expected/table.pb.txt
@@ -362,3 +362,59 @@ pipelines {
     source_fragment: "UselessEgress"
   }
 }
+errors {
+  values {
+    string_value: "NoError"
+  }
+  values {
+    number_value: 0
+  }
+}
+errors {
+  values {
+    string_value: "PacketTooShort"
+  }
+  values {
+    number_value: 1
+  }
+}
+errors {
+  values {
+    string_value: "NoMatch"
+  }
+  values {
+    number_value: 2
+  }
+}
+errors {
+  values {
+    string_value: "StackOutOfBounds"
+  }
+  values {
+    number_value: 3
+  }
+}
+errors {
+  values {
+    string_value: "HeaderTooShort"
+  }
+  values {
+    number_value: 4
+  }
+}
+errors {
+  values {
+    string_value: "ParserTimeout"
+  }
+  values {
+    number_value: 5
+  }
+}
+errors {
+  values {
+    string_value: "ParserInvalidArgument"
+  }
+  values {
+    number_value: 6
+  }
+}

--- a/p4_symbolic/bmv2/test.cc
+++ b/p4_symbolic/bmv2/test.cc
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 // objects using protobuf text format and json format to two output files.
 // The output files paths are provided as command line flags.
 
+#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -27,11 +28,11 @@
 #include "absl/flags/usage.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
+#include "google/protobuf/text_format.h"
 #include "google/protobuf/util/json_util.h"
-#include "gutil/io.h"
-#include "gutil/proto.h"
 #include "gutil/status.h"
 #include "p4_symbolic/bmv2/bmv2.h"
+#include "p4_symbolic/util/io.h"
 
 ABSL_FLAG(std::string, bmv2, "", "The path to the bmv2 json file (required)");
 ABSL_FLAG(std::string, protobuf, "",
@@ -39,8 +40,6 @@ ABSL_FLAG(std::string, protobuf, "",
 ABSL_FLAG(std::string, json, "", "The path to the output json file (required)");
 
 namespace {
-
-using ::gutil::PrintTextProto;
 
 absl::Status Test() {
   const std::string &bmv2_path = absl::GetFlag(FLAGS_bmv2);
@@ -57,7 +56,7 @@ absl::Status Test() {
 
   // Dumping protobuf.
   RETURN_IF_ERROR(
-      gutil::WriteFile(PrintTextProto(bmv2), protobuf_path.c_str()));
+      p4_symbolic::util::WriteFile(bmv2.DebugString(), protobuf_path.c_str()));
 
   // Dumping JSON.
   google::protobuf::util::JsonPrintOptions dumping_options;
@@ -69,7 +68,8 @@ absl::Status Test() {
   RETURN_IF_ERROR(
       gutil::ToAbslStatus(google::protobuf::util::MessageToJsonString(
           bmv2, &json_output_str, dumping_options)));
-  RETURN_IF_ERROR(gutil::WriteFile(json_output_str, json_path.c_str()));
+  RETURN_IF_ERROR(
+      p4_symbolic::util::WriteFile(json_output_str, json_path.c_str()));
 
   return absl::OkStatus();
 }
@@ -80,7 +80,7 @@ int main(int argc, char *argv[]) {
   // Verify link and compile versions are the same.
   // GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-  // Command line arguments and help message.
+  // Command line arugments and help message.
   absl::SetProgramUsageMessage(
       absl::StrFormat("usage: %s %s", argv[0],
                       "--bmv2=path/to/bmv2.json "

--- a/p4_symbolic/symbolic/test.bzl
+++ b/p4_symbolic/symbolic/test.bzl
@@ -1,0 +1,124 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rules for testing p4-symbolic.
+
+This file contains rule definitions for running
+the test binary to produce output json and protobuf files,
+subset diff the input and output json files, and golden file
+testing the output protobuf files against the expected files.
+It also defines a Macro that simplifies defining a protobuf test
+over a sample P4 program.
+"""
+
+load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
+load("//p4_pdpi/testing:diff_test.bzl", "diff_test")
+
+def end_to_end_test(
+        name,
+        p4_program,
+        output_golden_file,
+        smt_golden_file,
+        table_entries = None,
+        p4_deps = []):
+    """Macro that defines our end to end tests.
+    Given a p4 program, this macro runs our main binary
+    on the p4 program and its table entries (if they exist).
+    The binary outputs a debugging dump of the underlying smt program,
+    as well as the output test packets.
+    The macro compares both of these outputs against the provided
+    expected golden files.
+    The macro defines these rules in order:
+    1. A rule for producing bmv2 json and p4info files from a .p4 file using p4c.
+    2. A rule for running the main binary on the inputs using p4_symbolic/main.cc,
+       and dumping both output files.
+    3. Two rules for golden file testing of the two output files.
+    4. A test suite combining the two rules above with the same name
+       as given to the macro.
+    Use the p4_deps list to specify dependent files that p4_program input
+    file depends on (e.g. by including them).
+    """
+    p4c_name = "%s_p4c" % name
+    run_name = "%s_main" % name
+    p4info_file = "%s_bazel-p4c-tmp-output/p4info.pb.txt" % p4c_name
+    output_test_name = "%s_output" % name
+    smt_test_name = "%s_smt" % name
+
+    bmv2_file = "tmp/%s.bmv2.json" % name
+    p4info_file = "tmp/%s.p4info.pb.txt" % name
+    test_output_file = "tmp/%s_output" % name
+
+    optional_table_entries = []
+    optional_table_entry_arg = ""
+    if table_entries:
+        optional_table_entries = [table_entries]
+        optional_table_entry_arg = "--entries=$(location %s)" % table_entries
+
+    # Run p4c to get bmv2 JSON and p4info.pb.txt files.
+    tmp_bmv2_file = "%s.tmp" % bmv2_file
+    p4_library(
+        name = p4c_name,
+        src = p4_program,
+        deps = p4_deps,
+        target = "bmv2",
+        target_out = tmp_bmv2_file,
+        p4info_out = p4info_file,
+    )
+    native.genrule(
+        name = "%s_strip_files_paths_for_portability" % name,
+        visibility = ["//visibility:private"],
+        srcs = [tmp_bmv2_file],
+        outs = [bmv2_file],
+        cmd = """sed -e 's|"[^"]*\\.p4"|""|g' $(SRCS) > $(OUTS)""",
+    )
+
+    # Use p4_symbolic/main.cc to run our tool on the p4 program
+    # and produce a debugging smt file and an output file with
+    # interesting testing packets.
+    test_output_file = "generated/%s.txt" % name
+    smt_output_file = "generated/%s.smt2" % name
+    native.genrule(
+        name = "%s_test_runner" % name,
+        srcs = [
+            bmv2_file,
+            p4info_file,
+        ] + ([table_entries] if table_entries else []),
+        outs = [test_output_file, smt_output_file],
+        tools = ["//p4_symbolic:main"],
+        cmd = " ".join([
+            "$(location //p4_symbolic:main)",
+            "--hardcoded_parser=false",
+            ("--bmv2=$(location %s)" % bmv2_file),
+            ("--p4info=$(location %s)" % p4info_file),
+            ("--entries=$(location %s)" % table_entries if table_entries else ""),
+            ("--debug=$(location %s)" % smt_output_file),
+            ("&> $(location %s)" % test_output_file),
+        ]),
+    )
+
+    # Exact diff test for the packet output file.
+    diff_test(
+        name = output_test_name,
+        actual = test_output_file,
+        expected = output_golden_file,
+    )
+
+    # Group tests into a test_suite with the given name.
+    # This is just to make the provided name alias to something.
+    native.test_suite(
+        name = name,
+        tests = [
+            (":%s" % output_test_name),
+        ],
+    )

--- a/p4_symbolic/symbolic/util.cc
+++ b/p4_symbolic/symbolic/util.cc
@@ -1,0 +1,177 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Helpful utilities for managing symbolic and concrete headers and values.
+
+#include "p4_symbolic/symbolic/util.h"
+
+#include <string>
+
+#include "absl/strings/str_format.h"
+#include "p4_pdpi/utils/ir.h"
+#include "p4_symbolic/symbolic/operators.h"
+#include "p4_symbolic/symbolic/packet.h"
+
+namespace p4_symbolic {
+namespace symbolic {
+namespace util {
+
+namespace {
+
+bool Z3BooltoBool(Z3_lbool z3_bool) {
+  switch (z3_bool) {
+    case Z3_L_TRUE:
+      return true;
+    default:
+      return false;
+  }
+}
+
+}  // namespace
+
+absl::StatusOr<std::unordered_map<std::string, z3::expr>> FreeSymbolicHeaders(
+    const google::protobuf::Map<std::string, ir::HeaderType> &headers) {
+  // Loop over every header instance in the p4 program.
+  // Find its type, and loop over every field in it, creating a symbolic free
+  // variable for every field in every header instance.
+  std::unordered_map<std::string, z3::expr> symbolic_headers;
+  for (const auto &[header_name, header_type] : headers) {
+    // Special validity field.
+    std::string valid_field_name = absl::StrFormat("%s.$valid$", header_name);
+    z3::expr valid_expression =
+        Z3Context().bool_const(valid_field_name.c_str());
+    symbolic_headers.insert({valid_field_name, valid_expression});
+
+    // Regular fields defined in the p4 program or v1model.
+    for (const auto &[field_name, field] : header_type.fields()) {
+      if (field.signed_()) {
+        return absl::UnimplementedError(
+            "Negative header fields are not supported");
+      }
+
+      std::string field_full_name =
+          absl::StrFormat("%s.%s", header_name, field_name);
+      z3::expr field_expression =
+          Z3Context().bv_const(field_full_name.c_str(), field.bitwidth());
+      symbolic_headers.insert({field_full_name, field_expression});
+    }
+  }
+
+  // Finally, we have a special field marking if the packet represented by
+  // these headers was dropped.
+  symbolic_headers.insert({"$dropped$", Z3Context().bool_val(false)});
+  return symbolic_headers;
+}
+
+SymbolicTableMatch DefaultTableMatch() {
+  return {
+      Z3Context().bool_val(false),  // No match yet!
+      Z3Context().int_val(-1)       // No match index.
+  };
+}
+
+absl::StatusOr<ConcreteContext> ExtractFromModel(
+    SymbolicContext context, z3::model model,
+    const values::P4RuntimeTranslator &translator) {
+  // Extract ports.
+  std::string ingress_port = model.eval(context.ingress_port, true).to_string();
+  std::string egress_port = model.eval(context.egress_port, true).to_string();
+
+  // Extract an input packet and its predicted output.
+  ConcretePacket ingress_packet =
+      packet::ExtractConcretePacket(context.ingress_packet, model);
+  ConcretePacket egress_packet =
+      packet::ExtractConcretePacket(context.egress_packet, model);
+
+  // Extract the ingress and egress headers.
+  ConcretePerPacketState ingress_headers;
+  for (const auto &[name, expr] : context.ingress_headers) {
+    ASSIGN_OR_RETURN(ingress_headers[name],
+                     values::TranslateValueToP4RT(
+                         name, model.eval(expr, true).to_string(), translator));
+  }
+  ConcretePerPacketState egress_headers;
+  for (const auto &[name, expr] : context.egress_headers) {
+    ASSIGN_OR_RETURN(egress_headers[name],
+                     values::TranslateValueToP4RT(
+                         name, model.eval(expr, true).to_string(), translator));
+  }
+
+  // Extract the trace (matches on every table).
+  bool dropped =
+      Z3BooltoBool(model.eval(context.trace.dropped, true).bool_value());
+  std::unordered_map<std::string, ConcreteTableMatch> matches;
+  for (const auto &[table, match] : context.trace.matched_entries) {
+    matches[table] = {
+        Z3BooltoBool(model.eval(match.matched, true).bool_value()),
+        model.eval(match.entry_index, true).get_numeral_int()};
+  }
+  ConcreteTrace trace = {matches, dropped};
+
+  return ConcreteContext{ingress_port,  egress_port,     ingress_packet,
+                         egress_packet, ingress_headers, egress_headers,
+                         trace};
+}
+
+absl::StatusOr<SymbolicTrace> MergeTracesOnCondition(
+    const z3::expr &condition, const SymbolicTrace &true_trace,
+    const SymbolicTrace &false_trace) {
+  ASSIGN_OR_RETURN(
+      z3::expr merged_dropped,
+      operators::Ite(condition, true_trace.dropped, false_trace.dropped));
+
+  // The merged trace is initially empty.
+  SymbolicTrace merged = {{}, merged_dropped};
+
+  // Merge all tables matches in true_trace (including ones in both traces).
+  for (const auto &[name, true_match] : true_trace.matched_entries) {
+    // Find match in other trace (or use default).
+    SymbolicTableMatch false_match = DefaultTableMatch();
+    if (false_trace.matched_entries.count(name) > 0) {
+      false_match = false_trace.matched_entries.at(name);
+    }
+
+    // Merge this match.
+    ASSIGN_OR_RETURN(
+        z3::expr matched,
+        operators::Ite(condition, true_match.matched, false_match.matched));
+    ASSIGN_OR_RETURN(z3::expr index,
+                     operators::Ite(condition, true_match.entry_index,
+                                    false_match.entry_index));
+    merged.matched_entries.insert({name, {matched, index}});
+  }
+
+  // Merge all tables matches in false_trace only.
+  for (const auto &[name, false_match] : false_trace.matched_entries) {
+    SymbolicTableMatch true_match = DefaultTableMatch();
+    if (true_trace.matched_entries.count(name) > 0) {
+      continue;  // Already covered.
+    }
+
+    // Merge this match.
+    ASSIGN_OR_RETURN(
+        z3::expr matched,
+        operators::Ite(condition, true_match.matched, false_match.matched));
+    ASSIGN_OR_RETURN(z3::expr index,
+                     operators::Ite(condition, true_match.entry_index,
+                                    false_match.entry_index));
+    merged.matched_entries.insert({name, {matched, index}});
+  }
+
+  return merged;
+}
+
+}  // namespace util
+}  // namespace symbolic
+}  // namespace p4_symbolic

--- a/p4_symbolic/symbolic/util.h
+++ b/p4_symbolic/symbolic/util.h
@@ -1,0 +1,63 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Helpful utilities for managing symbolic and concrete headers and values.
+
+#ifndef P4_SYMBOLIC_SYMBOLIC_UTIL_H_
+#define P4_SYMBOLIC_SYMBOLIC_UTIL_H_
+
+#include <string>
+#include <unordered_map>
+
+#include "google/protobuf/map.h"
+#include "gutil/status.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4_symbolic/ir/ir.pb.h"
+#include "p4_symbolic/symbolic/symbolic.h"
+#include "p4_symbolic/symbolic/values.h"
+#include "z3++.h"
+
+namespace p4_symbolic {
+namespace symbolic {
+namespace util {
+
+// Free (unconstrained) symbolic headers consisting of free symbolic variables
+// for every field in every header instance defined in the P4 program.
+absl::StatusOr<std::unordered_map<std::string, z3::expr>> FreeSymbolicHeaders(
+    const google::protobuf::Map<std::string, ir::HeaderType> &headers);
+
+// Returns an symbolic table match containing default values.
+// The table match expression is false, the index is -1, and the value is
+// undefined.
+SymbolicTableMatch DefaultTableMatch();
+
+// Extract a concrete context by evaluating every component's corresponding
+// expression in the model.
+absl::StatusOr<ConcreteContext> ExtractFromModel(
+    SymbolicContext context, z3::model model,
+    const values::P4RuntimeTranslator &translator);
+
+// Merges two symbolic traces into a single trace. A field in the new trace
+// has the value of the changed trace if the condition is true, and the value
+// of the original one otherwise.
+// Assertion: both traces must contain matches for the same set of table names.
+absl::StatusOr<SymbolicTrace> MergeTracesOnCondition(
+    const z3::expr &condition, const SymbolicTrace &true_trace,
+    const SymbolicTrace &false_trace);
+
+}  // namespace util
+}  // namespace symbolic
+}  // namespace p4_symbolic
+
+#endif  // P4_SYMBOLIC_SYMBOLIC_UTIL_H_

--- a/p4_symbolic/testdata/BUILD.bazel
+++ b/p4_symbolic/testdata/BUILD.bazel
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test", "diff_test")
+load("//p4_pdpi:pdgen.bzl", "p4_pd_proto")
+load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
+
+# Make sure programs under p4-samples are visible to other
+# bazel packages.
+exports_files(
+    glob([
+        "**/*.p4",
+        "**/*.txt",
+    ]),
+    licenses = ["notice"],
+    visibility = ["//p4_symbolic:__subpackages__"],
+)

--- a/p4_symbolic/testdata/hardcoded/hardcoded.p4
+++ b/p4_symbolic/testdata/hardcoded/hardcoded.p4
@@ -1,0 +1,70 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* -*- P4_16 -*- */
+#include <core.p4>
+#include <v1model.p4>
+
+struct metadata {}
+struct headers {}
+
+parser UselessParser(packet_in packet,
+                out headers hdr,
+                inout metadata meta,
+                inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control UselessChecksum(inout headers hdr, inout metadata meta) {   
+    apply {  }
+}
+
+control UselessEgress(inout headers hdr,
+                 inout metadata meta,
+                 inout standard_metadata_t standard_metadata) {
+    apply { }
+}
+
+control UselessComputeChecksum(inout headers  hdr, inout metadata meta) {
+    apply { }
+}
+
+control UselessDeparser(packet_out packet, in headers hdr) {
+    apply { }
+}
+
+// Forwarding Code
+control MyIngress(inout headers hdr,
+                  inout metadata meta,
+                  inout standard_metadata_t standard_metadata) {    
+    apply {
+        if (standard_metadata.ingress_port == 0) {
+            standard_metadata.egress_spec = 1;
+        } else {
+            standard_metadata.egress_spec = 0;
+        }
+    }
+}
+
+// Switch
+V1Switch(
+    UselessParser(),
+    UselessChecksum(),
+    MyIngress(),
+    UselessEgress(),
+    UselessComputeChecksum(),
+    UselessDeparser()
+) main;


### PR DESCRIPTION
/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/Tools/keyword_checks.sh .
Keyword check Passed.



/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
DEBUG: Rule 'sonic_swss_common' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "fbd1f2ef83af06af744491253a66315b8bfe64227e19f0357c2fb560a8da57f0"
DEBUG: Repository sonic_swss_common instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:19:16: in <toplevel>
  /sonic/src/sonic-p4rt/sonic-pins/pins_infra_deps.bzl:239:21: in pins_infra_deps
Repository rule http_archive defined at:
  /var/vsurya/.cache/bazel/_bazel_vsurya/5fd88bad78ef03829a4685c83637a020/external/bazel_tools/tools/build_defs/repo/http.bzl:353:31: in <toplevel>
INFO: Analyzed 435 targets (0 packages loaded, 0 targets configured).
INFO: Found 435 targets...
INFO: Elapsed time: 36.294s, Critical Path: 22.75s
INFO: 61 processes: 37 internal, 24 linux-sandbox.
INFO: Build completed successfully, 61 total actions




/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
INFO: Build options --copt, --cxxopt, --host_copt, and 1 more have changed, discarding analysis cache.
DEBUG: Rule 'sonic_swss_common' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "fbd1f2ef83af06af744491253a66315b8bfe64227e19f0357c2fb560a8da57f0"
DEBUG: Repository sonic_swss_common instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:19:16: in <toplevel>
  /sonic/src/sonic-p4rt/sonic-pins/pins_infra_deps.bzl:239:21: in pins_infra_deps
Repository rule http_archive defined at:
  /var/vsurya/.cache/bazel/_bazel_vsurya/5fd88bad78ef03829a4685c83637a020/external/bazel_tools/tools/build_defs/repo/http.bzl:353:31: in <toplevel>
INFO: Analyzed 435 targets (0 packages loaded, 19949 targets configured).
INFO: Found 279 targets and 156 test targets...
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.0s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.0s

Executed 4 out of 156 tests: 156 tests pass.
INFO: Build completed successfully, 2528 total actions
