### PR TITLE
[SAIP4] Add rest of the required match fields to mirror and redirect table, Add priorities to Pre-Ingress ACL tables & Increase priority spacing in pre-ingress ACL tables.

### DIFF
--- a/sai_p4/instantiations/google/acl_ingress.p4
+++ b/sai_p4/instantiations/google/acl_ingress.p4
@@ -430,11 +430,56 @@ control acl_ingress(in headers_t headers,
   @id(ACL_INGRESS_MIRROR_AND_REDIRECT_TABLE_ID)
   @sai_acl(INGRESS)
   @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @entry_restriction("
+    // Forbid illegal combinations of IP_TYPE fields.
+    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
+    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
+    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);
+    // Forbid unsupported combinations of IP_TYPE fields.
+    is_ipv4::mask != 0 -> (is_ipv4 == 1);
+    is_ipv6::mask != 0 -> (is_ipv6 == 1);
+  ")
   table acl_ingress_mirror_and_redirect_table {
     key = {
       local_metadata.ingress_port : optional
-          @id(1) @name("in_port")  @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT);
-      // TODO: Add keys needed for redirect.
+        @name("in_port")
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT)
+        @id(1);
+
+      headers.ipv4.isValid() || headers.ipv6.isValid() : optional
+        @name("is_ip")
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IP)
+        @id(2);
+
+      headers.ipv4.isValid() : optional
+        @name("is_ipv4")
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV4ANY)
+        @id(3);
+
+      headers.ipv6.isValid() : optional
+        @name("is_ipv6")
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV6ANY)
+        @id(4);
+
+      headers.ipv6.dst_addr[127:64] : ternary
+        @name("dst_ipv6")
+        @composite_field(
+            @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD3),
+            @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD2))
+        @format(IPV6_ADDRESS)
+        @id(5);
+
+      local_metadata.acl_metadata : ternary
+        @name("acl_metadata")
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_USER_META)
+        @id(6);
+
+      local_metadata.vlan_id : ternary
+        @name("vlan_id")
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID)
+        @id(7);
+
+      // TODO: Add match on vrf_id and l3_host_table_hit.
     }
     actions = {
       @proto_id(1) acl_mirror();

--- a/sai_p4/instantiations/google/acl_pre_ingress.p4
+++ b/sai_p4/instantiations/google/acl_pre_ingress.p4
@@ -67,6 +67,7 @@ control acl_pre_ingress(in headers_t headers,
   @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
   @id(ACL_PRE_INGRESS_TABLE_ID)
   @sai_acl(PRE_INGRESS)
+  @sai_acl_priority(11)
   @entry_restriction("
     // Only allow IP field matches for IP packets.
     dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
@@ -122,6 +123,7 @@ control acl_pre_ingress(in headers_t headers,
   @id(ACL_PRE_INGRESS_VLAN_TABLE_ID)
   @sai_acl(PRE_INGRESS)
   @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @sai_acl_priority(1)
   @entry_restriction("
     // Forbid using ether_type for IP packets (by convention, use is_ip* instead).
     ether_type != 0x0800 && ether_type != 0x86dd;
@@ -164,6 +166,7 @@ control acl_pre_ingress(in headers_t headers,
   @id(ACL_PRE_INGRESS_METADATA_TABLE_ID)
   @sai_acl(PRE_INGRESS)
   @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @sai_acl_priority(5)
   @entry_restriction("
     // Forbid illegal combinations of IP_TYPE fields.
     is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);

--- a/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
@@ -63,6 +63,7 @@ tables {
     alias: "acl_pre_ingress_table"
     annotations: "@p4runtime_role(\"sdn_controller\")"
     annotations: "@sai_acl(PRE_INGRESS)"
+    annotations: "@sai_acl_priority(11)"
     annotations: "@entry_restriction(\"\n    // Only allow IP field matches for IP packets.\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    dst_ip::mask != 0 -> is_ipv4 == 1;\n    dst_ipv6::mask != 0 -> is_ipv6 == 1;\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n    // Reserve high priorities for switch-internal use.\n    // TODO: Remove once inband workaround is obsolete.\n    ::priority < 0x7fffffff;\n  \")"
   }
   match_fields {

--- a/sai_p4/instantiations/google/middleblock.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock.p4info.pb.txt
@@ -63,6 +63,7 @@ tables {
     alias: "acl_pre_ingress_table"
     annotations: "@p4runtime_role(\"sdn_controller\")"
     annotations: "@sai_acl(PRE_INGRESS)"
+    annotations: "@sai_acl_priority(11)"
     annotations: "@entry_restriction(\"\n    // Only allow IP field matches for IP packets.\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    dst_ip::mask != 0 -> is_ipv4 == 1;\n    dst_ipv6::mask != 0 -> is_ipv6 == 1;\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n    // Reserve high priorities for switch-internal use.\n    // TODO: Remove once inband workaround is obsolete.\n    ::priority < 0x7fffffff;\n  \")"
   }
   match_fields {

--- a/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock_with_s2_ecmp_profile.p4info.pb.txt
@@ -63,6 +63,7 @@ tables {
     alias: "acl_pre_ingress_table"
     annotations: "@p4runtime_role(\"sdn_controller\")"
     annotations: "@sai_acl(PRE_INGRESS)"
+    annotations: "@sai_acl_priority(11)"
     annotations: "@entry_restriction(\"\n    // Only allow IP field matches for IP packets.\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    dst_ip::mask != 0 -> is_ipv4 == 1;\n    dst_ipv6::mask != 0 -> is_ipv6 == 1;\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n\n\n\n\n    // Reserve high priorities for switch-internal use.\n    // TODO: Remove once inband workaround is obsolete.\n    ::priority < 0x7fffffff;\n  \")"
   }
   match_fields {

--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -674,9 +674,23 @@ message AclIngressSecurityTableEntry {
   bytes controller_metadata = 8;
 }
 
+// Table entry restrictions:
+// ## Forbid illegal combinations of IP_TYPE fields.
+//   is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
+//   is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
+//   is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);
+// ## Forbid unsupported combinations of IP_TYPE fields.
+//   is_ipv4::mask != 0 -> (is_ipv4 == 1);
+//   is_ipv6::mask != 0 -> (is_ipv6 == 1);
 message AclIngressMirrorAndRedirectTableEntry {
   message Match {
-    Optional in_port = 1;  // optional match / Format::STRING
+    Optional in_port = 1;      // optional match / Format::STRING
+    Optional is_ip = 2;        // optional match / Format::HEX_STRING / 1 bits
+    Optional is_ipv4 = 3;      // optional match / Format::HEX_STRING / 1 bits
+    Optional is_ipv6 = 4;      // optional match / Format::HEX_STRING / 1 bits
+    Ternary dst_ipv6 = 5;      // ternary match / Format::IPV6 / upper 64 bits
+    Ternary acl_metadata = 6;  // ternary match / Format::HEX_STRING / 8 bits
+    Ternary vlan_id = 7;       // ternary match / Format::HEX_STRING / 12 bits
   }
   Match match = 1;
   message Action {

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -37,6 +37,7 @@ tables {
     alias: "acl_pre_ingress_table"
     annotations: "@p4runtime_role(\"sdn_controller\")"
     annotations: "@sai_acl(PRE_INGRESS)"
+    annotations: "@sai_acl_priority(11)"
     annotations: "@entry_restriction(\"\n    // Only allow IP field matches for IP packets.\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    dst_ip::mask != 0 -> is_ipv4 == 1;\n    dst_ipv6::mask != 0 -> is_ipv6 == 1;\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n    // Reserve high priorities for switch-internal use.\n    // TODO: Remove once inband workaround is obsolete.\n    ::priority < 0x7fffffff;\n  \")"
   }
   match_fields {
@@ -135,6 +136,7 @@ tables {
     alias: "acl_pre_ingress_vlan_table"
     annotations: "@sai_acl(PRE_INGRESS)"
     annotations: "@p4runtime_role(\"sdn_controller\")"
+    annotations: "@sai_acl_priority(1)"
     annotations: "@entry_restriction(\"\n    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).\n    ether_type != 0x0800 && ether_type != 0x86dd;\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n    // Disallow match on reserved VLAN IDs to rule out vendor specific behavior.\n    vlan_id::mask != 0 -> (vlan_id != 4095 && vlan_id != 0);\n    // TODO: Disallow setting to reserved VLAN IDs when supported.\n  \")"
   }
   match_fields {
@@ -192,6 +194,7 @@ tables {
     alias: "acl_pre_ingress_metadata_table"
     annotations: "@sai_acl(PRE_INGRESS)"
     annotations: "@p4runtime_role(\"sdn_controller\")"
+    annotations: "@sai_acl_priority(5)"
     annotations: "@entry_restriction(\"\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // DSCP is only allowed on IP traffic.\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n    // Only allow icmp_type matches for ICMP packets\n    icmpv6_type::mask != 0 -> ip_protocol == 58;\n  \")"
   }
   match_fields {

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -63,6 +63,7 @@ tables {
     alias: "acl_pre_ingress_table"
     annotations: "@p4runtime_role(\"sdn_controller\")"
     annotations: "@sai_acl(PRE_INGRESS)"
+    annotations: "@sai_acl_priority(11)"
     annotations: "@entry_restriction(\"\n    // Only allow IP field matches for IP packets.\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    dst_ip::mask != 0 -> is_ipv4 == 1;\n    dst_ipv6::mask != 0 -> is_ipv6 == 1;\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n    // Reserve high priorities for switch-internal use.\n    // TODO: Remove once inband workaround is obsolete.\n    ::priority < 0x7fffffff;\n  \")"
   }
   match_fields {
@@ -968,6 +969,7 @@ tables {
     alias: "acl_pre_ingress_vlan_table"
     annotations: "@sai_acl(PRE_INGRESS)"
     annotations: "@p4runtime_role(\"sdn_controller\")"
+    annotations: "@sai_acl_priority(1)"
     annotations: "@entry_restriction(\"\n    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).\n    ether_type != 0x0800 && ether_type != 0x86dd;\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n    // Disallow match on reserved VLAN IDs to rule out vendor specific behavior.\n    vlan_id::mask != 0 -> (vlan_id != 4095 && vlan_id != 0);\n    // TODO: Disallow setting to reserved VLAN IDs when supported.\n  \")"
   }
   match_fields {
@@ -1025,6 +1027,7 @@ tables {
     alias: "acl_pre_ingress_metadata_table"
     annotations: "@sai_acl(PRE_INGRESS)"
     annotations: "@p4runtime_role(\"sdn_controller\")"
+    annotations: "@sai_acl_priority(5)"
     annotations: "@entry_restriction(\"\n    // Forbid illegal combinations of IP_TYPE fields.\n    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);\n    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);\n    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);\n    // DSCP is only allowed on IP traffic.\n    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);\n    // Forbid unsupported combinations of IP_TYPE fields.\n    is_ipv4::mask != 0 -> (is_ipv4 == 1);\n    is_ipv6::mask != 0 -> (is_ipv6 == 1);\n    // Only allow icmp_type matches for ICMP packets\n    icmpv6_type::mask != 0 -> ip_protocol == 58;\n  \")"
   }
   match_fields {


### PR DESCRIPTION
### keyword check:
sdivya@eonms6vm1:~/sonic_sep6/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_check.sh .
Keyword check Passed.

### Build and Test Results:
...
INFO: Elapsed time: 777.827s, Critical Path: 114.71s
INFO: 2601 processes: 2629 linux-sandbox, 18 local.
INFO: Build completed successfully, 2601 total actions
//gutil:collections_test                                                 PASSED in 0.6s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.6s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.7s
//gutil:testing_test                                                     PASSED in 0.7s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 1.0s
//lib:basic_switch_test                                                  PASSED in 0.9s
//lib:ixia_helper_test                                                   PASSED in 1.4s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 0.9s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 14.9s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.9s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 0.9s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.2s
//lib/utils:json_utils_test                                              PASSED in 0.5s
//lib/validator:validator_backend_test                                   PASSED in 0.6s
//lib/validator:validator_lib_test                                       PASSED in 25.8s
//p4_fuzzer:constraints_util_integration_test                            PASSED in 0.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 4.9s
//p4_fuzzer:oracle_util_test                                             PASSED in 0.7s
//p4_fuzzer:switch_state_test                                            PASSED in 0.9s
//p4_fuzzer:table_entry_key_test                                         PASSED in 0.4s
//p4_pdpi:built_ins_test                                                 PASSED in 0.6s
//p4_pdpi:entity_keys_test                                               PASSED in 0.6s
//p4_pdpi:ir_properties_test                                             PASSED in 0.7s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 0.6s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.7s
//p4_pdpi:names_test                                                     PASSED in 0.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 0.8s
//p4_pdpi:reference_annotations_test                                     PASSED in 2.5s
//p4_pdpi:references_test                                                PASSED in 0.6s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.6s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.6s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.3s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.2s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 9.3s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.6s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.0s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.6s
//p4_pdpi/testing:helper_function_test                                   PASSED in 0.7s
//p4_pdpi/testing:info_test                                              PASSED in 0.4s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.1s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.7s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.4s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.1s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.5s
//p4_pdpi/testing:references_test                                        PASSED in 0.3s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.1s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.4s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.3s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.7s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.9s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.4s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.1s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.6s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 0.1s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.0s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 1.1s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.0s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 0.2s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.0s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.0s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.0s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.0s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/symbolic:ipv4_routing_test_output                          PASSED in 0.0s
//p4_symbolic/symbolic:port_hardcoded_test_output                        PASSED in 0.0s
//p4_symbolic/symbolic:port_table_test_output                            PASSED in 0.0s
//p4_symbolic/symbolic:reflector_test_output                             PASSED in 0.1s
//p4_symbolic/tests:sai_p4_component_test                                PASSED in 1.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.0s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 1.0s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 7.0s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.1s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 1.1s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 0.8s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 0.7s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 1.1s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 0.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 0.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 1.0s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 0.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 0.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 0.8s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 0.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.6s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 0.7s
//p4rt_app/sonic:state_verification_test                                 PASSED in 0.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.2s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.0s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.8s
//p4rt_app/tests:action_set_test                                         PASSED in 1.5s
//p4rt_app/tests:api_access_test                                         PASSED in 1.6s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.3s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.2s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.1s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 7.6s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.6s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.3s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.4s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.0s
//p4rt_app/tests:packetio_test                                           PASSED in 4.5s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.8s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.7s
//p4rt_app/tests:response_path_test                                      PASSED in 5.8s
//p4rt_app/tests:role_test                                               PASSED in 1.4s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.4s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.3s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.9s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.8s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.0s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.8s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 2.2s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.0s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//thinkit:bazel_test_environment_test                                    PASSED in 1.8s
//thinkit:generic_testbed_test                                           PASSED in 1.5s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.1s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.9s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 84.6s
  Stats over 5 runs: max = 84.6s, min = 0.9s, avg = 37.9s, dev = 30.9s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.0s
  Stats over 5 runs: max = 1.0s, min = 0.7s, avg = 0.8s, dev = 0.1s

Executed 169 out of 169 tests: 169 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these a
INFO: Build completed successfully, 2601 total actions
sdivya@e25b91aea928:/sonic/src/sonic-p4rt/sonic-pins$ 
