### PR TITLE
[SAIP4] Create and implement set_ip_nexthop_and_disable_rewrites action in P4.

### DIFF
--- a/sai_p4/fixed/ids.h
+++ b/sai_p4/fixed/ids.h
@@ -37,6 +37,8 @@
 #define ROUTING_SET_WCMP_GROUP_ID_ACTION_ID 0x01000004               // 16777220
 #define ROUTING_SET_WCMP_GROUP_ID_AND_METADATA_ACTION_ID 0x01000011  // 16777233
 #define ROUTING_SET_NEXTHOP_ID_ACTION_ID 0x01000005                  // 16777221
+// 16777239
+#define ROUTING_SET_IP_NEXTHOP_AND_DISABLE_REWRITES_ACTION_ID 0x01000017
 #define ROUTING_SET_NEXTHOP_ID_AND_METADATA_ACTION_ID 0x01000010     // 16777232
 #define ROUTING_DROP_ACTION_ID 0x01000006                            // 16777222
 #define ROUTING_SET_P2P_TUNNEL_ENCAP_NEXTHOP_ACTION_ID 0x01000012    // 16777234
@@ -52,7 +54,7 @@
 #define TRAP_ACTION_ID 0x0100000F                                    // 16777231
 #define ROUTING_SET_METADATA_AND_DROP_ACTION_ID 0x01000015           // 16777237
 #define MARK_FOR_TUNNEL_DECAP_AND_SET_VRF_ACTION_ID 0x01000016       // 16777238
-// Next available action id: 0x01000017 (16777239)
+// Next available action id: 0x01000018 (16777240)
 
 // --- Action Profiles and Selectors (8 most significant bits = 0x11) ----------
 // This value should ideally be 0x11000001, but we currently have this value for

--- a/sai_p4/fixed/metadata.p4
+++ b/sai_p4/fixed/metadata.p4
@@ -197,7 +197,13 @@ struct local_metadata_t {
   bool vlan_id_valid;  // True iff `vlan_id` is valid.
   bool admit_to_l3;
   vrf_id_t vrf_id;
+
+  // Rewrite related fields.
+  bool enable_ttl_rewrite;
+  bool enable_src_mac_rewrite;
+  bool enable_dst_mac_rewrite;
   packet_rewrites_t packet_rewrites;
+
   bit<16> l4_src_port;
   bit<16> l4_dst_port;
   bit<WCMP_SELECTOR_INPUT_BITWIDTH> wcmp_selector_input;

--- a/sai_p4/fixed/parser.p4
+++ b/sai_p4/fixed/parser.p4
@@ -13,6 +13,9 @@ parser packet_parser(packet_in packet, out headers_t headers,
     // Initialize local metadata fields.
     local_metadata.admit_to_l3 = false;
     local_metadata.vrf_id = kDefaultVrf;
+    local_metadata.enable_ttl_rewrite = false;
+    local_metadata.enable_src_mac_rewrite = false;
+    local_metadata.enable_dst_mac_rewrite = false;
     local_metadata.packet_rewrites.src_mac = 0;
     local_metadata.packet_rewrites.dst_mac = 0;
     local_metadata.l4_src_port = 0;

--- a/sai_p4/fixed/routing.p4
+++ b/sai_p4/fixed/routing.p4
@@ -106,46 +106,39 @@ control routing(in headers_t headers,
     size = ROUTER_INTERFACE_TABLE_MINIMUM_GUARANTEED_SIZE;
   }
 
-  // Sets SAI_TUNNEL_ATTR_TYPE to SAI_TUNNEL_TYPE_IPINIP_GRE,
-  // SAI_TUNNEL_PEER_MODE to SAI_TUNNEL_PEER_MODE_P2P and
-  // also sets SAI_TUNNEL_ATTR_ENCAP_SRC_IP, SAI_TUNNEL_ATTR_ENCAP_DST_IP
-  // and SAI_TUNNEL_ATTR_UNDERLAY_INTERFACE.
-  //
-  // Because we are using P2P tunnels, this action requires an `encap_dst_ip`,
-  // which will also be the `neighbor_id` of an associated `neighbor_table`
-  // entry.
-  @id(ROUTING_MARK_FOR_P2P_TUNNEL_ENCAP_ACTION_ID)
-  action mark_for_p2p_tunnel_encap(@id(1) @format(IPV6_ADDRESS)
-                              ipv6_addr_t encap_src_ip,
-                              @id(2) @format(IPV6_ADDRESS)
-                              @refers_to(neighbor_table, neighbor_id)
-                              ipv6_addr_t encap_dst_ip,
-                              @id(3)
-                              @refers_to(router_interface_table,
-                              router_interface_id)
-                              router_interface_id_t router_interface_id) {
-    local_metadata.tunnel_encap_src_ipv6 = encap_src_ip;
-    local_metadata.tunnel_encap_dst_ipv6 = encap_dst_ip;
-    local_metadata.apply_tunnel_encap_at_egress = true;
+  // Sets SAI_NEXT_HOP_ATTR_TYPE to SAI_NEXT_HOP_TYPE_IP. Also sets
+  // SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID, SAI_NEXT_HOP_ATTR_IP,
+  // SAI_NEXT_HOP_ATTR_DISABLE_SRC_MAC_REWRITE,
+  // SAI_NEXT_HOP_ATTR_DISABLE_DST_MAC_REWRITE,
+  // SAI_NEXT_HOP_ATTR_DISABLE_DECREMENT_TTL and
+  // SAI_NEXT_HOP_ATTR_DISABLE_VLAN_REWRITE based on action parameters.
+  // TODO Remove unsupported annotation once the switch stack
+  // supports this action.
+  @unsupported
+  @id(ROUTING_SET_IP_NEXTHOP_AND_DISABLE_REWRITES_ACTION_ID)
+  action set_ip_nexthop_and_disable_rewrites(
+      @id(1)
+      @refers_to(router_interface_table,
+      router_interface_id)
+      @refers_to(neighbor_table, router_interface_id)
+      router_interface_id_t router_interface_id,
+      @id(2) @format(IPV6_ADDRESS)
+      @refers_to(neighbor_table, neighbor_id)
+      ipv6_addr_t neighbor_id,
+      // TODO: Use @format(BOOL) once PDPI
+      // supports it.
+      @id(3) bit<1> disable_ttl_rewrite,
+      @id(4) bit<1> disable_src_mac_rewrite,
+      @id(5) bit<1> disable_dst_mac_rewrite,
+      // TODO: Implement disable_vlan_rewrite.
+      @id(6) bit<1> disable_vlan_rewrite) {
     router_interface_id_valid = true;
     router_interface_id_value = router_interface_id;
     neighbor_id_valid = true;
-    neighbor_id_value = encap_dst_ip;
-  }
-
-  @p4runtime_role(P4RUNTIME_ROLE_ROUTING)
-  @id(ROUTING_TUNNEL_TABLE_ID)
-  table tunnel_table {
-    key = {
-      tunnel_id_value : exact @id(1)
-                              @name("tunnel_id");
-    }
-    actions = {
-      @proto_id(1) mark_for_p2p_tunnel_encap;
-      @defaultonly NoAction;
-    }
-    const default_action = NoAction;
-    size = ROUTING_TUNNEL_TABLE_MINIMUM_GUARANTEED_SIZE;
+    neighbor_id_value = neighbor_id;
+    local_metadata.enable_ttl_rewrite = !(bool) disable_ttl_rewrite;
+    local_metadata.enable_src_mac_rewrite = !(bool) disable_src_mac_rewrite;
+    local_metadata.enable_dst_mac_rewrite = !(bool) disable_dst_mac_rewrite;
   }
 
   // Sets SAI_NEXT_HOP_ATTR_TYPE to SAI_NEXT_HOP_TYPE_IP, and
@@ -161,30 +154,31 @@ control routing(in headers_t headers,
   // two match fields in neighbor_table. This is still correct, but less
   // precise.
   @id(ROUTING_SET_IP_NEXTHOP_ACTION_ID)
-  action set_ip_nexthop(@id(1)
-                        @refers_to(router_interface_table, router_interface_id)
-                        @refers_to(neighbor_table, router_interface_id)
-                        router_interface_id_t router_interface_id,
-                        @id(2) @format(IPV6_ADDRESS)
-                        @refers_to(neighbor_table, neighbor_id)
-                        ipv6_addr_t neighbor_id) {
-    router_interface_id_valid = true;
-    router_interface_id_value = router_interface_id;
-    neighbor_id_valid = true;
-    neighbor_id_value = neighbor_id;
+  action set_ip_nexthop(
+      @id(1)
+      @refers_to(router_interface_table, router_interface_id)
+      @refers_to(neighbor_table, router_interface_id)
+      router_interface_id_t router_interface_id,
+      @id(2) @format(IPV6_ADDRESS)
+      @refers_to(neighbor_table, neighbor_id)
+      ipv6_addr_t neighbor_id) {
+    set_ip_nexthop_and_disable_rewrites(router_interface_id, neighbor_id,
+      /*disable_ttl_rewrite*/0x0, /*disable_src_mac_rewrite*/0x0,
+      /*disable_dst_mac_rewrite*/0x0, /*disable_vlan_rewrite*/0x0);
   }
 
   @id(ROUTING_SET_NEXTHOP_ACTION_ID)
   @deprecated("Use set_ip_nexthop instead.")
   // TODO: Remove this action once migration to `set_ip_nexthop`
   // is complete & rolled out.
-  action set_nexthop(@id(1)
-                     @refers_to(router_interface_table, router_interface_id)
-                     @refers_to(neighbor_table, router_interface_id)
-                     router_interface_id_t router_interface_id,
-                     @id(2)  @format(IPV6_ADDRESS)
-                     @refers_to(neighbor_table, neighbor_id)
-                     ipv6_addr_t neighbor_id) {
+  action set_nexthop(
+      @id(1)
+      @refers_to(router_interface_table, router_interface_id)
+      @refers_to(neighbor_table, router_interface_id)
+      router_interface_id_t router_interface_id,
+      @id(2)  @format(IPV6_ADDRESS)
+      @refers_to(neighbor_table, neighbor_id)
+      ipv6_addr_t neighbor_id) {
     set_ip_nexthop(router_interface_id, neighbor_id);
   }
 
@@ -212,10 +206,50 @@ control routing(in headers_t headers,
     actions = {
       @proto_id(1) set_ip_nexthop;
       @proto_id(2) set_p2p_tunnel_encap_nexthop;
+      @proto_id(3) set_ip_nexthop_and_disable_rewrites;
       @defaultonly NoAction;
     }
     const default_action = NoAction;
     size = NEXTHOP_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  // Sets SAI_TUNNEL_ATTR_TYPE to SAI_TUNNEL_TYPE_IPINIP_GRE,
+  // SAI_TUNNEL_PEER_MODE to SAI_TUNNEL_PEER_MODE_P2P and
+  // also sets SAI_TUNNEL_ATTR_ENCAP_SRC_IP, SAI_TUNNEL_ATTR_ENCAP_DST_IP
+  // and SAI_TUNNEL_ATTR_UNDERLAY_INTERFACE.
+  //
+  // Because we are using P2P tunnels, this action requires an `encap_dst_ip`,
+  // which will also be the `neighbor_id` of an associated `neighbor_table`
+  // entry.
+  @id(ROUTING_MARK_FOR_P2P_TUNNEL_ENCAP_ACTION_ID)
+  action mark_for_p2p_tunnel_encap(
+      @id(1) @format(IPV6_ADDRESS)
+      ipv6_addr_t encap_src_ip,
+      @id(2) @format(IPV6_ADDRESS)
+      @refers_to(neighbor_table, neighbor_id)
+      ipv6_addr_t encap_dst_ip,
+      @id(3) @refers_to(neighbor_table, router_interface_id)
+      @refers_to(router_interface_table, router_interface_id)
+      router_interface_id_t router_interface_id) {
+    local_metadata.tunnel_encap_src_ipv6 = encap_src_ip;
+    local_metadata.tunnel_encap_dst_ipv6 = encap_dst_ip;
+    local_metadata.apply_tunnel_encap_at_egress = true;
+    set_ip_nexthop(router_interface_id, encap_dst_ip);
+  }
+
+  @p4runtime_role(P4RUNTIME_ROLE_ROUTING)
+  @id(ROUTING_TUNNEL_TABLE_ID)
+  table tunnel_table {
+    key = {
+      tunnel_id_value : exact @id(1)
+                              @name("tunnel_id");
+    }
+    actions = {
+      @proto_id(1) mark_for_p2p_tunnel_encap;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    size = ROUTING_TUNNEL_TABLE_MINIMUM_GUARANTEED_SIZE;
   }
 
   // When called from a route, sets SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION to

--- a/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
@@ -226,6 +226,41 @@ tables {
 }
 tables {
   preamble {
+    id: 33554498
+    name: "ingress.routing.nexthop_table"
+    alias: "nexthop_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "nexthop_id"
+    match_type: EXACT
+    type_name {
+      name: "nexthop_id_t"
+    }
+  }
+  action_refs {
+    id: 16777236
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 16777234
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
+    id: 16777239
+    annotations: "@proto_id(3)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 1024
+}
+tables {
+  preamble {
     id: 33554512
     name: "ingress.routing.tunnel_table"
     alias: "tunnel_table"
@@ -250,37 +285,6 @@ tables {
   }
   const_default_action_id: 21257015
   size: 512
-}
-tables {
-  preamble {
-    id: 33554498
-    name: "ingress.routing.nexthop_table"
-    alias: "nexthop_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-  }
-  match_fields {
-    id: 1
-    name: "nexthop_id"
-    match_type: EXACT
-    type_name {
-      name: "nexthop_id_t"
-    }
-  }
-  action_refs {
-    id: 16777236
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 16777234
-    annotations: "@proto_id(2)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  size: 1024
 }
 tables {
   preamble {
@@ -902,30 +906,46 @@ actions {
 }
 actions {
   preamble {
-    id: 16777235
-    name: "ingress.routing.mark_for_p2p_tunnel_encap"
-    alias: "mark_for_p2p_tunnel_encap"
+    id: 16777239
+    name: "ingress.routing.set_ip_nexthop_and_disable_rewrites"
+    alias: "set_ip_nexthop_and_disable_rewrites"
+    annotations: "@unsupported"
   }
   params {
     id: 1
-    name: "encap_src_ip"
-    annotations: "@format(IPV6_ADDRESS)"
-    bitwidth: 128
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
   }
   params {
     id: 2
-    name: "encap_dst_ip"
+    name: "neighbor_id"
     annotations: "@format(IPV6_ADDRESS)"
     annotations: "@refers_to(neighbor_table , neighbor_id)"
     bitwidth: 128
   }
   params {
     id: 3
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    type_name {
-      name: "router_interface_id_t"
-    }
+    name: "disable_ttl_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 4
+    name: "disable_src_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 5
+    name: "disable_dst_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 6
+    name: "disable_vlan_rewrite"
+    bitwidth: 1
   }
 }
 actions {
@@ -963,6 +983,35 @@ actions {
     annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
       name: "tunnel_id_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
     }
   }
 }

--- a/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
@@ -226,6 +226,33 @@ tables {
 }
 tables {
   preamble {
+    id: 33554512
+    name: "ingress.routing.tunnel_table"
+    alias: "tunnel_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "tunnel_id"
+    match_type: EXACT
+    type_name {
+      name: "tunnel_id_t"
+    }
+  }
+  action_refs {
+    id: 16777235
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 512
+}
+tables {
+  preamble {
     id: 33554498
     name: "ingress.routing.nexthop_table"
     alias: "nexthop_table"
@@ -240,12 +267,12 @@ tables {
     }
   }
   action_refs {
-    id: 16777219
+    id: 16777236
     annotations: "@proto_id(1)"
   }
   action_refs {
-    id: 16777236
-    annotations: "@proto_id(3)"
+    id: 16777234
+    annotations: "@proto_id(2)"
   }
   action_refs {
     id: 21257015
@@ -875,6 +902,34 @@ actions {
 }
 actions {
   preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
+  }
+}
+actions {
+  preamble {
     id: 16777236
     name: "ingress.routing.set_ip_nexthop"
     alias: "set_ip_nexthop"
@@ -898,26 +953,17 @@ actions {
 }
 actions {
   preamble {
-    id: 16777219
-    name: "ingress.routing.set_nexthop"
-    alias: "set_nexthop"
-    annotations: "@deprecated(\"Use set_ip_nexthop instead.\")"
+    id: 16777234
+    name: "ingress.routing.set_p2p_tunnel_encap_nexthop"
+    alias: "set_p2p_tunnel_encap_nexthop"
   }
   params {
     id: 1
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    name: "tunnel_id"
+    annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
-      name: "router_interface_id_t"
+      name: "tunnel_id_t"
     }
-  }
-  params {
-    id: 2
-    name: "neighbor_id"
-    annotations: "@format(IPV6_ADDRESS)"
-    annotations: "@refers_to(neighbor_table , neighbor_id)"
-    bitwidth: 128
   }
 }
 actions {
@@ -1307,6 +1353,15 @@ type_info {
   }
   new_types {
     key: "router_interface_id_t"
+    value {
+      translated_type {
+        sdn_string {
+        }
+      }
+    }
+  }
+  new_types {
+    key: "tunnel_id_t"
     value {
       translated_type {
         sdn_string {

--- a/sai_p4/instantiations/google/middleblock.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock.p4info.pb.txt
@@ -226,6 +226,41 @@ tables {
 }
 tables {
   preamble {
+    id: 33554498
+    name: "ingress.routing.nexthop_table"
+    alias: "nexthop_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "nexthop_id"
+    match_type: EXACT
+    type_name {
+      name: "nexthop_id_t"
+    }
+  }
+  action_refs {
+    id: 16777236
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 16777234
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
+    id: 16777239
+    annotations: "@proto_id(3)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 1024
+}
+tables {
+  preamble {
     id: 33554512
     name: "ingress.routing.tunnel_table"
     alias: "tunnel_table"
@@ -250,37 +285,6 @@ tables {
   }
   const_default_action_id: 21257015
   size: 512
-}
-tables {
-  preamble {
-    id: 33554498
-    name: "ingress.routing.nexthop_table"
-    alias: "nexthop_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-  }
-  match_fields {
-    id: 1
-    name: "nexthop_id"
-    match_type: EXACT
-    type_name {
-      name: "nexthop_id_t"
-    }
-  }
-  action_refs {
-    id: 16777236
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 16777234
-    annotations: "@proto_id(2)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  size: 1024
 }
 tables {
   preamble {
@@ -824,30 +828,46 @@ actions {
 }
 actions {
   preamble {
-    id: 16777235
-    name: "ingress.routing.mark_for_p2p_tunnel_encap"
-    alias: "mark_for_p2p_tunnel_encap"
+    id: 16777239
+    name: "ingress.routing.set_ip_nexthop_and_disable_rewrites"
+    alias: "set_ip_nexthop_and_disable_rewrites"
+    annotations: "@unsupported"
   }
   params {
     id: 1
-    name: "encap_src_ip"
-    annotations: "@format(IPV6_ADDRESS)"
-    bitwidth: 128
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
   }
   params {
     id: 2
-    name: "encap_dst_ip"
+    name: "neighbor_id"
     annotations: "@format(IPV6_ADDRESS)"
     annotations: "@refers_to(neighbor_table , neighbor_id)"
     bitwidth: 128
   }
   params {
     id: 3
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    type_name {
-      name: "router_interface_id_t"
-    }
+    name: "disable_ttl_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 4
+    name: "disable_src_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 5
+    name: "disable_dst_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 6
+    name: "disable_vlan_rewrite"
+    bitwidth: 1
   }
 }
 actions {
@@ -885,6 +905,35 @@ actions {
     annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
       name: "tunnel_id_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
     }
   }
 }

--- a/sai_p4/instantiations/google/middleblock.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock.p4info.pb.txt
@@ -226,6 +226,33 @@ tables {
 }
 tables {
   preamble {
+    id: 33554512
+    name: "ingress.routing.tunnel_table"
+    alias: "tunnel_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "tunnel_id"
+    match_type: EXACT
+    type_name {
+      name: "tunnel_id_t"
+    }
+  }
+  action_refs {
+    id: 16777235
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 512
+}
+tables {
+  preamble {
     id: 33554498
     name: "ingress.routing.nexthop_table"
     alias: "nexthop_table"
@@ -240,12 +267,12 @@ tables {
     }
   }
   action_refs {
-    id: 16777219
+    id: 16777236
     annotations: "@proto_id(1)"
   }
   action_refs {
-    id: 16777236
-    annotations: "@proto_id(3)"
+    id: 16777234
+    annotations: "@proto_id(2)"
   }
   action_refs {
     id: 21257015
@@ -797,6 +824,34 @@ actions {
 }
 actions {
   preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
+  }
+}
+actions {
+  preamble {
     id: 16777236
     name: "ingress.routing.set_ip_nexthop"
     alias: "set_ip_nexthop"
@@ -820,26 +875,17 @@ actions {
 }
 actions {
   preamble {
-    id: 16777219
-    name: "ingress.routing.set_nexthop"
-    alias: "set_nexthop"
-    annotations: "@deprecated(\"Use set_ip_nexthop instead.\")"
+    id: 16777234
+    name: "ingress.routing.set_p2p_tunnel_encap_nexthop"
+    alias: "set_p2p_tunnel_encap_nexthop"
   }
   params {
     id: 1
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    name: "tunnel_id"
+    annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
-      name: "router_interface_id_t"
+      name: "tunnel_id_t"
     }
-  }
-  params {
-    id: 2
-    name: "neighbor_id"
-    annotations: "@format(IPV6_ADDRESS)"
-    annotations: "@refers_to(neighbor_table , neighbor_id)"
-    bitwidth: 128
   }
 }
 actions {
@@ -1206,6 +1252,15 @@ type_info {
   }
   new_types {
     key: "router_interface_id_t"
+    value {
+      translated_type {
+        sdn_string {
+        }
+      }
+    }
+  }
+  new_types {
+    key: "tunnel_id_t"
     value {
       translated_type {
         sdn_string {

--- a/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
@@ -218,33 +218,6 @@ tables {
 }
 tables {
   preamble {
-    id: 33554512
-    name: "ingress.routing.tunnel_table"
-    alias: "tunnel_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-  }
-  match_fields {
-    id: 1
-    name: "tunnel_id"
-    match_type: EXACT
-    type_name {
-      name: "tunnel_id_t"
-    }
-  }
-  action_refs {
-    id: 16777235
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  size: 512
-}
-tables {
-  preamble {
     id: 33554498
     name: "ingress.routing.nexthop_table"
     alias: "nexthop_table"
@@ -271,12 +244,43 @@ tables {
     annotations: "@proto_id(3)"
   }
   action_refs {
+    id: 16777239
+    annotations: "@proto_id(4)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
   size: 1024
+}
+tables {
+  preamble {
+    id: 33554512
+    name: "ingress.routing.tunnel_table"
+    alias: "tunnel_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "tunnel_id"
+    match_type: EXACT
+    type_name {
+      name: "tunnel_id_t"
+    }
+  }
+  action_refs {
+    id: 16777235
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 512
 }
 tables {
   preamble {
@@ -853,31 +857,46 @@ actions {
 }
 actions {
   preamble {
-    id: 16777235
-    name: "ingress.routing.mark_for_p2p_tunnel_encap"
-    alias: "mark_for_p2p_tunnel_encap"
+    id: 16777239
+    name: "ingress.routing.set_ip_nexthop_and_disable_rewrites"
+    alias: "set_ip_nexthop_and_disable_rewrites"
+    annotations: "@unsupported"
   }
   params {
     id: 1
-    name: "encap_src_ip"
-    annotations: "@format(IPV6_ADDRESS)"
-    bitwidth: 128
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
   }
   params {
     id: 2
-    name: "encap_dst_ip"
+    name: "neighbor_id"
     annotations: "@format(IPV6_ADDRESS)"
     annotations: "@refers_to(neighbor_table , neighbor_id)"
     bitwidth: 128
   }
   params {
     id: 3
-    name: "router_interface_id"
-    annotations: "@refers_to(neighbor_table , router_interface_id)"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    type_name {
-      name: "router_interface_id_t"
-    }
+    name: "disable_ttl_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 4
+    name: "disable_src_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 5
+    name: "disable_dst_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 6
+    name: "disable_vlan_rewrite"
+    bitwidth: 1
   }
 }
 actions {
@@ -939,6 +958,35 @@ actions {
     annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
       name: "tunnel_id_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
     }
   }
 }

--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -78,9 +78,11 @@ message NexthopTableEntry {
   Match match = 1;
   message Action {
     oneof action {
-      SetNexthopAction set_nexthop = 1;
       SetP2pTunnelEncapNexthopAction set_p2p_tunnel_encap_nexthop = 2;
-      SetIpNexthopAction set_ip_nexthop = 3;
+      SetIpNexthopAction set_ip_nexthop = 1;
+      // CAUTION: This action is not (yet) supported.
+      SetIpNexthopAndDisableRewritesAction set_ip_nexthop_and_disable_rewrites =
+          3;
     }
   }
   Action action = 2;
@@ -720,6 +722,19 @@ message SetMetadataAndDropAction {
 
 message MarkForTunnelDecapAndSetVrfAction {
   string vrf_id = 1;  // Format::STRING
+}
+
+// CAUTION: This action is not (yet) supported.
+message SetIpNexthopAndDisableRewritesAction {
+  // Refers to 'router_interface_table.router_interface_id'.
+  // Refers to 'neighbor_table.router_interface_id'.
+  string router_interface_id = 1;  // Format::STRING
+  // Refers to 'neighbor_table.neighbor_id'.
+  string neighbor_id = 2;              // Format::IPV6 / 128 bits
+  string disable_ttl_rewrite = 3;      // Format::HEX_STRING / 1 bits
+  string disable_src_mac_rewrite = 4;  // Format::HEX_STRING / 1 bits
+  string disable_dst_mac_rewrite = 5;  // Format::HEX_STRING / 1 bits
+  string disable_vlan_rewrite = 6;     // Format::HEX_STRING / 1 bits
 }
 
 message SetVrfAction {

--- a/sai_p4/instantiations/google/test_tools/BUILD.bazel
+++ b/sai_p4/instantiations/google/test_tools/BUILD.bazel
@@ -31,6 +31,7 @@ cc_library(
         "//p4_pdpi:ir",
         "//p4_pdpi:ir_cc_proto",
         "//p4_pdpi:pd",
+        "//p4_pdpi:translation_options",
         "//sai_p4/instantiations/google:sai_pd_cc_proto",
         "@com_github_google_glog//:glog",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",

--- a/sai_p4/instantiations/google/test_tools/test_entries_test.cc
+++ b/sai_p4/instantiations/google/test_tools/test_entries_test.cc
@@ -63,24 +63,6 @@ TEST_P(TestEntriesTest, MakePdEntryPuntingAllPacketsDoesNotError) {
   ASSERT_THAT(MakePdEntryPuntingAllPackets(PuntAction::kTrap), IsOkAndHolds(_));
 }
 
-TEST_P(TestEntriesTest,
-       MakePiEntriesForwardingIpPacketsToGivenPortDoesNotError) {
-  ASSERT_THAT(MakePiEntriesForwardingIpPacketsToGivenPort(
-                  /*egress_port=*/"42", sai::GetIrP4Info(GetParam())),
-              IsOkAndHolds(_));
-}
-TEST_P(TestEntriesTest,
-       MakeIrEntriesForwardingIpPacketsToGivenPortDoesNotError) {
-  ASSERT_THAT(MakeIrEntriesForwardingIpPacketsToGivenPort(
-                  /*egress_port=*/"42", sai::GetIrP4Info(GetParam())),
-              IsOkAndHolds(_));
-}
-TEST_P(TestEntriesTest,
-       MakePdEntriesForwardingIpPacketsToGivenPortDoesNotError) {
-  ASSERT_THAT(MakePdEntriesForwardingIpPacketsToGivenPort(/*egress_port=*/"42"),
-              IsOkAndHolds(_));
-}
-
 INSTANTIATE_TEST_SUITE_P(, TestEntriesTest,
                          testing::ValuesIn(sai::AllSaiInstantiations()),
                          [](const auto& info) -> std::string {

--- a/sai_p4/instantiations/google/tests/sai_p4_bmv2_packet_rewrites_test.cc
+++ b/sai_p4/instantiations/google/tests/sai_p4_bmv2_packet_rewrites_test.cc
@@ -1,0 +1,448 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+
+#include "absl/log/check.h"
+#include "absl/strings/string_view.h"
+#include "glog/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status.h"
+#include "gutil/status_matchers.h"
+#include "gutil/testing.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/p4_runtime_matchers.h"
+#include "p4_pdpi/p4_runtime_session.h"
+#include "p4_pdpi/p4_runtime_session_extras.h"
+#include "p4_pdpi/packetlib/packetlib.h"
+#include "p4_pdpi/packetlib/packetlib.pb.h"
+#include "p4_pdpi/pd.h"
+#include "p4_pdpi/string_encodings/byte_string.h"
+#include "p4_pdpi/translation_options.h"
+#include "platforms/networking/p4/p4_infra/bmv2/bmv2.h"
+#include "sai_p4/instantiations/google/instantiations.h"
+#include "sai_p4/instantiations/google/sai_p4info.h"
+#include "sai_p4/instantiations/google/sai_pd.pb.h"
+#include "sai_p4/instantiations/google/test_tools/set_up_bmv2.h"
+#include "sai_p4/instantiations/google/test_tools/test_entries.h"
+#include "tests/forwarding/packet_at_port.h"
+
+namespace pins {
+namespace {
+
+using ::gutil::EqualsProto;
+using ::gutil::IsOkAndHolds;
+using ::orion::p4::test::Bmv2;
+using ::pdpi::HasPacketIn;
+using ::pdpi::ParsedPayloadIs;
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
+using ::testing::ValuesIn;
+
+// Returns an Ipv6 packet.
+packetlib::Packet GetIpv6Packet(absl::string_view ttl) {
+  packetlib::Packet packet = gutil::ParseProtoOrDie<packetlib::Packet>(R"pb(
+    headers {
+      ethernet_header {
+        ethernet_destination: "02:03:04:05:06:77"
+        ethernet_source: "00:01:02:03:04:55"
+        ethertype: "0x86dd"  # IPv6
+      }
+    }
+    headers {
+      ipv6_header {
+        version: "0x6"
+        dscp: "0x00"
+        ecn: "0x0"
+        flow_label: "0x12345"
+        next_header: "0x11"  # UDP
+        hop_limit: "0x22"
+        ipv6_source: "2001::1"
+        ipv6_destination: "2001::2"
+      }
+    }
+    headers {
+      udp_header {
+        source_port: "0x0000"
+        destination_port: "0x0000"
+        length: "0x0013"
+      }
+    }
+    payload: "ipv6 packet"
+  )pb");
+  packet.mutable_headers(1)->mutable_ipv6_header()->set_hop_limit(ttl);
+  CHECK_OK(packetlib::PadPacketToMinimumSize(packet));
+  CHECK_OK(packetlib::UpdateAllComputedFields(packet));
+  return packet;
+}
+
+// Returns an Ipv4 packet.
+packetlib::Packet GetIpv4Packet(absl::string_view ttl) {
+  packetlib::Packet packet = gutil::ParseProtoOrDie<packetlib::Packet>(
+      R"pb(
+        headers {
+          ethernet_header {
+            ethernet_destination: "02:03:04:05:06:77"
+            ethernet_source: "00:01:02:03:04:55"
+            ethertype: "0x0800"
+          }
+        }
+        headers {
+          ipv4_header {
+            version: "0x4"
+            ihl: "0x5"
+            dscp: "0x1c"
+            ecn: "0x0"
+            total_length: "0x002e"
+            identification: "0x0000"
+            flags: "0x0"
+            fragment_offset: "0x0000"
+            ttl: "0x22"
+            protocol: "0x11"
+            ipv4_source: "192.168.100.2"
+            ipv4_destination: "192.168.100.1"
+          }
+        }
+        headers {
+          udp_header {
+            source_port: "0x0000"
+            destination_port: "0x0000"
+            length: "0x001a"
+          }
+        }
+        payload: "packet"
+      )pb");
+  packet.mutable_headers(1)->mutable_ipv4_header()->set_ttl(ttl);
+  CHECK_OK(packetlib::PadPacketToMinimumSize(packet));
+  CHECK_OK(packetlib::UpdateAllComputedFields(packet));
+  return packet;
+}
+// Returns an Ip packet for given `ip_version` and `ttl`.
+packetlib::Packet GetIpPacket(sai::IpVersion ip_version,
+                              absl::string_view ttl) {
+  switch (ip_version) {
+    case sai::IpVersion::kIpv4:
+      return GetIpv4Packet(ttl);
+    case sai::IpVersion::kIpv6:
+      return GetIpv6Packet(ttl);
+    default:
+      LOG(FATAL) << "Unsupported ip_version: "  // Crash ok
+                 << static_cast<int>(ip_version);
+  }
+}
+
+// Verifies that for each disable rewrite option in `rewrite_options`, if
+// it is set to false, the field associated with that option is rewritten. Else,
+// the field associated with that option remains the same for `input_packet` and
+// `output_packet`.
+// Note, this helper function assumes `input_packet` and `output_packet` both
+// have headers that look like [Ethernet,IP{v4,v6}]
+void VerifyOutputPacketIsRewritten(
+    const packetlib::Packet& input_packet,
+    const packetlib::Packet& output_packet,
+    const sai::NexthopRewriteOptions& rewrite_options,
+    const sai::IpVersion& ip_version) {
+  ASSERT_TRUE(input_packet.headers(0).has_ethernet_header());
+  ASSERT_TRUE(output_packet.headers(0).has_ethernet_header());
+
+  if (rewrite_options.disable_src_mac_rewrite) {
+    EXPECT_EQ(input_packet.headers(0).ethernet_header().ethernet_source(),
+              output_packet.headers(0).ethernet_header().ethernet_source());
+  } else {
+    EXPECT_NE(input_packet.headers(0).ethernet_header().ethernet_source(),
+              output_packet.headers(0).ethernet_header().ethernet_source());
+  }
+
+  if (rewrite_options.disable_dst_mac_rewrite) {
+    EXPECT_EQ(
+        input_packet.headers(0).ethernet_header().ethernet_destination(),
+        output_packet.headers(0).ethernet_header().ethernet_destination());
+  } else {
+    EXPECT_NE(
+        input_packet.headers(0).ethernet_header().ethernet_destination(),
+        output_packet.headers(0).ethernet_header().ethernet_destination());
+  }
+  switch (ip_version) {
+    case sai::IpVersion::kIpv4: {
+      ASSERT_TRUE(input_packet.headers(1).has_ipv4_header());
+      ASSERT_TRUE(output_packet.headers(1).has_ipv4_header());
+
+      if (rewrite_options.disable_ttl_rewrite) {
+        EXPECT_EQ(input_packet.headers(1).ipv4_header().ttl(),
+                  output_packet.headers(1).ipv4_header().ttl());
+      } else {
+        EXPECT_NE(input_packet.headers(1).ipv4_header().ttl(),
+                  output_packet.headers(1).ipv4_header().ttl());
+      }
+      break;
+    }
+    case sai::IpVersion::kIpv6:
+      ASSERT_TRUE(input_packet.headers(1).has_ipv6_header());
+      ASSERT_TRUE(output_packet.headers(1).has_ipv6_header());
+
+      if (rewrite_options.disable_ttl_rewrite) {
+        EXPECT_EQ(input_packet.headers(1).ipv6_header().hop_limit(),
+                  output_packet.headers(1).ipv6_header().hop_limit());
+      } else {
+        EXPECT_NE(input_packet.headers(1).ipv6_header().hop_limit(),
+                  output_packet.headers(1).ipv6_header().hop_limit());
+      }
+      break;
+    case sai::IpVersion::kIpv4And6:
+      FAIL() << "Unsupported ip_version: kIpv4And6";
+      break;
+  }
+}
+
+struct PacketRewritesTestParams {
+  sai::NexthopRewriteOptions nexthop_rewrite_options;
+  sai::IpVersion ip_version;
+  sai::Instantiation instantiation;
+};
+
+template <typename Sink>
+void AbslStringify(Sink& sink, const PacketRewritesTestParams& param) {
+  absl::Format(&sink,
+               "[disable_ttl_rewrite: %v, disable_src_mac_rewrite: %v, "
+               "disable_dst_mac_rewrite: %v, ip_version: %v, instantiation: "
+               "%v]",
+               param.nexthop_rewrite_options.disable_ttl_rewrite,
+               param.nexthop_rewrite_options.disable_src_mac_rewrite,
+               param.nexthop_rewrite_options.disable_dst_mac_rewrite,
+               param.ip_version,
+               sai::InstantiationToString(param.instantiation));
+}
+
+// Generates Cartesian product of NexthopRewriteOptions's TTL, SrcMac and DstMac
+// rewrite options.
+std::vector<sai::NexthopRewriteOptions>
+CartesianProductOfNexthopRewriteOptions() {
+  std::vector<sai::NexthopRewriteOptions> options;
+  for (bool disable_ttl_rewrite : {false, true}) {
+    for (bool disable_src_mac_rewrite : {false, true}) {
+      for (bool disable_dst_mac_rewrite : {false, true}) {
+        options.push_back(sai::NexthopRewriteOptions{
+            .disable_ttl_rewrite = disable_ttl_rewrite,
+            .disable_src_mac_rewrite = disable_src_mac_rewrite,
+            .disable_dst_mac_rewrite = disable_dst_mac_rewrite,
+        });
+      }
+    }
+  }
+  return options;
+}
+
+// Generates Cartesian product of {`nexthop_rewrite_options` x IpVersions x
+// SaiInstantiations}.
+std::vector<PacketRewritesTestParams>
+CartesianProductOfIpVersionsAndInstantiationsAndGivenRewriteOptions(
+    const std::vector<sai::NexthopRewriteOptions>& nexthop_rewrite_options) {
+  std::vector<PacketRewritesTestParams> params;
+  for (const sai::NexthopRewriteOptions& rewrite_options :
+       nexthop_rewrite_options) {
+    for (sai::IpVersion ip_version : {
+             sai::IpVersion::kIpv4,
+             sai::IpVersion::kIpv6,
+         }) {
+      for (sai::Instantiation instantiation : sai::AllSaiInstantiations()) {
+        params.push_back(PacketRewritesTestParams{
+            .nexthop_rewrite_options = rewrite_options,
+            .ip_version = ip_version,
+            .instantiation = instantiation,
+        });
+      }
+    }
+  }
+  return params;
+}
+
+constexpr int kBmv2PortBitwidth = 9;
+
+// Translates `entries` into PI form and installs them to `bmv2`.
+absl::Status InstallEntriesToBmv2(const sai::TableEntries& entries,
+                                  const sai::Instantiation& instantiation,
+                                  Bmv2& bmv2) {
+  ASSIGN_OR_RETURN(std::vector<p4::v1::Entity> pi_entries,
+                   pdpi::PdTableEntriesToPiEntities(
+                       sai::GetIrP4Info(instantiation), entries,
+                       // TODO: Remove once `@unsupported` annotation is removed
+                       // from set_ip_nexthop_and_disable_rewrites.
+                       pdpi::TranslationOptions{.allow_unsupported = true}));
+  return pdpi::InstallPiEntities(bmv2.P4RuntimeSession(), pi_entries);
+}
+
+class PacketRewritesTest
+    : public testing::TestWithParam<PacketRewritesTestParams> {};
+
+TEST_P(PacketRewritesTest, PacketsAreForwardedWithCorrectRewrites) {
+  constexpr int kIngressPort = 2;
+  constexpr int kEgressPort = 1;
+  const sai::Instantiation instantiation = GetParam().instantiation;
+  const sai::IpVersion ip_version = GetParam().ip_version;
+  const sai::NexthopRewriteOptions rewrite_options =
+      GetParam().nexthop_rewrite_options;
+
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, sai::SetUpBmv2ForSaiP4(instantiation));
+  ASSERT_OK(InstallEntriesToBmv2(
+      sai::PdEntryBuilder()
+          .AddEntriesForwardingIpPacketsToGivenPort(
+              pdpi::BitsetToP4RuntimeByteString<kBmv2PortBitwidth>(kEgressPort),
+              rewrite_options)
+          .GetDedupedEntries(),
+      instantiation, bmv2));
+  // Use input packet with TTL !=0/1. TTL == 0/1 scenarios are tested in
+  // another test below.
+  packetlib::Packet input_packet = GetIpPacket(ip_version, /*ttl=*/"0x22");
+
+  ASSERT_OK_AND_ASSIGN(std::string raw_input_packet,
+                       packetlib::SerializePacket(input_packet));
+  ASSERT_OK_AND_ASSIGN(std::vector<pins::PacketAtPort> output_packets,
+                       bmv2.SendPacket(pins::PacketAtPort{
+                           .port = kIngressPort,
+                           .data = raw_input_packet,
+                       }));
+  ASSERT_THAT(output_packets, SizeIs(1));
+  packetlib::Packet output_packet =
+      packetlib::ParsePacket(output_packets[0].data);
+  VerifyOutputPacketIsRewritten(input_packet, output_packet, rewrite_options,
+                                ip_version);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CartesianProductOfRewriteOptionsAndInstantiationsAndIpVersions,
+    PacketRewritesTest,
+    ValuesIn(
+        CartesianProductOfIpVersionsAndInstantiationsAndGivenRewriteOptions(
+            CartesianProductOfNexthopRewriteOptions())));
+
+class TtlRewriteTest : public testing::TestWithParam<PacketRewritesTestParams> {
+};
+
+// Test when TTL rewrite is disabled, packet with TTL == 1 is forwarded and
+// packet with TTL == 0 is dropped.
+TEST_P(TtlRewriteTest, PacketWithZeroOrOneTtlTest) {
+  constexpr int kIngressPort = 2;
+  constexpr int kEgressPort = 1;
+  const sai::Instantiation instantiation = GetParam().instantiation;
+  const sai::IpVersion ip_version = GetParam().ip_version;
+  const sai::NexthopRewriteOptions rewrite_options =
+      GetParam().nexthop_rewrite_options;
+
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, sai::SetUpBmv2ForSaiP4(instantiation));
+  ASSERT_OK(InstallEntriesToBmv2(
+      sai::PdEntryBuilder()
+          .AddEntriesForwardingIpPacketsToGivenPort(
+              pdpi::BitsetToP4RuntimeByteString<kBmv2PortBitwidth>(kEgressPort),
+              rewrite_options)
+          .GetDedupedEntries(),
+      instantiation, bmv2));
+
+  // Input packet with TTL == 1 should be forwarded.
+  packetlib::Packet input_packet = GetIpPacket(ip_version, /*ttl=*/"0x01");
+  ASSERT_OK_AND_ASSIGN(std::string raw_input_packet,
+                       packetlib::SerializePacket(input_packet));
+  ASSERT_OK_AND_ASSIGN(std::vector<pins::PacketAtPort> output_packets,
+                       bmv2.SendPacket(pins::PacketAtPort{
+                           .port = kIngressPort,
+                           .data = raw_input_packet,
+                       }));
+  ASSERT_THAT(output_packets, SizeIs(1));
+
+  packetlib::Packet output_packet =
+      packetlib::ParsePacket(output_packets[0].data);
+  switch (ip_version) {
+    case sai::IpVersion::kIpv4:
+      EXPECT_EQ(output_packet.headers(1).ipv4_header().ttl(), "0x01");
+      break;
+    case sai::IpVersion::kIpv6:
+      EXPECT_EQ(output_packet.headers(1).ipv6_header().hop_limit(), "0x01");
+      break;
+    default:
+      FAIL() << "Unsupported ip_version: " << static_cast<int>(ip_version);
+  }
+
+  // Input packet with TTL == 0 should be dropped.
+  input_packet = GetIpPacket(ip_version, /*ttl=*/"0x00");
+  ASSERT_OK_AND_ASSIGN(raw_input_packet,
+                       packetlib::SerializePacket(input_packet));
+  EXPECT_THAT(bmv2.SendPacket(pins::PacketAtPort{
+                  .port = kIngressPort,
+                  .data = raw_input_packet,
+              }),
+              IsOkAndHolds(IsEmpty()));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CartesianProductOfInstantiationsAndIpVersions, TtlRewriteTest,
+    ValuesIn(
+        CartesianProductOfIpVersionsAndInstantiationsAndGivenRewriteOptions(
+            {sai::NexthopRewriteOptions{.disable_ttl_rewrite = true}})));
+
+class TtlRewriteAndPuntTest
+    : public testing::TestWithParam<PacketRewritesTestParams> {};
+
+// When 0/1 ACL punt rules are present, packets with 0/1 TTL should be trapped
+// instead of being dropped by packet_rewrites.
+TEST_P(TtlRewriteAndPuntTest, ZeroAndOneTtlPacketsAreTrapped) {
+  constexpr int kIngressPort = 2;
+  const sai::Instantiation instantiation = GetParam().instantiation;
+  const sai::IpVersion ip_version = GetParam().ip_version;
+
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, sai::SetUpBmv2ForSaiP4(instantiation));
+  ASSERT_OK(InstallEntriesToBmv2(sai::PdEntryBuilder()
+                                     .AddEntryPuntingPacketsWithTtlZeroAndOne()
+                                     .GetDedupedEntries(),
+                                 instantiation, bmv2));
+
+  // Input packet with TTL == 1 should be trapped.
+  packetlib::Packet ttl_1_input_packet =
+      GetIpPacket(ip_version, /*ttl=*/"0x01");
+  ASSERT_OK_AND_ASSIGN(std::string raw_input_packet,
+                       packetlib::SerializePacket(ttl_1_input_packet));
+  EXPECT_THAT(bmv2.SendPacket(pins::PacketAtPort{
+                  .port = kIngressPort,
+                  .data = raw_input_packet,
+              }),
+              IsOkAndHolds(IsEmpty()));
+
+  // Input packet with TTL == 0 should be trapped.
+  packetlib::Packet ttl_0_input_packet =
+      GetIpPacket(ip_version, /*ttl=*/"0x00");
+  ASSERT_OK_AND_ASSIGN(raw_input_packet,
+                       packetlib::SerializePacket(ttl_0_input_packet));
+  EXPECT_THAT(bmv2.SendPacket(pins::PacketAtPort{
+                  .port = kIngressPort,
+                  .data = raw_input_packet,
+              }),
+              IsOkAndHolds(IsEmpty()));
+
+  // Check trapped packets.
+  EXPECT_THAT(
+      bmv2.P4RuntimeSession().ReadStreamChannelResponsesAndFinish(),
+      IsOkAndHolds(ElementsAre(
+          HasPacketIn(ParsedPayloadIs(EqualsProto(ttl_1_input_packet))),
+          HasPacketIn(ParsedPayloadIs(EqualsProto(ttl_0_input_packet))))));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CartesianProductOfInstantiationsAndIpVersions, TtlRewriteAndPuntTest,
+    ValuesIn(
+        CartesianProductOfIpVersionsAndInstantiationsAndGivenRewriteOptions(
+            {sai::NexthopRewriteOptions{.disable_ttl_rewrite = false}})));
+
+}  // namespace
+}  // namespace pins

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -300,6 +300,33 @@ tables {
 }
 tables {
   preamble {
+    id: 33554512
+    name: "ingress.routing.tunnel_table"
+    alias: "tunnel_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "tunnel_id"
+    match_type: EXACT
+    type_name {
+      name: "tunnel_id_t"
+    }
+  }
+  action_refs {
+    id: 16777235
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 512
+}
+tables {
+  preamble {
     id: 33554498
     name: "ingress.routing.nexthop_table"
     alias: "nexthop_table"
@@ -314,12 +341,12 @@ tables {
     }
   }
   action_refs {
-    id: 16777219
+    id: 16777236
     annotations: "@proto_id(1)"
   }
   action_refs {
-    id: 16777236
-    annotations: "@proto_id(3)"
+    id: 16777234
+    annotations: "@proto_id(2)"
   }
   action_refs {
     id: 21257015
@@ -1072,6 +1099,34 @@ actions {
 }
 actions {
   preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
+  }
+}
+actions {
+  preamble {
     id: 16777236
     name: "ingress.routing.set_ip_nexthop"
     alias: "set_ip_nexthop"
@@ -1095,26 +1150,17 @@ actions {
 }
 actions {
   preamble {
-    id: 16777219
-    name: "ingress.routing.set_nexthop"
-    alias: "set_nexthop"
-    annotations: "@deprecated(\"Use set_ip_nexthop instead.\")"
+    id: 16777234
+    name: "ingress.routing.set_p2p_tunnel_encap_nexthop"
+    alias: "set_p2p_tunnel_encap_nexthop"
   }
   params {
     id: 1
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    name: "tunnel_id"
+    annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
-      name: "router_interface_id_t"
+      name: "tunnel_id_t"
     }
-  }
-  params {
-    id: 2
-    name: "neighbor_id"
-    annotations: "@format(IPV6_ADDRESS)"
-    annotations: "@refers_to(neighbor_table , neighbor_id)"
-    bitwidth: 128
   }
 }
 actions {
@@ -1553,6 +1599,15 @@ type_info {
   }
   new_types {
     key: "router_interface_id_t"
+    value {
+      translated_type {
+        sdn_string {
+        }
+      }
+    }
+  }
+  new_types {
+    key: "tunnel_id_t"
     value {
       translated_type {
         sdn_string {

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -300,6 +300,41 @@ tables {
 }
 tables {
   preamble {
+    id: 33554498
+    name: "ingress.routing.nexthop_table"
+    alias: "nexthop_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "nexthop_id"
+    match_type: EXACT
+    type_name {
+      name: "nexthop_id_t"
+    }
+  }
+  action_refs {
+    id: 16777236
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 16777234
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
+    id: 16777239
+    annotations: "@proto_id(3)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 1024
+}
+tables {
+  preamble {
     id: 33554512
     name: "ingress.routing.tunnel_table"
     alias: "tunnel_table"
@@ -324,37 +359,6 @@ tables {
   }
   const_default_action_id: 21257015
   size: 512
-}
-tables {
-  preamble {
-    id: 33554498
-    name: "ingress.routing.nexthop_table"
-    alias: "nexthop_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-  }
-  match_fields {
-    id: 1
-    name: "nexthop_id"
-    match_type: EXACT
-    type_name {
-      name: "nexthop_id_t"
-    }
-  }
-  action_refs {
-    id: 16777236
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 16777234
-    annotations: "@proto_id(2)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  size: 1024
 }
 tables {
   preamble {
@@ -1099,30 +1103,46 @@ actions {
 }
 actions {
   preamble {
-    id: 16777235
-    name: "ingress.routing.mark_for_p2p_tunnel_encap"
-    alias: "mark_for_p2p_tunnel_encap"
+    id: 16777239
+    name: "ingress.routing.set_ip_nexthop_and_disable_rewrites"
+    alias: "set_ip_nexthop_and_disable_rewrites"
+    annotations: "@unsupported"
   }
   params {
     id: 1
-    name: "encap_src_ip"
-    annotations: "@format(IPV6_ADDRESS)"
-    bitwidth: 128
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
   }
   params {
     id: 2
-    name: "encap_dst_ip"
+    name: "neighbor_id"
     annotations: "@format(IPV6_ADDRESS)"
     annotations: "@refers_to(neighbor_table , neighbor_id)"
     bitwidth: 128
   }
   params {
     id: 3
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    type_name {
-      name: "router_interface_id_t"
-    }
+    name: "disable_ttl_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 4
+    name: "disable_src_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 5
+    name: "disable_dst_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 6
+    name: "disable_vlan_rewrite"
+    bitwidth: 1
   }
 }
 actions {
@@ -1160,6 +1180,35 @@ actions {
     annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
       name: "tunnel_id_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
     }
   }
 }

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -226,6 +226,33 @@ tables {
 }
 tables {
   preamble {
+    id: 33554512
+    name: "ingress.routing.tunnel_table"
+    alias: "tunnel_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "tunnel_id"
+    match_type: EXACT
+    type_name {
+      name: "tunnel_id_t"
+    }
+  }
+  action_refs {
+    id: 16777235
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 512
+}
+tables {
+  preamble {
     id: 33554498
     name: "ingress.routing.nexthop_table"
     alias: "nexthop_table"
@@ -240,12 +267,12 @@ tables {
     }
   }
   action_refs {
-    id: 16777219
+    id: 16777236
     annotations: "@proto_id(1)"
   }
   action_refs {
-    id: 16777236
-    annotations: "@proto_id(3)"
+    id: 16777234
+    annotations: "@proto_id(2)"
   }
   action_refs {
     id: 21257015
@@ -1332,6 +1359,34 @@ actions {
 }
 actions {
   preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
+  }
+}
+actions {
+  preamble {
     id: 16777236
     name: "ingress.routing.set_ip_nexthop"
     alias: "set_ip_nexthop"
@@ -1355,26 +1410,17 @@ actions {
 }
 actions {
   preamble {
-    id: 16777219
-    name: "ingress.routing.set_nexthop"
-    alias: "set_nexthop"
-    annotations: "@deprecated(\"Use set_ip_nexthop instead.\")"
+    id: 16777234
+    name: "ingress.routing.set_p2p_tunnel_encap_nexthop"
+    alias: "set_p2p_tunnel_encap_nexthop"
   }
   params {
     id: 1
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    name: "tunnel_id"
+    annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
-      name: "router_interface_id_t"
+      name: "tunnel_id_t"
     }
-  }
-  params {
-    id: 2
-    name: "neighbor_id"
-    annotations: "@format(IPV6_ADDRESS)"
-    annotations: "@refers_to(neighbor_table , neighbor_id)"
-    bitwidth: 128
   }
 }
 actions {
@@ -1949,6 +1995,15 @@ type_info {
   }
   new_types {
     key: "router_interface_id_t"
+    value {
+      translated_type {
+        sdn_string {
+        }
+      }
+    }
+  }
+  new_types {
+    key: "tunnel_id_t"
     value {
       translated_type {
         sdn_string {

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -226,6 +226,41 @@ tables {
 }
 tables {
   preamble {
+    id: 33554498
+    name: "ingress.routing.nexthop_table"
+    alias: "nexthop_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "nexthop_id"
+    match_type: EXACT
+    type_name {
+      name: "nexthop_id_t"
+    }
+  }
+  action_refs {
+    id: 16777236
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 16777234
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
+    id: 16777239
+    annotations: "@proto_id(3)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 1024
+}
+tables {
+  preamble {
     id: 33554512
     name: "ingress.routing.tunnel_table"
     alias: "tunnel_table"
@@ -250,37 +285,6 @@ tables {
   }
   const_default_action_id: 21257015
   size: 512
-}
-tables {
-  preamble {
-    id: 33554498
-    name: "ingress.routing.nexthop_table"
-    alias: "nexthop_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-  }
-  match_fields {
-    id: 1
-    name: "nexthop_id"
-    match_type: EXACT
-    type_name {
-      name: "nexthop_id_t"
-    }
-  }
-  action_refs {
-    id: 16777236
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 16777234
-    annotations: "@proto_id(2)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  size: 1024
 }
 tables {
   preamble {
@@ -1359,30 +1363,46 @@ actions {
 }
 actions {
   preamble {
-    id: 16777235
-    name: "ingress.routing.mark_for_p2p_tunnel_encap"
-    alias: "mark_for_p2p_tunnel_encap"
+    id: 16777239
+    name: "ingress.routing.set_ip_nexthop_and_disable_rewrites"
+    alias: "set_ip_nexthop_and_disable_rewrites"
+    annotations: "@unsupported"
   }
   params {
     id: 1
-    name: "encap_src_ip"
-    annotations: "@format(IPV6_ADDRESS)"
-    bitwidth: 128
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
   }
   params {
     id: 2
-    name: "encap_dst_ip"
+    name: "neighbor_id"
     annotations: "@format(IPV6_ADDRESS)"
     annotations: "@refers_to(neighbor_table , neighbor_id)"
     bitwidth: 128
   }
   params {
     id: 3
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    type_name {
-      name: "router_interface_id_t"
-    }
+    name: "disable_ttl_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 4
+    name: "disable_src_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 5
+    name: "disable_dst_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 6
+    name: "disable_vlan_rewrite"
+    bitwidth: 1
   }
 }
 actions {
@@ -1420,6 +1440,35 @@ actions {
     annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
       name: "tunnel_id_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
     }
   }
 }


### PR DESCRIPTION
### Keyword Check:
sdivya@eonms6vm1:~/sonic_sep6/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_check.sh .
Keyword check Passed.

### Build Results:
sdivya@e25b91aea928:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 411 targets (0 packages loaded, 0 targets configured).
INFO: Found 411 targets...
...
INFO: Elapsed time: 661.198s, Critical Path: 62.17s
INFO: 2460 processes: 2 internal, 2443 linux-sandbox, 15 local.
INFO: Build completed successfully, 2460 total actions

### Test Results:
sdivya@e25b91aea928:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 411 targets (0 packages loaded, 302 targets configured).
INFO: Found 263 targets and 148 test targets...
INFO: Elapsed time: 105.879s, Critical Path: 25.88s
INFO: 153 processes: 163 linux-sandbox, 18 local.
INFO: Build completed successfully, 153 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.6s
//gutil:timer_test                                                       PASSED in 5.0s
//gutil:version_test                                                     PASSED in 1.0s
//lib:basic_switch_test                                                  PASSED in 0.8s
//lib:ixia_helper_test                                                   PASSED in 1.1s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 0.9s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 14.9s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.9s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.2s
//lib/utils:json_utils_test                                              PASSED in 0.7s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 25.8s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 0.8s
//p4_fuzzer:oracle_util_test                                             PASSED in 0.7s
//p4_fuzzer:switch_state_test                                            PASSED in 0.7s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_properties_test                                             PASSED in 0.5s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 0.6s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:names_test                                                     PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:references_test                                                PASSED in 0.6s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.7s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.4s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 2.0s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.7s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.6s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.1s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.1s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:references_test                                        PASSED in 0.1s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.3s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.1s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 1.0s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.8s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.8s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.0s
//p4rt_app/tests:action_set_test                                         PASSED in 1.4s
//p4rt_app/tests:api_access_test                                         PASSED in 1.2s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.3s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.3s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.3s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 6.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.3s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.5s
//p4rt_app/tests:packetio_test                                           PASSED in 4.5s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.8s
//p4rt_app/tests:resource_limits_test                                    PASSED in 2.9s
//p4rt_app/tests:response_path_test                                      PASSED in 4.1s
//p4rt_app/tests:role_test                                               PASSED in 1.4s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.2s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.2s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.6s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.6s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.9s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 1.0s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.6s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 23.4s
  Stats over 5 runs: max = 23.4s, min = 1.1s, avg = 8.1s, dev = 8.5s

Executed 148 out of 148 tests: 148 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these aINFO: Build completed successfully, 153 total actions
sdivya@e25b91aea928:/sonic/src/sonic-p4rt/sonic-pins$ 