### PR TITLE
[Dvaas]: Add library that allows DVaaS/Arriba to process user-provided test vectors using a bare-bones, but sane API. Adding user-provided test vectors Tests.

### DIFF
--- a/dvaas/BUILD.bazel
+++ b/dvaas/BUILD.bazel
@@ -256,3 +256,21 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "user_provided_packet_test_vector",
+    testonly = True,
+    srcs = ["user_provided_packet_test_vector.cc"],
+    hdrs = ["user_provided_packet_test_vector.h"],
+    deps = [
+        ":test_vector",
+        ":test_vector_cc_proto",
+        "//gutil:proto",
+        "//gutil:status",
+        "//p4_pdpi/packetlib",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:span",
+    ],
+)

--- a/dvaas/user_provided_packet_test_vector.cc
+++ b/dvaas/user_provided_packet_test_vector.cc
@@ -1,0 +1,113 @@
+#include "dvaas/user_provided_packet_test_vector.h"
+
+#include <string>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/escaping.h"
+#include "absl/types/span.h"
+#include "dvaas/test_vector.h"
+#include "dvaas/test_vector.pb.h"
+#include "gutil/proto.h"
+#include "gutil/status.h"
+#include "p4_pdpi/packetlib/packetlib.h"
+
+namespace dvaas {
+
+namespace {
+
+// Checks that the given `input_packet` is well-formed, returning it with
+// omittable fields filled in if that is the case, or an error otherwise.
+absl::StatusOr<Packet> LegitimizePacket(Packet packet) {
+  RETURN_IF_ERROR(
+      packetlib::UpdateMissingComputedFields(*packet.mutable_parsed())
+          .status());
+  RETURN_IF_ERROR(packetlib::ValidatePacket(packet.parsed()));
+  ASSIGN_OR_RETURN(std::string raw_packet,
+                   packetlib::RawSerializePacket(packet.parsed()));
+  packet.set_hex(absl::BytesToHexString(raw_packet));
+  return packet;
+}
+
+// Checks that the given `vector` is well-formed and if so adds it to
+// `legitimized_test_vectors_by_id`, or returns error otherwise.
+absl::Status LegitimizeTestVector(
+    PacketTestVector vector,
+    PacketTestVectorById& legitimized_test_vectors_by_id) {
+  if (vector.input().type() != SwitchInput::DATAPLANE) {
+    return gutil::UnimplementedErrorBuilder()
+           << "only supported input type is DATAPLANE; found "
+           << SwitchInput::Type_Name(vector.input().type());
+  }
+
+  // Legitimize input packet.
+  Packet& input_packet = *vector.mutable_input()->mutable_packet();
+  ASSIGN_OR_RETURN(int tag, ExtractTestPacketTag(input_packet.parsed()),
+                   _.SetPrepend() << "invalid input packet: ");
+  ASSIGN_OR_RETURN(input_packet, LegitimizePacket(input_packet),
+                   _.SetPrepend() << "invalid input packet: ");
+
+  // Legitimize acceptable outputs.
+  if (vector.acceptable_outputs().empty()) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "must specify at least 1 acceptable output, but 0 were found";
+  }
+  for (SwitchOutput& output : *vector.mutable_acceptable_outputs()) {
+    // Punted output packets are not supported for now.
+    if (!output.packet_ins().empty()) {
+      return gutil::UnimplementedErrorBuilder()
+             << "TODO: support vectors expecting `packet_ins` "
+                "(punting)";
+    }
+    // Legitimize forwarded output packets.
+    for (int i = 0; i < output.packets().size(); ++i) {
+      Packet& output_packet = *output.mutable_packets(i);
+      ASSIGN_OR_RETURN(
+          int output_tag, ExtractTestPacketTag(output_packet.parsed()),
+          _.SetPrepend() << "output packet #" << (i + 1) << " invalid: ");
+      ASSIGN_OR_RETURN(output_packet, LegitimizePacket(output_packet),
+                       _.SetPrepend()
+                           << "output packet #" << (i + 1) << " invalid: ");
+      if (output_tag != tag) {
+        return gutil::InvalidArgumentErrorBuilder()
+               << "mismatch of input packet tag vs output packet tag for "
+                  "output packet #"
+               << (i + 1) << ": " << tag << " vs " << output_tag;
+      }
+    }
+  }
+
+  // Add internalized vector to result.
+  const auto& [it, inserted] =
+      legitimized_test_vectors_by_id.insert({tag, vector});
+  if (!inserted) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "user-provided packet test vectors must be tagged with unique "
+              "IDs in their payload, but found multiple test vectors with ID "
+           << tag << ". Dumping offending test vectors:\n<"
+           << gutil::PrintTextProto(it->second) << ">\n<"
+           << gutil::PrintTextProto(vector) << ">\n";
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace
+
+absl::StatusOr<PacketTestVectorById> LegitimizeUserProvidedTestVectors(
+    absl::Span<const PacketTestVector> user_provided_test_vectors) {
+  PacketTestVectorById legitimized_test_vectors_by_id;
+  for (const PacketTestVector& vector : user_provided_test_vectors) {
+    absl::Status status =
+        LegitimizeTestVector(vector, legitimized_test_vectors_by_id);
+    if (!status.ok()) {
+      return gutil::StatusBuilder(status.code())
+             << "problem in user-provided packet test vector: "
+             << status.message() << "\nDumping offending test vector:\n"
+             << gutil::PrintTextProto(vector);
+    }
+  }
+  return legitimized_test_vectors_by_id;
+}
+
+}  // namespace dvaas

--- a/dvaas/user_provided_packet_test_vector.h
+++ b/dvaas/user_provided_packet_test_vector.h
@@ -1,0 +1,59 @@
+// Empowers users to specify custom packet test vectors that can be validated
+// by DVaaS or Arriba.
+
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PINS_DVAAS_USER_PROVIDED_PACKET_TEST_VECTOR_H_
+#define PINS_DVAAS_USER_PROVIDED_PACKET_TEST_VECTOR_H_
+
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "dvaas/test_vector.h"
+#include "dvaas/test_vector.pb.h"
+
+namespace dvaas {
+
+// Checks user-provided test vectors for well-formedness and prepares them for
+// internal use by DVaaS/Arriba:
+// * Fills in "omittable fields", see definition below.
+// * Checks that each test vector is "well-formed", see definition below.
+// * Returns updated, well-formed test vectors organized by ID, or returns an
+//   actionable, user-facing error if a test vector is not well-formed.
+//
+// The following `dvaas::Packet` message fields can be omitted by the user:
+// * All `hex` fields.
+// * All subfields of `packetlib::Packet` messages that are considered "computed
+//   fields" by packetlib. This includes checksum and length fields. See the
+//   packetlib library for the exact definition.
+//
+// To be "well-formed", a test vector must meet the following requirements:
+// * Must specify at least 1 acceptable output.
+// * Each input and output packet must:
+//   * Be valid according to `packetlib::ValidatePacket` after computed fields
+//     have been filled in.
+//   * Contain a test packet ID/tag according to `ExtractTestPacketTag`.
+//     This ID must be:
+//     * Shared among all packets within the test vector.
+//     * Unique among all test vectors.
+// * The input must be of type `DATAPLANE` (other types may be supported in the
+//   future).
+absl::StatusOr<PacketTestVectorById> LegitimizeUserProvidedTestVectors(
+    absl::Span<const PacketTestVector> user_provided_test_vectors);
+
+}  // namespace dvaas
+
+#endif  // PINS_DVAAS_USER_PROVIDED_PACKET_TEST_VECTOR_H_


### PR DESCRIPTION
Keyword Check:

```
~/pins_upstream/sonic-buildimage/src/sonic-p4rt/sonic-pins/dvaas$ ~/tools/keyword_checks.sh .
Keyword check Passed.

```

Build result:

```
sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 579 targets (0 packages loaded, 0 targets configured).
INFO: Found 579 targets...
INFO: Elapsed time: 23.757s, Critical Path: 20.22s
INFO: 6 processes: 2 internal, 4 linux-sandbox.
INFO: Build completed successfully, 6 total actions

```


Test result:


```
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 582 targets (0 packages loaded, 6 targets configured).
INFO: Found 390 targets and 192 test targets...
INFO: Elapsed time: 205.035s, Critical Path: 113.08s
INFO: 246 processes: 289 linux-sandbox, 18 local.
INFO: Build completed successfully, 246 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.7s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.0s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 0.6s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.1s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.0s
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.7s
//gutil:proto_ordering_test                                              PASSED in 0.6s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 1.7s
//gutil:test_artifact_writer_test                                        PASSED in 0.6s
//gutil:testing_test                                                     PASSED in 0.6s
//thinkit:bazel_test_environment_test                                    PASSED in 1.2s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.8s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.5s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.9s
  Stats over 5 runs: max = 0.9s, min = 0.7s, avg = 0.7s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 49.1s
  Stats over 50 runs: max = 49.1s, min = 0.8s, avg = 2.0s, dev = 6.8s

Executed 192 out of 192 tests: 192 tests pass.
INFO: Build completed successfully, 246 total actions

```
