### PR TITLE
[SAIP4] Add an in_port match key to the ACL Pre-Ingress Metadata table, Rename `*_ttl_rewrite` to `*_decrement_ttl` to be more aligned with SAI API, Fix comment for set_nexthop_id_and_metadata, fix format and update comment, Move @id(ROUTING_WCMP_GROUP_SELECTOR_ACTION_PROFILE_ID) to the correct place, Re-enable a disabled assertion & Fix bug causing acl_ingress_security match fields to not exist on Experimental ToR.

### DIFF
--- a/p4_pdpi/p4info_union_lib.cc
+++ b/p4_pdpi/p4info_union_lib.cc
@@ -332,36 +332,6 @@ absl::Status UnionFirstFieldIntoSecondAssertingIdenticalId(
   return absl::OkStatus();
 }
 
-// Specializes UnionFirstFieldIntoSecondAssertingIdenticalId for action
-// Profiles. Instead of requiring equality for all fields, it uses the max of
-// the sizes. This is to allow different roles to use different sizes.
-// Requires: GetId(action_profile) == GetId(unioned_action_profile)
-absl::Status UnionFirstFieldIntoSecondAssertingIdenticalId(
-    const p4::config::v1::ActionProfile& action_profile,
-    p4::config::v1::ActionProfile& unioned_action_profile) {
-  RETURN_IF_ERROR(
-      AssertIdsAreEqualForUnioning(action_profile, unioned_action_profile));
-
-  // For all sizes, use the max size of any action profile.
-  unioned_action_profile.set_size(
-      std::max(unioned_action_profile.size(), action_profile.size()));
-  unioned_action_profile.set_max_group_size(
-      std::max(unioned_action_profile.max_group_size(),
-               action_profile.max_group_size()));
-
-  if (auto diff_result =
-          DiffMessages(action_profile, unioned_action_profile,
-                       /*ignored_fields=*/{"size", "max_group_size"});
-      diff_result.has_value()) {
-    return absl::InvalidArgumentError(absl::Substitute(
-        "action profiles with identical id '$0' were incompatible. "
-        "Relevant differences: $1",
-        action_profile.preamble().id(), *diff_result));
-  }
-
-  return absl::OkStatus();
-}
-
 // Unions `fields` of type T into `unioned_fields` using their ids (as returned
 // by GetId) as keys to a map of the rest of their contents.
 template <class T>

--- a/sai_p4/fixed/ids.h
+++ b/sai_p4/fixed/ids.h
@@ -31,8 +31,10 @@
 // --- Actions -----------------------------------------------------------------
 
 // IDs of fixed SAI actions (8 most significant bits = 0x01).
-#define ROUTING_SET_DST_MAC_ACTION_ID 0x01000001                     // 16777217
-#define ROUTING_SET_PORT_AND_SRC_MAC_ACTION_ID 0x01000002            // 16777218
+#define ROUTING_SET_DST_MAC_ACTION_ID 0x01000001           // 16777217
+#define ROUTING_SET_PORT_AND_SRC_MAC_ACTION_ID 0x01000002  // 16777218
+#define ROUTING_SET_PORT_AND_SRC_MAC_AND_VLAN_ID_ACTION_ID \
+  0x0100001B                                                         // 16777243
 #define ROUTING_SET_NEXTHOP_ACTION_ID 0x01000003                     // 16777219
 #define ROUTING_SET_IP_NEXTHOP_ACTION_ID 0x01000014                  // 16777236
 #define ROUTING_SET_WCMP_GROUP_ID_ACTION_ID 0x01000004               // 16777220
@@ -56,7 +58,7 @@
 #define ROUTING_SET_METADATA_AND_DROP_ACTION_ID 0x01000015           // 16777237
 #define MARK_FOR_TUNNEL_DECAP_AND_SET_VRF_ACTION_ID 0x01000016       // 16777238
 #define DISABLE_VLAN_CHECKS_ACTION_ID 0x0100001A                   // 16777242
-// Next available action id: 0x0100001B (16777243)
+// Next available action id: 0x0100001C (16777244)
 
 // --- Action Profiles and Selectors (8 most significant bits = 0x11) ----------
 // This value should ideally be 0x11000001, but we currently have this value for

--- a/sai_p4/fixed/metadata.p4
+++ b/sai_p4/fixed/metadata.p4
@@ -202,7 +202,7 @@ struct local_metadata_t {
   vrf_id_t vrf_id;
 
   // Rewrite related fields.
-  bool enable_ttl_rewrite;
+  bool enable_decrement_ttl;
   bool enable_src_mac_rewrite;
   bool enable_dst_mac_rewrite;
   packet_rewrites_t packet_rewrites;

--- a/sai_p4/fixed/minimum_guaranteed_sizes.p4
+++ b/sai_p4/fixed/minimum_guaranteed_sizes.p4
@@ -57,15 +57,30 @@
 #define WCMP_GROUP_TABLE_MINIMUM_GUARANTEED_SIZE 0
 #endif
 
+#ifndef WCMP_GROUP_TABLE_MINIMUM_GUARANTEED_SIZE_TOR
+#define WCMP_GROUP_TABLE_MINIMUM_GUARANTEED_SIZE_TOR 0
+#endif
+
 // The size semantics for WCMP group selectors. Either SUM_OF_WEIGHTS or
 // SUM_OF_MEMBERS.
 #ifndef WCMP_GROUP_SELECTOR_SIZE_SEMANTICS
 #define WCMP_GROUP_SELECTOR_SIZE_SEMANTICS "SUM_OF_WEIGHTS"
 #endif
 
+// The size semantics for WCMP group selectors. Either SUM_OF_WEIGHTS or
+// SUM_OF_MEMBERS.
+#ifndef WCMP_GROUP_SELECTOR_SIZE_SEMANTICS_TOR
+#define WCMP_GROUP_SELECTOR_SIZE_SEMANTICS_TOR "SUM_OF_WEIGHTS"
+#endif
+
 // The maximum sum of weights or members across all wcmp groups.
 #ifndef WCMP_GROUP_SELECTOR_SIZE
 #define WCMP_GROUP_SELECTOR_SIZE 0
+#endif
+
+// The maximum sum of weights or members across all wcmp groups.
+#ifndef WCMP_GROUP_SELECTOR_SIZE_TOR
+#define WCMP_GROUP_SELECTOR_SIZE_TOR 0
 #endif
 
 // The maximum sum of weights or members for each wcmp group.

--- a/sai_p4/fixed/packet_rewrites.p4
+++ b/sai_p4/fixed/packet_rewrites.p4
@@ -15,6 +15,13 @@ control packet_rewrites(inout headers_t headers,
     // TODO: Use a more robust check to determine whether to rewrite
     // packets.
     if (local_metadata.admit_to_l3){
+      // VLAN id is kept in local_metadata until the end of egress pipeline
+      // where depending on the value of VLAN id and VLAN configuration the
+      // packet might potentially get VLAN tagged with that VLAN id.
+      // TODO: For now rewriting unconditionaly since disabling
+      // VLAN rewrite is not modeled yet. When modeled, this rewrite should
+      // become conditional too.
+//      local_metadata.vlan_id = local_metadata.packet_rewrites.vlan_id;
       if (local_metadata.enable_src_mac_rewrite) {
         headers.ethernet.src_addr = local_metadata.packet_rewrites.src_mac;
       }

--- a/sai_p4/fixed/packet_rewrites.p4
+++ b/sai_p4/fixed/packet_rewrites.p4
@@ -29,7 +29,7 @@ control packet_rewrites(inout headers_t headers,
         headers.ethernet.dst_addr = local_metadata.packet_rewrites.dst_mac;
       }
       if (headers.ipv4.isValid()) {
-        if (headers.ipv4.ttl > 0 && local_metadata.enable_ttl_rewrite) {
+        if (headers.ipv4.ttl > 0 && local_metadata.enable_decrement_ttl) {
           headers.ipv4.ttl = headers.ipv4.ttl - 1;
         }
         // TODO: Verify this is accurate when TTL rewrite is
@@ -39,7 +39,7 @@ control packet_rewrites(inout headers_t headers,
         }
       }
       if (headers.ipv6.isValid()) {
-        if (headers.ipv6.hop_limit > 0 && local_metadata.enable_ttl_rewrite) {
+        if (headers.ipv6.hop_limit > 0 && local_metadata.enable_decrement_ttl) {
           headers.ipv6.hop_limit = headers.ipv6.hop_limit - 1;
         }
         // TODO: Verify this is accurate when TTL rewrite is

--- a/sai_p4/fixed/parser.p4
+++ b/sai_p4/fixed/parser.p4
@@ -15,7 +15,7 @@ parser packet_parser(packet_in packet, out headers_t headers,
     local_metadata.vlan_id = 0;
     local_metadata.admit_to_l3 = false;
     local_metadata.vrf_id = kDefaultVrf;
-    local_metadata.enable_ttl_rewrite = false;
+    local_metadata.enable_decrement_ttl = false;
     local_metadata.enable_src_mac_rewrite = false;
     local_metadata.enable_dst_mac_rewrite = false;
     local_metadata.packet_rewrites.src_mac = 0;

--- a/sai_p4/fixed/routing.p4
+++ b/sai_p4/fixed/routing.p4
@@ -308,12 +308,24 @@ control routing(in headers_t headers,
 
   // TODO: When the P4RT compiler supports the size selector
   // annotation, this should be used to specify the semantics.
+  // #if defined(SAI_INSTANTIATION_TOR) || defined(SAI_INSTANTIATION_EXPERIMENTAL_TOR)
+  // @selector_size_semantics(WCMP_GROUP_SELECTOR_SIZE_SEMANTICS_TOR)
+  // #else
   // @selector_size_semantics(WCMP_GROUP_SELECTOR_SIZE_SEMANTICS)
+  // #endif
   // TODO: Uncomment when supported by the P4RT compiler.
   // @max_member_weight(WCMP_GROUP_SELECTOR_MAX_MEMBER_WEIGHT)
+#if defined(SAI_INSTANTIATION_TOR) || defined(SAI_INSTANTIATION_EXPERIMENTAL_TOR)
+  @max_group_size(WCMP_GROUP_SELECTOR_MAX_GROUP_SIZE_TOR)
+#else
   @max_group_size(WCMP_GROUP_SELECTOR_MAX_GROUP_SIZE)
+#endif
   action_selector(HashAlgorithm.identity,
-		  WCMP_GROUP_SELECTOR_SIZE,
+#if defined(SAI_INSTANTIATION_TOR) || defined(SAI_INSTANTIATION_EXPERIMENTAL_TOR)
+ WCMP_GROUP_SELECTOR_SIZE_TOR,
+#else
+ WCMP_GROUP_SELECTOR_SIZE,
+#endif
                   WCMP_SELECTOR_INPUT_BITWIDTH)
       wcmp_group_selector;
 
@@ -332,7 +344,11 @@ control routing(in headers_t headers,
     const default_action = NoAction;
     @id(ROUTING_WCMP_GROUP_SELECTOR_ACTION_PROFILE_ID)
         implementation = wcmp_group_selector;
+#if defined(SAI_INSTANTIATION_TOR) || defined(SAI_INSTANTIATION_EXPERIMENTAL_TOR)
+    size = WCMP_GROUP_TABLE_MINIMUM_GUARANTEED_SIZE_TOR;
+#else
     size = WCMP_GROUP_TABLE_MINIMUM_GUARANTEED_SIZE;
+#endif
   }
 
   // Action that does nothing. Like `NoAction` in `core.p4`, but following

--- a/sai_p4/fixed/vlan.p4
+++ b/sai_p4/fixed/vlan.p4
@@ -66,7 +66,7 @@ control vlan_untag(inout headers_t headers,
      // Check if VLAN checks need to be disabled.
      disable_vlan_checks_table.apply();
   }
-}  // control vlan_ingress
+}  // control vlan_untag
 
 control vlan_tag(inout headers_t headers,
                  inout local_metadata_t local_metadata,
@@ -90,6 +90,6 @@ control vlan_tag(inout headers_t headers,
         headers.ethernet.ether_type = ETHERTYPE_8021Q;
       }
   }
-}  // control vlan_egress
+}  // control vlan_tag
 
 #endif  // SAI_VLAN_P4_

--- a/sai_p4/instantiations/google/acl_ingress.p4
+++ b/sai_p4/instantiations/google/acl_ingress.p4
@@ -410,7 +410,7 @@ control acl_ingress(in headers_t headers,
 #endif
   // TODO: This comment is required for the preprocessor to not
   // spit out nonsense.
-#if defined(SAI_INSTANTIATION_TOR)
+#if defined(SAI_INSTANTIATION_EXPERIMENTAL_TOR)
     dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
     ip_protocol::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
     // Only allow l4_dst_port and l4_src_port matches for TCP/UDP packets.
@@ -453,7 +453,7 @@ control acl_ingress(in headers_t headers,
               @sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_IPV6_WORD2)
           ) @format(IPV6_ADDRESS);
 #endif
-#if defined(SAI_INSTANTIATION_TOR)
+#if defined(SAI_INSTANTIATION_EXPERIMENTAL_TOR)
       dscp : ternary
           @id(8) @name("dscp")
           @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DSCP);

--- a/sai_p4/instantiations/google/acl_pre_ingress.p4
+++ b/sai_p4/instantiations/google/acl_pre_ingress.p4
@@ -51,7 +51,8 @@ control acl_pre_ingress(in headers_t headers,
   action set_outer_vlan_id(
       @id(1) @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_SET_OUTER_VLAN_ID)
         vlan_id_t vlan_id) {
-    local_metadata.vlan_id = vlan_id;
+    // TODO: Add modeling support for VLANs if needed.
+    // local_metadata.vlan_id = vlan_id;
     acl_pre_ingress_vlan_counter.count();
   }
 
@@ -109,6 +110,10 @@ control acl_pre_ingress(in headers_t headers,
           @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ECN);
       local_metadata.ingress_port : optional @name("in_port") @id(8)
           @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT);
+#if defined(SAI_INSTANTIATION_EXPERIMENTAL_TOR)
+      local_metadata.vlan_id : ternary @name("vlan_id") @id(11)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID);
+#endif
     }
     actions = {
       @proto_id(1) set_vrf;

--- a/sai_p4/instantiations/google/acl_pre_ingress.p4
+++ b/sai_p4/instantiations/google/acl_pre_ingress.p4
@@ -201,6 +201,10 @@ control acl_pre_ingress(in headers_t headers,
       ecn : ternary
           @id(7) @name("ecn")
           @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ECN);
+#if defined(SAI_INSTANTIATION_EXPERIMENTAL_TOR)
+      local_metadata.ingress_port : optional @name("in_port") @id(8)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT);
+#endif
     }
     actions = {
       @proto_id(1) set_acl_metadata;

--- a/sai_p4/instantiations/google/acl_pre_ingress.p4
+++ b/sai_p4/instantiations/google/acl_pre_ingress.p4
@@ -128,6 +128,8 @@ control acl_pre_ingress(in headers_t headers,
   @sai_acl(PRE_INGRESS)
   @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
   @entry_restriction("
+    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).
+    ether_type != 0x0800 && ether_type != 0x86dd;
     // Forbid illegal combinations of IP_TYPE fields.
     is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
     is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
@@ -147,6 +149,8 @@ control acl_pre_ingress(in headers_t headers,
       headers.ipv6.isValid() : optional
           @id(3) @name("is_ipv6")
           @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV6ANY);
+      headers.ethernet.ether_type : ternary @name("ether_type") @id(4)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE);
     }
     actions = {
       @proto_id(1) set_outer_vlan_id;

--- a/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
@@ -992,7 +992,7 @@ actions {
   }
   params {
     id: 3
-    name: "disable_ttl_rewrite"
+    name: "disable_decrement_ttl"
     bitwidth: 1
   }
   params {

--- a/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
@@ -314,7 +314,7 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
-  size: 512
+  size: 2048
 }
 tables {
   preamble {

--- a/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
@@ -243,6 +243,10 @@ tables {
     annotations: "@proto_id(1)"
   }
   action_refs {
+    id: 16777243
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
@@ -915,6 +919,32 @@ actions {
     name: "dst_mac"
     annotations: "@format(MAC_ADDRESS)"
     bitwidth: 48
+  }
+}
+actions {
+  preamble {
+    id: 16777243
+    name: "ingress.routing.set_port_and_src_mac_and_vlan_id"
+    alias: "set_port_and_src_mac_and_vlan_id"
+    annotations: "@unsupported"
+  }
+  params {
+    id: 1
+    name: "port"
+    type_name {
+      name: "port_id_t"
+    }
+  }
+  params {
+    id: 2
+    name: "src_mac"
+    annotations: "@format(MAC_ADDRESS)"
+    bitwidth: 48
+  }
+  params {
+    id: 3
+    name: "vlan_id"
+    bitwidth: 12
   }
 }
 actions {

--- a/sai_p4/instantiations/google/middleblock.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock.p4info.pb.txt
@@ -914,7 +914,7 @@ actions {
   }
   params {
     id: 3
-    name: "disable_ttl_rewrite"
+    name: "disable_decrement_ttl"
     bitwidth: 1
   }
   params {

--- a/sai_p4/instantiations/google/middleblock.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock.p4info.pb.txt
@@ -314,7 +314,7 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
-  size: 512
+  size: 2048
 }
 tables {
   preamble {

--- a/sai_p4/instantiations/google/middleblock.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock.p4info.pb.txt
@@ -243,6 +243,10 @@ tables {
     annotations: "@proto_id(1)"
   }
   action_refs {
+    id: 16777243
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
@@ -837,6 +841,32 @@ actions {
     name: "dst_mac"
     annotations: "@format(MAC_ADDRESS)"
     bitwidth: 48
+  }
+}
+actions {
+  preamble {
+    id: 16777243
+    name: "ingress.routing.set_port_and_src_mac_and_vlan_id"
+    alias: "set_port_and_src_mac_and_vlan_id"
+    annotations: "@unsupported"
+  }
+  params {
+    id: 1
+    name: "port"
+    type_name {
+      name: "port_id_t"
+    }
+  }
+  params {
+    id: 2
+    name: "src_mac"
+    annotations: "@format(MAC_ADDRESS)"
+    bitwidth: 48
+  }
+  params {
+    id: 3
+    name: "vlan_id"
+    bitwidth: 12
   }
 }
 actions {

--- a/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
@@ -310,7 +310,7 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
-  size: 512
+  size: 2048
 }
 tables {
   preamble {

--- a/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
@@ -235,6 +235,10 @@ tables {
     annotations: "@proto_id(1)"
   }
   action_refs {
+    id: 16777243
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
@@ -866,6 +870,32 @@ actions {
     name: "dst_mac"
     annotations: "@format(MAC_ADDRESS)"
     bitwidth: 48
+  }
+}
+actions {
+  preamble {
+    id: 16777243
+    name: "ingress.routing.set_port_and_src_mac_and_vlan_id"
+    alias: "set_port_and_src_mac_and_vlan_id"
+    annotations: "@unsupported"
+  }
+  params {
+    id: 1
+    name: "port"
+    type_name {
+      name: "port_id_t"
+    }
+  }
+  params {
+    id: 2
+    name: "src_mac"
+    annotations: "@format(MAC_ADDRESS)"
+    bitwidth: 48
+  }
+  params {
+    id: 3
+    name: "vlan_id"
+    bitwidth: 12
   }
 }
 actions {

--- a/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
@@ -943,7 +943,7 @@ actions {
   }
   params {
     id: 3
-    name: "disable_ttl_rewrite"
+    name: "disable_decrement_ttl"
     bitwidth: 1
   }
   params {

--- a/sai_p4/instantiations/google/minimum_guaranteed_sizes.p4
+++ b/sai_p4/instantiations/google/minimum_guaranteed_sizes.p4
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef GOOGLE_SAI_RESOURCE_GUARANTEES_P4_
 #define GOOGLE_SAI_RESOURCE_GUARANTEES_P4_
 
@@ -34,22 +48,26 @@
 
 #define ROUTING_IPV6_TABLE_MINIMUM_GUARANTEED_SIZE 4096
 
-#define ROUTING_TUNNEL_TABLE_MINIMUM_GUARANTEED_SIZE 512
+#define ROUTING_TUNNEL_TABLE_MINIMUM_GUARANTEED_SIZE 2048
 
 #define L3_ADMIT_TABLE_MINIMUM_GUARANTEED_SIZE 128
 
 // The maximum number of wcmp groups.
 #define WCMP_GROUP_TABLE_MINIMUM_GUARANTEED_SIZE 3968
+#define WCMP_GROUP_TABLE_MINIMUM_GUARANTEED_SIZE_TOR 960
 
 
 // The size semantics for WCMP group selectors.
 #define WCMP_GROUP_SELECTOR_SIZE_SEMANTICS "SUM_OF_WEIGHTS"
+#define WCMP_GROUP_SELECTOR_SIZE_SEMANTICS_TOR "SUM_OF_WEIGHTS"
 
 // The maximum sum of members across all wcmp groups.
 #define WCMP_GROUP_SELECTOR_SIZE 49152 // 48k
+#define WCMP_GROUP_SELECTOR_SIZE_TOR 31296  // 31K
 
 // The maximum sum of weights for each wcmp group.
 #define WCMP_GROUP_SELECTOR_MAX_GROUP_SIZE 512
+#define WCMP_GROUP_SELECTOR_MAX_GROUP_SIZE_TOR 256
 
 // The max weight of an individual member when using the SUM_OF_MEMBERS size 
 // semantics.

--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -65,7 +65,11 @@ message RouterInterfaceTableEntry {
   }
   Match match = 1;
   message Action {
-    SetPortAndSrcMacAction set_port_and_src_mac = 1;
+    oneof action {
+      SetPortAndSrcMacAction set_port_and_src_mac = 1;
+      // CAUTION: This action is not (yet) supported.
+      SetPortAndSrcMacAndVlanIdAction set_port_and_src_mac_and_vlan_id = 2;
+    }
   }
   Action action = 2;
   bytes controller_metadata = 8;
@@ -762,6 +766,13 @@ message SetIpNexthopAndDisableRewritesAction {
 }
 
 message DisableVlanChecksAction {}
+
+// CAUTION: This action is not (yet) supported.
+message SetPortAndSrcMacAndVlanIdAction {
+  string port = 1;     // Format::STRING
+  string src_mac = 2;  // Format::MAC
+  string vlan_id = 3;  // Format::HEX_STRING / 12 bits
+}
 
 message SetVrfAction {
   // Refers to 'vrf_table.vrf_id'.

--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -491,6 +491,7 @@ message AclPreIngressMetadataTableEntry {
     Ternary icmpv6_type = 5;  // ternary match / Format::HEX_STRING / 8 bits
     Ternary dscp = 6;         // ternary match / Format::HEX_STRING / 6 bits
     Ternary ecn = 7;          // ternary match / Format::HEX_STRING / 2 bits
+    Optional in_port = 8;     // optional match / Format::STRING
   }
   Match match = 1;
   message Action {
@@ -633,13 +634,19 @@ message AclIngressCountingTableEntry {
 //   is_ipv6::mask != 0 -> (is_ipv6 == 1);
 message AclIngressSecurityTableEntry {
   message Match {
-    Optional is_ip = 1;      // optional match / Format::HEX_STRING / 1 bits
-    Optional is_ipv4 = 2;    // optional match / Format::HEX_STRING / 1 bits
-    Optional is_ipv6 = 3;    // optional match / Format::HEX_STRING / 1 bits
-    Ternary ether_type = 4;  // ternary match / Format::HEX_STRING / 16 bits
-    Ternary src_ip = 5;      // ternary match / Format::IPV4
-    Ternary dst_ip = 6;      // ternary match / Format::IPV4
-    Ternary src_ipv6 = 7;    // ternary match / Format::IPV6 / upper 64 bits
+    Optional is_ip = 1;        // optional match / Format::HEX_STRING / 1 bits
+    Optional is_ipv4 = 2;      // optional match / Format::HEX_STRING / 1 bits
+    Optional is_ipv6 = 3;      // optional match / Format::HEX_STRING / 1 bits
+    Ternary ether_type = 4;    // ternary match / Format::HEX_STRING / 16 bits
+    Ternary src_ip = 5;        // ternary match / Format::IPV4
+    Ternary dst_ip = 6;        // ternary match / Format::IPV4
+    Ternary src_ipv6 = 7;      // ternary match / Format::IPV6 / upper 64 bits
+    Ternary dscp = 8;          // ternary match / Format::HEX_STRING / 6 bits
+    Ternary ip_protocol = 9;   // ternary match / Format::HEX_STRING / 8 bits
+    Ternary l4_src_port = 10;  // ternary match / Format::HEX_STRING / 16 bits
+    Ternary l4_dst_port = 11;  // ternary match / Format::HEX_STRING / 16 bits
+    Ternary route_metadata = 12;  // ternary match / Format::HEX_STRING / 6 bits
+    Ternary acl_metadata = 13;    // ternary match / Format::HEX_STRING / 8 bits
   }
   Match match = 1;
   message Action {
@@ -763,7 +770,7 @@ message SetIpNexthopAndDisableRewritesAction {
   string router_interface_id = 1;  // Format::STRING
   // Refers to 'neighbor_table.neighbor_id'.
   string neighbor_id = 2;              // Format::IPV6 / 128 bits
-  string disable_ttl_rewrite = 3;      // Format::HEX_STRING / 1 bits
+  string disable_decrement_ttl = 3;    // Format::HEX_STRING / 1 bits
   string disable_src_mac_rewrite = 4;  // Format::HEX_STRING / 1 bits
   string disable_dst_mac_rewrite = 5;  // Format::HEX_STRING / 1 bits
   string disable_vlan_rewrite = 6;     // Format::HEX_STRING / 1 bits

--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -442,6 +442,9 @@ message AclEgressTableEntry {
 }
 
 // Table entry restrictions:
+// ## Forbid using ether_type for IP packets (by convention, use is_ip*
+// instead).
+//   ether_type != 0x0800 && ether_type != 0x86dd;
 // ## Forbid illegal combinations of IP_TYPE fields.
 //   is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
 //   is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
@@ -451,9 +454,10 @@ message AclEgressTableEntry {
 //   is_ipv6::mask != 0 -> (is_ipv6 == 1);
 message AclPreIngressVlanTableEntry {
   message Match {
-    Optional is_ip = 1;    // optional match / Format::HEX_STRING / 1 bits
-    Optional is_ipv4 = 2;  // optional match / Format::HEX_STRING / 1 bits
-    Optional is_ipv6 = 3;  // optional match / Format::HEX_STRING / 1 bits
+    Optional is_ip = 1;      // optional match / Format::HEX_STRING / 1 bits
+    Optional is_ipv4 = 2;    // optional match / Format::HEX_STRING / 1 bits
+    Optional is_ipv6 = 3;    // optional match / Format::HEX_STRING / 1 bits
+    Ternary ether_type = 4;  // ternary match / Format::HEX_STRING / 16 bits
   }
   Match match = 1;
   message Action {

--- a/sai_p4/instantiations/google/test_tools/test_entries.cc
+++ b/sai_p4/instantiations/google/test_tools/test_entries.cc
@@ -95,7 +95,7 @@ absl::StatusOr<sai::TableEntries> MakePdEntriesForwardingIpPacketsToGivenPort(
   nexthop_table_entry.mutable_nexthop_table_entry()
       ->mutable_match()
       ->set_nexthop_id("nexthop");
-  if (!nexthop_rewrite_options.disable_ttl_rewrite &&
+  if (!nexthop_rewrite_options.disable_decrement_ttl &&
       !nexthop_rewrite_options.disable_src_mac_rewrite &&
       !nexthop_rewrite_options.disable_dst_mac_rewrite) {
     SetIpNexthopAction* action =
@@ -111,8 +111,8 @@ absl::StatusOr<sai::TableEntries> MakePdEntriesForwardingIpPacketsToGivenPort(
             ->mutable_set_ip_nexthop_and_disable_rewrites();
     action->set_router_interface_id("rif");
     action->set_neighbor_id("fe80::2:2ff:fe02:202");
-    action->set_disable_ttl_rewrite(
-        nexthop_rewrite_options.disable_ttl_rewrite ? "0x1" : "0x0");
+    action->set_disable_decrement_ttl(
+        nexthop_rewrite_options.disable_decrement_ttl ? "0x1" : "0x0");
     action->set_disable_src_mac_rewrite(
         nexthop_rewrite_options.disable_src_mac_rewrite ? "0x1" : "0x0");
     action->set_disable_dst_mac_rewrite(

--- a/sai_p4/instantiations/google/test_tools/test_entries.cc
+++ b/sai_p4/instantiations/google/test_tools/test_entries.cc
@@ -15,6 +15,7 @@
 #include "sai_p4/instantiations/google/test_tools/test_entries.h"
 
 #include <algorithm>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -265,8 +266,8 @@ EntryBuilder& EntryBuilder::AddEntryPuntingAllPackets(PuntAction action) {
 }
 
 EntryBuilder& EntryBuilder::AddDefaultRouteForwardingAllPacketsToGivenPort(
-    absl::string_view egress_port, IpVersion ip_version,
-    absl::string_view vrf) {
+    absl::string_view egress_port, IpVersion ip_version, absl::string_view vrf,
+    std::optional<absl::string_view> vlan_hexstr) {
   const std::string kNexthopId =
       absl::StrFormat("nexthop(%s, %s)", egress_port, vrf);
   const std::string kRifId = absl::StrFormat("rif(port = %s)", egress_port);
@@ -334,21 +335,20 @@ EntryBuilder& EntryBuilder::AddDefaultRouteForwardingAllPacketsToGivenPort(
         ->set_router_interface_id(kRifId);
   }
   {
-    sai::TableEntry& entry = *entries_.add_entries();
-    entry = gutil::ParseProtoOrDie<sai::TableEntry>(R"pb(
-      router_interface_table_entry {
-        match { router_interface_id: "rif" }
-        action { set_port_and_src_mac { src_mac: "00:01:02:03:04:05" } }
-      }
-    )pb");
-    entry.mutable_router_interface_table_entry()
-        ->mutable_match()
-        ->set_router_interface_id(kRifId);
-    entry.mutable_router_interface_table_entry()
-        ->mutable_action()
-        ->mutable_set_port_and_src_mac()
-        // TODO: Pass string_view directly once proto supports it.
-        ->set_port(std::string(egress_port));
+    sai::RouterInterfaceTableEntry& entry =
+        *entries_.add_entries()->mutable_router_interface_table_entry();
+    entry.mutable_match()->set_router_interface_id(kRifId);
+    if (vlan_hexstr.has_value()) {
+      auto& action =
+          *entry.mutable_action()->mutable_set_port_and_src_mac_and_vlan_id();
+      action.set_vlan_id(*vlan_hexstr);
+      action.set_src_mac("00:01:02:03:04:05");
+      action.set_port(egress_port);
+    } else {
+      auto& action = *entry.mutable_action()->mutable_set_port_and_src_mac();
+      action.set_src_mac("00:01:02:03:04:05");
+      action.set_port(egress_port);
+    }
   }
   return *this;
 }
@@ -471,6 +471,15 @@ EntryBuilder& EntryBuilder::AddEntrySettingVrfBasedOnVlanId(
       *entries_.add_entries()->mutable_acl_pre_ingress_table_entry();
   entry.mutable_match()->mutable_vlan_id()->set_value(vlan_id_hexstr);
   entry.mutable_match()->mutable_vlan_id()->set_mask("0xfff");
+  entry.mutable_action()->mutable_set_vrf()->set_vrf_id(vrf);
+  entry.set_priority(1);
+  return *this;
+}
+
+EntryBuilder& EntryBuilder::AddEntrySettingVrfForAllPackets(
+    absl::string_view vrf) {
+  sai::AclPreIngressTableEntry& entry =
+      *entries_.add_entries()->mutable_acl_pre_ingress_table_entry();
   entry.mutable_action()->mutable_set_vrf()->set_vrf_id(vrf);
   entry.set_priority(1);
   return *this;

--- a/sai_p4/instantiations/google/test_tools/test_entries.h
+++ b/sai_p4/instantiations/google/test_tools/test_entries.h
@@ -20,6 +20,8 @@
 #ifndef GOOGLE_SAI_P4_INSTANTIATIONS_GOOGLE_TEST_TOOLS_TEST_ENTRIES_H_
 #define GOOGLE_SAI_P4_INSTANTIATIONS_GOOGLE_TEST_TOOLS_TEST_ENTRIES_H_
 
+#include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -106,7 +108,8 @@ class EntryBuilder {
   EntryBuilder& AddEntryAdmittingAllPacketsToL3();
   EntryBuilder& AddDefaultRouteForwardingAllPacketsToGivenPort(
       absl::string_view egress_port, IpVersion ip_version,
-      absl::string_view vrf);
+      absl::string_view vrf,
+      std::optional<absl::string_view> vlan_hexstr = std::nullopt);
   EntryBuilder& AddPreIngressAclEntryAssigningVrfForGivenIpType(
       absl::string_view vrf, IpVersion ip_version);
   EntryBuilder& AddEntryDecappingAllIpInIpv6PacketsAndSettingVrf(
@@ -115,6 +118,7 @@ class EntryBuilder {
   EntryBuilder& AddDisableVlanChecksEntry();
   EntryBuilder& AddEntrySettingVrfBasedOnVlanId(
       absl::string_view vlan_id_hexstr, absl::string_view vrf);
+  EntryBuilder& AddEntrySettingVrfForAllPackets(absl::string_view vrf);
 
  private:
   sai::TableEntries entries_;

--- a/sai_p4/instantiations/google/test_tools/test_entries.h
+++ b/sai_p4/instantiations/google/test_tools/test_entries.h
@@ -45,7 +45,7 @@ enum class PuntAction {
 
 // Rewrite-related options for nexthop action generation.
 struct NexthopRewriteOptions {
-  bool disable_ttl_rewrite = false;
+  bool disable_decrement_ttl = false;
   bool disable_src_mac_rewrite = false;
   bool disable_dst_mac_rewrite = false;
   bool disable_vlan_rewrite = false;

--- a/sai_p4/instantiations/google/tests/sai_p4_bmv2_packet_rewrites_test.cc
+++ b/sai_p4/instantiations/google/tests/sai_p4_bmv2_packet_rewrites_test.cc
@@ -181,7 +181,7 @@ void VerifyOutputPacketIsRewritten(
       ASSERT_TRUE(input_packet.headers(1).has_ipv4_header());
       ASSERT_TRUE(output_packet.headers(1).has_ipv4_header());
 
-      if (rewrite_options.disable_ttl_rewrite) {
+      if (rewrite_options.disable_decrement_ttl) {
         EXPECT_EQ(input_packet.headers(1).ipv4_header().ttl(),
                   output_packet.headers(1).ipv4_header().ttl());
       } else {
@@ -194,7 +194,7 @@ void VerifyOutputPacketIsRewritten(
       ASSERT_TRUE(input_packet.headers(1).has_ipv6_header());
       ASSERT_TRUE(output_packet.headers(1).has_ipv6_header());
 
-      if (rewrite_options.disable_ttl_rewrite) {
+      if (rewrite_options.disable_decrement_ttl) {
         EXPECT_EQ(input_packet.headers(1).ipv6_header().hop_limit(),
                   output_packet.headers(1).ipv6_header().hop_limit());
       } else {
@@ -217,10 +217,10 @@ struct PacketRewritesTestParams {
 template <typename Sink>
 void AbslStringify(Sink& sink, const PacketRewritesTestParams& param) {
   absl::Format(&sink,
-               "[disable_ttl_rewrite: %v, disable_src_mac_rewrite: %v, "
+               "[disable_decrement_ttl: %v, disable_src_mac_rewrite: %v, "
                "disable_dst_mac_rewrite: %v, ip_version: %v, instantiation: "
                "%v]",
-               param.nexthop_rewrite_options.disable_ttl_rewrite,
+               param.nexthop_rewrite_options.disable_decrement_ttl,
                param.nexthop_rewrite_options.disable_src_mac_rewrite,
                param.nexthop_rewrite_options.disable_dst_mac_rewrite,
                param.ip_version,
@@ -232,11 +232,11 @@ void AbslStringify(Sink& sink, const PacketRewritesTestParams& param) {
 std::vector<sai::NexthopRewriteOptions>
 CartesianProductOfNexthopRewriteOptions() {
   std::vector<sai::NexthopRewriteOptions> options;
-  for (bool disable_ttl_rewrite : {false, true}) {
+  for (bool disable_decrement_ttl : {false, true}) {
     for (bool disable_src_mac_rewrite : {false, true}) {
       for (bool disable_dst_mac_rewrite : {false, true}) {
         options.push_back(sai::NexthopRewriteOptions{
-            .disable_ttl_rewrite = disable_ttl_rewrite,
+            .disable_decrement_ttl = disable_decrement_ttl,
             .disable_src_mac_rewrite = disable_src_mac_rewrite,
             .disable_dst_mac_rewrite = disable_dst_mac_rewrite,
         });
@@ -390,7 +390,7 @@ INSTANTIATE_TEST_SUITE_P(
     CartesianProductOfInstantiationsAndIpVersions, TtlRewriteTest,
     ValuesIn(
         CartesianProductOfIpVersionsAndInstantiationsAndGivenRewriteOptions(
-            {sai::NexthopRewriteOptions{.disable_ttl_rewrite = true}})));
+            {sai::NexthopRewriteOptions{.disable_decrement_ttl = true}})));
 
 class TtlRewriteAndPuntTest
     : public testing::TestWithParam<PacketRewritesTestParams> {};
@@ -442,7 +442,7 @@ INSTANTIATE_TEST_SUITE_P(
     CartesianProductOfInstantiationsAndIpVersions, TtlRewriteAndPuntTest,
     ValuesIn(
         CartesianProductOfIpVersionsAndInstantiationsAndGivenRewriteOptions(
-            {sai::NexthopRewriteOptions{.disable_ttl_rewrite = false}})));
+            {sai::NexthopRewriteOptions{.disable_decrement_ttl = false}})));
 
 }  // namespace
 }  // namespace pins

--- a/sai_p4/instantiations/google/tests/sai_p4_bmv2_vlan_test.cc
+++ b/sai_p4/instantiations/google/tests/sai_p4_bmv2_vlan_test.cc
@@ -240,12 +240,9 @@ TEST_P(VlanTest,
 
   // The packet must be forwarded.
   ASSERT_EQ(output_by_port.size(), 1);
-  // TODO: Add the check when the logic is implemented.
-  // // The VLAN header must be removed because default entries rewrite VLAN
-  // // to 4095.
-  // ASSERT_THAT(output_by_port.at(kEgressPort).packets().at(0).headers(),
-  //             ElementsAre(HasHeaderCase(packetlib::Header::kEthernetHeader),
-  //                         HasHeaderCase(packetlib::Header::kIpv4Header)));
+  ASSERT_THAT(output_by_port.at(kEgressPort).packets().at(0).headers(),
+              ElementsAre(HasHeaderCase(packetlib::Header::kEthernetHeader),
+                          HasHeaderCase(packetlib::Header::kIpv4Header)));
 }
 
 TEST_P(VlanTest, NonVlanPacketGetsFowardedWhenVlanChecksDisabled) {

--- a/sai_p4/instantiations/google/tests/sai_p4_bmv2_vlan_test.cc
+++ b/sai_p4/instantiations/google/tests/sai_p4_bmv2_vlan_test.cc
@@ -45,6 +45,7 @@ using ::orion::p4::test::Bmv2;
 using ::packetlib::HasHeaderCase;
 using ::testing::_;
 using ::testing::ElementsAre;
+using ::testing::Eq;
 using ::testing::IsEmpty;
 using ::testing::Pair;
 
@@ -155,7 +156,7 @@ TEST_P(VlanTest, VlanPacketWithNonReservedVidGetsDroppedByDefault) {
   // Install entries to forward all IP packets.
   ASSERT_OK(InstallEntries(
       bmv2, kIrP4Info,
-      sai::PdEntryBuilder()
+      sai::EntryBuilder()
           .AddEntriesForwardingIpPacketsToGivenPort(kEgressPortProto)
           .GetDedupedEntries()));
 
@@ -177,7 +178,7 @@ TEST_P(VlanTest, VlanPacketWithVid4095GetsForwardedWithoutVlanTagByDefault) {
   // Install entries to forward all IP packets.
   ASSERT_OK(InstallEntries(
       bmv2, kIrP4Info,
-      sai::PdEntryBuilder()
+      sai::EntryBuilder()
           .AddEntriesForwardingIpPacketsToGivenPort(kEgressPortProto)
           .GetDedupedEntries()));
 
@@ -202,7 +203,7 @@ TEST_P(VlanTest, NonVlanPacketGetsForwardedByDefault) {
   // Install entries to forward all IP packets.
   ASSERT_OK(InstallEntries(
       bmv2, kIrP4Info,
-      sai::PdEntryBuilder()
+      sai::EntryBuilder()
           .AddEntriesForwardingIpPacketsToGivenPort(kEgressPortProto)
           .GetDedupedEntries()));
 
@@ -226,7 +227,7 @@ TEST_P(VlanTest,
   // Install entries to disable vlan checks and forward all IP packets
   ASSERT_OK(InstallEntries(
       bmv2, kIrP4Info,
-      sai::PdEntryBuilder()
+      sai::EntryBuilder()
           .AddEntriesForwardingIpPacketsToGivenPort(kEgressPortProto)
           .AddDisableVlanChecksEntry()
           .GetDedupedEntries()));
@@ -255,7 +256,7 @@ TEST_P(VlanTest, NonVlanPacketGetsFowardedWhenVlanChecksDisabled) {
   // Install entries to disable vlan checks and forward all IP packets
   ASSERT_OK(InstallEntries(
       bmv2, kIrP4Info,
-      sai::PdEntryBuilder()
+      sai::EntryBuilder()
           .AddEntriesForwardingIpPacketsToGivenPort(kEgressPortProto)
           .AddDisableVlanChecksEntry()
           .GetDedupedEntries()));
@@ -273,7 +274,7 @@ TEST_P(VlanTest, NonVlanPacketGetsFowardedWhenVlanChecksDisabled) {
 
 sai::TableEntries EntriesOnlyFowardingPacketsMatchingVlanIdInAclPreIngress(
     absl::string_view vlan_id_hexstr, absl::string_view egress_port) {
-  return sai::PdEntryBuilder()
+  return sai::EntryBuilder()
       .AddDisableVlanChecksEntry()
       .AddEntrySettingVrfBasedOnVlanId(vlan_id_hexstr, "vrf-forward")
       .AddEntryAdmittingAllPacketsToL3()
@@ -352,6 +353,171 @@ TEST(ExperimentalTorVlanTest, VrfTableMatchOnVlanId4095MatchesPacketWithNoVlanTa
                                           /*vid_hexstr=*/"0xfff")));
     // The packet must be forwarded.
     ASSERT_THAT(output_by_port, ElementsAre(Pair(kEgressPort, _)));
+  }
+}
+
+sai::TableEntries EntriesForwardingAndRewritingVlanInRifTable(
+    absl::string_view vlan_id_hexstr, absl::string_view egress_port,
+    bool disable_vlan_checks) {
+  sai::TableEntries entries =
+      sai::EntryBuilder()
+          .AddEntrySettingVrfForAllPackets("vrf-forward")
+          .AddEntryAdmittingAllPacketsToL3()
+          .AddDefaultRouteForwardingAllPacketsToGivenPort(
+              egress_port, sai::IpVersion::kIpv4, "vrf-forward",
+              /*vlan_hexstr=*/vlan_id_hexstr)
+          .GetDedupedEntries();
+  if (disable_vlan_checks) {
+    *entries.add_entries() = sai::EntryBuilder()
+                                 .AddDisableVlanChecksEntry()
+                                 .GetDedupedEntries()
+                                 .entries()[0];
+  }
+  return entries;
+}
+
+TEST(VlanTest,
+     SettingNonReservedVidInRifWithoutVlanChecksResultsInPacketWithThatId) {
+  const sai::Instantiation kInstantiation = sai::Instantiation::kExperimentalTor;
+  const pdpi::IrP4Info kIrP4Info = sai::GetIrP4Info(kInstantiation);
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, sai::SetUpBmv2ForSaiP4(kInstantiation));
+
+  constexpr absl::string_view kEgressVlan = "0x003";
+  ASSERT_OK(InstallEntries(
+      bmv2, kIrP4Info,
+      EntriesForwardingAndRewritingVlanInRifTable(
+          kEgressVlan, kEgressPortProto, /*disable_vlan_checks=*/true)));
+  {
+    // Inject packet without a VLAN tag.
+    ASSERT_OK_AND_ASSIGN(PacketsByPort output_by_port,
+                         bmv2.SendPacket(kIngressPort, GetIpv4PacketOrDie()));
+    // The packet must be forwarded with VLAN kEgressVlan.
+    ASSERT_THAT(output_by_port, ElementsAre(Pair(kEgressPort, _)));
+    ASSERT_THAT(output_by_port.at(kEgressPort)
+                    .packets()
+                    .at(0)
+                    .headers()
+                    .at(1)
+                    .vlan_header()
+                    .vlan_identifier(),
+                Eq(kEgressVlan));
+  }
+  {
+    // Inject VLAN packet with VLAN 0x00b.
+    ASSERT_OK_AND_ASSIGN(
+        PacketsByPort output_by_port,
+        bmv2.SendPacket(kIngressPort, GetVlanIpv4PacketOrDie(
+                                          /*vid_hexstr=*/"0x00b")));
+    // The packet must be forwarded with VLAN kEgressVlan.
+    ASSERT_THAT(output_by_port, ElementsAre(Pair(kEgressPort, _)));
+    ASSERT_THAT(output_by_port.at(kEgressPort)
+                    .packets()
+                    .at(0)
+                    .headers()
+                    .at(1)
+                    .vlan_header()
+                    .vlan_identifier(),
+                Eq(kEgressVlan));
+  }
+  {
+    // Inject VLAN packet with VLAN 0xfff.
+    ASSERT_OK_AND_ASSIGN(
+        PacketsByPort output_by_port,
+        bmv2.SendPacket(kIngressPort, GetVlanIpv4PacketOrDie(
+                                          /*vid_hexstr=*/"0xfff")));
+    // The packet must be forwarded with VLAN kEgressVlan.
+    ASSERT_THAT(output_by_port, ElementsAre(Pair(kEgressPort, _)));
+    ASSERT_THAT(output_by_port.at(kEgressPort)
+                    .packets()
+                    .at(0)
+                    .headers()
+                    .at(1)
+                    .vlan_header()
+                    .vlan_identifier(),
+                Eq(kEgressVlan));
+  }
+}
+
+TEST(VlanTest, SettingNonReservedVidInRifWithVlanChecksResultsInDrop) {
+  const sai::Instantiation kInstantiation = sai::Instantiation::kExperimentalTor;
+  const pdpi::IrP4Info kIrP4Info = sai::GetIrP4Info(kInstantiation);
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, sai::SetUpBmv2ForSaiP4(kInstantiation));
+
+  constexpr absl::string_view kEgressVlan = "0x003";
+  ASSERT_OK(InstallEntries(
+      bmv2, kIrP4Info,
+      EntriesForwardingAndRewritingVlanInRifTable(
+          kEgressVlan, kEgressPortProto, /*disable_vlan_checks=*/false)));
+  {
+    // Inject packet without a VLAN tag.
+    ASSERT_OK_AND_ASSIGN(PacketsByPort output_by_port,
+                         bmv2.SendPacket(kIngressPort, GetIpv4PacketOrDie()));
+    // The packet must be dropped.
+    ASSERT_THAT(output_by_port, IsEmpty());
+  }
+  {
+    // Inject VLAN packet with VLAN 0x00b.
+    ASSERT_OK_AND_ASSIGN(
+        PacketsByPort output_by_port,
+        bmv2.SendPacket(kIngressPort, GetVlanIpv4PacketOrDie(
+                                          /*vid_hexstr=*/"0x00b")));
+    // The packet must be dropped.
+    ASSERT_THAT(output_by_port, IsEmpty());
+  }
+  {
+    // Inject VLAN packet with VLAN 0xfff.
+    ASSERT_OK_AND_ASSIGN(
+        PacketsByPort output_by_port,
+        bmv2.SendPacket(kIngressPort, GetVlanIpv4PacketOrDie(
+                                          /*vid_hexstr=*/"0xfff")));
+    // The packet must be dropped.
+    ASSERT_THAT(output_by_port, IsEmpty());
+  }
+}
+
+TEST(VlanTest, SettingVid4095InRifResultsOutputPacketWithNoVlanTag) {
+  const sai::Instantiation kInstantiation = sai::Instantiation::kExperimentalTor;
+  const pdpi::IrP4Info kIrP4Info = sai::GetIrP4Info(kInstantiation);
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, sai::SetUpBmv2ForSaiP4(kInstantiation));
+
+  constexpr absl::string_view kEgressVlan = "0xfff";
+  ASSERT_OK(InstallEntries(
+      bmv2, kIrP4Info,
+      EntriesForwardingAndRewritingVlanInRifTable(
+          kEgressVlan, kEgressPortProto, /*disable_vlan_checks=*/true)));
+  {
+    // Inject packet without a VLAN tag.
+    ASSERT_OK_AND_ASSIGN(PacketsByPort output_by_port,
+                         bmv2.SendPacket(kIngressPort, GetIpv4PacketOrDie()));
+    // The packet must be forwarded with no VLAN tag.
+    ASSERT_EQ(output_by_port.size(), 1);
+    ASSERT_THAT(output_by_port.at(kEgressPort).packets().at(0).headers(),
+                ElementsAre(HasHeaderCase(packetlib::Header::kEthernetHeader),
+                            HasHeaderCase(packetlib::Header::kIpv4Header)));
+  }
+  {
+    // Inject VLAN packet with VLAN 0x00b.
+    ASSERT_OK_AND_ASSIGN(
+        PacketsByPort output_by_port,
+        bmv2.SendPacket(kIngressPort, GetVlanIpv4PacketOrDie(
+                                          /*vid_hexstr=*/"0x00b")));
+    // The packet must be forwarded with no VLAN tag.
+    ASSERT_EQ(output_by_port.size(), 1);
+    ASSERT_THAT(output_by_port.at(kEgressPort).packets().at(0).headers(),
+                ElementsAre(HasHeaderCase(packetlib::Header::kEthernetHeader),
+                            HasHeaderCase(packetlib::Header::kIpv4Header)));
+  }
+  {
+    // Inject VLAN packet with VLAN 0xfff.
+    ASSERT_OK_AND_ASSIGN(
+        PacketsByPort output_by_port,
+        bmv2.SendPacket(kIngressPort, GetVlanIpv4PacketOrDie(
+                                          /*vid_hexstr=*/"0xfff")));
+    // The packet must be forwarded with no VLAN tag.
+    ASSERT_EQ(output_by_port.size(), 1);
+    ASSERT_THAT(output_by_port.at(kEgressPort).packets().at(0).headers(),
+                ElementsAre(HasHeaderCase(packetlib::Header::kEthernetHeader),
+                            HasHeaderCase(packetlib::Header::kIpv4Header)));
   }
 }
 

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -331,6 +331,10 @@ tables {
     annotations: "@proto_id(1)"
   }
   action_refs {
+    id: 16777243
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
@@ -1126,6 +1130,32 @@ actions {
     name: "dst_mac"
     annotations: "@format(MAC_ADDRESS)"
     bitwidth: 48
+  }
+}
+actions {
+  preamble {
+    id: 16777243
+    name: "ingress.routing.set_port_and_src_mac_and_vlan_id"
+    alias: "set_port_and_src_mac_and_vlan_id"
+    annotations: "@unsupported"
+  }
+  params {
+    id: 1
+    name: "port"
+    type_name {
+      name: "port_id_t"
+    }
+  }
+  params {
+    id: 2
+    name: "src_mac"
+    annotations: "@format(MAC_ADDRESS)"
+    bitwidth: 48
+  }
+  params {
+    id: 3
+    name: "vlan_id"
+    bitwidth: 12
   }
 }
 actions {

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -1210,7 +1210,7 @@ actions {
   }
   params {
     id: 3
-    name: "disable_ttl_rewrite"
+    name: "disable_decrement_ttl"
     bitwidth: 1
   }
   params {

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -135,7 +135,7 @@ tables {
     alias: "acl_pre_ingress_vlan_table"
     annotations: "@sai_acl(PRE_INGRESS)"
     annotations: "@p4runtime_role(\"sdn_controller\")"
-    annotations: "@entry_restriction(\"\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n  \")"
+    annotations: "@entry_restriction(\"\n    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).\n    ether_type != 0x0800 && ether_type != 0x86dd;\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n  \")"
   }
   match_fields {
     id: 1
@@ -157,6 +157,13 @@ tables {
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE / IPV6ANY)"
     bitwidth: 1
     match_type: OPTIONAL
+  }
+  match_fields {
+    id: 4
+    name: "ether_type"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE)"
+    bitwidth: 16
+    match_type: TERNARY
   }
   action_refs {
     id: 16777482
@@ -402,7 +409,7 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
-  size: 512
+  size: 2048
 }
 tables {
   preamble {
@@ -431,7 +438,7 @@ tables {
   }
   const_default_action_id: 21257015
   implementation_id: 299650760
-  size: 3968
+  size: 960
 }
 tables {
   preamble {
@@ -1547,8 +1554,8 @@ action_profiles {
   }
   table_ids: 33554499
   with_selector: true
-  size: 49152
-  max_group_size: 512
+  size: 31296
+  max_group_size: 256
 }
 direct_counters {
   preamble {

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -1470,7 +1470,7 @@ actions {
   }
   params {
     id: 3
-    name: "disable_ttl_rewrite"
+    name: "disable_decrement_ttl"
     bitwidth: 1
   }
   params {

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -314,7 +314,7 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
-  size: 512
+  size: 2048
 }
 tables {
   preamble {
@@ -959,7 +959,7 @@ tables {
     alias: "acl_pre_ingress_vlan_table"
     annotations: "@sai_acl(PRE_INGRESS)"
     annotations: "@p4runtime_role(\"sdn_controller\")"
-    annotations: "@entry_restriction(\"\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n  \")"
+    annotations: "@entry_restriction(\"\n    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).\n    ether_type != 0x0800 && ether_type != 0x86dd;\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n  \")"
   }
   match_fields {
     id: 1
@@ -981,6 +981,13 @@ tables {
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE / IPV6ANY)"
     bitwidth: 1
     match_type: OPTIONAL
+  }
+  match_fields {
+    id: 4
+    name: "ether_type"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE)"
+    bitwidth: 16
+    match_type: TERNARY
   }
   action_refs {
     id: 16777482

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -243,6 +243,10 @@ tables {
     annotations: "@proto_id(1)"
   }
   action_refs {
+    id: 16777243
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
@@ -1386,6 +1390,32 @@ actions {
     name: "dst_mac"
     annotations: "@format(MAC_ADDRESS)"
     bitwidth: 48
+  }
+}
+actions {
+  preamble {
+    id: 16777243
+    name: "ingress.routing.set_port_and_src_mac_and_vlan_id"
+    alias: "set_port_and_src_mac_and_vlan_id"
+    annotations: "@unsupported"
+  }
+  params {
+    id: 1
+    name: "port"
+    type_name {
+      name: "port_id_t"
+    }
+  }
+  params {
+    id: 2
+    name: "src_mac"
+    annotations: "@format(MAC_ADDRESS)"
+    bitwidth: 48
+  }
+  params {
+    id: 3
+    name: "vlan_id"
+    bitwidth: 12
   }
 }
 actions {


### PR DESCRIPTION
### Keyword Check:
sdivya@eonms6vm1:~/sonic_sep6/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_check.sh .
Keyword check Passed.

### Build and Test Results:
sdivya@e25b91aea928:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 477 targets (0 packages loaded, 0 targets configured).
INFO: Found 314 targets and 163 test targets...
INFO: Elapsed time: 90.173s, Critical Path: 25.79s
INFO: 168 processes: 194 linux-sandbox, 18 local.
INFO: Build completed successfully, 168 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:timer_test                                                       PASSED in 5.0s
//gutil:version_test                                                     PASSED in 0.9s
//lib:basic_switch_test                                                  PASSED in 0.8s
//lib:ixia_helper_test                                                   PASSED in 1.1s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 0.9s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 14.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.2s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.5s
//lib/validator:validator_lib_test                                       PASSED in 25.8s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 0.6s
//p4_fuzzer:oracle_util_test                                             PASSED in 0.7s
//p4_fuzzer:switch_state_test                                            PASSED in 0.6s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.1s
//p4_pdpi:built_ins_test                                                 PASSED in 0.5s
//p4_pdpi:entity_keys_test                                               PASSED in 0.5s
//p4_pdpi:ir_properties_test                                             PASSED in 0.5s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 0.6s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:names_test                                                     PASSED in 0.6s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 0.6s
//p4_pdpi:references_test                                                PASSED in 0.6s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.6s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.7s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.1s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.6s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.1s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.1s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:references_test                                        PASSED in 0.1s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.1s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.0s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 0.1s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.0s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 0.1s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.0s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.0s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.0s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.0s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.0s
//p4_symbolic/symbolic:ipv4_routing_test_output                          PASSED in 0.0s
//p4_symbolic/symbolic:port_hardcoded_test_output                        PASSED in 0.0s
//p4_symbolic/symbolic:port_table_test_output                            PASSED in 0.0s
//p4_symbolic/symbolic:reflector_test_output                             PASSED in 0.0s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.0s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 0.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 0.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 0.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 0.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 0.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 0.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.0s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.9s
//p4rt_app/tests:action_set_test                                         PASSED in 1.3s
//p4rt_app/tests:api_access_test                                         PASSED in 1.2s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.3s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.1s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.3s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.3s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 7.1s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.3s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.2s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.7s
//p4rt_app/tests:packetio_test                                           PASSED in 4.1s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.8s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.2s
//p4rt_app/tests:response_path_test                                      PASSED in 4.3s
//p4rt_app/tests:role_test                                               PASSED in 1.3s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.5s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.1s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 0.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.7s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.7s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.8s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.6s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 3.6s
  Stats over 5 runs: max = 3.6s, min = 0.9s, avg = 1.7s, dev = 1.1s

Executed 163 out of 163 tests: 163 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these a INFO: Build completed successfully, 3057 total actions
sdivya@e25b91aea928:/sonic/src/sonic-p4rt/sonic-pins$ 