### PR TITLE
[Thinkit] Test sFlow interface counter value during standalone test. Use `pins-sampling-sflow` namespace for `actual-ingress-sampling-rate`. do not fail test when `/etc/hsflowd.auto` is not present. Add a restart test.

### DIFF
--- a/tests/sflow/BUILD.bazel
+++ b/tests/sflow/BUILD.bazel
@@ -34,6 +34,7 @@ cc_library(
         "//p4_pdpi:p4_runtime_session",
         "//p4_pdpi:p4_runtime_session_extras",
         "//p4_pdpi:pd",
+        "//p4_pdpi/netaddr:ipv4_address",
         "//p4_pdpi/packetlib",
         "//sai_p4/instantiations/google:sai_pd_cc_proto",
         "//tests:thinkit_sanity_tests",

--- a/tests/sflow/sflow_util.h
+++ b/tests/sflow/sflow_util.h
@@ -61,10 +61,9 @@ absl::Status SetSflowIngressSamplingRate(
 
 // Sets sFlow interface config and waits until it's converged in state path.
 // `interface` must be present.
-absl::Status SetSflowInterfaceConfig(gnmi::gNMI::StubInterface* gnmi_stub,
-                                     absl::string_view interface, bool enabled,
-                                     int samping_rate,
-                                     absl::Duration timeout = absl::Seconds(5));
+absl::Status SetSflowInterfaceConfigEnable(
+    gnmi::gNMI::StubInterface* gnmi_stub, absl::string_view interface,
+    bool enabled, absl::Duration timeout = absl::Seconds(5));
 
 // Verifies all sFlow-related config is consumed by switch by reading
 // corresponding gNMI state paths. Returns an FailedPreconditionError if


### PR DESCRIPTION
Key_word Check:

```
~/pins_upstream/sonic-buildimage/src/sonic-p4rt/sonic-pins/tests/sflow$ ~/tools/keyword_checks.sh .
Keyword check Passed.

```

Build result:

```
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 638 targets (0 packages loaded, 0 targets configured).
INFO: Found 638 targets...
INFO: Elapsed time: 0.533s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

```


Test result:

```
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 638 targets (0 packages loaded, 0 targets configured).
INFO: Found 426 targets and 212 test targets...
INFO: Elapsed time: 161.150s, Critical Path: 115.30s
INFO: 266 processes: 321 linux-sandbox, 18 local.
INFO: Build completed successfully, 266 total actions
//dvaas:port_id_map_test                                                 PASSED in 1.5s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.0s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//thinkit:mock_control_device_test                                       PASSED in 1.0s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.4s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.2s
//thinkit:mock_ssh_client_test                                           PASSED in 0.2s
//thinkit:mock_switch_test                                               PASSED in 1.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.3s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.6s
  Stats over 5 runs: max = 1.6s, min = 1.1s, avg = 1.3s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 43.6s
  Stats over 50 runs: max = 43.6s, min = 0.9s, avg = 3.3s, dev = 8.2s

Executed 212 out of 212 tests: 212 tests pass.
INFO: Build completed successfully, 266 total actions

```