### PR TITLE
[P4-Symbolic] Fix implementation of shift and add support forbitvector slicing.

### DIFF
--- a/p4_symbolic/symbolic/guarded_map.cc
+++ b/p4_symbolic/symbolic/guarded_map.cc
@@ -43,8 +43,7 @@ absl::StatusOr<z3::expr> SymbolicGuardedMap::Get(const std::string &key) const {
       absl::StrCat("Cannot find key \"", key, "\" in SymbolicGuardedMap!"));
 }
 
-absl::Status SymbolicGuardedMap::Set(const std::string &key,
-                                     const z3::expr &value,
+absl::Status SymbolicGuardedMap::Set(const std::string &key, z3::expr value,
                                      const z3::expr &guard) {
   if (!this->ContainsKey(key)) {
     return absl::InvalidArgumentError(absl::StrCat(
@@ -53,20 +52,12 @@ absl::Status SymbolicGuardedMap::Set(const std::string &key,
 
   z3::expr &old_value = this->map_.at(key);
 
-  // operators::Ite will check for sort compatibility and pad when needed.
-  // However, Ite() does not have a notion of pre-defined size, and will padd
-  // to the maximum bitsize of the two operands. We perform that check
-  // explicitly here.
-  if (old_value.get_sort().is_bv() && value.get_sort().is_bv()) {
-    unsigned int new_size = value.get_sort().bv_size();
-    unsigned int old_size = old_value.get_sort().bv_size();
-    if (new_size > old_size) {
-      return absl::InvalidArgumentError(
-          absl::StrFormat("Cannot assign to key \"%s\" a value whose bit size "
-                          "%d is greater than the pre-defined bit size %d in "
-                          "SymbolicGuardedMap!",
-                          key, new_size, old_size));
-    }
+  // Ite will pad bitvectors to the same size, but this is not the right
+  // semantics if we assign a larger bitvector into a smaller one. Instead, the
+  // assigned value needs to be truncated to the bitsize of the asignee.
+  if (old_value.get_sort().is_bv() && value.get_sort().is_bv() &&
+      old_value.get_sort().bv_size() < value.get_sort().bv_size()) {
+    value = value.extract(old_value.get_sort().bv_size() - 1, 0);
   }
 
   // This will return an absl error if the sorts are incompatible, and will pad

--- a/p4_symbolic/symbolic/guarded_map.h
+++ b/p4_symbolic/symbolic/guarded_map.h
@@ -70,7 +70,7 @@ class SymbolicGuardedMap {
   // Guarded setter.
   // Returns an error if the assigned value has incompatible sort with the
   // pre-defined value.
-  absl::Status Set(const std::string &key, const z3::expr &value,
+  absl::Status Set(const std::string &key, z3::expr value,
                    const z3::expr &guard);
 
   // Constant iterators.

--- a/p4_symbolic/symbolic/operators.cc
+++ b/p4_symbolic/symbolic/operators.cc
@@ -131,55 +131,55 @@ absl::StatusOr<z3::expr> FreeVariable(const std::string &variable_base_name,
 absl::StatusOr<z3::expr> Plus(const z3::expr &a, const z3::expr &b) {
   ASSIGN_OR_RETURN(auto pair,
                    p4_symbolic::symbolic::operators::SortCheckAndPad(a, b));
-  auto [a_expr, b_expr] = pair;
+  auto &[a_expr, b_expr] = pair;
   return a_expr + b_expr;
 }
 absl::StatusOr<z3::expr> Minus(const z3::expr &a, const z3::expr &b) {
   ASSIGN_OR_RETURN(auto pair,
                    p4_symbolic::symbolic::operators::SortCheckAndPad(a, b));
-  auto [a_expr, b_expr] = pair;
+  auto &[a_expr, b_expr] = pair;
   return a_expr - b_expr;
 }
 absl::StatusOr<z3::expr> Times(const z3::expr &a, const z3::expr &b) {
   ASSIGN_OR_RETURN(auto pair,
                    p4_symbolic::symbolic::operators::SortCheckAndPad(a, b));
-  auto [a_expr, b_expr] = pair;
+  auto &[a_expr, b_expr] = pair;
   return a_expr * b_expr;
 }
 absl::StatusOr<z3::expr> Eq(const z3::expr &a, const z3::expr &b) {
   ASSIGN_OR_RETURN(auto pair,
                    p4_symbolic::symbolic::operators::SortCheckAndPad(a, b));
-  auto [a_expr, b_expr] = pair;
+  auto &[a_expr, b_expr] = pair;
   return a_expr == b_expr;
 }
 absl::StatusOr<z3::expr> Neq(const z3::expr &a, const z3::expr &b) {
   ASSIGN_OR_RETURN(auto pair,
                    p4_symbolic::symbolic::operators::SortCheckAndPad(a, b));
-  auto [a_expr, b_expr] = pair;
+  auto &[a_expr, b_expr] = pair;
   return a_expr != b_expr;
 }
 absl::StatusOr<z3::expr> Lt(const z3::expr &a, const z3::expr &b) {
   ASSIGN_OR_RETURN(auto pair,
                    p4_symbolic::symbolic::operators::SortCheckAndPad(a, b));
-  auto [a_expr, b_expr] = pair;
+  auto &[a_expr, b_expr] = pair;
   return z3::ult(a_expr, b_expr);
 }
 absl::StatusOr<z3::expr> Lte(const z3::expr &a, const z3::expr &b) {
   ASSIGN_OR_RETURN(auto pair,
                    p4_symbolic::symbolic::operators::SortCheckAndPad(a, b));
-  auto [a_expr, b_expr] = pair;
+  auto &[a_expr, b_expr] = pair;
   return z3::ule(a_expr, b_expr);
 }
 absl::StatusOr<z3::expr> Gt(const z3::expr &a, const z3::expr &b) {
   ASSIGN_OR_RETURN(auto pair,
                    p4_symbolic::symbolic::operators::SortCheckAndPad(a, b));
-  auto [a_expr, b_expr] = pair;
+  auto &[a_expr, b_expr] = pair;
   return z3::ugt(a_expr, b_expr);
 }
 absl::StatusOr<z3::expr> Gte(const z3::expr &a, const z3::expr &b) {
   ASSIGN_OR_RETURN(auto pair,
                    p4_symbolic::symbolic::operators::SortCheckAndPad(a, b));
-  auto [a_expr, b_expr] = pair;
+  auto &[a_expr, b_expr] = pair;
   return z3::uge(a_expr, b_expr);
 }
 absl::StatusOr<z3::expr> Not(const z3::expr &a) { return !a; }
@@ -224,27 +224,31 @@ absl::StatusOr<z3::expr> BitNeg(const z3::expr &a) { return ~a; }
 absl::StatusOr<z3::expr> BitAnd(const z3::expr &a, const z3::expr &b) {
   ASSIGN_OR_RETURN(auto pair,
                    p4_symbolic::symbolic::operators::SortCheckAndExtract(a, b));
-  auto [a_expr, b_expr] = pair;
+  auto &[a_expr, b_expr] = pair;
   return a_expr & b_expr;
 }
 
 absl::StatusOr<z3::expr> BitOr(const z3::expr &a, const z3::expr &b) {
   ASSIGN_OR_RETURN(auto pair,
                    p4_symbolic::symbolic::operators::SortCheckAndPad(a, b));
-  auto [a_expr, b_expr] = pair;
+  auto &[a_expr, b_expr] = pair;
   return a_expr | b_expr;
 }
 absl::StatusOr<z3::expr> BitXor(const z3::expr &a, const z3::expr &b) {
   ASSIGN_OR_RETURN(auto pair,
                    p4_symbolic::symbolic::operators::SortCheckAndPad(a, b));
-  auto [a_expr, b_expr] = pair;
+  auto &[a_expr, b_expr] = pair;
   return a_expr ^ b_expr;
 }
 absl::StatusOr<z3::expr> LShift(const z3::expr &bits, const z3::expr &shift) {
-  return z3::shl(bits, shift);
+  ASSIGN_OR_RETURN(auto pair, SortCheckAndPad(bits, shift));
+  auto &[a_expr, b_expr] = pair;
+  return z3::shl(a_expr, b_expr);
 }
 absl::StatusOr<z3::expr> RShift(const z3::expr &bits, const z3::expr &shift) {
-  return z3::lshr(bits, shift);
+  ASSIGN_OR_RETURN(auto pair, SortCheckAndPad(bits, shift));
+  auto &[a_expr, b_expr] = pair;
+  return z3::lshr(a_expr, b_expr);
 }
 
 // If then else.
@@ -260,7 +264,7 @@ absl::StatusOr<z3::expr> Ite(const z3::expr &condition,
 
   // Values in both cases must have the same sort and signedness.
   ASSIGN_OR_RETURN(auto pair, SortCheckAndPad(true_value, false_value));
-  auto [a_expr, b_expr] = pair;
+  auto &[a_expr, b_expr] = pair;
   return z3::ite(condition, a_expr, b_expr);
 }
 

--- a/p4_symbolic/symbolic/operators.h
+++ b/p4_symbolic/symbolic/operators.h
@@ -65,8 +65,9 @@ absl::StatusOr<z3::expr> Ite(const z3::expr &condition,
                              const z3::expr &true_value,
                              const z3::expr &false_value);
 
-// Converts the expression into a semantically equivalent boolean expression.
+// Converts the given expression to a boolean expression.
 absl::StatusOr<z3::expr> ToBoolSort(const z3::expr &a);
+// Converts the given expression to a bit vector expression.
 absl::StatusOr<z3::expr> ToBitVectorSort(const z3::expr &a, unsigned int size);
 
 // Prefix equality: this is the basis for evaluating LPMs.


### PR DESCRIPTION
Keyword Check :

/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.




Build Result:

/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 514 targets (0 packages loaded, 324 targets configured).
INFO: Found 514 targets...
INFO: From Compiling p4_symbolic/symbolic/values.cc [for host]:
In file included from ./p4_pdpi/netaddr/network_address.h:28,
                 from ./p4_pdpi/netaddr/ipv4_address.h:22,
                 from p4_symbolic/symbolic/values.cc:34:
./p4_pdpi/string_encodings/hex_string.h: In instantiation of 'std::string pdpi::BitsetToHexString(const std::bitset<_Nb>&) [with long unsigned int num_bits = 32; std::string = std::__cxx11::basic_string<char>]':
./p4_pdpi/netaddr/network_address.h:86:67:   required from 'std::string netaddr::NetworkAddress<num_bits, T>::ToHexString() const [with long unsigned int num_bits = 32; T = netaddr::Ipv4Address; std::string = std::__cxx11::basic_string<char>]'
p4_symbolic/symbolic/values.cc:129:49:   required from here
./p4_pdpi/string_encodings/hex_string.h:95:24: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   95 |       int kth_bit = (k < num_bits) ? bitset[k] : 0;  // Implicit bits are 0.
      |                     ~~~^~~~~~~~~~~
./p4_pdpi/string_encodings/hex_string.h: In instantiation of 'std::string pdpi::BitsetToHexString(const std::bitset<_Nb>&) [with long unsigned int num_bits = 128; std::string = std::__cxx11::basic_string<char>]':
In file included from p4_symbolic/tests/sai_p4_component_test.cc:9:
p4_symbolic/tests/sai_p4_component_test.cc:104:85: warning: 'absl::lts_20230802::StatusOr<p4::v1::TableEntry> pdpi::PartialPdTableEntryToPiTableEntry(const pdpi::IrP4Info&, const google::protobuf::Message&, const pdpi::TranslationOptions&)' is deprecated: Use PdTableEntryToPiEntity instead [-Wdeprecated-declarations]
  104 |                          pdpi::PartialPdTableEntryToPiTableEntry(ir_p4info, pd_entry));
      |                                                                                     ^
./gutil/status_matchers.h:64:43: note: in definition of macro 'ASSERT_OK_AND_ASSIGN'
   64 |   auto __ASSIGN_OR_RETURN_VAL(__LINE__) = expression;                   \
      |                                           ^~~~~~~~~~
In file included from p4_symbolic/tests/sai_p4_component_test.cc:14:
./p4_pdpi/pd.h:141:36: note: declared here
  141 | absl::StatusOr<p4::v1::TableEntry> PartialPdTableEntryToPiTableEntry(
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO: Elapsed time: 43.460s, Critical Path: 20.89s
INFO: 44 processes: 2 internal, 42 linux-sandbox.
INFO: Build completed successfully, 44 total actions
 




Test Result:

/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 514 targets (0 packages loaded, 0 targets configured).
INFO: Found 344 targets and 170 test targets...
INFO: Elapsed time: 197.304s, Critical Path: 128.56s
INFO: 179 processes: 211 linux-sandbox, 18 local.
INFO: Build completed successfully, 179 total actions
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.7s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.0s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 2.5s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.9s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.9s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 1.0s
//thinkit:mock_control_device_test                                       PASSED in 0.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.8s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 128.5s
  Stats over 5 runs: max = 128.5s, min = 0.9s, avg = 54.3s, dev = 41.3s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.0s
  Stats over 5 runs: max = 1.0s, min = 0.7s, avg = 0.7s, dev = 0.2s

Executed 170 out of 170 tests: 170 tests pass.
INFO: Build completed successfully, 179 total actions
