### PR TITLE
[SAIP4] Add tunnel encap support & Align SAI P4 naming more closely to SAI.

### DIFF
--- a/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
@@ -226,6 +226,33 @@ tables {
 }
 tables {
   preamble {
+    id: 33554512
+    name: "ingress.routing.tunnel_table"
+    alias: "tunnel_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "tunnel_id"
+    match_type: EXACT
+    type_name {
+      name: "tunnel_id_t"
+    }
+  }
+  action_refs {
+    id: 16777235
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 512
+}
+tables {
+  preamble {
     id: 33554498
     name: "ingress.routing.nexthop_table"
     alias: "nexthop_table"
@@ -240,12 +267,12 @@ tables {
     }
   }
   action_refs {
-    id: 16777219
+    id: 16777236
     annotations: "@proto_id(1)"
   }
   action_refs {
-    id: 16777236
-    annotations: "@proto_id(3)"
+    id: 16777234
+    annotations: "@proto_id(2)"
   }
   action_refs {
     id: 21257015
@@ -875,6 +902,34 @@ actions {
 }
 actions {
   preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
+  }
+}
+actions {
+  preamble {
     id: 16777236
     name: "ingress.routing.set_ip_nexthop"
     alias: "set_ip_nexthop"
@@ -898,26 +953,17 @@ actions {
 }
 actions {
   preamble {
-    id: 16777219
-    name: "ingress.routing.set_nexthop"
-    alias: "set_nexthop"
-    annotations: "@deprecated(\"Use set_ip_nexthop instead.\")"
+    id: 16777234
+    name: "ingress.routing.set_p2p_tunnel_encap_nexthop"
+    alias: "set_p2p_tunnel_encap_nexthop"
   }
   params {
     id: 1
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    name: "tunnel_id"
+    annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
-      name: "router_interface_id_t"
+      name: "tunnel_id_t"
     }
-  }
-  params {
-    id: 2
-    name: "neighbor_id"
-    annotations: "@format(IPV6_ADDRESS)"
-    annotations: "@refers_to(neighbor_table , neighbor_id)"
-    bitwidth: 128
   }
 }
 actions {
@@ -1307,6 +1353,15 @@ type_info {
   }
   new_types {
     key: "router_interface_id_t"
+    value {
+      translated_type {
+        sdn_string {
+        }
+      }
+    }
+  }
+  new_types {
+    key: "tunnel_id_t"
     value {
       translated_type {
         sdn_string {

--- a/sai_p4/instantiations/google/middleblock.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock.p4info.pb.txt
@@ -226,6 +226,33 @@ tables {
 }
 tables {
   preamble {
+    id: 33554512
+    name: "ingress.routing.tunnel_table"
+    alias: "tunnel_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "tunnel_id"
+    match_type: EXACT
+    type_name {
+      name: "tunnel_id_t"
+    }
+  }
+  action_refs {
+    id: 16777235
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 512
+}
+tables {
+  preamble {
     id: 33554498
     name: "ingress.routing.nexthop_table"
     alias: "nexthop_table"
@@ -240,12 +267,12 @@ tables {
     }
   }
   action_refs {
-    id: 16777219
+    id: 16777236
     annotations: "@proto_id(1)"
   }
   action_refs {
-    id: 16777236
-    annotations: "@proto_id(3)"
+    id: 16777234
+    annotations: "@proto_id(2)"
   }
   action_refs {
     id: 21257015
@@ -797,6 +824,34 @@ actions {
 }
 actions {
   preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
+  }
+}
+actions {
+  preamble {
     id: 16777236
     name: "ingress.routing.set_ip_nexthop"
     alias: "set_ip_nexthop"
@@ -820,26 +875,17 @@ actions {
 }
 actions {
   preamble {
-    id: 16777219
-    name: "ingress.routing.set_nexthop"
-    alias: "set_nexthop"
-    annotations: "@deprecated(\"Use set_ip_nexthop instead.\")"
+    id: 16777234
+    name: "ingress.routing.set_p2p_tunnel_encap_nexthop"
+    alias: "set_p2p_tunnel_encap_nexthop"
   }
   params {
     id: 1
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    name: "tunnel_id"
+    annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
-      name: "router_interface_id_t"
+      name: "tunnel_id_t"
     }
-  }
-  params {
-    id: 2
-    name: "neighbor_id"
-    annotations: "@format(IPV6_ADDRESS)"
-    annotations: "@refers_to(neighbor_table , neighbor_id)"
-    bitwidth: 128
   }
 }
 actions {
@@ -1206,6 +1252,15 @@ type_info {
   }
   new_types {
     key: "router_interface_id_t"
+    value {
+      translated_type {
+        sdn_string {
+        }
+      }
+    }
+  }
+  new_types {
+    key: "tunnel_id_t"
     value {
       translated_type {
         sdn_string {

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -300,6 +300,33 @@ tables {
 }
 tables {
   preamble {
+    id: 33554512
+    name: "ingress.routing.tunnel_table"
+    alias: "tunnel_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "tunnel_id"
+    match_type: EXACT
+    type_name {
+      name: "tunnel_id_t"
+    }
+  }
+  action_refs {
+    id: 16777235
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 512
+}
+tables {
+  preamble {
     id: 33554498
     name: "ingress.routing.nexthop_table"
     alias: "nexthop_table"
@@ -314,12 +341,12 @@ tables {
     }
   }
   action_refs {
-    id: 16777219
+    id: 16777236
     annotations: "@proto_id(1)"
   }
   action_refs {
-    id: 16777236
-    annotations: "@proto_id(3)"
+    id: 16777234
+    annotations: "@proto_id(2)"
   }
   action_refs {
     id: 21257015
@@ -1072,6 +1099,34 @@ actions {
 }
 actions {
   preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
+  }
+}
+actions {
+  preamble {
     id: 16777236
     name: "ingress.routing.set_ip_nexthop"
     alias: "set_ip_nexthop"
@@ -1095,26 +1150,17 @@ actions {
 }
 actions {
   preamble {
-    id: 16777219
-    name: "ingress.routing.set_nexthop"
-    alias: "set_nexthop"
-    annotations: "@deprecated(\"Use set_ip_nexthop instead.\")"
+    id: 16777234
+    name: "ingress.routing.set_p2p_tunnel_encap_nexthop"
+    alias: "set_p2p_tunnel_encap_nexthop"
   }
   params {
     id: 1
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    name: "tunnel_id"
+    annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
-      name: "router_interface_id_t"
+      name: "tunnel_id_t"
     }
-  }
-  params {
-    id: 2
-    name: "neighbor_id"
-    annotations: "@format(IPV6_ADDRESS)"
-    annotations: "@refers_to(neighbor_table , neighbor_id)"
-    bitwidth: 128
   }
 }
 actions {
@@ -1553,6 +1599,15 @@ type_info {
   }
   new_types {
     key: "router_interface_id_t"
+    value {
+      translated_type {
+        sdn_string {
+        }
+      }
+    }
+  }
+  new_types {
+    key: "tunnel_id_t"
     value {
       translated_type {
         sdn_string {

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -226,6 +226,33 @@ tables {
 }
 tables {
   preamble {
+    id: 33554512
+    name: "ingress.routing.tunnel_table"
+    alias: "tunnel_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "tunnel_id"
+    match_type: EXACT
+    type_name {
+      name: "tunnel_id_t"
+    }
+  }
+  action_refs {
+    id: 16777235
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 512
+}
+tables {
+  preamble {
     id: 33554498
     name: "ingress.routing.nexthop_table"
     alias: "nexthop_table"
@@ -240,12 +267,12 @@ tables {
     }
   }
   action_refs {
-    id: 16777219
+    id: 16777236
     annotations: "@proto_id(1)"
   }
   action_refs {
-    id: 16777236
-    annotations: "@proto_id(3)"
+    id: 16777234
+    annotations: "@proto_id(2)"
   }
   action_refs {
     id: 21257015
@@ -1332,6 +1359,34 @@ actions {
 }
 actions {
   preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
+  }
+}
+actions {
+  preamble {
     id: 16777236
     name: "ingress.routing.set_ip_nexthop"
     alias: "set_ip_nexthop"
@@ -1355,26 +1410,17 @@ actions {
 }
 actions {
   preamble {
-    id: 16777219
-    name: "ingress.routing.set_nexthop"
-    alias: "set_nexthop"
-    annotations: "@deprecated(\"Use set_ip_nexthop instead.\")"
+    id: 16777234
+    name: "ingress.routing.set_p2p_tunnel_encap_nexthop"
+    alias: "set_p2p_tunnel_encap_nexthop"
   }
   params {
     id: 1
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    name: "tunnel_id"
+    annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
-      name: "router_interface_id_t"
+      name: "tunnel_id_t"
     }
-  }
-  params {
-    id: 2
-    name: "neighbor_id"
-    annotations: "@format(IPV6_ADDRESS)"
-    annotations: "@refers_to(neighbor_table , neighbor_id)"
-    bitwidth: 128
   }
 }
 actions {
@@ -1949,6 +1995,15 @@ type_info {
   }
   new_types {
     key: "router_interface_id_t"
+    value {
+      translated_type {
+        sdn_string {
+        }
+      }
+    }
+  }
+  new_types {
+    key: "tunnel_id_t"
     value {
       translated_type {
         sdn_string {


### PR DESCRIPTION
### Keyword Check:
sdivya@eonms6vm1:~/sonic_sep6/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/key.sh .
Keyword check Passed.

### Build Results:
divya@ddb4b377439b:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 410 targets (0 packages loaded, 0 targets configured).
INFO: Found 410 targets...
...
INFO: Elapsed time: 113.033s, Critical Path: 54.22s
INFO: 106 processes: 6 internal, 100 linux-sandbox.
INFO: Build completed successfully, 106 total actions

### Test Results:
divya@ddb4b377439b:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 410 targets (0 packages loaded, 302 targets configured).
INFO: Found 262 targets and 148 test targets...
INFO: Elapsed time: 92.581s, Critical Path: 25.82s
INFO: 153 processes: 163 linux-sandbox, 18 local.
INFO: Build completed successfully, 153 total actions
//gutil:collections_test PASSED in 0.5s
//gutil:io_test PASSED in 0.5s
//gutil:proto_matchers_test PASSED in 0.6s
//gutil:proto_ordering_test PASSED in 0.6s
//gutil:proto_test PASSED in 0.5s
//gutil:status_matchers_test PASSED in 0.4s
//gutil:test_artifact_writer_test PASSED in 0.5s
//gutil:testing_test PASSED in 0.6s
//gutil:timer_test PASSED in 5.0s
//gutil:version_test PASSED in 0.7s
//lib:basic_switch_test PASSED in 0.8s
//lib:ixia_helper_test PASSED in 1.1s
//lib/basic_traffic:basic_p4rt_util_test PASSED in 0.9s
//lib/basic_traffic:basic_traffic_test PASSED in 14.9s
//lib/gnmi:gnmi_helper_test PASSED in 2.8s
//lib/gnoi:gnoi_helper_test PASSED in 0.4s
//lib/p4rt:p4rt_port_test PASSED in 0.4s
//lib/p4rt:p4rt_programming_context_test PASSED in 0.7s
//lib/utils:generic_testbed_utils_test PASSED in 1.1s
//lib/utils:json_utils_test PASSED in 0.5s
//lib/validator:validator_backend_test PASSED in 0.5s
//lib/validator:validator_lib_test PASSED in 25.8s
//p4_fuzzer:constraints_util_integration_test PASSED in 0.6s
//p4_fuzzer:fuzz_util_test PASSED in 0.6s
//p4_fuzzer:fuzzer_showcase_test PASSED in 1.0s
//p4_fuzzer:oracle_util_test PASSED in 0.6s
//p4_fuzzer:switch_state_test PASSED in 0.6s
//p4_fuzzer:table_entry_key_test PASSED in 0.1s
//p4_pdpi:built_ins_test PASSED in 0.5s
//p4_pdpi:entity_keys_test PASSED in 0.5s
//p4_pdpi:ir_properties_test PASSED in 0.7s
//p4_pdpi:ir_to_ir_test PASSED in 0.6s
//p4_pdpi:ir_tools_test PASSED in 0.6s
//p4_pdpi:names_test PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test PASSED in 0.6s
//p4_pdpi:reference_annotations_test PASSED in 0.7s
//p4_pdpi:references_test PASSED in 0.8s
//p4_pdpi:sequencing_util_test PASSED in 0.5s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test PASSED in 1.8s
//p4_pdpi/packetlib:packetlib_fuzzer_test PASSED in 16.2s
//p4_pdpi/packetlib:packetlib_matchers_test PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_unit_test PASSED in 1.9s
//p4_pdpi/string_encodings:bit_string_test PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test PASSED in 0.6s
//p4_pdpi/string_encodings:decimal_string_test PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test PASSED in 0.5s
//p4_pdpi/testing:helper_function_test PASSED in 0.7s
//p4_pdpi/testing:info_test PASSED in 0.1s
//p4_pdpi/testing:info_test_runner PASSED in 0.1s
//p4_pdpi/testing:main_pd_test PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test PASSED in 1.6s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.1s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.1s
//p4_pdpi/testing:packet_io_test PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner PASSED in 0.1s
//p4_pdpi/testing:references_test PASSED in 0.2s
//p4_pdpi/testing:references_test_runner PASSED in 0.1s
//p4_pdpi/testing:rpc_test PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_test PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner PASSED in 0.0s
//p4_pdpi/testing:table_entry_gunit_test PASSED in 0.7s
//p4_pdpi/testing:table_entry_test PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test PASSED in 0.4s
//p4_pdpi/utils:ir_test PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.8s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test PASSED in 1.0s
//p4rt_app/event_monitoring:debug_data_dump_events_test PASSED in 0.8s
//p4rt_app/event_monitoring:state_verification_events_test PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test PASSED in 1.4s
//p4rt_app/p4runtime:ir_translation_test PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test PASSED in 0.8s
//p4rt_app/p4runtime:packetio_helpers_test PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test PASSED in 0.7s
//p4rt_app/sonic:app_db_acl_def_table_manager_test PASSED in 0.8s
//p4rt_app/sonic:app_db_manager_test PASSED in 0.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test PASSED in 0.9s
//p4rt_app/sonic:hashing_test PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test PASSED in 0.5s
//p4rt_app/sonic:packetio_port_test PASSED in 0.5s
//p4rt_app/sonic:response_handler_test PASSED in 0.6s
//p4rt_app/sonic:state_verification_test PASSED in 0.6s
//p4rt_app/sonic:vrf_entry_translation_test PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test PASSED in 0.0s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test PASSED in 0.0s
//p4rt_app/tests:acl_table_test PASSED in 1.3s
//p4rt_app/tests:action_set_test PASSED in 1.1s
//p4rt_app/tests:api_access_test PASSED in 0.9s
//p4rt_app/tests:arbitration_test PASSED in 1.0s
//p4rt_app/tests:cpu_queue_name_and_id_test PASSED in 1.6s
//p4rt_app/tests:debug_data_dump_test PASSED in 1.0s
//p4rt_app/tests:fixed_l3_tables_test PASSED in 2.5s
//p4rt_app/tests:forwarding_pipeline_config_test PASSED in 3.8s
//p4rt_app/tests:grpc_behavior_test PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test PASSED in 0.4s
//p4rt_app/tests:p4_constraints_test_runner PASSED in 0.2s
//p4rt_app/tests:p4_programs_test PASSED in 1.5s
//p4rt_app/tests:packet_replication_table_test PASSED in 1.7s
//p4rt_app/tests:packetio_test PASSED in 3.6s
//p4rt_app/tests:port_name_and_id_test PASSED in 2.3s
//p4rt_app/tests:resource_limits_test PASSED in 3.6s
//p4rt_app/tests:response_path_test PASSED in 2.8s
//p4rt_app/tests:role_test PASSED in 1.2s
//p4rt_app/tests:state_verification_test PASSED in 1.8s
//p4rt_app/tests:vrf_table_test PASSED in 1.5s
//p4rt_app/tests/lib:app_db_entry_builder_test PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test PASSED in 0.0s
//p4rt_app/utils:table_utility_test PASSED in 0.6s
//sai_p4/instantiations/google:clos_stage_test PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test PASSED in 0.8s
//sai_p4/instantiations/google:sai_pd_proto_test PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.1s
//sai_p4/instantiations/google/test_tools:test_entries_test PASSED in 1.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test PASSED in 0.7s
//sai_p4/tools:p4info_tools_test PASSED in 0.5s
//sai_p4/tools:packetio_tools_test PASSED in 0.7s
//thinkit:bazel_test_environment_test PASSED in 0.5s
//thinkit:generic_testbed_test PASSED in 0.8s
//thinkit:mock_control_device_test PASSED in 0.5s
//thinkit:mock_generic_testbed_test PASSED in 0.6s
//thinkit:mock_mirror_testbed_test PASSED in 0.8s
//thinkit:mock_ssh_client_test PASSED in 0.1s
//thinkit:mock_switch_test PASSED in 0.6s
//thinkit:mock_test_environment_test PASSED in 0.1s
//thinkit:switch_test PASSED in 0.6s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test PASSED in 12.7s
Stats over 5 runs: max = 12.7s, min = 1.2s, avg = 8.4s, dev = 5.0s

Executed 148 out of 148 tests: 148 tests pass.
INFO: Build completed successfully, 153 total actions
divya@ddb4b377439b:/sonic/src/sonic-p4rt/sonic-pins$