### PR TITLE
[Thinkit] Use `int64_t` for packets_num in SflowResult. collect `proc/bcm/knet-cb/psample/map` data during setup and teardown. Use `state/actual-ingress-sample-rate` to read the sample rate for backoff test.

### DIFF
--- a/tests/sflow/sflow_util.h
+++ b/tests/sflow/sflow_util.h
@@ -15,6 +15,7 @@
 #ifndef PINS_TESTS_SFLOW_SFLOW_UTIL_H_
 #define PINS_TESTS_SFLOW_SFLOW_UTIL_H_
 
+#include <cstdint>
 #include <utility>
 
 #include "absl/container/flat_hash_map.h"
@@ -91,11 +92,17 @@ absl::StatusOr<std::string> UpdateSflowConfig(
 absl::StatusOr<std::string> UpdateQueueLimit(absl::string_view gnmi_config,
                                              absl::string_view queue_name,
                                              int queue_limit);
-
-// Returns <interface name, interface sflow sampling rate> map of each interface
-// in `interfaces`.
+// Returns <interface name, state/ingress-sampling-rate> map of each
+// interface in `interfaces`.
 absl::StatusOr<absl::flat_hash_map<std::string, int>>
 GetSflowSamplingRateForInterfaces(
+    gnmi::gNMI::StubInterface* gnmi_stub,
+    const absl::flat_hash_set<std::string>& interfaces);
+
+// Returns <interface name, state/actual-ingress-sampling-rate> map of each
+// interface in `interfaces`.
+absl::StatusOr<absl::flat_hash_map<std::string, int>>
+GetSflowActualSamplingRateForInterfaces(
     gnmi::gNMI::StubInterface* gnmi_stub,
     const absl::flat_hash_set<std::string>& interfaces);
 
@@ -109,6 +116,17 @@ absl::Status VerifySflowQueueLimitState(
 // ToS value are not identical or failed to find ToS value in `tcpdump_result`.
 absl::StatusOr<int> ExtractTosFromTcpdumpResult(
     absl::string_view tcpdump_result);
+
+// Reads and returns value from
+// `/sampling/sflow/interfaces/interface[name=<interface_name>]/state/packets-sampled`.
+absl::StatusOr<int64_t> GetSflowInterfacePacketsSampledCounter(
+    gnmi::gNMI::StubInterface* gnmi_stub, absl::string_view interface_name);
+
+// Read and returns value from
+// /sampling/sflow/collectors/collector[address=<collector_ip>][port=<port_num>]/state/packets-sent
+absl::StatusOr<int64_t> GetSflowCollectorPacketsSentCounter(
+    gnmi::gNMI::StubInterface* gnmi_stub, absl::string_view collector_ip,
+    int port_num);
 
 }  // namespace pins
 #endif  // PINS_TESTS_SFLOW_SFLOW_UTIL_H_


### PR DESCRIPTION
Key_word Check:

```
~/pins_upstream/sonic-buildimage/src/sonic-p4rt/sonic-pins/tests/sflow$ ~/tools/keyword_checks.sh .
Keyword check Passed.

```

Build result:

```
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 638 targets (0 packages loaded, 0 targets configured).
INFO: Found 638 targets...
INFO: Elapsed time: 0.533s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

```


Test result:

```
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 638 targets (0 packages loaded, 0 targets configured).
INFO: Found 426 targets and 212 test targets...
INFO: Elapsed time: 161.150s, Critical Path: 115.30s
INFO: 266 processes: 321 linux-sandbox, 18 local.
INFO: Build completed successfully, 266 total actions
//dvaas:port_id_map_test                                                 PASSED in 1.5s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.0s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//thinkit:mock_control_device_test                                       PASSED in 1.0s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.4s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.2s
//thinkit:mock_ssh_client_test                                           PASSED in 0.2s
//thinkit:mock_switch_test                                               PASSED in 1.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.3s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.6s
  Stats over 5 runs: max = 1.6s, min = 1.1s, avg = 1.3s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 43.6s
  Stats over 50 runs: max = 43.6s, min = 0.9s, avg = 3.3s, dev = 8.2s

Executed 212 out of 212 tests: 212 tests pass.
INFO: Build completed successfully, 266 total actions

```