### PR TITLE
[p4-symbolic] Adding packet_synthesizer proto file.

### DIFF
--- a/p4_symbolic/packet_synthesizer/BUILD.bazel
+++ b/p4_symbolic/packet_synthesizer/BUILD.bazel
@@ -1,0 +1,34 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+proto_library(
+    name = "packet_synthesizer_proto",
+    srcs = ["packet_synthesizer.proto"],
+    deps = [
+        "//p4_pdpi/packetlib:packetlib_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "packet_synthesizer_cc_proto",
+    deps = [":packet_synthesizer_proto"],
+)
+

--- a/p4_symbolic/packet_synthesizer/packet_synthesizer.proto
+++ b/p4_symbolic/packet_synthesizer/packet_synthesizer.proto
@@ -1,0 +1,59 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package p4_symbolic.packet_synthesizer;
+
+import "p4/v1/p4runtime.proto";
+import "p4_pdpi/packetlib/packetlib.proto";
+
+// Protobuf equivalent of the struct in
+// third_party/pins_infra/p4_symbolic/symbolic/values.h.
+message TranslationData {
+  // Static mapping between string values and ids.
+  message StaticMapping {
+    string string_value = 1;
+    int32 integer_value = 2;
+  }
+
+  repeated StaticMapping static_mapping = 1;
+  bool dynamic_translation = 2;
+}
+
+// Contains the input parameters (P4 program, table entries, etc.) for
+// PacketSynthesizer to build the initial SMT formula.
+message PacketSynthesisParams {
+  p4.v1.ForwardingPipelineConfig pipeline_config = 1;
+  repeated p4.v1.TableEntry pi_entries = 2;
+  repeated int32 physical_port = 3;
+  map<string, TranslationData> translation_per_type = 4;
+}
+
+// Describes a packet synthesized for a given packet synthesis criteria, with an
+// expectation whether the packet gets dropped, punted to the controller, and/or
+// mirrored.
+message SynthesizedPacket {
+  packetlib.Packet packet = 1;
+  string ingress_port = 5;
+  bool drop_expected = 2;
+  bool punt_expected = 3;
+  bool mirror_expected = 4;
+}
+
+// The output of PacketSynthesizer::SynthesizePacket
+message PacketSynthesisResult {
+  // If empty, it means the input criteria was not satifiable.
+  SynthesizedPacket synthesized_packet = 1;
+}


### PR DESCRIPTION
Keyword Check:
eonms6vm2@eonms6vm2:~/psj-sonic-pins/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/key_check.sh .
Keyword check Passed.

Build and Test Results:
...
INFO: Elapsed time: 3331.898s, Critical Path: 925.27s
INFO: 9350 processes: 2819 internal, 6531 linux-sandbox.
INFO: Build completed successfully, 9350 total actions

eonms6vm2@6c57970698de:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
...
INFO: Found 314 targets and 163 test targets...
INFO: Elapsed time: 123.711s, Critical Path: 25.92s
INFO: 168 processes: 194 linux-sandbox, 18 local.
INFO: Build completed successfully, 168 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:timer_test                                                       PASSED in 5.0s
//gutil:version_test                                                     PASSED in 0.9s
//lib:basic_switch_test                                                  PASSED in 0.9s
//lib:ixia_helper_test                                                   PASSED in 3.9s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 1.0s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 15.4s
//lib/gnmi:gnmi_helper_test                                              PASSED in 3.0s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.9s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.4s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 25.9s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.7s
//p4_fuzzer:oracle_util_test                                             PASSED in 0.7s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 3.5s
//p4_pdpi:ir_properties_test                                             PASSED in 0.5s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 0.6s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:names_test                                                     PASSED in 0.8s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.7s
//p4_pdpi:references_test                                                PASSED in 0.7s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.6s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.7s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.9s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.7s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.6s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.2s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.7s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.1s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.1s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:references_test                                        PASSED in 0.1s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.4s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.3s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 0.4s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.0s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 0.1s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 0.2s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.0s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 0.4s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.0s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.0s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.0s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.0s
//p4_symbolic/symbolic:ipv4_routing_test_output                          PASSED in 0.0s
//p4_symbolic/symbolic:port_hardcoded_test_output                        PASSED in 0.0s
//p4_symbolic/symbolic:port_table_test_output                            PASSED in 0.0s
//p4_symbolic/symbolic:reflector_test_output                             PASSED in 0.0s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.7s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.3s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.3s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.2s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 1.1s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 1.0s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.9s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.8s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 1.5s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.8s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.8s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.0s
//p4rt_app/tests:action_set_test                                         PASSED in 1.4s
//p4rt_app/tests:api_access_test                                         PASSED in 1.4s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.6s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.3s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.0s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 6.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.4s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.4s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.8s
//p4rt_app/tests:packetio_test                                           PASSED in 4.2s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.8s
//p4rt_app/tests:resource_limits_test                                    PASSED in 2.1s
//p4rt_app/tests:response_path_test                                      PASSED in 4.3s
//p4rt_app/tests:role_test                                               PASSED in 1.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.8s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.0s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.8s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.2s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.9s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 5.3s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.9s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.2s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 1.0s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.0s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.9s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 3.5s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 3.5s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 13.1s
  Stats over 5 runs: max = 13.1s, min = 1.1s, avg = 6.4s, dev = 5.0s

Executed 163 out of 163 tests: 163 tests pass.
INFO: Build completed successfully, 168 total actions
eonms6vm2@6c57970698de:/sonic/src/sonic-p4rt/sonic-pins$ 