### PR TITLE
[SAIP4] Enable VLAN ID rewrite in router_interface table.

### DIFF
--- a/sai_p4/fixed/headers.p4
+++ b/sai_p4/fixed/headers.p4
@@ -5,6 +5,7 @@
 #define ETHERTYPE_IPV6  0x86dd
 #define ETHERTYPE_ARP   0x0806
 #define ETHERTYPE_LLDP  0x88cc
+#define ETHERTYPE_8021Q 0x8100
 
 #define IP_PROTOCOL_IPV4   0x04
 #define IP_PROTOCOL_TCP    0x06
@@ -31,6 +32,9 @@ const vlan_id_t INTERNAL_VLAN_ID = 0xfff;
 // in this case, the 802.1Q tag specifies only a priority"
 // (https://en.wikipedia.org/wiki/IEEE_802.1Q).
 const vlan_id_t NO_VLAN_ID = 0x000;
+
+#define IS_RESERVED_VLAN_ID(vlan_id) \
+    (vlan_id == NO_VLAN_ID || vlan_id == INTERNAL_VLAN_ID)
 
 // -- Protocol headers ---------------------------------------------------------
 

--- a/sai_p4/fixed/ids.h
+++ b/sai_p4/fixed/ids.h
@@ -31,8 +31,10 @@
 // --- Actions -----------------------------------------------------------------
 
 // IDs of fixed SAI actions (8 most significant bits = 0x01).
-#define ROUTING_SET_DST_MAC_ACTION_ID 0x01000001                     // 16777217
-#define ROUTING_SET_PORT_AND_SRC_MAC_ACTION_ID 0x01000002            // 16777218
+#define ROUTING_SET_DST_MAC_ACTION_ID 0x01000001           // 16777217
+#define ROUTING_SET_PORT_AND_SRC_MAC_ACTION_ID 0x01000002  // 16777218
+#define ROUTING_SET_PORT_AND_SRC_MAC_AND_VLAN_ID_ACTION_ID \
+  0x0100001B                                                         // 16777243
 #define ROUTING_SET_NEXTHOP_ACTION_ID 0x01000003                     // 16777219
 #define ROUTING_SET_IP_NEXTHOP_ACTION_ID 0x01000014                  // 16777236
 #define ROUTING_SET_WCMP_GROUP_ID_ACTION_ID 0x01000004               // 16777220
@@ -56,7 +58,7 @@
 #define ROUTING_SET_METADATA_AND_DROP_ACTION_ID 0x01000015           // 16777237
 #define MARK_FOR_TUNNEL_DECAP_AND_SET_VRF_ACTION_ID 0x01000016       // 16777238
 #define DISABLE_VLAN_CHECKS_ACTION_ID 0x0100001A                   // 16777242
-// Next available action id: 0x0100001B (16777243)
+// Next available action id: 0x0100001C (16777244)
 
 // --- Action Profiles and Selectors (8 most significant bits = 0x11) ----------
 // This value should ideally be 0x11000001, but we currently have this value for

--- a/sai_p4/fixed/ids.h
+++ b/sai_p4/fixed/ids.h
@@ -37,6 +37,8 @@
 #define ROUTING_SET_WCMP_GROUP_ID_ACTION_ID 0x01000004               // 16777220
 #define ROUTING_SET_WCMP_GROUP_ID_AND_METADATA_ACTION_ID 0x01000011  // 16777233
 #define ROUTING_SET_NEXTHOP_ID_ACTION_ID 0x01000005                  // 16777221
+// 16777239
+#define ROUTING_SET_IP_NEXTHOP_AND_DISABLE_REWRITES_ACTION_ID 0x01000017
 #define ROUTING_SET_NEXTHOP_ID_AND_METADATA_ACTION_ID 0x01000010     // 16777232
 #define ROUTING_DROP_ACTION_ID 0x01000006                            // 16777222
 #define ROUTING_SET_P2P_TUNNEL_ENCAP_NEXTHOP_ACTION_ID 0x01000012    // 16777234
@@ -52,7 +54,7 @@
 #define TRAP_ACTION_ID 0x0100000F                                    // 16777231
 #define ROUTING_SET_METADATA_AND_DROP_ACTION_ID 0x01000015           // 16777237
 #define MARK_FOR_TUNNEL_DECAP_AND_SET_VRF_ACTION_ID 0x01000016       // 16777238
-// Next available action id: 0x01000017 (16777239)
+// Next available action id: 0x01000018 (16777240)
 
 // --- Action Profiles and Selectors (8 most significant bits = 0x11) ----------
 // This value should ideally be 0x11000001, but we currently have this value for

--- a/sai_p4/fixed/ids.h
+++ b/sai_p4/fixed/ids.h
@@ -25,7 +25,8 @@
 #define ECMP_HASHING_TABLE_ID 0x02000049                // 33554505
 #define ROUTING_TUNNEL_TABLE_ID 0x02000050              // 33554512
 #define IPV6_TUNNEL_TERMINATION_TABLE_ID 0x0200004B     // 33554507
-// Next available table id: 0x0200004C (33554508)
+#define DISABLE_VLAN_CHECKS_TABLE_ID 0x0200004D                 // 33554509
+// Next available table id: 0x0200004E (33554510)
 
 // --- Actions -----------------------------------------------------------------
 
@@ -54,7 +55,8 @@
 #define TRAP_ACTION_ID 0x0100000F                                    // 16777231
 #define ROUTING_SET_METADATA_AND_DROP_ACTION_ID 0x01000015           // 16777237
 #define MARK_FOR_TUNNEL_DECAP_AND_SET_VRF_ACTION_ID 0x01000016       // 16777238
-// Next available action id: 0x01000018 (16777240)
+#define DISABLE_VLAN_CHECKS_ACTION_ID 0x0100001A                   // 16777242
+// Next available action id: 0x0100001B (16777243)
 
 // --- Action Profiles and Selectors (8 most significant bits = 0x11) ----------
 // This value should ideally be 0x11000001, but we currently have this value for

--- a/sai_p4/fixed/l3_admit.p4
+++ b/sai_p4/fixed/l3_admit.p4
@@ -33,7 +33,17 @@ control l3_admit(in headers_t headers,
   }
 
   apply {
-    l3_admit_table.apply();
+   // TODO: Properly model the behavior for VIDs 0x001 and 0xFFF
+   // when Packet-IO is properly modeled (see go/gpins-vlan).
+   // TODO: Consider moving vlan check logic to drop_martians.
+   if (local_metadata.enable_vlan_checks &&
+       !IS_RESERVED_VLAN_ID(local_metadata.vlan_id)) {
+     // Explicitly reject VLAN packets from L3 routing to cancel override
+     // in other parts of the code (e.g. admit_google_system_mac).
+     local_metadata.admit_to_l3 = false;
+   } else {
+     l3_admit_table.apply();
+   }
   }
 }  // control l3_admit
 

--- a/sai_p4/fixed/metadata.p4
+++ b/sai_p4/fixed/metadata.p4
@@ -197,7 +197,13 @@ struct local_metadata_t {
   bool vlan_id_valid;  // True iff `vlan_id` is valid.
   bool admit_to_l3;
   vrf_id_t vrf_id;
+
+  // Rewrite related fields.
+  bool enable_ttl_rewrite;
+  bool enable_src_mac_rewrite;
+  bool enable_dst_mac_rewrite;
   packet_rewrites_t packet_rewrites;
+
   bit<16> l4_src_port;
   bit<16> l4_dst_port;
   bit<WCMP_SELECTOR_INPUT_BITWIDTH> wcmp_selector_input;

--- a/sai_p4/fixed/metadata.p4
+++ b/sai_p4/fixed/metadata.p4
@@ -184,6 +184,9 @@ struct packet_rewrites_t {
 
 // Local metadata for each packet being processed.
 struct local_metadata_t {
+  // If true, ingress packets with ingress VID and egress packets with
+  // egress VID besides the reserved ones (0, 4095) get dropped.
+  bool enable_vlan_checks;
   // The VLAN ID used for the packet throughout the pipeline. If the input
   // packet has a VLAN tag, the VID from the outer VLAN tag is used
   // (and the VLAN header gets invalidated at the beginning of the ingress
@@ -194,7 +197,7 @@ struct local_metadata_t {
   // used at the end of the egress pipeline to determine whether or not the
   // packet should be VLAN tagged (if not dropped).
   vlan_id_t vlan_id;
-  bool vlan_id_valid;  // True iff `vlan_id` is valid.
+
   bool admit_to_l3;
   vrf_id_t vrf_id;
 

--- a/sai_p4/fixed/packet_rewrites.p4
+++ b/sai_p4/fixed/packet_rewrites.p4
@@ -15,6 +15,13 @@ control packet_rewrites(inout headers_t headers,
     // TODO: Use a more robust check to determine whether to rewrite
     // packets.
     if (local_metadata.admit_to_l3){
+      // VLAN id is kept in local_metadata until the end of egress pipeline
+      // where depending on the value of VLAN id and VLAN configuration the
+      // packet might potentially get VLAN tagged with that VLAN id.
+      // TODO: For now rewriting unconditionaly since disabling
+      // VLAN rewrite is not modeled yet. When modeled, this rewrite should
+      // become conditional too.
+      local_metadata.vlan_id = local_metadata.packet_rewrites.vlan_id;
       if (local_metadata.enable_src_mac_rewrite) {
         headers.ethernet.src_addr = local_metadata.packet_rewrites.src_mac;
       }

--- a/sai_p4/fixed/parser.p4
+++ b/sai_p4/fixed/parser.p4
@@ -13,6 +13,9 @@ parser packet_parser(packet_in packet, out headers_t headers,
     // Initialize local metadata fields.
     local_metadata.admit_to_l3 = false;
     local_metadata.vrf_id = kDefaultVrf;
+    local_metadata.enable_ttl_rewrite = false;
+    local_metadata.enable_src_mac_rewrite = false;
+    local_metadata.enable_dst_mac_rewrite = false;
     local_metadata.packet_rewrites.src_mac = 0;
     local_metadata.packet_rewrites.dst_mac = 0;
     local_metadata.l4_src_port = 0;

--- a/sai_p4/fixed/parser.p4
+++ b/sai_p4/fixed/parser.p4
@@ -11,6 +11,8 @@ parser packet_parser(packet_in packet, out headers_t headers,
                      inout standard_metadata_t standard_metadata) {
   state start {
     // Initialize local metadata fields.
+    local_metadata.enable_vlan_checks = false;
+    local_metadata.vlan_id = 0;
     local_metadata.admit_to_l3 = false;
     local_metadata.vrf_id = kDefaultVrf;
     local_metadata.enable_ttl_rewrite = false;

--- a/sai_p4/fixed/vlan.p4
+++ b/sai_p4/fixed/vlan.p4
@@ -11,13 +11,60 @@
 control vlan_untag(inout headers_t headers,
                    inout local_metadata_t local_metadata,
                    inout standard_metadata_t standard_metadata) {
-  apply {
-     if (headers.vlan.isValid()) {
-        headers.ethernet.ether_type = headers.vlan.ether_type;
-        local_metadata.vlan_id_valid = true;
-        local_metadata.vlan_id = headers.vlan.vlan_id;
-        headers.vlan.setInvalid();
+
+  @id(DISABLE_VLAN_CHECKS_ACTION_ID)
+  action disable_vlan_checks() {
+    local_metadata.enable_vlan_checks = false;
+  }
+
+  // Models SAI_DISABLE_VLAN_CHECKS.
+  // If VLAN checks are enabled (i.e. if the table is empty), an ingress/egress
+  // packet with a VLAN tag containing a VID beside the reserved ones (0, 4095)
+  // gets dropped in ingress/egress pipelines, respectively (given the
+  // current switch configuration). With VLAN checks disabled, such drops do
+  // not happen.
+  // TODO: Remove @unsupported when the switch supports this table.
+  @unsupported
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @id(DISABLE_VLAN_CHECKS_TABLE_ID)
+  @entry_restriction("
+    // Force the dummy_match to be wildcard.
+    dummy_match::mask == 0;
+  ")
+  table disable_vlan_checks_table {
+    key = {
+      // Note: In the P4_16 specification, a table with no match keys cannot have
+      // entries (only the default action can be programmed which does not fit
+      // well in our SDN ecosystem). To alleviate this, we add a dummy match but
+      // force it to always be wildcard.
+      1w1 : ternary @id(1) @name("dummy_match");
     }
+    actions = {
+      @proto_id(1) disable_vlan_checks;
+    }
+    size = 1;
+  }
+
+  apply {
+     // Determine the vlan_id metadata.
+     if (headers.vlan.isValid()) {
+        // If input packet has a VLAN tag, use the VID from the tag.
+        local_metadata.vlan_id = headers.vlan.vlan_id;
+        // Invalidate the VLAN header. In doing so we move the ethertype placed
+        // after the VLAN tag (which we model as part of the VLAN tag due to P4
+        // language's limitations) to ethernet.ether_type.
+        headers.ethernet.ether_type = headers.vlan.ether_type;
+        headers.vlan.setInvalid();
+     } else {
+        // Otherwise, use native VID (4095 for all ports given the current
+        // configuration).
+        local_metadata.vlan_id = INTERNAL_VLAN_ID;
+     }
+
+     // VLAN checks are enabled by default.
+     local_metadata.enable_vlan_checks = true;
+     // Check if VLAN checks need to be disabled.
+     disable_vlan_checks_table.apply();
   }
 }  // control vlan_ingress
 
@@ -25,10 +72,23 @@ control vlan_tag(inout headers_t headers,
                  inout local_metadata_t local_metadata,
                  inout standard_metadata_t standard_metadata) {
   apply {
-    // Currently no VLAN tagged packet gets forwarded, thus tagging is not
-    // modeled yet. When modeling vlan tagging, note that ethernet.ether_type
-    // must be copied into vlan.ether_type due to the way it is currently
-    // modeled (see headers.p4).
+      if (IS_RESERVED_VLAN_ID(local_metadata.vlan_id)) {
+        // No VLAN tag.
+      } else if (local_metadata.enable_vlan_checks) {
+        // With VLAN checks enabled, an egress packet with VIDs besides the
+        // reserved ones (0, 4095) gets dropped.
+        mark_to_drop(standard_metadata);
+      } else {
+        // Add a VLAN tag.
+        headers.vlan.setValid();
+        headers.vlan.priority_code_point = 0;
+        headers.vlan.drop_eligible_indicator = 0;
+        headers.vlan.vlan_id = local_metadata.vlan_id;
+        // Move ethernet.ether_type to vlan.ether_type so that it can be
+        // placed after the VLAN tag during deparsing.
+        headers.vlan.ether_type = headers.ethernet.ether_type;
+        headers.ethernet.ether_type = ETHERTYPE_8021Q;
+      }
   }
 }  // control vlan_egress
 

--- a/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
@@ -32,6 +32,32 @@ tables {
 }
 tables {
   preamble {
+    id: 33554509
+    name: "ingress.vlan_untag.disable_vlan_checks_table"
+    alias: "disable_vlan_checks_table"
+    annotations: "@unsupported"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+    annotations: "@entry_restriction(\"\n    // Force the dummy_match to be wildcard.\n    dummy_match::mask == 0;\n  \")"
+  }
+  match_fields {
+    id: 1
+    name: "dummy_match"
+    bitwidth: 1
+    match_type: TERNARY
+  }
+  action_refs {
+    id: 16777242
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 1
+}
+tables {
+  preamble {
     id: 33554689
     name: "ingress.acl_pre_ingress.acl_pre_ingress_table"
     alias: "acl_pre_ingress_table"
@@ -845,6 +871,13 @@ actions {
     type_name {
       name: "vrf_id_t"
     }
+  }
+}
+actions {
+  preamble {
+    id: 16777242
+    name: "ingress.vlan_untag.disable_vlan_checks"
+    alias: "disable_vlan_checks"
   }
 }
 actions {

--- a/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
@@ -226,6 +226,41 @@ tables {
 }
 tables {
   preamble {
+    id: 33554498
+    name: "ingress.routing.nexthop_table"
+    alias: "nexthop_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "nexthop_id"
+    match_type: EXACT
+    type_name {
+      name: "nexthop_id_t"
+    }
+  }
+  action_refs {
+    id: 16777236
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 16777234
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
+    id: 16777239
+    annotations: "@proto_id(3)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 1024
+}
+tables {
+  preamble {
     id: 33554512
     name: "ingress.routing.tunnel_table"
     alias: "tunnel_table"
@@ -250,37 +285,6 @@ tables {
   }
   const_default_action_id: 21257015
   size: 512
-}
-tables {
-  preamble {
-    id: 33554498
-    name: "ingress.routing.nexthop_table"
-    alias: "nexthop_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-  }
-  match_fields {
-    id: 1
-    name: "nexthop_id"
-    match_type: EXACT
-    type_name {
-      name: "nexthop_id_t"
-    }
-  }
-  action_refs {
-    id: 16777236
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 16777234
-    annotations: "@proto_id(2)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  size: 1024
 }
 tables {
   preamble {
@@ -902,30 +906,46 @@ actions {
 }
 actions {
   preamble {
-    id: 16777235
-    name: "ingress.routing.mark_for_p2p_tunnel_encap"
-    alias: "mark_for_p2p_tunnel_encap"
+    id: 16777239
+    name: "ingress.routing.set_ip_nexthop_and_disable_rewrites"
+    alias: "set_ip_nexthop_and_disable_rewrites"
+    annotations: "@unsupported"
   }
   params {
     id: 1
-    name: "encap_src_ip"
-    annotations: "@format(IPV6_ADDRESS)"
-    bitwidth: 128
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
   }
   params {
     id: 2
-    name: "encap_dst_ip"
+    name: "neighbor_id"
     annotations: "@format(IPV6_ADDRESS)"
     annotations: "@refers_to(neighbor_table , neighbor_id)"
     bitwidth: 128
   }
   params {
     id: 3
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    type_name {
-      name: "router_interface_id_t"
-    }
+    name: "disable_ttl_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 4
+    name: "disable_src_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 5
+    name: "disable_dst_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 6
+    name: "disable_vlan_rewrite"
+    bitwidth: 1
   }
 }
 actions {
@@ -963,6 +983,35 @@ actions {
     annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
       name: "tunnel_id_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
     }
   }
 }

--- a/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
@@ -243,6 +243,10 @@ tables {
     annotations: "@proto_id(1)"
   }
   action_refs {
+    id: 16777243
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
@@ -915,6 +919,32 @@ actions {
     name: "dst_mac"
     annotations: "@format(MAC_ADDRESS)"
     bitwidth: 48
+  }
+}
+actions {
+  preamble {
+    id: 16777243
+    name: "ingress.routing.set_port_and_src_mac_and_vlan_id"
+    alias: "set_port_and_src_mac_and_vlan_id"
+    annotations: "@unsupported"
+  }
+  params {
+    id: 1
+    name: "port"
+    type_name {
+      name: "port_id_t"
+    }
+  }
+  params {
+    id: 2
+    name: "src_mac"
+    annotations: "@format(MAC_ADDRESS)"
+    bitwidth: 48
+  }
+  params {
+    id: 3
+    name: "vlan_id"
+    bitwidth: 12
   }
 }
 actions {

--- a/sai_p4/instantiations/google/middleblock.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock.p4info.pb.txt
@@ -226,6 +226,41 @@ tables {
 }
 tables {
   preamble {
+    id: 33554498
+    name: "ingress.routing.nexthop_table"
+    alias: "nexthop_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "nexthop_id"
+    match_type: EXACT
+    type_name {
+      name: "nexthop_id_t"
+    }
+  }
+  action_refs {
+    id: 16777236
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 16777234
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
+    id: 16777239
+    annotations: "@proto_id(3)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 1024
+}
+tables {
+  preamble {
     id: 33554512
     name: "ingress.routing.tunnel_table"
     alias: "tunnel_table"
@@ -250,37 +285,6 @@ tables {
   }
   const_default_action_id: 21257015
   size: 512
-}
-tables {
-  preamble {
-    id: 33554498
-    name: "ingress.routing.nexthop_table"
-    alias: "nexthop_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-  }
-  match_fields {
-    id: 1
-    name: "nexthop_id"
-    match_type: EXACT
-    type_name {
-      name: "nexthop_id_t"
-    }
-  }
-  action_refs {
-    id: 16777236
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 16777234
-    annotations: "@proto_id(2)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  size: 1024
 }
 tables {
   preamble {
@@ -824,30 +828,46 @@ actions {
 }
 actions {
   preamble {
-    id: 16777235
-    name: "ingress.routing.mark_for_p2p_tunnel_encap"
-    alias: "mark_for_p2p_tunnel_encap"
+    id: 16777239
+    name: "ingress.routing.set_ip_nexthop_and_disable_rewrites"
+    alias: "set_ip_nexthop_and_disable_rewrites"
+    annotations: "@unsupported"
   }
   params {
     id: 1
-    name: "encap_src_ip"
-    annotations: "@format(IPV6_ADDRESS)"
-    bitwidth: 128
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
   }
   params {
     id: 2
-    name: "encap_dst_ip"
+    name: "neighbor_id"
     annotations: "@format(IPV6_ADDRESS)"
     annotations: "@refers_to(neighbor_table , neighbor_id)"
     bitwidth: 128
   }
   params {
     id: 3
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    type_name {
-      name: "router_interface_id_t"
-    }
+    name: "disable_ttl_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 4
+    name: "disable_src_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 5
+    name: "disable_dst_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 6
+    name: "disable_vlan_rewrite"
+    bitwidth: 1
   }
 }
 actions {
@@ -885,6 +905,35 @@ actions {
     annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
       name: "tunnel_id_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
     }
   }
 }

--- a/sai_p4/instantiations/google/middleblock.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock.p4info.pb.txt
@@ -32,6 +32,32 @@ tables {
 }
 tables {
   preamble {
+    id: 33554509
+    name: "ingress.vlan_untag.disable_vlan_checks_table"
+    alias: "disable_vlan_checks_table"
+    annotations: "@unsupported"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+    annotations: "@entry_restriction(\"\n    // Force the dummy_match to be wildcard.\n    dummy_match::mask == 0;\n  \")"
+  }
+  match_fields {
+    id: 1
+    name: "dummy_match"
+    bitwidth: 1
+    match_type: TERNARY
+  }
+  action_refs {
+    id: 16777242
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 1
+}
+tables {
+  preamble {
     id: 33554689
     name: "ingress.acl_pre_ingress.acl_pre_ingress_table"
     alias: "acl_pre_ingress_table"
@@ -767,6 +793,13 @@ actions {
     type_name {
       name: "vrf_id_t"
     }
+  }
+}
+actions {
+  preamble {
+    id: 16777242
+    name: "ingress.vlan_untag.disable_vlan_checks"
+    alias: "disable_vlan_checks"
   }
 }
 actions {

--- a/sai_p4/instantiations/google/middleblock.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock.p4info.pb.txt
@@ -243,6 +243,10 @@ tables {
     annotations: "@proto_id(1)"
   }
   action_refs {
+    id: 16777243
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
@@ -837,6 +841,32 @@ actions {
     name: "dst_mac"
     annotations: "@format(MAC_ADDRESS)"
     bitwidth: 48
+  }
+}
+actions {
+  preamble {
+    id: 16777243
+    name: "ingress.routing.set_port_and_src_mac_and_vlan_id"
+    alias: "set_port_and_src_mac_and_vlan_id"
+    annotations: "@unsupported"
+  }
+  params {
+    id: 1
+    name: "port"
+    type_name {
+      name: "port_id_t"
+    }
+  }
+  params {
+    id: 2
+    name: "src_mac"
+    annotations: "@format(MAC_ADDRESS)"
+    bitwidth: 48
+  }
+  params {
+    id: 3
+    name: "vlan_id"
+    bitwidth: 12
   }
 }
 actions {

--- a/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
@@ -218,33 +218,6 @@ tables {
 }
 tables {
   preamble {
-    id: 33554512
-    name: "ingress.routing.tunnel_table"
-    alias: "tunnel_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-  }
-  match_fields {
-    id: 1
-    name: "tunnel_id"
-    match_type: EXACT
-    type_name {
-      name: "tunnel_id_t"
-    }
-  }
-  action_refs {
-    id: 16777235
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  size: 512
-}
-tables {
-  preamble {
     id: 33554498
     name: "ingress.routing.nexthop_table"
     alias: "nexthop_table"
@@ -271,12 +244,43 @@ tables {
     annotations: "@proto_id(3)"
   }
   action_refs {
+    id: 16777239
+    annotations: "@proto_id(4)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
   size: 1024
+}
+tables {
+  preamble {
+    id: 33554512
+    name: "ingress.routing.tunnel_table"
+    alias: "tunnel_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "tunnel_id"
+    match_type: EXACT
+    type_name {
+      name: "tunnel_id_t"
+    }
+  }
+  action_refs {
+    id: 16777235
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 512
 }
 tables {
   preamble {
@@ -853,31 +857,46 @@ actions {
 }
 actions {
   preamble {
-    id: 16777235
-    name: "ingress.routing.mark_for_p2p_tunnel_encap"
-    alias: "mark_for_p2p_tunnel_encap"
+    id: 16777239
+    name: "ingress.routing.set_ip_nexthop_and_disable_rewrites"
+    alias: "set_ip_nexthop_and_disable_rewrites"
+    annotations: "@unsupported"
   }
   params {
     id: 1
-    name: "encap_src_ip"
-    annotations: "@format(IPV6_ADDRESS)"
-    bitwidth: 128
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
   }
   params {
     id: 2
-    name: "encap_dst_ip"
+    name: "neighbor_id"
     annotations: "@format(IPV6_ADDRESS)"
     annotations: "@refers_to(neighbor_table , neighbor_id)"
     bitwidth: 128
   }
   params {
     id: 3
-    name: "router_interface_id"
-    annotations: "@refers_to(neighbor_table , router_interface_id)"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    type_name {
-      name: "router_interface_id_t"
-    }
+    name: "disable_ttl_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 4
+    name: "disable_src_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 5
+    name: "disable_dst_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 6
+    name: "disable_vlan_rewrite"
+    bitwidth: 1
   }
 }
 actions {
@@ -939,6 +958,35 @@ actions {
     annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
       name: "tunnel_id_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
     }
   }
 }

--- a/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
@@ -32,6 +32,32 @@ tables {
 }
 tables {
   preamble {
+    id: 33554509
+    name: "ingress.vlan_untag.disable_vlan_checks_table"
+    alias: "disable_vlan_checks_table"
+    annotations: "@unsupported"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+    annotations: "@entry_restriction(\"\n    // Force the dummy_match to be wildcard.\n    dummy_match::mask == 0;\n  \")"
+  }
+  match_fields {
+    id: 1
+    name: "dummy_match"
+    bitwidth: 1
+    match_type: TERNARY
+  }
+  action_refs {
+    id: 16777242
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 1
+}
+tables {
+  preamble {
     id: 33554689
     name: "ingress.acl_pre_ingress.acl_pre_ingress_table"
     alias: "acl_pre_ingress_table"
@@ -763,6 +789,13 @@ actions {
     type_name {
       name: "vrf_id_t"
     }
+  }
+}
+actions {
+  preamble {
+    id: 16777242
+    name: "ingress.vlan_untag.disable_vlan_checks"
+    alias: "disable_vlan_checks"
   }
 }
 actions {

--- a/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
@@ -235,6 +235,10 @@ tables {
     annotations: "@proto_id(1)"
   }
   action_refs {
+    id: 16777243
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
@@ -866,6 +870,32 @@ actions {
     name: "dst_mac"
     annotations: "@format(MAC_ADDRESS)"
     bitwidth: 48
+  }
+}
+actions {
+  preamble {
+    id: 16777243
+    name: "ingress.routing.set_port_and_src_mac_and_vlan_id"
+    alias: "set_port_and_src_mac_and_vlan_id"
+    annotations: "@unsupported"
+  }
+  params {
+    id: 1
+    name: "port"
+    type_name {
+      name: "port_id_t"
+    }
+  }
+  params {
+    id: 2
+    name: "src_mac"
+    annotations: "@format(MAC_ADDRESS)"
+    bitwidth: 48
+  }
+  params {
+    id: 3
+    name: "vlan_id"
+    bitwidth: 12
   }
 }
 actions {

--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -65,7 +65,11 @@ message RouterInterfaceTableEntry {
   }
   Match match = 1;
   message Action {
-    SetPortAndSrcMacAction set_port_and_src_mac = 1;
+    oneof action {
+      SetPortAndSrcMacAction set_port_and_src_mac = 1;
+      // CAUTION: This action is not (yet) supported.
+      SetPortAndSrcMacAndVlanIdAction set_port_and_src_mac_and_vlan_id = 2;
+    }
   }
   Action action = 2;
   bytes controller_metadata = 8;
@@ -762,6 +766,13 @@ message SetIpNexthopAndDisableRewritesAction {
 }
 
 message DisableVlanChecksAction {}
+
+// CAUTION: This action is not (yet) supported.
+message SetPortAndSrcMacAndVlanIdAction {
+  string port = 1;     // Format::STRING
+  string src_mac = 2;  // Format::MAC
+  string vlan_id = 3;  // Format::HEX_STRING / 12 bits
+}
 
 message SetVrfAction {
   // Refers to 'vrf_table.vrf_id'.

--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -210,6 +210,23 @@ message Ipv6TunnelTerminationTableEntry {
   bytes controller_metadata = 8;
 }
 
+// CAUTION: This table is not (yet) supported.
+// Table entry restrictions:
+// ## Force the dummy_match to be wildcard.
+//   dummy_match::mask == 0;
+message DisableVlanChecksTableEntry {
+  message Match {
+    Ternary dummy_match = 1;  // ternary match / Format::HEX_STRING / 1 bits
+  }
+  Match match = 1;
+  message Action {
+    DisableVlanChecksAction disable_vlan_checks = 1;
+  }
+  Action action = 2;
+  int32 priority = 3;
+  bytes controller_metadata = 8;
+}
+
 message TunnelTableEntry {
   message Match {
     string tunnel_id = 1;  // exact match / Format::STRING
@@ -738,6 +755,8 @@ message SetIpNexthopAndDisableRewritesAction {
   string disable_vlan_rewrite = 6;     // Format::HEX_STRING / 1 bits
 }
 
+message DisableVlanChecksAction {}
+
 message SetVrfAction {
   // Refers to 'vrf_table.vrf_id'.
   string vrf_id = 1;  // Format::STRING
@@ -816,6 +835,8 @@ message TableEntry {
     VrfTableEntry vrf_table_entry = 74;
     // CAUTION: This table is not (yet) supported.
     Ipv6TunnelTerminationTableEntry ipv6_tunnel_termination_table_entry = 75;
+    // CAUTION: This table is not (yet) supported.
+    DisableVlanChecksTableEntry disable_vlan_checks_table_entry = 77;
     TunnelTableEntry tunnel_table_entry = 80;
     AclIngressTableEntry acl_ingress_table_entry = 256;
     AclPreIngressTableEntry acl_pre_ingress_table_entry = 257;

--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -333,6 +333,7 @@ message AclPreIngressTableEntry {
     Optional in_port = 8;  // optional match / Format::STRING
     Ternary dst_mac = 9;   // ternary match / Format::MAC
     Ternary ecn = 10;      // ternary match / Format::HEX_STRING / 2 bits
+    Ternary vlan_id = 11;  // ternary match / Format::HEX_STRING / 12 bits
   }
   Match match = 1;
   message Action {
@@ -465,6 +466,9 @@ message AclPreIngressVlanTableEntry {
 //   is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
 //   is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
 //   is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);
+// ## DSCP is only allowed on IP traffic.
+//   dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+//   ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
 // ## Forbid unsupported combinations of IP_TYPE fields.
 //   is_ipv4::mask != 0 -> (is_ipv4 == 1);
 //   is_ipv6::mask != 0 -> (is_ipv6 == 1);
@@ -477,6 +481,8 @@ message AclPreIngressMetadataTableEntry {
     Optional is_ipv6 = 3;     // optional match / Format::HEX_STRING / 1 bits
     Ternary ip_protocol = 4;  // ternary match / Format::HEX_STRING / 8 bits
     Ternary icmpv6_type = 5;  // ternary match / Format::HEX_STRING / 8 bits
+    Ternary dscp = 6;         // ternary match / Format::HEX_STRING / 6 bits
+    Ternary ecn = 7;          // ternary match / Format::HEX_STRING / 2 bits
   }
   Match match = 1;
   message Action {

--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -81,6 +81,9 @@ message NexthopTableEntry {
       SetNexthopAction set_nexthop = 1;
       SetP2pTunnelEncapNexthopAction set_p2p_tunnel_encap_nexthop = 2;
       SetIpNexthopAction set_ip_nexthop = 3;
+      // CAUTION: This action is not (yet) supported.
+      SetIpNexthopAndDisableRewritesAction set_ip_nexthop_and_disable_rewrites =
+          4;
     }
   }
   Action action = 2;
@@ -720,6 +723,19 @@ message SetMetadataAndDropAction {
 
 message MarkForTunnelDecapAndSetVrfAction {
   string vrf_id = 1;  // Format::STRING
+}
+
+// CAUTION: This action is not (yet) supported.
+message SetIpNexthopAndDisableRewritesAction {
+  // Refers to 'router_interface_table.router_interface_id'.
+  // Refers to 'neighbor_table.router_interface_id'.
+  string router_interface_id = 1;  // Format::STRING
+  // Refers to 'neighbor_table.neighbor_id'.
+  string neighbor_id = 2;              // Format::IPV6 / 128 bits
+  string disable_ttl_rewrite = 3;      // Format::HEX_STRING / 1 bits
+  string disable_src_mac_rewrite = 4;  // Format::HEX_STRING / 1 bits
+  string disable_dst_mac_rewrite = 5;  // Format::HEX_STRING / 1 bits
+  string disable_vlan_rewrite = 6;     // Format::HEX_STRING / 1 bits
 }
 
 message SetVrfAction {

--- a/sai_p4/instantiations/google/test_tools/BUILD.bazel
+++ b/sai_p4/instantiations/google/test_tools/BUILD.bazel
@@ -31,6 +31,7 @@ cc_library(
         "//p4_pdpi:ir",
         "//p4_pdpi:ir_cc_proto",
         "//p4_pdpi:pd",
+        "//p4_pdpi:translation_options",
         "//sai_p4/instantiations/google:sai_pd_cc_proto",
         "@com_github_google_glog//:glog",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",

--- a/sai_p4/instantiations/google/test_tools/table_entry_generator.cc
+++ b/sai_p4/instantiations/google/test_tools/table_entry_generator.cc
@@ -274,6 +274,9 @@ const absl::flat_hash_set<std::string>& KnownUnsupportedTables() {
           // TODO: Add support for this table once the switch
           // supports it.
           "ipv6_tunnel_termination_table",
+          // TODO: Add support for this table once the switch
+          // supports it.
+          "disable_vlan_checks_table",
       });
   return *kUnsupportedTables;
 }

--- a/sai_p4/instantiations/google/test_tools/test_entries.cc
+++ b/sai_p4/instantiations/google/test_tools/test_entries.cc
@@ -455,4 +455,14 @@ EntryBuilder& EntryBuilder::AddEntryDecappingAllIpInIpv6PacketsAndSettingVrf(
   return *this;
 }
 
+EntryBuilder& EntryBuilder::AddDisableVlanChecksEntry() {
+  *entries_.add_entries() = gutil::ParseProtoOrDie<sai::TableEntry>(R"pb(
+    disable_vlan_checks_table_entry {
+      action { disable_vlan_checks {} }
+      priority: 1
+    }
+  )pb");
+  return *this;
+}
+
 }  // namespace sai

--- a/sai_p4/instantiations/google/test_tools/test_entries.cc
+++ b/sai_p4/instantiations/google/test_tools/test_entries.cc
@@ -142,8 +142,8 @@ absl::StatusOr<sai::TableEntry> MakePdEntryPuntingAllPackets(
                    gutil::ParseTextProto<sai::TableEntry>(
                        R"pb(
                          acl_ingress_table_entry {
-                           match {}     # Wildcard match
-                           priority: 1  # Highest priority
+                           match {}  # Wildcard match
+                           priority: 1
                          }
                        )pb"));
   auto& acl_action = *entry.mutable_acl_ingress_table_entry()->mutable_action();
@@ -444,7 +444,7 @@ EntryBuilder& EntryBuilder::AddEntryDecappingAllIpInIpv6PacketsAndSettingVrf(
     ipv6_tunnel_termination_table_entry {
       match {}  # Wildcard match
       action { mark_for_tunnel_decap_and_set_vrf { vrf_id: "" } }
-      priority: 1  # Highest priority
+      priority: 1
     }
   )pb");
   entry.mutable_ipv6_tunnel_termination_table_entry()
@@ -462,6 +462,17 @@ EntryBuilder& EntryBuilder::AddDisableVlanChecksEntry() {
       priority: 1
     }
   )pb");
+  return *this;
+}
+
+EntryBuilder& EntryBuilder::AddEntrySettingVrfBasedOnVlanId(
+    absl::string_view vlan_id_hexstr, absl::string_view vrf) {
+  sai::AclPreIngressTableEntry& entry =
+      *entries_.add_entries()->mutable_acl_pre_ingress_table_entry();
+  entry.mutable_match()->mutable_vlan_id()->set_value(vlan_id_hexstr);
+  entry.mutable_match()->mutable_vlan_id()->set_mask("0xfff");
+  entry.mutable_action()->mutable_set_vrf()->set_vrf_id(vrf);
+  entry.set_priority(1);
   return *this;
 }
 

--- a/sai_p4/instantiations/google/test_tools/test_entries.h
+++ b/sai_p4/instantiations/google/test_tools/test_entries.h
@@ -113,6 +113,8 @@ class EntryBuilder {
       absl::string_view vrf);
   EntryBuilder& AddEntryPuntingPacketsWithTtlZeroAndOne();
   EntryBuilder& AddDisableVlanChecksEntry();
+  EntryBuilder& AddEntrySettingVrfBasedOnVlanId(
+      absl::string_view vlan_id_hexstr, absl::string_view vrf);
 
  private:
   sai::TableEntries entries_;

--- a/sai_p4/instantiations/google/test_tools/test_entries.h
+++ b/sai_p4/instantiations/google/test_tools/test_entries.h
@@ -20,6 +20,8 @@
 #ifndef GOOGLE_SAI_P4_INSTANTIATIONS_GOOGLE_TEST_TOOLS_TEST_ENTRIES_H_
 #define GOOGLE_SAI_P4_INSTANTIATIONS_GOOGLE_TEST_TOOLS_TEST_ENTRIES_H_
 
+#include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -106,7 +108,8 @@ class EntryBuilder {
   EntryBuilder& AddEntryAdmittingAllPacketsToL3();
   EntryBuilder& AddDefaultRouteForwardingAllPacketsToGivenPort(
       absl::string_view egress_port, IpVersion ip_version,
-      absl::string_view vrf);
+      absl::string_view vrf,
+      std::optional<absl::string_view> vlan_hexstr = std::nullopt);
   EntryBuilder& AddPreIngressAclEntryAssigningVrfForGivenIpType(
       absl::string_view vrf, IpVersion ip_version);
   EntryBuilder& AddEntryDecappingAllIpInIpv6PacketsAndSettingVrf(
@@ -115,6 +118,7 @@ class EntryBuilder {
   EntryBuilder& AddDisableVlanChecksEntry();
   EntryBuilder& AddEntrySettingVrfBasedOnVlanId(
       absl::string_view vlan_id_hexstr, absl::string_view vrf);
+  EntryBuilder& AddEntrySettingVrfForAllPackets(absl::string_view vrf);
 
  private:
   sai::TableEntries entries_;

--- a/sai_p4/instantiations/google/test_tools/test_entries.h
+++ b/sai_p4/instantiations/google/test_tools/test_entries.h
@@ -112,6 +112,7 @@ class EntryBuilder {
   EntryBuilder& AddEntryDecappingAllIpInIpv6PacketsAndSettingVrf(
       absl::string_view vrf);
   EntryBuilder& AddEntryPuntingPacketsWithTtlZeroAndOne();
+  EntryBuilder& AddDisableVlanChecksEntry();
 
  private:
   sai::TableEntries entries_;

--- a/sai_p4/instantiations/google/test_tools/test_entries_test.cc
+++ b/sai_p4/instantiations/google/test_tools/test_entries_test.cc
@@ -63,24 +63,6 @@ TEST_P(TestEntriesTest, MakePdEntryPuntingAllPacketsDoesNotError) {
   ASSERT_THAT(MakePdEntryPuntingAllPackets(PuntAction::kTrap), IsOkAndHolds(_));
 }
 
-TEST_P(TestEntriesTest,
-       MakePiEntriesForwardingIpPacketsToGivenPortDoesNotError) {
-  ASSERT_THAT(MakePiEntriesForwardingIpPacketsToGivenPort(
-                  /*egress_port=*/"42", sai::GetIrP4Info(GetParam())),
-              IsOkAndHolds(_));
-}
-TEST_P(TestEntriesTest,
-       MakeIrEntriesForwardingIpPacketsToGivenPortDoesNotError) {
-  ASSERT_THAT(MakeIrEntriesForwardingIpPacketsToGivenPort(
-                  /*egress_port=*/"42", sai::GetIrP4Info(GetParam())),
-              IsOkAndHolds(_));
-}
-TEST_P(TestEntriesTest,
-       MakePdEntriesForwardingIpPacketsToGivenPortDoesNotError) {
-  ASSERT_THAT(MakePdEntriesForwardingIpPacketsToGivenPort(/*egress_port=*/"42"),
-              IsOkAndHolds(_));
-}
-
 INSTANTIATE_TEST_SUITE_P(, TestEntriesTest,
                          testing::ValuesIn(sai::AllSaiInstantiations()),
                          [](const auto& info) -> std::string {

--- a/sai_p4/instantiations/google/tests/sai_p4_bmv2_packet_rewrites_test.cc
+++ b/sai_p4/instantiations/google/tests/sai_p4_bmv2_packet_rewrites_test.cc
@@ -1,0 +1,448 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+
+#include "absl/log/check.h"
+#include "absl/strings/string_view.h"
+#include "glog/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status.h"
+#include "gutil/status_matchers.h"
+#include "gutil/testing.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/p4_runtime_matchers.h"
+#include "p4_pdpi/p4_runtime_session.h"
+#include "p4_pdpi/p4_runtime_session_extras.h"
+#include "p4_pdpi/packetlib/packetlib.h"
+#include "p4_pdpi/packetlib/packetlib.pb.h"
+#include "p4_pdpi/pd.h"
+#include "p4_pdpi/string_encodings/byte_string.h"
+#include "p4_pdpi/translation_options.h"
+#include "platforms/networking/p4/p4_infra/bmv2/bmv2.h"
+#include "sai_p4/instantiations/google/instantiations.h"
+#include "sai_p4/instantiations/google/sai_p4info.h"
+#include "sai_p4/instantiations/google/sai_pd.pb.h"
+#include "sai_p4/instantiations/google/test_tools/set_up_bmv2.h"
+#include "sai_p4/instantiations/google/test_tools/test_entries.h"
+#include "tests/forwarding/packet_at_port.h"
+
+namespace pins {
+namespace {
+
+using ::gutil::EqualsProto;
+using ::gutil::IsOkAndHolds;
+using ::orion::p4::test::Bmv2;
+using ::pdpi::HasPacketIn;
+using ::pdpi::ParsedPayloadIs;
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
+using ::testing::ValuesIn;
+
+// Returns an Ipv6 packet.
+packetlib::Packet GetIpv6Packet(absl::string_view ttl) {
+  packetlib::Packet packet = gutil::ParseProtoOrDie<packetlib::Packet>(R"pb(
+    headers {
+      ethernet_header {
+        ethernet_destination: "02:03:04:05:06:77"
+        ethernet_source: "00:01:02:03:04:55"
+        ethertype: "0x86dd"  # IPv6
+      }
+    }
+    headers {
+      ipv6_header {
+        version: "0x6"
+        dscp: "0x00"
+        ecn: "0x0"
+        flow_label: "0x12345"
+        next_header: "0x11"  # UDP
+        hop_limit: "0x22"
+        ipv6_source: "2001::1"
+        ipv6_destination: "2001::2"
+      }
+    }
+    headers {
+      udp_header {
+        source_port: "0x0000"
+        destination_port: "0x0000"
+        length: "0x0013"
+      }
+    }
+    payload: "ipv6 packet"
+  )pb");
+  packet.mutable_headers(1)->mutable_ipv6_header()->set_hop_limit(ttl);
+  CHECK_OK(packetlib::PadPacketToMinimumSize(packet));
+  CHECK_OK(packetlib::UpdateAllComputedFields(packet));
+  return packet;
+}
+
+// Returns an Ipv4 packet.
+packetlib::Packet GetIpv4Packet(absl::string_view ttl) {
+  packetlib::Packet packet = gutil::ParseProtoOrDie<packetlib::Packet>(
+      R"pb(
+        headers {
+          ethernet_header {
+            ethernet_destination: "02:03:04:05:06:77"
+            ethernet_source: "00:01:02:03:04:55"
+            ethertype: "0x0800"
+          }
+        }
+        headers {
+          ipv4_header {
+            version: "0x4"
+            ihl: "0x5"
+            dscp: "0x1c"
+            ecn: "0x0"
+            total_length: "0x002e"
+            identification: "0x0000"
+            flags: "0x0"
+            fragment_offset: "0x0000"
+            ttl: "0x22"
+            protocol: "0x11"
+            ipv4_source: "192.168.100.2"
+            ipv4_destination: "192.168.100.1"
+          }
+        }
+        headers {
+          udp_header {
+            source_port: "0x0000"
+            destination_port: "0x0000"
+            length: "0x001a"
+          }
+        }
+        payload: "packet"
+      )pb");
+  packet.mutable_headers(1)->mutable_ipv4_header()->set_ttl(ttl);
+  CHECK_OK(packetlib::PadPacketToMinimumSize(packet));
+  CHECK_OK(packetlib::UpdateAllComputedFields(packet));
+  return packet;
+}
+// Returns an Ip packet for given `ip_version` and `ttl`.
+packetlib::Packet GetIpPacket(sai::IpVersion ip_version,
+                              absl::string_view ttl) {
+  switch (ip_version) {
+    case sai::IpVersion::kIpv4:
+      return GetIpv4Packet(ttl);
+    case sai::IpVersion::kIpv6:
+      return GetIpv6Packet(ttl);
+    default:
+      LOG(FATAL) << "Unsupported ip_version: "  // Crash ok
+                 << static_cast<int>(ip_version);
+  }
+}
+
+// Verifies that for each disable rewrite option in `rewrite_options`, if
+// it is set to false, the field associated with that option is rewritten. Else,
+// the field associated with that option remains the same for `input_packet` and
+// `output_packet`.
+// Note, this helper function assumes `input_packet` and `output_packet` both
+// have headers that look like [Ethernet,IP{v4,v6}]
+void VerifyOutputPacketIsRewritten(
+    const packetlib::Packet& input_packet,
+    const packetlib::Packet& output_packet,
+    const sai::NexthopRewriteOptions& rewrite_options,
+    const sai::IpVersion& ip_version) {
+  ASSERT_TRUE(input_packet.headers(0).has_ethernet_header());
+  ASSERT_TRUE(output_packet.headers(0).has_ethernet_header());
+
+  if (rewrite_options.disable_src_mac_rewrite) {
+    EXPECT_EQ(input_packet.headers(0).ethernet_header().ethernet_source(),
+              output_packet.headers(0).ethernet_header().ethernet_source());
+  } else {
+    EXPECT_NE(input_packet.headers(0).ethernet_header().ethernet_source(),
+              output_packet.headers(0).ethernet_header().ethernet_source());
+  }
+
+  if (rewrite_options.disable_dst_mac_rewrite) {
+    EXPECT_EQ(
+        input_packet.headers(0).ethernet_header().ethernet_destination(),
+        output_packet.headers(0).ethernet_header().ethernet_destination());
+  } else {
+    EXPECT_NE(
+        input_packet.headers(0).ethernet_header().ethernet_destination(),
+        output_packet.headers(0).ethernet_header().ethernet_destination());
+  }
+  switch (ip_version) {
+    case sai::IpVersion::kIpv4: {
+      ASSERT_TRUE(input_packet.headers(1).has_ipv4_header());
+      ASSERT_TRUE(output_packet.headers(1).has_ipv4_header());
+
+      if (rewrite_options.disable_ttl_rewrite) {
+        EXPECT_EQ(input_packet.headers(1).ipv4_header().ttl(),
+                  output_packet.headers(1).ipv4_header().ttl());
+      } else {
+        EXPECT_NE(input_packet.headers(1).ipv4_header().ttl(),
+                  output_packet.headers(1).ipv4_header().ttl());
+      }
+      break;
+    }
+    case sai::IpVersion::kIpv6:
+      ASSERT_TRUE(input_packet.headers(1).has_ipv6_header());
+      ASSERT_TRUE(output_packet.headers(1).has_ipv6_header());
+
+      if (rewrite_options.disable_ttl_rewrite) {
+        EXPECT_EQ(input_packet.headers(1).ipv6_header().hop_limit(),
+                  output_packet.headers(1).ipv6_header().hop_limit());
+      } else {
+        EXPECT_NE(input_packet.headers(1).ipv6_header().hop_limit(),
+                  output_packet.headers(1).ipv6_header().hop_limit());
+      }
+      break;
+    case sai::IpVersion::kIpv4And6:
+      FAIL() << "Unsupported ip_version: kIpv4And6";
+      break;
+  }
+}
+
+struct PacketRewritesTestParams {
+  sai::NexthopRewriteOptions nexthop_rewrite_options;
+  sai::IpVersion ip_version;
+  sai::Instantiation instantiation;
+};
+
+template <typename Sink>
+void AbslStringify(Sink& sink, const PacketRewritesTestParams& param) {
+  absl::Format(&sink,
+               "[disable_ttl_rewrite: %v, disable_src_mac_rewrite: %v, "
+               "disable_dst_mac_rewrite: %v, ip_version: %v, instantiation: "
+               "%v]",
+               param.nexthop_rewrite_options.disable_ttl_rewrite,
+               param.nexthop_rewrite_options.disable_src_mac_rewrite,
+               param.nexthop_rewrite_options.disable_dst_mac_rewrite,
+               param.ip_version,
+               sai::InstantiationToString(param.instantiation));
+}
+
+// Generates Cartesian product of NexthopRewriteOptions's TTL, SrcMac and DstMac
+// rewrite options.
+std::vector<sai::NexthopRewriteOptions>
+CartesianProductOfNexthopRewriteOptions() {
+  std::vector<sai::NexthopRewriteOptions> options;
+  for (bool disable_ttl_rewrite : {false, true}) {
+    for (bool disable_src_mac_rewrite : {false, true}) {
+      for (bool disable_dst_mac_rewrite : {false, true}) {
+        options.push_back(sai::NexthopRewriteOptions{
+            .disable_ttl_rewrite = disable_ttl_rewrite,
+            .disable_src_mac_rewrite = disable_src_mac_rewrite,
+            .disable_dst_mac_rewrite = disable_dst_mac_rewrite,
+        });
+      }
+    }
+  }
+  return options;
+}
+
+// Generates Cartesian product of {`nexthop_rewrite_options` x IpVersions x
+// SaiInstantiations}.
+std::vector<PacketRewritesTestParams>
+CartesianProductOfIpVersionsAndInstantiationsAndGivenRewriteOptions(
+    const std::vector<sai::NexthopRewriteOptions>& nexthop_rewrite_options) {
+  std::vector<PacketRewritesTestParams> params;
+  for (const sai::NexthopRewriteOptions& rewrite_options :
+       nexthop_rewrite_options) {
+    for (sai::IpVersion ip_version : {
+             sai::IpVersion::kIpv4,
+             sai::IpVersion::kIpv6,
+         }) {
+      for (sai::Instantiation instantiation : sai::AllSaiInstantiations()) {
+        params.push_back(PacketRewritesTestParams{
+            .nexthop_rewrite_options = rewrite_options,
+            .ip_version = ip_version,
+            .instantiation = instantiation,
+        });
+      }
+    }
+  }
+  return params;
+}
+
+constexpr int kBmv2PortBitwidth = 9;
+
+// Translates `entries` into PI form and installs them to `bmv2`.
+absl::Status InstallEntriesToBmv2(const sai::TableEntries& entries,
+                                  const sai::Instantiation& instantiation,
+                                  Bmv2& bmv2) {
+  ASSIGN_OR_RETURN(std::vector<p4::v1::Entity> pi_entries,
+                   pdpi::PdTableEntriesToPiEntities(
+                       sai::GetIrP4Info(instantiation), entries,
+                       // TODO: Remove once `@unsupported` annotation is removed
+                       // from set_ip_nexthop_and_disable_rewrites.
+                       pdpi::TranslationOptions{.allow_unsupported = true}));
+  return pdpi::InstallPiEntities(bmv2.P4RuntimeSession(), pi_entries);
+}
+
+class PacketRewritesTest
+    : public testing::TestWithParam<PacketRewritesTestParams> {};
+
+TEST_P(PacketRewritesTest, PacketsAreForwardedWithCorrectRewrites) {
+  constexpr int kIngressPort = 2;
+  constexpr int kEgressPort = 1;
+  const sai::Instantiation instantiation = GetParam().instantiation;
+  const sai::IpVersion ip_version = GetParam().ip_version;
+  const sai::NexthopRewriteOptions rewrite_options =
+      GetParam().nexthop_rewrite_options;
+
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, sai::SetUpBmv2ForSaiP4(instantiation));
+  ASSERT_OK(InstallEntriesToBmv2(
+      sai::PdEntryBuilder()
+          .AddEntriesForwardingIpPacketsToGivenPort(
+              pdpi::BitsetToP4RuntimeByteString<kBmv2PortBitwidth>(kEgressPort),
+              rewrite_options)
+          .GetDedupedEntries(),
+      instantiation, bmv2));
+  // Use input packet with TTL !=0/1. TTL == 0/1 scenarios are tested in
+  // another test below.
+  packetlib::Packet input_packet = GetIpPacket(ip_version, /*ttl=*/"0x22");
+
+  ASSERT_OK_AND_ASSIGN(std::string raw_input_packet,
+                       packetlib::SerializePacket(input_packet));
+  ASSERT_OK_AND_ASSIGN(std::vector<pins::PacketAtPort> output_packets,
+                       bmv2.SendPacket(pins::PacketAtPort{
+                           .port = kIngressPort,
+                           .data = raw_input_packet,
+                       }));
+  ASSERT_THAT(output_packets, SizeIs(1));
+  packetlib::Packet output_packet =
+      packetlib::ParsePacket(output_packets[0].data);
+  VerifyOutputPacketIsRewritten(input_packet, output_packet, rewrite_options,
+                                ip_version);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CartesianProductOfRewriteOptionsAndInstantiationsAndIpVersions,
+    PacketRewritesTest,
+    ValuesIn(
+        CartesianProductOfIpVersionsAndInstantiationsAndGivenRewriteOptions(
+            CartesianProductOfNexthopRewriteOptions())));
+
+class TtlRewriteTest : public testing::TestWithParam<PacketRewritesTestParams> {
+};
+
+// Test when TTL rewrite is disabled, packet with TTL == 1 is forwarded and
+// packet with TTL == 0 is dropped.
+TEST_P(TtlRewriteTest, PacketWithZeroOrOneTtlTest) {
+  constexpr int kIngressPort = 2;
+  constexpr int kEgressPort = 1;
+  const sai::Instantiation instantiation = GetParam().instantiation;
+  const sai::IpVersion ip_version = GetParam().ip_version;
+  const sai::NexthopRewriteOptions rewrite_options =
+      GetParam().nexthop_rewrite_options;
+
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, sai::SetUpBmv2ForSaiP4(instantiation));
+  ASSERT_OK(InstallEntriesToBmv2(
+      sai::PdEntryBuilder()
+          .AddEntriesForwardingIpPacketsToGivenPort(
+              pdpi::BitsetToP4RuntimeByteString<kBmv2PortBitwidth>(kEgressPort),
+              rewrite_options)
+          .GetDedupedEntries(),
+      instantiation, bmv2));
+
+  // Input packet with TTL == 1 should be forwarded.
+  packetlib::Packet input_packet = GetIpPacket(ip_version, /*ttl=*/"0x01");
+  ASSERT_OK_AND_ASSIGN(std::string raw_input_packet,
+                       packetlib::SerializePacket(input_packet));
+  ASSERT_OK_AND_ASSIGN(std::vector<pins::PacketAtPort> output_packets,
+                       bmv2.SendPacket(pins::PacketAtPort{
+                           .port = kIngressPort,
+                           .data = raw_input_packet,
+                       }));
+  ASSERT_THAT(output_packets, SizeIs(1));
+
+  packetlib::Packet output_packet =
+      packetlib::ParsePacket(output_packets[0].data);
+  switch (ip_version) {
+    case sai::IpVersion::kIpv4:
+      EXPECT_EQ(output_packet.headers(1).ipv4_header().ttl(), "0x01");
+      break;
+    case sai::IpVersion::kIpv6:
+      EXPECT_EQ(output_packet.headers(1).ipv6_header().hop_limit(), "0x01");
+      break;
+    default:
+      FAIL() << "Unsupported ip_version: " << static_cast<int>(ip_version);
+  }
+
+  // Input packet with TTL == 0 should be dropped.
+  input_packet = GetIpPacket(ip_version, /*ttl=*/"0x00");
+  ASSERT_OK_AND_ASSIGN(raw_input_packet,
+                       packetlib::SerializePacket(input_packet));
+  EXPECT_THAT(bmv2.SendPacket(pins::PacketAtPort{
+                  .port = kIngressPort,
+                  .data = raw_input_packet,
+              }),
+              IsOkAndHolds(IsEmpty()));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CartesianProductOfInstantiationsAndIpVersions, TtlRewriteTest,
+    ValuesIn(
+        CartesianProductOfIpVersionsAndInstantiationsAndGivenRewriteOptions(
+            {sai::NexthopRewriteOptions{.disable_ttl_rewrite = true}})));
+
+class TtlRewriteAndPuntTest
+    : public testing::TestWithParam<PacketRewritesTestParams> {};
+
+// When 0/1 ACL punt rules are present, packets with 0/1 TTL should be trapped
+// instead of being dropped by packet_rewrites.
+TEST_P(TtlRewriteAndPuntTest, ZeroAndOneTtlPacketsAreTrapped) {
+  constexpr int kIngressPort = 2;
+  const sai::Instantiation instantiation = GetParam().instantiation;
+  const sai::IpVersion ip_version = GetParam().ip_version;
+
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, sai::SetUpBmv2ForSaiP4(instantiation));
+  ASSERT_OK(InstallEntriesToBmv2(sai::PdEntryBuilder()
+                                     .AddEntryPuntingPacketsWithTtlZeroAndOne()
+                                     .GetDedupedEntries(),
+                                 instantiation, bmv2));
+
+  // Input packet with TTL == 1 should be trapped.
+  packetlib::Packet ttl_1_input_packet =
+      GetIpPacket(ip_version, /*ttl=*/"0x01");
+  ASSERT_OK_AND_ASSIGN(std::string raw_input_packet,
+                       packetlib::SerializePacket(ttl_1_input_packet));
+  EXPECT_THAT(bmv2.SendPacket(pins::PacketAtPort{
+                  .port = kIngressPort,
+                  .data = raw_input_packet,
+              }),
+              IsOkAndHolds(IsEmpty()));
+
+  // Input packet with TTL == 0 should be trapped.
+  packetlib::Packet ttl_0_input_packet =
+      GetIpPacket(ip_version, /*ttl=*/"0x00");
+  ASSERT_OK_AND_ASSIGN(raw_input_packet,
+                       packetlib::SerializePacket(ttl_0_input_packet));
+  EXPECT_THAT(bmv2.SendPacket(pins::PacketAtPort{
+                  .port = kIngressPort,
+                  .data = raw_input_packet,
+              }),
+              IsOkAndHolds(IsEmpty()));
+
+  // Check trapped packets.
+  EXPECT_THAT(
+      bmv2.P4RuntimeSession().ReadStreamChannelResponsesAndFinish(),
+      IsOkAndHolds(ElementsAre(
+          HasPacketIn(ParsedPayloadIs(EqualsProto(ttl_1_input_packet))),
+          HasPacketIn(ParsedPayloadIs(EqualsProto(ttl_0_input_packet))))));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CartesianProductOfInstantiationsAndIpVersions, TtlRewriteAndPuntTest,
+    ValuesIn(
+        CartesianProductOfIpVersionsAndInstantiationsAndGivenRewriteOptions(
+            {sai::NexthopRewriteOptions{.disable_ttl_rewrite = false}})));
+
+}  // namespace
+}  // namespace pins

--- a/sai_p4/instantiations/google/tests/sai_p4_bmv2_vlan_test.cc
+++ b/sai_p4/instantiations/google/tests/sai_p4_bmv2_vlan_test.cc
@@ -1,0 +1,282 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/log/check.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status.h"
+#include "gutil/testing.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4_pdpi/p4_runtime_session.h"
+#include "p4_pdpi/packetlib/packetlib.h"
+#include "p4_pdpi/packetlib/packetlib.pb.h"
+#include "p4_pdpi/packetlib/packetlib_matchers.h"
+#include "p4_pdpi/pd.h"
+#include "p4_pdpi/translation_options.h"
+#include "platforms/networking/p4/p4_infra/bmv2/bmv2.h"
+#include "sai_p4/instantiations/google/instantiations.h"
+#include "sai_p4/instantiations/google/sai_p4info.h"
+#include "sai_p4/instantiations/google/sai_pd.pb.h"
+#include "sai_p4/instantiations/google/test_tools/set_up_bmv2.h"
+#include "sai_p4/instantiations/google/test_tools/test_entries.h"
+
+namespace pins {
+namespace {
+
+using ::orion::p4::test::Bmv2;
+using ::packetlib::HasHeaderCase;
+using ::testing::ElementsAre;
+
+using PacketsByPort = absl::flat_hash_map<int, packetlib::Packets>;
+using VlanTest = testing::TestWithParam<sai::Instantiation>;
+
+constexpr int kIngressPort = 42;
+constexpr int kEgressPort = 1;
+constexpr absl::string_view kEgressPortProto = "\001";
+
+void PreparePacketOrDie(packetlib::Packet& packet) {
+  CHECK_OK(packetlib::PadPacketToMinimumSize(packet).status());  // Crash OK.
+  CHECK_OK(
+      packetlib::UpdateMissingComputedFields(packet).status());  // Crash OK.
+}
+
+packetlib::Packet GetIpv4PacketOrDie() {
+  auto packet = gutil::ParseProtoOrDie<packetlib::Packet>(R"pb(
+    headers {
+      ethernet_header {
+        ethernet_destination: "02:03:04:05:06:07"
+        ethernet_source: "00:01:02:03:04:05"
+        ethertype: "0x0800"  # IPv4
+      }
+    }
+    headers {
+      ipv4_header {
+        version: "0x4"
+        ihl: "0x5"
+        dscp: "0x1c"
+        ecn: "0x0"
+        identification: "0x0000"
+        flags: "0x0"
+        fragment_offset: "0x0000"
+        ttl: "0x20"
+        protocol: "0xfe"
+        ipv4_source: "192.168.100.2"
+        ipv4_destination: "192.168.100.1"
+      }
+    }
+    payload: "Untagged IPv4 packet."
+  )pb");
+  PreparePacketOrDie(packet);
+  return packet;
+}
+
+packetlib::Packet GetVlanIpv4PacketOrDie(absl::string_view vid_hexstr) {
+  auto packet = gutil::ParseProtoOrDie<packetlib::Packet>(R"pb(
+    headers {
+      ethernet_header {
+        ethernet_destination: "02:03:04:05:06:07"
+        ethernet_source: "00:01:02:03:04:05"
+        ethertype: "0x8100"  # VLAN
+      }
+    }
+    headers {
+      vlan_header {
+        priority_code_point: "0x0",
+        drop_eligible_indicator: "0x0",
+        vlan_identifier: "0x0",
+        ethertype: "0x0800"  # IPv4
+      }
+    }
+    headers {
+      ipv4_header {
+        version: "0x4"
+        ihl: "0x5"
+        dscp: "0x1c"
+        ecn: "0x0"
+        identification: "0x0000"
+        flags: "0x0"
+        fragment_offset: "0x0000"
+        ttl: "0x20"
+        protocol: "0xfe"
+        ipv4_source: "192.168.100.2"
+        ipv4_destination: "192.168.100.1"
+      }
+    }
+    payload: "VLAN tagged IPv4 packet."
+  )pb");
+  packet.mutable_headers()
+      ->Mutable(1)
+      ->mutable_vlan_header()
+      ->set_vlan_identifier(vid_hexstr);
+  PreparePacketOrDie(packet);
+  return packet;
+}
+
+absl::Status InstallEntries(Bmv2& bmv2, pdpi::IrP4Info ir_p4info,
+                            sai::TableEntries entries,
+                            pdpi::TranslationOptions options = {}) {
+  ASSIGN_OR_RETURN(
+      std::vector<p4::v1::Entity> pi_entries,
+      pdpi::PdTableEntriesToPiEntities(ir_p4info, entries,
+                                       // TODO: Remove once switch
+                                       // stack supports VLAN features.
+                                       {.allow_unsupported = true}));
+
+  // TODO: Use pdpi::InstallPiEntities instead when supported.
+  for (const auto& pi_entry : pi_entries) {
+    RETURN_IF_ERROR(pdpi::InstallPiEntity(&bmv2.P4RuntimeSession(), pi_entry));
+  }
+
+  return absl::OkStatus();
+}
+
+TEST_P(VlanTest, VlanPacketWithNonReservedVidGetsDroppedByDefault) {
+  const sai::Instantiation kInstantiation = GetParam();
+  const pdpi::IrP4Info kIrP4Info = sai::GetIrP4Info(kInstantiation);
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, sai::SetUpBmv2ForSaiP4(kInstantiation));
+
+  // Install entries to forward all IP packets.
+  ASSERT_OK(InstallEntries(
+      bmv2, kIrP4Info,
+      sai::PdEntryBuilder()
+          .AddEntriesForwardingIpPacketsToGivenPort(kEgressPortProto)
+          .GetDedupedEntries()));
+
+  // Inject VLAN tagged IPv4 test packet.
+  ASSERT_OK_AND_ASSIGN(
+      PacketsByPort output_by_port,
+      bmv2.SendPacket(kIngressPort, GetVlanIpv4PacketOrDie(
+                                        /*vid_hexstr=*/"0x002")));
+
+  // The packet must be dropped.
+  ASSERT_EQ(output_by_port.size(), 0);
+}
+
+TEST_P(VlanTest, VlanPacketWithVid4095GetsForwardedWithoutVlanTagByDefault) {
+  const sai::Instantiation kInstantiation = GetParam();
+  const pdpi::IrP4Info kIrP4Info = sai::GetIrP4Info(kInstantiation);
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, sai::SetUpBmv2ForSaiP4(kInstantiation));
+
+  // Install entries to forward all IP packets.
+  ASSERT_OK(InstallEntries(
+      bmv2, kIrP4Info,
+      sai::PdEntryBuilder()
+          .AddEntriesForwardingIpPacketsToGivenPort(kEgressPortProto)
+          .GetDedupedEntries()));
+
+  // Inject VLAN tagged IPv4 test packet.
+  ASSERT_OK_AND_ASSIGN(
+      PacketsByPort output_by_port,
+      bmv2.SendPacket(kIngressPort, GetVlanIpv4PacketOrDie(
+                                        /*vid_hexstr=*/"0xFFF")));
+
+  // The packet must be forwarded with no VLAN tag.
+  ASSERT_EQ(output_by_port.size(), 1);
+  ASSERT_THAT(output_by_port.at(kEgressPort).packets().at(0).headers(),
+              ElementsAre(HasHeaderCase(packetlib::Header::kEthernetHeader),
+                          HasHeaderCase(packetlib::Header::kIpv4Header)));
+}
+
+TEST_P(VlanTest, NonVlanPacketGetsForwardedByDefault) {
+  const sai::Instantiation kInstantiation = GetParam();
+  const pdpi::IrP4Info kIrP4Info = sai::GetIrP4Info(kInstantiation);
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, sai::SetUpBmv2ForSaiP4(kInstantiation));
+
+  // Install entries to forward all IP packets.
+  ASSERT_OK(InstallEntries(
+      bmv2, kIrP4Info,
+      sai::PdEntryBuilder()
+          .AddEntriesForwardingIpPacketsToGivenPort(kEgressPortProto)
+          .GetDedupedEntries()));
+
+  // Inject IPv4 test packet.
+  ASSERT_OK_AND_ASSIGN(PacketsByPort output_by_port,
+                       bmv2.SendPacket(kIngressPort, GetIpv4PacketOrDie()));
+
+  // The packet must be forwarded with no VLAN tag.
+  ASSERT_EQ(output_by_port.size(), 1);
+  ASSERT_THAT(output_by_port.at(kEgressPort).packets().at(0).headers(),
+              ElementsAre(HasHeaderCase(packetlib::Header::kEthernetHeader),
+                          HasHeaderCase(packetlib::Header::kIpv4Header)));
+}
+
+TEST_P(VlanTest,
+       VlanPacketWithNonReservedVidGetsFowardedWhenVlanChecksDisabled) {
+  const sai::Instantiation kInstantiation = GetParam();
+  const pdpi::IrP4Info kIrP4Info = sai::GetIrP4Info(kInstantiation);
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, sai::SetUpBmv2ForSaiP4(kInstantiation));
+
+  // Install entries to disable vlan checks and forward all IP packets
+  ASSERT_OK(InstallEntries(
+      bmv2, kIrP4Info,
+      sai::PdEntryBuilder()
+          .AddEntriesForwardingIpPacketsToGivenPort(kEgressPortProto)
+          .AddDisableVlanChecksEntry()
+          .GetDedupedEntries()));
+
+  // Inject VLAN tagged IPv4 test packet.
+  ASSERT_OK_AND_ASSIGN(
+      PacketsByPort output_by_port,
+      bmv2.SendPacket(kIngressPort, GetVlanIpv4PacketOrDie(
+                                        /*vid_hexstr=*/"0x002")));
+
+  // The packet must be forwarded.
+  ASSERT_EQ(output_by_port.size(), 1);
+  // TODO: Add the check when the logic is implemented.
+  // // The VLAN header must be removed because default entries rewrite VLAN
+  // // to 4095.
+  // ASSERT_THAT(output_by_port.at(kEgressPort).packets().at(0).headers(),
+  //             ElementsAre(HasHeaderCase(packetlib::Header::kEthernetHeader),
+  //                         HasHeaderCase(packetlib::Header::kIpv4Header)));
+}
+
+TEST_P(VlanTest, NonVlanPacketGetsFowardedWhenVlanChecksDisabled) {
+  const sai::Instantiation kInstantiation = GetParam();
+  const pdpi::IrP4Info kIrP4Info = sai::GetIrP4Info(kInstantiation);
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, sai::SetUpBmv2ForSaiP4(kInstantiation));
+
+  // Install entries to disable vlan checks and forward all IP packets
+  ASSERT_OK(InstallEntries(
+      bmv2, kIrP4Info,
+      sai::PdEntryBuilder()
+          .AddEntriesForwardingIpPacketsToGivenPort(kEgressPortProto)
+          .AddDisableVlanChecksEntry()
+          .GetDedupedEntries()));
+
+  // Inject IPv4 test packet.
+  ASSERT_OK_AND_ASSIGN(PacketsByPort output_by_port,
+                       bmv2.SendPacket(kIngressPort, GetIpv4PacketOrDie()));
+
+  // The packet must be forwarded with no VLAN tag.
+  ASSERT_EQ(output_by_port.size(), 1);
+  ASSERT_THAT(output_by_port.at(kEgressPort).packets().at(0).headers(),
+              ElementsAre(HasHeaderCase(packetlib::Header::kEthernetHeader),
+                          HasHeaderCase(packetlib::Header::kIpv4Header)));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    VlanTest, VlanTest, testing::ValuesIn(sai::AllSaiInstantiations()),
+    [&](const testing::TestParamInfo<sai::Instantiation>& info) {
+      return InstantiationToString(info.param);
+    });
+
+}  // namespace
+}  // namespace pins

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -6,6 +6,32 @@ pkg_info {
 }
 tables {
   preamble {
+    id: 33554509
+    name: "ingress.vlan_untag.disable_vlan_checks_table"
+    alias: "disable_vlan_checks_table"
+    annotations: "@unsupported"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+    annotations: "@entry_restriction(\"\n    // Force the dummy_match to be wildcard.\n    dummy_match::mask == 0;\n  \")"
+  }
+  match_fields {
+    id: 1
+    name: "dummy_match"
+    bitwidth: 1
+    match_type: TERNARY
+  }
+  action_refs {
+    id: 16777242
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 1
+}
+tables {
+  preamble {
     id: 33554689
     name: "ingress.acl_pre_ingress.acl_pre_ingress_table"
     alias: "acl_pre_ingress_table"
@@ -1014,6 +1040,13 @@ actions {
     name: "acl_drop"
     alias: "acl_drop"
     annotations: "@sai_action(SAI_PACKET_ACTION_DROP)"
+  }
+}
+actions {
+  preamble {
+    id: 16777242
+    name: "ingress.vlan_untag.disable_vlan_checks"
+    alias: "disable_vlan_checks"
   }
 }
 actions {

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -331,6 +331,10 @@ tables {
     annotations: "@proto_id(1)"
   }
   action_refs {
+    id: 16777243
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
@@ -1126,6 +1130,32 @@ actions {
     name: "dst_mac"
     annotations: "@format(MAC_ADDRESS)"
     bitwidth: 48
+  }
+}
+actions {
+  preamble {
+    id: 16777243
+    name: "ingress.routing.set_port_and_src_mac_and_vlan_id"
+    alias: "set_port_and_src_mac_and_vlan_id"
+    annotations: "@unsupported"
+  }
+  params {
+    id: 1
+    name: "port"
+    type_name {
+      name: "port_id_t"
+    }
+  }
+  params {
+    id: 2
+    name: "src_mac"
+    annotations: "@format(MAC_ADDRESS)"
+    bitwidth: 48
+  }
+  params {
+    id: 3
+    name: "vlan_id"
+    bitwidth: 12
   }
 }
 actions {

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -178,7 +178,7 @@ tables {
     alias: "acl_pre_ingress_metadata_table"
     annotations: "@sai_acl(PRE_INGRESS)"
     annotations: "@p4runtime_role(\"sdn_controller\")"
-    annotations: "@entry_restriction(\"\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n    // Only allow icmp_type matches for ICMP packets\n    icmpv6_type::mask != 0 -> ip_protocol == 58;\n  \")"
+    annotations: "@entry_restriction(\"\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // DSCP is only allowed on IP traffic.\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n    // Only allow icmp_type matches for ICMP packets\n    icmpv6_type::mask != 0 -> ip_protocol == 58;\n  \")"
   }
   match_fields {
     id: 1
@@ -213,6 +213,20 @@ tables {
     name: "icmpv6_type"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ICMPV6_TYPE)"
     bitwidth: 8
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 6
+    name: "dscp"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_DSCP)"
+    bitwidth: 6
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 7
+    name: "ecn"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ECN)"
+    bitwidth: 2
     match_type: TERNARY
   }
   action_refs {

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -300,6 +300,41 @@ tables {
 }
 tables {
   preamble {
+    id: 33554498
+    name: "ingress.routing.nexthop_table"
+    alias: "nexthop_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "nexthop_id"
+    match_type: EXACT
+    type_name {
+      name: "nexthop_id_t"
+    }
+  }
+  action_refs {
+    id: 16777236
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 16777234
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
+    id: 16777239
+    annotations: "@proto_id(3)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 1024
+}
+tables {
+  preamble {
     id: 33554512
     name: "ingress.routing.tunnel_table"
     alias: "tunnel_table"
@@ -324,37 +359,6 @@ tables {
   }
   const_default_action_id: 21257015
   size: 512
-}
-tables {
-  preamble {
-    id: 33554498
-    name: "ingress.routing.nexthop_table"
-    alias: "nexthop_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-  }
-  match_fields {
-    id: 1
-    name: "nexthop_id"
-    match_type: EXACT
-    type_name {
-      name: "nexthop_id_t"
-    }
-  }
-  action_refs {
-    id: 16777236
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 16777234
-    annotations: "@proto_id(2)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  size: 1024
 }
 tables {
   preamble {
@@ -1099,30 +1103,46 @@ actions {
 }
 actions {
   preamble {
-    id: 16777235
-    name: "ingress.routing.mark_for_p2p_tunnel_encap"
-    alias: "mark_for_p2p_tunnel_encap"
+    id: 16777239
+    name: "ingress.routing.set_ip_nexthop_and_disable_rewrites"
+    alias: "set_ip_nexthop_and_disable_rewrites"
+    annotations: "@unsupported"
   }
   params {
     id: 1
-    name: "encap_src_ip"
-    annotations: "@format(IPV6_ADDRESS)"
-    bitwidth: 128
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
   }
   params {
     id: 2
-    name: "encap_dst_ip"
+    name: "neighbor_id"
     annotations: "@format(IPV6_ADDRESS)"
     annotations: "@refers_to(neighbor_table , neighbor_id)"
     bitwidth: 128
   }
   params {
     id: 3
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    type_name {
-      name: "router_interface_id_t"
-    }
+    name: "disable_ttl_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 4
+    name: "disable_src_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 5
+    name: "disable_dst_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 6
+    name: "disable_vlan_rewrite"
+    bitwidth: 1
   }
 }
 actions {
@@ -1160,6 +1180,35 @@ actions {
     annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
       name: "tunnel_id_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
     }
   }
 }

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -998,7 +998,7 @@ tables {
     alias: "acl_pre_ingress_metadata_table"
     annotations: "@sai_acl(PRE_INGRESS)"
     annotations: "@p4runtime_role(\"sdn_controller\")"
-    annotations: "@entry_restriction(\"\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n    // Only allow icmp_type matches for ICMP packets\n    icmpv6_type::mask != 0 -> ip_protocol == 58;\n  \")"
+    annotations: "@entry_restriction(\"\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // DSCP is only allowed on IP traffic.\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n    // Only allow icmp_type matches for ICMP packets\n    icmpv6_type::mask != 0 -> ip_protocol == 58;\n  \")"
   }
   match_fields {
     id: 1
@@ -1033,6 +1033,20 @@ tables {
     name: "icmpv6_type"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ICMPV6_TYPE)"
     bitwidth: 8
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 6
+    name: "dscp"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_DSCP)"
+    bitwidth: 6
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 7
+    name: "ecn"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ECN)"
+    bitwidth: 2
     match_type: TERNARY
   }
   action_refs {

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -226,6 +226,41 @@ tables {
 }
 tables {
   preamble {
+    id: 33554498
+    name: "ingress.routing.nexthop_table"
+    alias: "nexthop_table"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+  }
+  match_fields {
+    id: 1
+    name: "nexthop_id"
+    match_type: EXACT
+    type_name {
+      name: "nexthop_id_t"
+    }
+  }
+  action_refs {
+    id: 16777236
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 16777234
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
+    id: 16777239
+    annotations: "@proto_id(3)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 1024
+}
+tables {
+  preamble {
     id: 33554512
     name: "ingress.routing.tunnel_table"
     alias: "tunnel_table"
@@ -250,37 +285,6 @@ tables {
   }
   const_default_action_id: 21257015
   size: 512
-}
-tables {
-  preamble {
-    id: 33554498
-    name: "ingress.routing.nexthop_table"
-    alias: "nexthop_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-  }
-  match_fields {
-    id: 1
-    name: "nexthop_id"
-    match_type: EXACT
-    type_name {
-      name: "nexthop_id_t"
-    }
-  }
-  action_refs {
-    id: 16777236
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 16777234
-    annotations: "@proto_id(2)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  size: 1024
 }
 tables {
   preamble {
@@ -1359,30 +1363,46 @@ actions {
 }
 actions {
   preamble {
-    id: 16777235
-    name: "ingress.routing.mark_for_p2p_tunnel_encap"
-    alias: "mark_for_p2p_tunnel_encap"
+    id: 16777239
+    name: "ingress.routing.set_ip_nexthop_and_disable_rewrites"
+    alias: "set_ip_nexthop_and_disable_rewrites"
+    annotations: "@unsupported"
   }
   params {
     id: 1
-    name: "encap_src_ip"
-    annotations: "@format(IPV6_ADDRESS)"
-    bitwidth: 128
+    name: "router_interface_id"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
+    }
   }
   params {
     id: 2
-    name: "encap_dst_ip"
+    name: "neighbor_id"
     annotations: "@format(IPV6_ADDRESS)"
     annotations: "@refers_to(neighbor_table , neighbor_id)"
     bitwidth: 128
   }
   params {
     id: 3
-    name: "router_interface_id"
-    annotations: "@refers_to(router_interface_table , router_interface_id)"
-    type_name {
-      name: "router_interface_id_t"
-    }
+    name: "disable_ttl_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 4
+    name: "disable_src_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 5
+    name: "disable_dst_mac_rewrite"
+    bitwidth: 1
+  }
+  params {
+    id: 6
+    name: "disable_vlan_rewrite"
+    bitwidth: 1
   }
 }
 actions {
@@ -1420,6 +1440,35 @@ actions {
     annotations: "@refers_to(tunnel_table , tunnel_id)"
     type_name {
       name: "tunnel_id_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 16777235
+    name: "ingress.routing.mark_for_p2p_tunnel_encap"
+    alias: "mark_for_p2p_tunnel_encap"
+  }
+  params {
+    id: 1
+    name: "encap_src_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    bitwidth: 128
+  }
+  params {
+    id: 2
+    name: "encap_dst_ip"
+    annotations: "@format(IPV6_ADDRESS)"
+    annotations: "@refers_to(neighbor_table , neighbor_id)"
+    bitwidth: 128
+  }
+  params {
+    id: 3
+    name: "router_interface_id"
+    annotations: "@refers_to(neighbor_table , router_interface_id)"
+    annotations: "@refers_to(router_interface_table , router_interface_id)"
+    type_name {
+      name: "router_interface_id_t"
     }
   }
 }

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -243,6 +243,10 @@ tables {
     annotations: "@proto_id(1)"
   }
   action_refs {
+    id: 16777243
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
@@ -1386,6 +1390,32 @@ actions {
     name: "dst_mac"
     annotations: "@format(MAC_ADDRESS)"
     bitwidth: 48
+  }
+}
+actions {
+  preamble {
+    id: 16777243
+    name: "ingress.routing.set_port_and_src_mac_and_vlan_id"
+    alias: "set_port_and_src_mac_and_vlan_id"
+    annotations: "@unsupported"
+  }
+  params {
+    id: 1
+    name: "port"
+    type_name {
+      name: "port_id_t"
+    }
+  }
+  params {
+    id: 2
+    name: "src_mac"
+    annotations: "@format(MAC_ADDRESS)"
+    bitwidth: 48
+  }
+  params {
+    id: 3
+    name: "vlan_id"
+    bitwidth: 12
   }
 }
 actions {

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -32,6 +32,32 @@ tables {
 }
 tables {
   preamble {
+    id: 33554509
+    name: "ingress.vlan_untag.disable_vlan_checks_table"
+    alias: "disable_vlan_checks_table"
+    annotations: "@unsupported"
+    annotations: "@p4runtime_role(\"sdn_controller\")"
+    annotations: "@entry_restriction(\"\n    // Force the dummy_match to be wildcard.\n    dummy_match::mask == 0;\n  \")"
+  }
+  match_fields {
+    id: 1
+    name: "dummy_match"
+    bitwidth: 1
+    match_type: TERNARY
+  }
+  action_refs {
+    id: 16777242
+    annotations: "@proto_id(1)"
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 1
+}
+tables {
+  preamble {
     id: 33554689
     name: "ingress.acl_pre_ingress.acl_pre_ingress_table"
     alias: "acl_pre_ingress_table"
@@ -1302,6 +1328,13 @@ actions {
     type_name {
       name: "vrf_id_t"
     }
+  }
+}
+actions {
+  preamble {
+    id: 16777242
+    name: "ingress.vlan_untag.disable_vlan_checks"
+    alias: "disable_vlan_checks"
   }
 }
 actions {


### PR DESCRIPTION
### Keyword Check:
sdivya@eonms6vm1:~/sonic_sep6/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_check.sh .
Keyword check Passed.

### Build Results:
sdivya@e25b91aea928:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 411 targets (0 packages loaded, 0 targets configured).
INFO: Found 411 targets...
...
INFO: Elapsed time: 1264.738s, Critical Path: 79.87s
INFO: 2804 processes: 1 internal, 2803 linux-sandbox.
INFO: Build completed successfully, 2804 total actions

### Test Results:
sdivya@e25b91aea928:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 411 targets (0 packages loaded, 302 targets configured).
INFO: Found 263 targets and 148 test targets...
INFO: Elapsed time: 106.186s, Critical Path: 25.90s
INFO: 153 processes: 163 linux-sandbox, 18 local.
INFO: Build completed successfully, 153 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.6s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.7s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 0.9s
//lib:basic_switch_test                                                  PASSED in 1.1s
//lib:ixia_helper_test                                                   PASSED in 1.2s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 0.9s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 15.1s
//lib/gnmi:gnmi_helper_test                                              PASSED in 3.2s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.4s
//lib/utils:json_utils_test                                              PASSED in 0.6s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 25.9s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.7s
//p4_fuzzer:fuzzer_showcase_test                                         PASSED in 1.1s
//p4_fuzzer:oracle_util_test                                             PASSED in 0.7s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.6s
//p4_pdpi:ir_properties_test                                             PASSED in 0.5s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 0.6s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:names_test                                                     PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:references_test                                                PASSED in 0.8s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.7s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.6s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.6s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 3.2s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.3s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.7s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.8s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.2s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:references_test                                        PASSED in 2.0s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.4s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.3s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.2s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.3s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.1s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.2s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 1.1s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.1s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.0s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 1.0s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 1.0s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 1.0s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 3.3s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 1.0s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.9s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.8s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.0s
//p4rt_app/tests:action_set_test                                         PASSED in 1.5s
//p4rt_app/tests:api_access_test                                         PASSED in 2.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.6s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.3s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.8s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 7.5s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.5s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.2s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.9s
//p4rt_app/tests:packetio_test                                           PASSED in 4.5s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 2.9s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.0s
//p4rt_app/tests:response_path_test                                      PASSED in 4.6s
//p4rt_app/tests:role_test                                               PASSED in 1.4s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.6s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.3s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.6s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.2s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.0s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.8s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.6s
//thinkit:generic_testbed_test                                           PASSED in 1.0s
//thinkit:mock_control_device_test                                       PASSED in 0.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 3.2s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.8s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 23.7s
  Stats over 5 runs: max = 23.7s, min = 1.4s, avg = 10.4s, dev = 7.8s

Executed 148 out of 148 tests: 148 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these aINFO: Build completed successfully, 153 total actions
sdivya@e25b91aea928:/sonic/src/sonic-p4rt/sonic-pins$ 