### PR TITLE
[Thinkit] Add a test case for sFlow backoff. Add a util function to verify dscp value.

### DIFF
--- a/tests/sflow/BUILD.bazel
+++ b/tests/sflow/BUILD.bazel
@@ -83,6 +83,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
+        "@com_googlesource_code_re2//:re2",
     ],
 )
 

--- a/tests/sflow/sflow_test.h
+++ b/tests/sflow/sflow_test.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/strings/substitute.h"
 #include "gtest/gtest.h"
 #include "p4_pdpi/p4_runtime_session.h"
 #include "proto/gnmi/gnmi.grpc.pb.h"
@@ -63,6 +64,7 @@ class SflowTestFixture : public ::testing::TestWithParam<SflowTestParams> {
   std::unique_ptr<thinkit::GenericTestbed> testbed_;
   pdpi::IrP4Info ir_p4_info_;
   std::unique_ptr<gnmi::gNMI::StubInterface> gnmi_stub_;
+  std::string gnmi_config_with_sflow_;
   std::unique_ptr<pdpi::P4RuntimeSession> sut_p4_session_;
   thinkit::SSHClient* ssh_client_ = GetParam().ssh_client;
 
@@ -72,6 +74,8 @@ class SflowTestFixture : public ::testing::TestWithParam<SflowTestParams> {
 class SampleSizeTest : public SflowTestFixture {};
 
 class SampleRateTest : public SflowTestFixture {};
+
+class BackoffTest : public SflowTestFixture {};
 
 struct SflowMirrorTestParams {
   thinkit::MirrorTestbedInterface* testbed_interface;

--- a/tests/sflow/sflow_util.cc
+++ b/tests/sflow/sflow_util.cc
@@ -14,9 +14,12 @@
 
 #include "tests/sflow/sflow_util.h"
 
+#include <string>
+
 #include "absl/container/btree_map.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
+#include "absl/strings/ascii.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -28,6 +31,7 @@
 #include "lib/gnmi/gnmi_helper.h"
 #include "lib/utils/json_utils.h"
 #include "lib/validator/validator_lib.h"
+#include "re2/re2.h"
 
 namespace pins {
 namespace {
@@ -59,6 +63,10 @@ constexpr absl::string_view kSflowGnmiStateCollectorAddressPath =
     "/sampling/sflow/collectors/collector[address=$0][port=$1]/state/address";
 constexpr absl::string_view kSflowGnmiStateCollectorPortPath =
     "/sampling/sflow/collectors/collector[address=$0][port=$1]/state/port";
+
+// ToS is present in tcp dump like
+// ... (class 0x80, ....)
+constexpr LazyRE2 kPacketTosMatchPattern{R"(class 0x([a-f0-9]+),)"};
 
 }  // namespace
 
@@ -386,6 +394,21 @@ absl::Status VerifySflowQueueLimitState(gnmi::gNMI::StubInterface* gnmi_stub,
         state_value, ", expected value is ", expected_queue_limit));
   };
   return pins_test::WaitForCondition(verify_queue_limit, timeout);
+}
+
+absl::StatusOr<int> ExtractTosFromTcpdumpResult(
+    absl::string_view tcpdump_result) {
+  if (std::string tos;
+      RE2::PartialMatch(tcpdump_result, *kPacketTosMatchPattern, &tos)) {
+    int tos_int;
+    if (absl::SimpleHexAtoi(tos, &tos_int)) {
+      return tos_int;
+    }
+    return absl::InvalidArgumentError(
+        absl::StrCat("Failed to convert ", tos, " to int value."));
+  }
+  return absl::InvalidArgumentError(
+      "Failed to find ToS value in tcpdump result.");
 }
 
 }  // namespace pins

--- a/tests/sflow/sflow_util.h
+++ b/tests/sflow/sflow_util.h
@@ -98,5 +98,10 @@ absl::Status VerifySflowQueueLimitState(
     gnmi::gNMI::StubInterface* gnmi_stub, int queue_number,
     int expected_queue_limit, absl::Duration timeout = absl::Seconds(5));
 
+// Extracts ToS value from `tcpdump_result`. Returns InvalidArgument error if
+// failed to find ToS value in `tcpdump_result`.
+absl::StatusOr<int> ExtractTosFromTcpdumpResult(
+    absl::string_view tcpdump_result);
+
 }  // namespace pins
 #endif  // PINS_TESTS_SFLOW_SFLOW_UTIL_H_

--- a/tests/sflow/sflow_util_test.cc
+++ b/tests/sflow/sflow_util_test.cc
@@ -624,5 +624,49 @@ TEST(SflowUtilTest, UpdateQueueLimitSucceed) {
                                        /*expected_queue_limit=*/120));
 }
 
+TEST(SflowDscpTest, ParseTcpdumpResultA1Success) {
+  const std::string tcpdump_result =
+      R"(tcpdump: listening on lo, link-type EN10MB (Ethernet), capture size "
+      "262144 bytes 18:10:50.401908 00:00:00:00:00:00 (oui Ethernet) > "
+      "00:00:00:00:00:00 (oui Ethernet), ethertype IPv6 (0x86dd), length 230: "
+      "(class 0xa1, flowlabel 0x20016, hlim 127, next-header UDP (17) payload "
+      "length: 176) localhost.56223 > localhost.6343: [bad udp cksum 0x00c3 -> "
+      "0x6a10!] sFlowv5, IPv6 agent 38.7.248.176, agent-id 2157511939, seqnum "
+      "0, uptime 0, samples 100000, length 168 flow sample (1), length "
+      "50018,[|SFLOW] 0x0000:  6802 0016 00b0 117f 0000 0000 0000 0000  "
+      "h...............)";
+  ASSERT_THAT(ExtractTosFromTcpdumpResult(tcpdump_result), IsOkAndHolds(161));
+}
+
+TEST(SflowDscpTest, ParseTcpdumpResultFFSuccess) {
+  const std::string tcpdump_result =
+      R"(tcpdump: listening on lo, link-type EN10MB (Ethernet), capture size "
+      "262144 bytes 18:10:50.401908 00:00:00:00:00:00 (oui Ethernet) > "
+      "00:00:00:00:00:00 (oui Ethernet), ethertype IPv6 (0x86dd), length 230: "
+      "(class 0xff, flowlabel 0x20016, hlim 127, next-header UDP (17) payload "
+      "length: 176) localhost.56223 > localhost.6343: [bad udp cksum 0x00c3 -> "
+      "0x6a10!] sFlowv5, IPv6 agent 38.7.248.176, agent-id 2157511939, seqnum "
+      "0, uptime 0, samples 100000, length 168 flow sample (1), length "
+      "50018,[|SFLOW] 0x0000:  6802 0016 00b0 117f 0000 0000 0000 0000  "
+      "h...............)";
+  ASSERT_THAT(ExtractTosFromTcpdumpResult(tcpdump_result), IsOkAndHolds(255));
+}
+
+TEST(SflowDscpTest, ParseTcpdumpResultFailure) {
+  const std::string tcpdump_result =
+      R"(tcpdump: listening on lo, link-type EN10MB (Ethernet), capture size "
+      "262144 bytes 18:10:50.401908 00:00:00:00:00:00 (oui Ethernet) > "
+      "00:00:00:00:00:00 (oui Ethernet), ethertype IPv6 (0x86dd), length 230: "
+      "(flowlabel 0x20016, hlim 127, next-header UDP (17) payload length: 176) "
+      "localhost.56223 > localhost.6343: [bad udp cksum 0x00c3 -> 0x6a10!] "
+      "sFlowv5, IPv6 agent 38.7.248.176, agent-id 2157511939, seqnum 0, uptime "
+      "0, samples 100000, length 168 flow sample (1), length 50018,[|SFLOW] "
+      "0x0000:  6802 0016 00b0 117f 0000 0000 0000 0000  h...............)";
+  ASSERT_THAT(
+      ExtractTosFromTcpdumpResult(tcpdump_result),
+      StatusIs(absl::StatusCode::kInvalidArgument,
+               HasSubstr("Failed to find ToS value in tcpdump result.")));
+}
+
 }  // namespace
 }  // namespace pins


### PR DESCRIPTION
Key_word Check:

```
~/pins_upstream/sonic-buildimage/src/sonic-p4rt/sonic-pins/tests/sflow$ ~/tools/keyword_checks.sh .
Keyword check Passed.

```

Build result:

```
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 636 targets (0 packages loaded, 0 targets configured).
INFO: Found 636 targets...
INFO: Elapsed time: 0.444s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

```


Test result:

```
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 636 targets (0 packages loaded, 0 targets configured).
INFO: Found 424 targets and 212 test targets...
INFO: Elapsed time: 161.726s, Critical Path: 116.14s
INFO: 266 processes: 321 linux-sandbox, 18 local.
INFO: Build completed successfully, 266 total actions
//dvaas:port_id_map_test                                                 PASSED in 1.8s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.3s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//thinkit:mock_control_device_test                                       PASSED in 0.9s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.0s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.5s
//thinkit:mock_ssh_client_test                                           PASSED in 0.2s
//thinkit:mock_switch_test                                               PASSED in 1.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.4s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.7s
  Stats over 5 runs: max = 1.7s, min = 1.4s, avg = 1.5s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 44.0s
  Stats over 50 runs: max = 44.0s, min = 1.2s, avg = 3.2s, dev = 8.3s

Executed 212 out of 212 tests: 212 tests pass.
INFO: Build completed successfully, 266 total actions

```