### PR TITLE
improve the precision of the fuzzer.

### DIFF
--- a/p4_fuzzer/BUILD.bazel
+++ b/p4_fuzzer/BUILD.bazel
@@ -53,28 +53,6 @@ cc_test(
 )
 
 cc_library(
-    name = "fuzzer_config",
-    srcs = [
-        "fuzzer_config.cc",
-    ],
-    hdrs = [
-        "fuzzer_config.h",
-    ],
-    deps = [
-        "//gutil:status",
-        "//lib/p4rt:p4rt_port",
-        "//p4_pdpi:ir",
-        "//p4_pdpi:ir_cc_proto",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
-        "@com_google_absl//absl/container:btree",
-        "@com_google_absl//absl/container:flat_hash_set",
-        "@com_google_absl//absl/status",
-        "@com_google_absl//absl/status:statusor",
-    ],
-)
-
-cc_library(
     name = "table_entry_key",
     srcs = ["table_entry_key.cc"],
     hdrs = ["table_entry_key.h"],
@@ -100,6 +78,16 @@ cc_test(
 )
 
 cc_library(
+    name = "fuzzer_config",
+    hdrs = [
+        "fuzzer_config.h",
+    ],
+    deps = [
+        "//p4_pdpi:ir_cc_proto",
+    ],
+)
+
+cc_library(
     name = "mutation_and_fuzz_util",
     srcs = [ 
         "fuzz_util.cc",
@@ -112,22 +100,26 @@ cc_library(
     deps = [ 
         ":annotation_util",
         ":fuzzer_cc_proto",
+        ":fuzzer_config",
         ":switch_state",
+        "//gutil:collections",
+        "//gutil:status",
+        "//p4_pdpi:ir",
+        "//p4_pdpi:ir_cc_proto",
+        "//p4_pdpi:pd",
+        "//p4_pdpi/netaddr:ipv6_address",
+        "//p4_pdpi/utils:ir",
         "@com_github_google_glog//:glog",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4types_cc_proto",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:endian",
         "@com_google_absl//absl/random",
         "@com_google_absl//absl/strings",
-        # TODO: This target is not visible in google3.
-        # "//third_party/libprotobuf_mutator:libprotobuf_mutator_internals",
-        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
-        "//gutil:collections",
-        "//p4_pdpi:ir",
-        "//p4_pdpi:pd",
-        "//p4_pdpi/utils:ir",
-    ],  
+        "@com_google_protobuf//:protobuf_lite",
+    ],
 )
 
 cc_test(

--- a/p4_fuzzer/fuzz_util.cc
+++ b/p4_fuzzer/fuzz_util.cc
@@ -3,10 +3,18 @@
 #include "absl/algorithm/container.h"
 #include "absl/base/casts.h"
 #include "absl/base/internal/endian.h"
+#include "absl/random/distributions.h"
+#include "absl/status/statusor.h"
+#include "google/protobuf/repeated_field.h"
 #include "gutil/collections.h"
+#include "gutil/status.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4/config/v1/p4types.pb.h"
 #include "p4/v1/p4runtime.pb.h"
 #include "p4_fuzzer/annotation_util.h"
 #include "p4_fuzzer/mutation.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4_pdpi/netaddr/ipv6_address.h"
 #include "p4_pdpi/pd.h"
 #include "p4_pdpi/utils/ir.h"
 
@@ -52,13 +60,17 @@ inline int DivideRoundedUp(const unsigned int n, const unsigned int d) {
   return (n - 1) / d + 1;
 }
 
-p4::v1::ActionProfileAction FuzzActionProfileAction(
-    absl::BitGen* gen, const pdpi::IrP4Info& ir_p4_info,
+absl::StatusOr<p4::v1::ActionProfileAction> FuzzActionProfileAction(
+    absl::BitGen* gen, const FuzzerConfig& config,
+    const SwitchState& switch_state,
     const pdpi::IrTableDefinition& ir_table_info) {
   p4::v1::ActionProfileAction action;
 
-  *action.mutable_action() =
-      FuzzAction(gen, ChooseNonDefaultActionRef(gen, ir_table_info).action());
+  ASSIGN_OR_RETURN(
+      *action.mutable_action(),
+      FuzzAction(
+          gen, config, switch_state,
+          ChooseNonDefaultActionRef(gen, config, ir_table_info).action()));
 
   action.set_weight(Uniform<int32_t>(*gen, 1, kActionProfileActionMaxWeight));
 
@@ -68,12 +80,26 @@ p4::v1::ActionProfileAction FuzzActionProfileAction(
   return action;
 }
 
-// Returns the table ids of tables that use one shot action selector
-// programming.
-std::vector<uint32_t> GetOneShotTableIds(const pdpi::IrP4Info& ir_p4_info) {
+// Returns the set of tables the fuzzer is fuzzing.
+std::vector<uint32_t> TablesUsedByFuzzer(const FuzzerConfig& config) {
   std::vector<uint32_t> table_ids;
 
-  for (auto& [id, table] : ir_p4_info.tables_by_id()) {
+  for (auto& [key, table] : config.info.tables_by_id()) {
+    if (table.role() != config.role) continue;
+    // TODO: the switch is currently having issues with this table.
+    if (table.preamble().alias() == "mirror_session_table") continue;
+    table_ids.push_back(key);
+  }
+  return table_ids;
+}
+
+// Returns the table ids of tables that use one shot action selector
+// programming.
+std::vector<uint32_t> GetOneShotTableIds(const FuzzerConfig& config) {
+  std::vector<uint32_t> table_ids;
+
+  for (uint32_t id : TablesUsedByFuzzer(config)) {
+    const auto& table = gutil::FindOrDie(config.info.tables_by_id(), id);
     if (table.uses_oneshot()) {
       table_ids.push_back(id);
     }
@@ -83,11 +109,11 @@ std::vector<uint32_t> GetOneShotTableIds(const pdpi::IrP4Info& ir_p4_info) {
 }
 
 // Returns the table ids of tables that contain at least one exact match field.
-std::vector<uint32_t> GetMandatoryMatchTableIds(
-    const pdpi::IrP4Info& ir_p4_info) {
+std::vector<uint32_t> GetMandatoryMatchTableIds(const FuzzerConfig& config) {
   std::vector<uint32_t> table_ids;
 
-  for (auto& [id, table] : ir_p4_info.tables_by_id()) {
+  for (uint32_t id : TablesUsedByFuzzer(config)) {
+    const auto& table = gutil::FindOrDie(config.info.tables_by_id(), id);
     for (auto& [match_id, match] : table.match_fields_by_id()) {
       if (match.match_field().match_type() ==
           p4::config::v1::MatchField::EXACT) {
@@ -98,6 +124,19 @@ std::vector<uint32_t> GetMandatoryMatchTableIds(
   }
 
   return table_ids;
+}
+
+// Returns a random ID.
+std::string FuzzRandomId(absl::BitGen* gen) {
+  // Only sample from printable/readable characters, to make debugging easier.
+  // There is a smoke test that uses crazy characters.
+  static constexpr char kIdChars[] = "abcdefghijklmnopqrstuvwxyz0123456789-";
+  int num_chars = absl::Uniform(*gen, 0, 10);
+  std::string id;
+  for (int i = 0; i < num_chars; i++) {
+    id += kIdChars[absl::Uniform<int>(*gen, 0, sizeof(kIdChars) - 1)];
+  }
+  return id;
 }
 
 // Randomly generates an update type.
@@ -116,18 +155,20 @@ Update::Type FuzzUpdateType(absl::BitGen* gen, const SwitchState& state) {
 }
 
 // Randomly generates the table id of a non-empty table.
-int FuzzNonEmptyTableId(absl::BitGen* gen, const SwitchState& switch_state) {
+int FuzzNonEmptyTableId(absl::BitGen* gen, const FuzzerConfig& config,
+                        const SwitchState& switch_state) {
   CHECK(!switch_state.AllTablesEmpty())
       << "state: " << switch_state.SwitchStateSummary();
   int table_id;
   do {
-    table_id = FuzzTableId(gen, switch_state);
+    table_id = FuzzTableId(gen, config);
   } while (switch_state.IsTableEmpty(table_id));
   return table_id;
 }
 
 // Randomly changes the table_entry, without affecting the key fields.
-void FuzzNonKeyFields(absl::BitGen* gen, TableEntry* table_entry) {
+void FuzzNonKeyFields(absl::BitGen* gen, const FuzzerConfig& config,
+                      TableEntry* table_entry) {
   // With some probability, don't modify the element at all.
   if (absl::Bernoulli(*gen, 0.5)) return;
 
@@ -141,9 +182,9 @@ void FuzzNonKeyFields(absl::BitGen* gen, TableEntry* table_entry) {
 
 // Randomly generates an INSERT or DELETE update. The update may be mutated (see
 // go/p4-fuzzer-design for mutation types).
-AnnotatedUpdate FuzzUpdate(absl::BitGen* gen, const pdpi::IrP4Info& ir_p4_info,
+AnnotatedUpdate FuzzUpdate(absl::BitGen* gen, const FuzzerConfig& config,
                            const SwitchState& switch_state) {
-  std::vector<uint32_t> table_ids = switch_state.AllTableIds();
+  std::vector<uint32_t> table_ids = TablesUsedByFuzzer(config);
   CHECK_GT(table_ids.size(), 0)
       << "Cannot generate updates for program with no tables";
 
@@ -152,22 +193,22 @@ AnnotatedUpdate FuzzUpdate(absl::BitGen* gen, const pdpi::IrP4Info& ir_p4_info,
 
   if (absl::Bernoulli(*gen, kMutateUpdateProbability)) {
     do_mutate = true;
-    mutation = FuzzMutation(gen);
+    mutation = FuzzMutation(gen, config);
     switch (mutation) {
       case Mutation::INVALID_ACTION_SELECTOR_WEIGHT:
-        table_ids = GetOneShotTableIds(ir_p4_info);
+        table_ids = GetOneShotTableIds(config);
         if (table_ids.empty()) {
           // Retry.
-          return FuzzUpdate(gen, ir_p4_info, switch_state);
+          return FuzzUpdate(gen, config, switch_state);
         }
 
         break;
 
       case Mutation::MISSING_MANDATORY_MATCH_FIELD:
-        table_ids = GetMandatoryMatchTableIds(ir_p4_info);
+        table_ids = GetMandatoryMatchTableIds(config);
         if (table_ids.empty()) {
           // Retry.
-          return FuzzUpdate(gen, ir_p4_info, switch_state);
+          return FuzzUpdate(gen, config, switch_state);
         }
         break;
 
@@ -188,22 +229,26 @@ AnnotatedUpdate FuzzUpdate(absl::BitGen* gen, const pdpi::IrP4Info& ir_p4_info,
       // exists leading to a duplicate insert. This is fine, this update is just
       // rendered invalid and the oracle incorporates this in its prediction of
       // switch behavior.
-      p4::v1::TableEntry table_entry =
-          FuzzValidTableEntry(gen, ir_p4_info, table_id);
+      absl::StatusOr<p4::v1::TableEntry> table_entry =
+          FuzzValidTableEntry(gen, config, switch_state, table_id);
+      if (!table_entry.ok()) {
+        // Retry.
+        return FuzzUpdate(gen, config, switch_state);
+      }
 
-      *update.mutable_entity()->mutable_table_entry() = table_entry;
+      *update.mutable_entity()->mutable_table_entry() = *table_entry;
 
       break;
     }
     case Update::DELETE: {
-      const int table_id = FuzzNonEmptyTableId(gen, switch_state);
+      const int table_id = FuzzNonEmptyTableId(gen, config, switch_state);
       // Within a single call of FuzzWriteRequest, this might delete the same
       // entry multiple times.  This is fine, all but one of the deletes are
       // just invalid (and it is the oracle's job to know what the switch is
       // supposed to do with this).
       TableEntry table_entry =
           UniformFromVector(gen, switch_state.GetTableEntries(table_id));
-      FuzzNonKeyFields(gen, &table_entry);
+      FuzzNonKeyFields(gen, config, &table_entry);
       *update.mutable_entity()->mutable_table_entry() = table_entry;
       break;
     }
@@ -212,28 +257,35 @@ AnnotatedUpdate FuzzUpdate(absl::BitGen* gen, const pdpi::IrP4Info& ir_p4_info,
   }
 
   if (do_mutate) {
-    if (!MutateUpdate(gen, &update, ir_p4_info, switch_state, mutation).ok()) {
+    if (!MutateUpdate(gen, config, &update, switch_state, mutation).ok()) {
       // Retry mutating the update.
-      return FuzzUpdate(gen, ir_p4_info, switch_state);
+      return FuzzUpdate(gen, config, switch_state);
     }
 
-    return GetAnnotatedUpdate(ir_p4_info, update, /* mutations = */ {mutation});
+    return GetAnnotatedUpdate(config.info, update,
+                              /* mutations = */ {mutation});
   }
 
-  return GetAnnotatedUpdate(ir_p4_info, update, /* mutations = */ {});
+  return GetAnnotatedUpdate(config.info, update, /* mutations = */ {});
 }
 
 }  // namespace
 
 // Randomly generates a table id.
-int FuzzTableId(absl::BitGen* gen, const SwitchState& switch_state) {
-  return UniformFromVector(gen, switch_state.AllTableIds());
+int FuzzTableId(absl::BitGen* gen, const FuzzerConfig& config) {
+  return UniformFromVector(gen, TablesUsedByFuzzer(config));
 }
 
-Mutation FuzzMutation(absl::BitGen* gen) {
+Mutation FuzzMutation(absl::BitGen* gen, const FuzzerConfig& config) {
   std::vector<int> valid_indexes;
 
   for (int i = Mutation_MIN; i <= Mutation_MAX; ++i) {
+    // TODO: implement missing mutations.
+    if (i == Mutation::INVALID_NEIGHBOR_ID || i == Mutation::INVALID_PORT ||
+        i == Mutation::INVALID_REFERRING_ID ||
+        i == Mutation::INVALID_QOS_QUEUE || i == Mutation::DIFFERENT_ROLE) {
+      continue;
+    }
     if (Mutation_IsValid(i)) {
       valid_indexes.push_back(i);
     }
@@ -244,7 +296,8 @@ Mutation FuzzMutation(absl::BitGen* gen) {
 }
 
 pdpi::IrActionReference ChooseNonDefaultActionRef(
-    absl::BitGen* gen, const pdpi::IrTableDefinition& ir_table_info) {
+    absl::BitGen* gen, const FuzzerConfig& config,
+    const pdpi::IrTableDefinition& ir_table_info) {
   std::vector<pdpi::IrActionReference> refs;
 
   for (const auto& action_ref : ir_table_info.entry_actions()) {
@@ -301,11 +354,6 @@ uint64_t BitsToUint64(const std::string& data) {
 }
 
 std::string FuzzBits(absl::BitGen* gen, int bits, int bytes) {
-  if (bits == 0 && bytes == 0) {
-    // TODO: For now, the fuzzer does not fuzz string fields (which have
-    // 0 bits), but instead just uses a fixed string.
-    return "some-id";
-  }
   std::string data(bytes, 0);
   for (int i = 0; i < bytes; ++i)
     data[i] = absl::implicit_cast<char>(Uniform<uint8_t>(*gen));
@@ -325,11 +373,49 @@ std::string FuzzNonZeroBits(absl::BitGen* gen, int bits) {
   }
 }
 
+// Fuzzes a value, with special handling for ports and IDs.
+absl::StatusOr<std::string> FuzzValue(
+    absl::BitGen* gen, const FuzzerConfig& config,
+    const SwitchState& switch_state,
+    const p4::config::v1::P4NamedType& type_name, int bits,
+    const google::protobuf::RepeatedPtrField<pdpi::IrMatchFieldReference>&
+        references,
+    bool non_zero) {
+  // A port: pick any valid port randomly.
+  if (type_name.name() == "port_id_t") {
+    return UniformFromVector(gen, config.ports);
+  }
+
+  // A qos queue: pick any valid qos queue randomly.
+  if (type_name.name() == "qos_queue_t") {
+    return UniformFromVector(gen, config.qos_queues);
+  }
+
+  // A neighbor ID (not referring to anything): Pick a random IPv6 address.
+  if (type_name.name() == "neighbor_id_t" && references.empty()) {
+    std::bitset<128> ipv6_bits;
+    for (int i = 0; i < 128; ++i) {
+      ipv6_bits.set(i, absl::Uniform<int>(*gen, 0, 1));
+    }
+    return netaddr::Ipv6Address::OfBitset(ipv6_bits).ToString();
+  }
+
+  // A string ID (not referring to anything): Pick a fresh random ID.
+  if (bits == 0 && references.empty()) {
+    return FuzzRandomId(gen);
+  }
+
+  // Some other value: Normally fuzz bits randomly.
+  if (non_zero) return FuzzNonZeroBits(gen, bits);
+  return FuzzBits(gen, bits);
+}
+
 uint64_t FuzzUint64(absl::BitGen* gen, int bits) {
   return BitsToUint64(FuzzBits(gen, bits, sizeof(uint64_t)));
 }
 
-p4::v1::FieldMatch FuzzTernaryFieldMatch(absl::BitGen* gen, int bits) {
+p4::v1::FieldMatch FuzzTernaryFieldMatch(absl::BitGen* gen,
+                                         const FuzzerConfig& config, int bits) {
   std::string mask = FuzzNonZeroBits(gen, bits);
   std::string value = FuzzBits(gen, bits);
 
@@ -342,7 +428,10 @@ p4::v1::FieldMatch FuzzTernaryFieldMatch(absl::BitGen* gen, int bits) {
   return match;
 }
 
-p4::v1::FieldMatch FuzzLpmFieldMatch(absl::BitGen* gen, int bits) {
+p4::v1::FieldMatch FuzzLpmFieldMatch(absl::BitGen* gen,
+                                     const FuzzerConfig& config,
+                                     const SwitchState& switch_state,
+                                     int bits) {
   // Since /8, /16, /24, and /32 are common, we want to bias the fuzzer to
   // generate more of them.
   std::vector<int> likely_bits;
@@ -366,47 +455,64 @@ p4::v1::FieldMatch FuzzLpmFieldMatch(absl::BitGen* gen, int bits) {
   return match;
 }
 
-p4::v1::FieldMatch FuzzExactFieldMatch(absl::BitGen* gen, int bits) {
+absl::StatusOr<p4::v1::FieldMatch> FuzzExactFieldMatch(
+    absl::BitGen* gen, const FuzzerConfig& config,
+    const SwitchState& switch_state,
+    const pdpi::IrMatchFieldDefinition& ir_match_field_info) {
   p4::v1::FieldMatch match;
+  p4::config::v1::MatchField field = ir_match_field_info.match_field();
   // Note that exact messages have to be provided, even if the value is 0.
-  match.mutable_exact()->set_value(FuzzBits(gen, bits));
+  ASSIGN_OR_RETURN(
+      std::string value,
+      FuzzValue(gen, config, switch_state, field.type_name(), field.bitwidth(),
+                ir_match_field_info.references(), /*non_zero=*/false));
+
+  match.mutable_exact()->set_value(value);
   return match;
 }
 
-p4::v1::FieldMatch FuzzOptionalFieldMatch(absl::BitGen* gen, int bits) {
+absl::StatusOr<p4::v1::FieldMatch> FuzzOptionalFieldMatch(
+    absl::BitGen* gen, const FuzzerConfig& config,
+    const SwitchState& switch_state,
+    const pdpi::IrMatchFieldDefinition& ir_match_field_info) {
   p4::v1::FieldMatch match;
-  if (absl::Bernoulli(*gen, 0.5)) {
-    match.mutable_optional()->set_value(FuzzBits(gen, bits));
-  }
+  p4::config::v1::MatchField field = ir_match_field_info.match_field();
+  ASSIGN_OR_RETURN(
+      std::string value,
+      FuzzValue(gen, config, switch_state, field.type_name(), field.bitwidth(),
+                ir_match_field_info.references(), /*non_zero=*/true));
+  match.mutable_optional()->set_value(value);
   return match;
 }
 
-p4::v1::FieldMatch FuzzExactFieldMatch(absl::BitGen* gen, int bits, int bytes) {
-  p4::v1::FieldMatch match;
-  match.mutable_optional()->set_value(FuzzNonZeroBits(gen, bits));
-  return match;
-}
-
-p4::v1::FieldMatch FuzzFieldMatch(
-    absl::BitGen* gen,
+absl::StatusOr<p4::v1::FieldMatch> FuzzFieldMatch(
+    absl::BitGen* gen, const FuzzerConfig& config,
+    const SwitchState& switch_state,
     const pdpi::IrMatchFieldDefinition& ir_match_field_info) {
   const p4::config::v1::MatchField& match_field_info =
       ir_match_field_info.match_field();
 
   p4::v1::FieldMatch match;
   switch (match_field_info.match_type()) {
-    case p4::config::v1::MatchField::TERNARY:
-      match = FuzzTernaryFieldMatch(gen, match_field_info.bitwidth());
+    case p4::config::v1::MatchField::TERNARY: {
+      match = FuzzTernaryFieldMatch(gen, config, match_field_info.bitwidth());
       break;
-    case p4::config::v1::MatchField::LPM:
-      match = FuzzLpmFieldMatch(gen, match_field_info.bitwidth());
+    }
+    case p4::config::v1::MatchField::LPM: {
+      match = FuzzLpmFieldMatch(gen, config, switch_state,
+                                match_field_info.bitwidth());
       break;
-    case p4::config::v1::MatchField::EXACT:
-      match = FuzzExactFieldMatch(gen, match_field_info.bitwidth());
+    }
+    case p4::config::v1::MatchField::EXACT: {
+      ASSIGN_OR_RETURN(match, FuzzExactFieldMatch(gen, config, switch_state,
+                                                  ir_match_field_info));
       break;
-    case p4::config::v1::MatchField::OPTIONAL:
-      match = FuzzOptionalFieldMatch(gen, match_field_info.bitwidth());
+    }
+    case p4::config::v1::MatchField::OPTIONAL: {
+      ASSIGN_OR_RETURN(match, FuzzOptionalFieldMatch(gen, config, switch_state,
+                                                     ir_match_field_info));
       break;
+    }
     default:
       LOG(FATAL) << "Unsupported match: " << match_field_info.DebugString();
   }
@@ -414,22 +520,30 @@ p4::v1::FieldMatch FuzzFieldMatch(
   return match;
 }
 
-p4::v1::Action FuzzAction(absl::BitGen* gen,
-                          const pdpi::IrActionDefinition& ir_action_info) {
+absl::StatusOr<p4::v1::Action> FuzzAction(
+    absl::BitGen* gen, const FuzzerConfig& config,
+    const SwitchState& switch_state,
+    const pdpi::IrActionDefinition& ir_action_info) {
   p4::v1::Action action;
   action.set_action_id(ir_action_info.preamble().id());
 
   for (auto& [id, ir_param] : ir_action_info.params_by_id()) {
     p4::v1::Action::Param* param = action.add_params();
     param->set_param_id(id);
-    param->set_value(FuzzBits(gen, ir_param.param().bitwidth()));
+    ASSIGN_OR_RETURN(
+        std::string value,
+        FuzzValue(gen, config, switch_state, ir_param.param().type_name(),
+                  ir_param.param().bitwidth(), ir_param.references(),
+                  /*non_zero=*/false));
+    param->set_value(value);
   }
 
   return action;
 }
 
-p4::v1::ActionProfileActionSet FuzzActionProfileActionSet(
-    absl::BitGen* gen, const pdpi::IrP4Info& ir_p4_info,
+absl::StatusOr<p4::v1::ActionProfileActionSet> FuzzActionProfileActionSet(
+    absl::BitGen* gen, const FuzzerConfig& config,
+    const SwitchState& switch_state,
     const pdpi::IrTableDefinition& ir_table_info) {
   p4::v1::ActionProfileActionSet action_set;
 
@@ -437,23 +551,25 @@ p4::v1::ActionProfileActionSet FuzzActionProfileActionSet(
       Uniform<int32_t>(*gen, 0, kActionProfileActionSetMax);
 
   for (auto i = 0; i < number_of_actions; i++) {
-    *action_set.add_action_profile_actions() =
-        FuzzActionProfileAction(gen, ir_p4_info, ir_table_info);
+    ASSIGN_OR_RETURN(
+        *action_set.add_action_profile_actions(),
+        FuzzActionProfileAction(gen, config, switch_state, ir_table_info));
   }
 
   return action_set;
 }
 
-void EnforceTableConstraints(absl::BitGen* gen,
-                             const pdpi::IrP4Info& ir_p4_info,
+void EnforceTableConstraints(absl::BitGen* gen, const FuzzerConfig& config,
+                             const SwitchState& switch_state,
                              const pdpi::IrTableDefinition& ir_table_info,
                              TableEntry* table_entry) {
   // TODO: implement program independent version of this function.
 }
 
-TableEntry FuzzValidTableEntry(absl::BitGen* gen,
-                               const pdpi::IrP4Info& ir_p4_info,
-                               const pdpi::IrTableDefinition& ir_table_info) {
+absl::StatusOr<TableEntry> FuzzValidTableEntry(
+    absl::BitGen* gen, const FuzzerConfig& config,
+    const SwitchState& switch_state,
+    const pdpi::IrTableDefinition& ir_table_info) {
   TableEntry table_entry;
   table_entry.set_table_id(ir_table_info.preamble().id());
 
@@ -470,29 +586,49 @@ TableEntry FuzzValidTableEntry(absl::BitGen* gen,
     // If the field can have wildcards, this may generate a wildcard match.
     // That's illegal according to P4RT spec, because wilcards must be
     // represented as the absence of that match.
-    if (match_field_info.match_field().match_type() ==
-            p4::config::v1::MatchField::TERNARY ||
-        match_field_info.match_field().match_type() ==
-            p4::config::v1::MatchField::OPTIONAL ||
-        (match_field_info.match_field().match_type() ==
-             p4::config::v1::MatchField::LPM &&
-         absl::Bernoulli(*gen, kFieldMatchWildcardProbability))) {
+    bool can_have_wildcard = match_field_info.match_field().match_type() ==
+                                 p4::config::v1::MatchField::TERNARY ||
+                             match_field_info.match_field().match_type() ==
+                                 p4::config::v1::MatchField::OPTIONAL ||
+                             match_field_info.match_field().match_type() ==
+                                 p4::config::v1::MatchField::LPM;
+    if (can_have_wildcard &&
+        absl::Bernoulli(*gen, kFieldMatchWildcardProbability)) {
       continue;
     }
 
-    *table_entry.add_match() = FuzzFieldMatch(gen, match_field_info);
+    // TODO: in_port causes the switch to return non-parsable
+    // status, skipping it for now.
+    if (match_field_info.match_field().name() == "in_port") {
+      continue;
+    }
+
+    auto match = FuzzFieldMatch(gen, config, switch_state, match_field_info);
+    if (match.ok()) {
+      *table_entry.add_match() = *match;
+    } else if (can_have_wildcard) {
+      // Skip this match since there is no valid one for it.
+      continue;
+    } else {
+      return match.status();
+    }
   }
 
-  EnforceTableConstraints(gen, ir_p4_info, ir_table_info, &table_entry);
+  EnforceTableConstraints(gen, config, switch_state, ir_table_info,
+                          &table_entry);
 
   // Generate the action.
   if (!ir_table_info.uses_oneshot()) {
     // Normal table, so choose a non-default action.
-    *table_entry.mutable_action()->mutable_action() =
-        FuzzAction(gen, ChooseNonDefaultActionRef(gen, ir_table_info).action());
+    ASSIGN_OR_RETURN(
+        *table_entry.mutable_action()->mutable_action(),
+        FuzzAction(
+            gen, config, switch_state,
+            ChooseNonDefaultActionRef(gen, config, ir_table_info).action()));
   } else {
-    *table_entry.mutable_action()->mutable_action_profile_action_set() =
-        FuzzActionProfileActionSet(gen, ir_p4_info, ir_table_info);
+    ASSIGN_OR_RETURN(
+        *table_entry.mutable_action()->mutable_action_profile_action_set(),
+        FuzzActionProfileActionSet(gen, config, switch_state, ir_table_info));
   }
 
   // Set cookie and priority.
@@ -506,47 +642,53 @@ TableEntry FuzzValidTableEntry(absl::BitGen* gen,
   return table_entry;
 }
 
-TableEntry FuzzValidTableEntry(absl::BitGen* gen,
-                               const pdpi::IrP4Info& ir_p4_info,
-                               const uint32_t table_id) {
+absl::StatusOr<TableEntry> FuzzValidTableEntry(absl::BitGen* gen,
+                                               const FuzzerConfig& config,
+                                               const SwitchState& switch_state,
+                                               const uint32_t table_id) {
   TableEntry entry;
   return FuzzValidTableEntry(
-      gen, ir_p4_info, gutil::FindOrDie(ir_p4_info.tables_by_id(), table_id));
+      gen, config, switch_state,
+      gutil::FindOrDie(config.info.tables_by_id(), table_id));
 }
 
 std::vector<AnnotatedTableEntry> ValidForwardingEntries(
-    absl::BitGen* gen, const pdpi::IrP4Info& ir_p4_info,
-    const int num_entries) {
+    absl::BitGen* gen, const FuzzerConfig& config, const int num_entries) {
   std::vector<AnnotatedTableEntry> entries;
-  SwitchState state(ir_p4_info);
+  SwitchState state(config.info);
 
   for (int i = 0; i < num_entries; ++i) {
-    p4::v1::TableEntry entry;
+    absl::StatusOr<p4::v1::TableEntry> entry;
 
     do {
-      entry = FuzzValidTableEntry(gen, ir_p4_info, FuzzTableId(gen, state));
-    } while (state.GetTableEntry(entry) != absl::nullopt);
+      entry = FuzzValidTableEntry(gen, config, state, FuzzTableId(gen, config));
+    } while (entry.ok() && state.GetTableEntry(*entry) != absl::nullopt);
+    if (!entry.ok()) {
+      // Failed to generate an entry, try again.
+      i -= 1;
+      continue;
+    }
 
     p4::v1::Update update;
     update.set_type(p4::v1::Update::INSERT);
-    *update.mutable_entity()->mutable_table_entry() = entry;
+    *update.mutable_entity()->mutable_table_entry() = *entry;
 
     CHECK(state.ApplyUpdate(update).ok());  // Crash okay
 
     entries.push_back(
-        GetAnnotatedTableEntry(ir_p4_info, entry, /*mutations = */ {}));
+        GetAnnotatedTableEntry(config.info, *entry, /*mutations = */ {}));
   }
 
   return entries;
 }
 
 AnnotatedWriteRequest FuzzWriteRequest(absl::BitGen* gen,
-                                       const pdpi::IrP4Info& ir_p4_info,
+                                       const FuzzerConfig& config,
                                        const SwitchState& switch_state) {
   AnnotatedWriteRequest request;
 
   while (absl::Bernoulli(*gen, kAddUpdateProbability)) {
-    *request.add_updates() = FuzzUpdate(gen, ir_p4_info, switch_state);
+    *request.add_updates() = FuzzUpdate(gen, config, switch_state);
     // TODO: For now, we only send requests of size <= 1. This makes
     // debugging easier.
     break;

--- a/p4_fuzzer/fuzzer.proto
+++ b/p4_fuzzer/fuzzer.proto
@@ -25,10 +25,6 @@ enum Mutation {
   // Duplicates a match field in a table entry.
   DUPLICATE_MATCH_FIELD = 4;
 
-  // Picks table entry fields and changes their value to randomly generated ones
-  // of the same type.
-  INVALID_GENERIC = 5;
-
   // Changes a table entry with an ActionProfileActionSet (intended for tables
   // that implement one-shot action selector programming) to a table that
   // expects a single action and vice versa.
@@ -43,6 +39,21 @@ enum Mutation {
 
   // Attempts to delete a table entry that does not exist in the switch.
   NONEXISTING_DELETE = 9;
+
+  // Picks a port that does not exist.
+  INVALID_PORT = 10;
+
+  // Picks an invalid qos_queue.
+  INVALID_QOS_QUEUE = 11;
+
+  // Picks an invalid neighbor id.
+  INVALID_NEIGHBOR_ID = 12;
+
+  // Picks a non-existing ID for a field that refers to another field.
+  INVALID_REFERRING_ID = 13;
+
+  // Picks a table that is not owned by the fuzzer role.
+  DIFFERENT_ROLE = 14;
 }
 
 // Human readable version of a (fuzzed) table entry. Contains the original

--- a/p4_fuzzer/fuzzer_config.h
+++ b/p4_fuzzer/fuzzer_config.h
@@ -1,99 +1,21 @@
-// Copyright 2024 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-#ifndef PINS_P4_FUZZER_FUZZER_CONFIG_H_
-#define PINS_P4_FUZZER_FUZZER_CONFIG_H_
+#ifndef GOOGLE_P4_FUZZER_FUZZER_CONFIG_H_
+#define GOOGLE_P4_FUZZER_FUZZER_CONFIG_H_
 
-#include <functional>
-#include <optional>
-#include <string>
-#include <vector>
-
-#include "absl/container/btree_set.h"
-#include "absl/container/flat_hash_set.h"
-#include "absl/status/status.h"
-#include "absl/status/statusor.h"
-#include "lib/p4rt/p4rt_port.h"
-#include "p4/config/v1/p4info.pb.h"
-#include "p4/v1/p4runtime.pb.h"
 #include "p4_pdpi/ir.pb.h"
 
 namespace p4_fuzzer {
 
-class FuzzerConfig {
- public:
-  static absl::StatusOr<FuzzerConfig> Create(
-      const p4::config::v1::P4Info& info);
-
-  absl::Status SetP4Info(const p4::config::v1::P4Info& info);
-
-  const p4::config::v1::P4Info& GetP4Info() const { return info_; }
-  const pdpi::IrP4Info& GetIrP4Info() const { return ir_info_; }
-
-  // TODO: These should be taken in as parameters and populated
-  // with Create instead.
-  // -- Required ---------------------------------------------------------------
-  // NOTE: These values are required for correct function. All of them are
-  // initialized to values that should usually work for GPINs switches.
-  // ---------------------------------------------------------------------------
-  // The set of valid port names. 1 tends to be mapped on most GPINs switches.
-  std::vector<pins_test::P4rtPortId> ports =
-      pins_test::P4rtPortId::MakeVectorFromOpenConfigEncodings({1});
-  // The set of valid QOS queues. CONTROLLER_PRIORITY_5 tends to be mapped on
-  // most GPINs switches.
-  std::vector<std::string> qos_queues = {"CONTROLLER_PRIORITY_5"};
+struct FuzzerConfig {
+  // The IrP4Info of the program to be fuzzed.
+  pdpi::IrP4Info info;
+  // The set of valid port names.
+  std::vector<std::string> ports;
+  // The set of valid QOS queues.
+  std::vector<std::string> qos_queues;
   // The P4RT role the fuzzer should use.
-  std::string role = "sdn_controller";
-  // The probability of performing a mutation on a given table entry.
-  float mutate_update_probability = 0.1;
-
-  // -- Optional ---------------------------------------------------------------
-  // The set of tables where the fuzzer should treat their resource guarantees
-  // as hard limits rather than trying to go above them. If there are
-  // limitations or bugs on the switch causing it to behave incorrectly when the
-  // resource guarantees of particular tables are exceeded, this list can be
-  // used to allow the fuzzer to produce interesting results in spite of this
-  // shortcoming.
-  // This is a btree_set to ensure a deterministic ordering.
-  absl::btree_set<std::string>
-      tables_for_which_to_not_exceed_resource_guarantees;
-  // Fully qualified names of tables, actions, or match fields to skip during
-  // fuzzing. Match field names should be prepended with the relevant table name
-  // to uniquely identify them.
-  // Users should ensure that any set that makes it impossible to generate a
-  // valid table entry for a particular table contains the table itself.
-  // TODO: Check the property above instead.
-  absl::flat_hash_set<std::string> disabled_fully_qualified_names;
-  // TODO: Fully qualified names of tables that do not support
-  // MODIFY updates. This behaviour is not compliant with p4 runtime spec.
-  absl::flat_hash_set<std::string> non_modifiable_tables;
-  // A function for masking inequalities (due to known bugs) between entries
-  // with the same TableEntryKey on the switch and in the fuzzer.
-  std::optional<
-      std::function<bool(const pdpi::IrTableEntry&, const pdpi::IrTableEntry&)>>
-      TreatAsEqualDuringReadDueToKnownBug;
-  // Controls whether empty ActionProfile one-shots should be generated.
-  bool no_empty_action_profile_groups = false;
-
- private:
-  explicit FuzzerConfig() {}
-
-  // The P4Info of the program to be fuzzed.
-  p4::config::v1::P4Info info_;
-  // Invariant: The two P4Infos are always consistent.
-  pdpi::IrP4Info ir_info_;
+  std::string role;
 };
 
 }  // namespace p4_fuzzer
 
-#endif  // PINS_P4_FUZZER_FUZZER_CONFIG_H_
+#endif  // GOOGLE_P4_FUZZER_FUZZER_CONFIG_H_

--- a/p4_fuzzer/mutation.h
+++ b/p4_fuzzer/mutation.h
@@ -5,6 +5,7 @@
 #include "p4/config/v1/p4info.pb.h"
 #include "p4/v1/p4runtime.pb.h"
 #include "p4_fuzzer/fuzzer.pb.h"
+#include "p4_fuzzer/fuzzer_config.h"
 #include "p4_fuzzer/switch_state.h"
 
 namespace p4_fuzzer {
@@ -18,19 +19,19 @@ namespace p4_fuzzer {
 // Sets the table id of the table entry to a value that does no belong to any
 // table in the P4 program.
 void MutateInvalidTableId(absl::BitGen* gen, p4::v1::TableEntry* entry,
-                          const pdpi::IrP4Info& ir_p4_info);
+                          const FuzzerConfig& config);
 
 // Sets the action id of the table entry to a value that does not belong to
 // any action in the P4 program.
 void MutateInvalidActionId(absl::BitGen* gen, p4::v1::TableEntry* entry,
-                           const pdpi::IrP4Info& ir_p4_info);
+                           const FuzzerConfig& config);
 
 // Sets the id of one of the match fields in the table entry to a value that
 // does no belong to any table in the P4 program. Returns an error if the table
 // entry contains no match fields.
 absl::Status MutateInvalidMatchFieldId(absl::BitGen* gen,
                                        p4::v1::TableEntry* entry,
-                                       const pdpi::IrP4Info& ir_p4_info);
+                                       const FuzzerConfig& config);
 
 // Changes the number of match fields sent via a table entry to an invalid
 // smaller value e.g 4 fields sent for a table that matches on 3.
@@ -47,30 +48,31 @@ absl::Status MutateDuplicateMatchField(absl::BitGen* gen,
 // expects a single action and vice versa.
 absl::Status MutateInvalidTableImplementation(absl::BitGen* gen,
                                               p4::v1::TableEntry* entry,
-                                              const pdpi::IrP4Info& ir_p4_info);
+                                              const FuzzerConfig& config,
+                                              const SwitchState& switch_state);
 
 // This picks an action_profile_action and sets its weight to a non-positive
 // integer. This is only intended for tables that support one-shot action
 // selector programming.
-absl::Status MutateInvalidActionSelectorWeight(
-    absl::BitGen* gen, p4::v1::TableEntry* entry,
-    const pdpi::IrP4Info& ir_p4_info);
+absl::Status MutateInvalidActionSelectorWeight(absl::BitGen* gen,
+                                               p4::v1::TableEntry* entry,
+                                               const FuzzerConfig& config);
 
 // This randomly selects an already inserted table entry from the switch state
 // and sets the value of TableEntry* entry to that of the already inserted
 // entry.
 absl::Status MutateDuplicateInsert(absl::BitGen* gen, p4::v1::Update* update,
-                                   const pdpi::IrP4Info& ir_p4_info,
+                                   const FuzzerConfig& config,
                                    const SwitchState& switch_state);
 
 // This attempts to delete a table entry that does not exist in the switch.
 absl::Status MutateNonexistingDelete(absl::BitGen* gen, p4::v1::Update* update,
-                                     const pdpi::IrP4Info& ir_p4_info,
+                                     const FuzzerConfig& config,
                                      const SwitchState& switch_state);
 
 // Applied a given mutation to the update.
-absl::Status MutateUpdate(absl::BitGen* gen, p4::v1::Update* update,
-                          const pdpi::IrP4Info& ir_p4_info,
+absl::Status MutateUpdate(absl::BitGen* gen, const FuzzerConfig& config,
+                          p4::v1::Update* update,
                           const SwitchState& switch_state,
                           const Mutation& mutation);
 }  // namespace p4_fuzzer


### PR DESCRIPTION
Key word check:

```
pins_upstream/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh p4_fuzzer/
Keyword check Passed.
```

Build result:

```
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...

Starting local Bazel server and connecting to it...
... still trying to connect to local Bazel server after 10 seconds ...
... still trying to connect to local Bazel server after 20 seconds ...
INFO: Analyzed 475 targets (249 packages loaded, 22426 targets configured).
INFO: Found 475 targets...
INFO: Elapsed time: 401.069s, Critical Path: 58.30s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
```
Test result:

```
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...

INFO: Analyzed 475 targets (0 packages loaded, 317 targets configured).
INFO: Found 312 targets and 163 test targets...
INFO: Elapsed time: 118.474s, Critical Path: 26.59s
INFO: 168 processes: 194 linux-sandbox, 18 local.
INFO: Build completed successfully, 168 total actions
//gutil:collections_test                                                 PASSED in 1.0s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 1.4s
//gutil:proto_ordering_test                                              PASSED in 0.6s
//gutil:proto_test                                                       PASSED in 0.5s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 14.0s
  Stats over 5 runs: max = 14.0s, min = 1.2s, avg = 6.8s, dev = 5.5s

Executed 163 out of 163 tests: 163 tests pass.
INFO: Build completed successfully, 168 total actions
```