### PR TITLE
[P4_Symbolic] Extend BMv2 proto with error codes.

### DIFF
--- a/p4_symbolic/bmv2/bmv2.proto
+++ b/p4_symbolic/bmv2/bmv2.proto
@@ -78,7 +78,7 @@ message P4Program {
   repeated Deparser deparsers = 4;
   // All actions defined in the program, including their names
   // paramters, and bodies.
-  // Eventhough actions are typically attached to tables,
+  // Even though actions are typically attached to tables,
   // they are defined seperatly in the JSON format,
   // and the table definitions refer to them by their action id.
   repeated Action actions = 5;
@@ -86,6 +86,8 @@ message P4Program {
   // including all their tables, and the mapping of tables
   // to actions via match keys.
   repeated Pipeline pipelines = 6;
+  // All errors defined in the program.
+  repeated google.protobuf.ListValue errors = 7;
 }
 
 // A P4 header type definition.

--- a/p4_symbolic/bmv2/expected/basic.pb.txt
+++ b/p4_symbolic/bmv2/expected/basic.pb.txt
@@ -1109,3 +1109,59 @@ pipelines {
     source_fragment: "MyEgress"
   }
 }
+errors {
+  values {
+    string_value: "NoError"
+  }
+  values {
+    number_value: 0
+  }
+}
+errors {
+  values {
+    string_value: "PacketTooShort"
+  }
+  values {
+    number_value: 1
+  }
+}
+errors {
+  values {
+    string_value: "NoMatch"
+  }
+  values {
+    number_value: 2
+  }
+}
+errors {
+  values {
+    string_value: "StackOutOfBounds"
+  }
+  values {
+    number_value: 3
+  }
+}
+errors {
+  values {
+    string_value: "HeaderTooShort"
+  }
+  values {
+    number_value: 4
+  }
+}
+errors {
+  values {
+    string_value: "ParserTimeout"
+  }
+  values {
+    number_value: 5
+  }
+}
+errors {
+  values {
+    string_value: "ParserInvalidArgument"
+  }
+  values {
+    number_value: 6
+  }
+}

--- a/p4_symbolic/bmv2/expected/hardcoded.pb.txt
+++ b/p4_symbolic/bmv2/expected/hardcoded.pb.txt
@@ -522,3 +522,59 @@ pipelines {
     source_fragment: "UselessEgress"
   }
 }
+errors {
+  values {
+    string_value: "NoError"
+  }
+  values {
+    number_value: 0
+  }
+}
+errors {
+  values {
+    string_value: "PacketTooShort"
+  }
+  values {
+    number_value: 1
+  }
+}
+errors {
+  values {
+    string_value: "NoMatch"
+  }
+  values {
+    number_value: 2
+  }
+}
+errors {
+  values {
+    string_value: "StackOutOfBounds"
+  }
+  values {
+    number_value: 3
+  }
+}
+errors {
+  values {
+    string_value: "HeaderTooShort"
+  }
+  values {
+    number_value: 4
+  }
+}
+errors {
+  values {
+    string_value: "ParserTimeout"
+  }
+  values {
+    number_value: 5
+  }
+}
+errors {
+  values {
+    string_value: "ParserInvalidArgument"
+  }
+  values {
+    number_value: 6
+  }
+}

--- a/p4_symbolic/bmv2/expected/reflector.pb.txt
+++ b/p4_symbolic/bmv2/expected/reflector.pb.txt
@@ -350,3 +350,59 @@ pipelines {
     source_fragment: "UselessEgress"
   }
 }
+errors {
+  values {
+    string_value: "NoError"
+  }
+  values {
+    number_value: 0
+  }
+}
+errors {
+  values {
+    string_value: "PacketTooShort"
+  }
+  values {
+    number_value: 1
+  }
+}
+errors {
+  values {
+    string_value: "NoMatch"
+  }
+  values {
+    number_value: 2
+  }
+}
+errors {
+  values {
+    string_value: "StackOutOfBounds"
+  }
+  values {
+    number_value: 3
+  }
+}
+errors {
+  values {
+    string_value: "HeaderTooShort"
+  }
+  values {
+    number_value: 4
+  }
+}
+errors {
+  values {
+    string_value: "ParserTimeout"
+  }
+  values {
+    number_value: 5
+  }
+}
+errors {
+  values {
+    string_value: "ParserInvalidArgument"
+  }
+  values {
+    number_value: 6
+  }
+}

--- a/p4_symbolic/bmv2/expected/set_invalid.pb.txt
+++ b/p4_symbolic/bmv2/expected/set_invalid.pb.txt
@@ -644,3 +644,59 @@ pipelines {
     source_fragment: "UselessEgress"
   }
 }
+errors {
+  values {
+    string_value: "NoError"
+  }
+  values {
+    number_value: 0
+  }
+}
+errors {
+  values {
+    string_value: "PacketTooShort"
+  }
+  values {
+    number_value: 1
+  }
+}
+errors {
+  values {
+    string_value: "NoMatch"
+  }
+  values {
+    number_value: 2
+  }
+}
+errors {
+  values {
+    string_value: "StackOutOfBounds"
+  }
+  values {
+    number_value: 3
+  }
+}
+errors {
+  values {
+    string_value: "HeaderTooShort"
+  }
+  values {
+    number_value: 4
+  }
+}
+errors {
+  values {
+    string_value: "ParserTimeout"
+  }
+  values {
+    number_value: 5
+  }
+}
+errors {
+  values {
+    string_value: "ParserInvalidArgument"
+  }
+  values {
+    number_value: 6
+  }
+}

--- a/p4_symbolic/bmv2/expected/table.pb.txt
+++ b/p4_symbolic/bmv2/expected/table.pb.txt
@@ -362,3 +362,59 @@ pipelines {
     source_fragment: "UselessEgress"
   }
 }
+errors {
+  values {
+    string_value: "NoError"
+  }
+  values {
+    number_value: 0
+  }
+}
+errors {
+  values {
+    string_value: "PacketTooShort"
+  }
+  values {
+    number_value: 1
+  }
+}
+errors {
+  values {
+    string_value: "NoMatch"
+  }
+  values {
+    number_value: 2
+  }
+}
+errors {
+  values {
+    string_value: "StackOutOfBounds"
+  }
+  values {
+    number_value: 3
+  }
+}
+errors {
+  values {
+    string_value: "HeaderTooShort"
+  }
+  values {
+    number_value: 4
+  }
+}
+errors {
+  values {
+    string_value: "ParserTimeout"
+  }
+  values {
+    number_value: 5
+  }
+}
+errors {
+  values {
+    string_value: "ParserInvalidArgument"
+  }
+  values {
+    number_value: 6
+  }
+}

--- a/p4_symbolic/bmv2/expected/table_hit_1.pb.txt
+++ b/p4_symbolic/bmv2/expected/table_hit_1.pb.txt
@@ -860,3 +860,59 @@ pipelines {
     source_fragment: "MyEgress"
   }
 }
+errors {
+  values {
+    string_value: "NoError"
+  }
+  values {
+    number_value: 0
+  }
+}
+errors {
+  values {
+    string_value: "PacketTooShort"
+  }
+  values {
+    number_value: 1
+  }
+}
+errors {
+  values {
+    string_value: "NoMatch"
+  }
+  values {
+    number_value: 2
+  }
+}
+errors {
+  values {
+    string_value: "StackOutOfBounds"
+  }
+  values {
+    number_value: 3
+  }
+}
+errors {
+  values {
+    string_value: "HeaderTooShort"
+  }
+  values {
+    number_value: 4
+  }
+}
+errors {
+  values {
+    string_value: "ParserTimeout"
+  }
+  values {
+    number_value: 5
+  }
+}
+errors {
+  values {
+    string_value: "ParserInvalidArgument"
+  }
+  values {
+    number_value: 6
+  }
+}

--- a/p4_symbolic/bmv2/expected/table_hit_2.pb.txt
+++ b/p4_symbolic/bmv2/expected/table_hit_2.pb.txt
@@ -922,3 +922,59 @@ pipelines {
     source_fragment: "MyEgress"
   }
 }
+errors {
+  values {
+    string_value: "NoError"
+  }
+  values {
+    number_value: 0
+  }
+}
+errors {
+  values {
+    string_value: "PacketTooShort"
+  }
+  values {
+    number_value: 1
+  }
+}
+errors {
+  values {
+    string_value: "NoMatch"
+  }
+  values {
+    number_value: 2
+  }
+}
+errors {
+  values {
+    string_value: "StackOutOfBounds"
+  }
+  values {
+    number_value: 3
+  }
+}
+errors {
+  values {
+    string_value: "HeaderTooShort"
+  }
+  values {
+    number_value: 4
+  }
+}
+errors {
+  values {
+    string_value: "ParserTimeout"
+  }
+  values {
+    number_value: 5
+  }
+}
+errors {
+  values {
+    string_value: "ParserInvalidArgument"
+  }
+  values {
+    number_value: 6
+  }
+}


### PR DESCRIPTION
Keyword Check:
~/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.




Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 593 targets (2 packages loaded, 74 targets configured).
INFO: Found 593 targets...
INFO: From Compiling p4_symbolic/ir/cfg.cc [for host]:
In file included from p4_symbolic/ir/cfg.cc:15:
./p4_symbolic/ir/cfg.h:65:3: warning: multi-line comment [-Wcomment]
   65 |   //             /             \
      |   ^
p4_symbolic/ir/cfg.cc:260:5: warning: multi-line comment [-Wcomment]
  260 |     //      /  \
      |     ^
p4_symbolic/ir/cfg.cc:299:7: warning: multi-line comment [-Wcomment]
  299 |       //      /  \
      |       ^
p4_symbolic/ir/cfg.cc: In function 'p4_symbolic::ir::ControlPath p4_symbolic::ir::{anonymous}::LongestCommonPrefix(const ControlPath&, const ControlPath&)':
p4_symbolic/ir/cfg.cc:67:16: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<std::__cxx11::basic_string<char> >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   67 |   while (index < l.size() && index < r.size() && l[index] == r[index]) {
      |          ~~~~~~^~~~~~~~~~
p4_symbolic/ir/cfg.cc:67:36: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<std::__cxx11::basic_string<char> >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   67 |   while (index < l.size() && index < r.size() && l[index] == r[index]) {
      |                              ~~~~~~^~~~~~~~~~
INFO: From Compiling p4_symbolic/ir/ir.cc [for host]:
INFO: From Executing genrule //p4_symbolic/symbolic:condtional_test_test_runner:
Finding packet for table MyIngress.t_1 and row -1
	Dropped = 0
	standard_metadata.ingress_port = #b000000000
	standard_metadata.egress_spec = #b000000001

Finding packet for table MyIngress.t_2 and row -1
	Dropped = 0
	standard_metadata.ingress_port = #b000000001
	standard_metadata.egress_spec = #b000000001

Finding packet for table MyIngress.t_3 and row -1
Cannot find solution!

Finding packet for table MyIngress.t_3 and row 0
	Dropped = 0
	standard_metadata.ingress_port = #b000000001
	standard_metadata.egress_spec = #b000000001

INFO: From Executing genrule //p4_symbolic/symbolic:port_hardcoded_test_test_runner:
Finding packet for table tbl_hardcoded55 and row -1
	Dropped = 0
	standard_metadata.ingress_port = #b000000000
	standard_metadata.egress_spec = #b000000001

Finding packet for table tbl_hardcoded57 and row -1
	Dropped = 0
	standard_metadata.ingress_port = #b000000001
	standard_metadata.egress_spec = #b000000000

INFO: Elapsed time: 131.303s, Critical Path: 57.03s
INFO: 94 processes: 4 internal, 90 linux-sandbox.
INFO: Build completed successfully, 94 total actions




Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 593 targets (0 packages loaded, 352 targets configured).
INFO: Found 397 targets and 196 test targets...
INFO: Elapsed time: 224.164s, Critical Path: 113.44s
INFO: 250 processes: 294 linux-sandbox, 18 local.
INFO: Build completed successfully, 250 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.5s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.3s
//dvaas:test_vector_stats_test                                           PASSED in 0.0s
//dvaas:test_vector_test                                                 PASSED in 0.7s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.1s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.7s
//gutil:proto_ordering_test                                              PASSED in 0.8s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//p4rt_app/tests:packetio_test                                           PASSED in 4.9s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.9s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.1s
//p4rt_app/tests:response_path_test                                      PASSED in 6.2s
//p4rt_app/tests:role_test                                               PASSED in 1.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 3.2s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.4s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.8s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.4s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.8s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.7s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 2.4s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.8s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 3.6s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.7s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.1s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.5s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//thinkit:bazel_test_environment_test                                    PASSED in 0.6s
//thinkit:generic_testbed_test                                           PASSED in 1.0s
//thinkit:mock_control_device_test                                       PASSED in 0.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.1s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.9s
  Stats over 5 runs: max = 0.9s, min = 0.7s, avg = 0.8s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 44.4s
  Stats over 50 runs: max = 44.4s, min = 0.8s, avg = 3.9s, dev = 10.3s

Executed 196 out of 196 tests: 196 tests pass.
INFO: Build completed successfully, 250 total actions
