### PR TITLE
[P4-Symbolic] Adding BUILD.bazel, pdpi_driver.cc, pdpi_driver.h files to p4_symbolic/ir

### DIFF
--- a/p4_symbolic/ir/BUILD.bazel
+++ b/p4_symbolic/ir/BUILD.bazel
@@ -1,0 +1,38 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test", "diff_test")
+load("//p4_pdpi:pdgen.bzl", "p4_pd_proto")
+load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
+load("//p4_symbolic/ir:test.bzl", "ir_parsing_test")
+
+package(licenses = ["notice"])
+
+cc_library(
+    name = "pdpi_driver",
+    srcs = [
+        "pdpi_driver.cc",
+    ],
+    hdrs = [
+        "pdpi_driver.h",
+    ],
+    visibility = ["//p4_symbolic:__subpackages__"],
+    deps = [
+        "//gutil:proto",
+        "//gutil:status",
+        "//p4_pdpi:ir",
+        "//p4_pdpi:ir_cc_proto",
+    ],
+)

--- a/p4_symbolic/ir/pdpi_driver.cc
+++ b/p4_symbolic/ir/pdpi_driver.cc
@@ -1,0 +1,32 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "p4_symbolic/ir/pdpi_driver.h"
+
+#include <memory>
+
+#include "gutil/proto.h"
+#include "p4_pdpi/ir.h"
+
+namespace p4_symbolic {
+namespace ir {
+
+absl::StatusOr<pdpi::IrP4Info> ParseP4InfoFile(const std::string &p4info_path) {
+  p4::config::v1::P4Info p4info;
+  RETURN_IF_ERROR(gutil::ReadProtoFromFile(p4info_path.c_str(), &p4info));
+  return pdpi::CreateIrP4Info(p4info);
+}
+
+}  // namespace ir
+}  // namespace p4_symbolic

--- a/p4_symbolic/ir/pdpi_driver.h
+++ b/p4_symbolic/ir/pdpi_driver.h
@@ -1,0 +1,35 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef P4_SYMBOLIC_IR_PDPI_DRIVER_H_
+#define P4_SYMBOLIC_IR_PDPI_DRIVER_H_
+
+#include <string>
+
+#include "gutil/status.h"
+#include "p4_pdpi/ir.pb.h"
+
+namespace p4_symbolic {
+namespace ir {
+
+// Parses the p4info file given by "p4info_path" into a pdpi:IrP4Info
+// instance.
+// Returns the parsed IrP4Info instance, or an appropriate failure status
+// in case of a badly formatted input file, or if the file does not exist.
+absl::StatusOr<pdpi::IrP4Info> ParseP4InfoFile(const std::string &p4info_path);
+
+}  // namespace ir
+}  // namespace p4_symbolic
+
+#endif  // P4_SYMBOLIC_IR_PDPI_DRIVER_H_


### PR DESCRIPTION
/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/Tools/keyword_checks.sh .
Keyword check Passed.


/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...          

2024/09/10 06:06:05 Downloading https://releases.bazel.build/5.1.0/release/bazel-5.1.0-linux-x86_64...
Downloading: 49 MB out of 49 MB (100%) 
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
DEBUG: Rule 'com_github_nelhage_rules_boost' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1619053724 -0700"
DEBUG: Repository com_github_nelhage_rules_boost instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:75:9: in <toplevel>
In file included from p4rt_app/tests/port_name_and_id_test.cc:29:
./p4_pdpi/p4_runtime_session.h:360:49: note: declared here
  360 | absl::StatusOr<std::vector<p4::v1::TableEntry>> ReadPiTableEntries(
      |                                                 ^~~~~~~~~~~~~~~~~~
INFO: Elapsed time: 5595.013s, Critical Path: 225.10s
INFO: 9149 processes: 2728 internal, 6421 linux-sandbox.
INFO: Build completed successfully, 9149 total actions



/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...

DEBUG: Rule 'com_github_nelhage_rules_boost' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1619053724 -0700"
DEBUG: Repository com_github_nelhage_rules_boost instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:75:9: in <toplevel>
  /var/vsurya/.cache/bazel/_bazel_vsurya/5fd88bad78ef03829a4685c83637a020/external/com_github_p4lang_p4c/bazel/p4c_deps.bzl:25:23: in p4c_deps
Repository rule git_repository defined at:
  /var/vsurya/.cache/bazel/_bazel_vsurya/5fd88bad78ef03829a4685c83637a020/external/bazel_tools/tools/build_defs/repo/git.bzl:199:33: in <toplevel>
DEBUG: Rule 'sonic_swss_common' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "fbd1f2ef83af06af744491253a66315b8bfe64227e19f0357c2fb560a8da57f0"
DEBUG: Repository sonic_swss_common instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:19:16: in <toplevel>
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 22.0s
  Stats over 5 runs: max = 22.0s, min = 2.2s, avg = 12.9s, dev = 6.3s

Executed 148 out of 148 tests: 148 tests pass.
INFO: Build completed successfully, 153 total actions
