### PR TITLE
[Thinkit] Clean up redundant variables Associate test case ID.Add an `in-discards` counter for gnmi counter stats. Log CPU queue counter in sFlow inband tests. Dump hsflowd.auto file for sFlow tests.Test sampling works after reboot.

### DIFF
--- a/tests/sflow/BUILD.bazel
+++ b/tests/sflow/BUILD.bazel
@@ -35,6 +35,7 @@ cc_library(
         "//p4_pdpi:pd",
         "//p4_pdpi/packetlib",
         "//sai_p4/instantiations/google:sai_pd_cc_proto",
+        "//tests:thinkit_sanity_tests",
         "//tests/forwarding:group_programming_util",
         "//tests/forwarding:util",
         "//tests/lib:p4rt_fixed_table_programming_helper",

--- a/tests/sflow/sflow_test.h
+++ b/tests/sflow/sflow_test.h
@@ -67,10 +67,6 @@ class SflowTestFixture : public ::testing::TestWithParam<SflowTestParams> {
   thinkit::SSHClient* ssh_client_ = GetParam().ssh_client;
 
   std::vector<IxiaLink> ready_links_;
-
- private:
-  // Set to true when config already has sampling config and is set to true.
-  bool sflow_enabled_by_config_ = false;
 };
 
 class SampleSizeTest : public SflowTestFixture {};
@@ -105,10 +101,6 @@ class SflowMirrorTestFixture
   std::unique_ptr<gnmi::gNMI::StubInterface> sut_gnmi_stub_;
 
   std::string agent_address_;
-
- private:
-  // Set to true when config already has sampling config and is set to true.
-  bool sflow_enabled_by_config_ = false;
 };
 }  // namespace pins
 


### PR DESCRIPTION
Key_word Check:

```
~/pins_upstream/sonic-buildimage/src/sonic-p4rt/sonic-pins/tests/sflow$ ~/tools/keyword_checks.sh .
Keyword check Passed.

```

Build result:

```
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 636 targets (0 packages loaded, 0 targets configured).
INFO: Found 636 targets...
INFO: Elapsed time: 0.444s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

```


Test result:

```
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 636 targets (0 packages loaded, 0 targets configured).
INFO: Found 424 targets and 212 test targets...
INFO: Elapsed time: 161.726s, Critical Path: 116.14s
INFO: 266 processes: 321 linux-sandbox, 18 local.
INFO: Build completed successfully, 266 total actions
//dvaas:port_id_map_test                                                 PASSED in 1.8s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.3s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//thinkit:mock_control_device_test                                       PASSED in 0.9s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.0s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.5s
//thinkit:mock_ssh_client_test                                           PASSED in 0.2s
//thinkit:mock_switch_test                                               PASSED in 1.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.4s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.7s
  Stats over 5 runs: max = 1.7s, min = 1.4s, avg = 1.5s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 44.0s
  Stats over 50 runs: max = 44.0s, min = 1.2s, avg = 3.2s, dev = 8.3s

Executed 212 out of 212 tests: 212 tests pass.
INFO: Build completed successfully, 266 total actions

```