### PR TITLE
[Thinkit] Add detailed error message.Set expectation on `decodedVLAN` fieldHsflowd restart is raising minor alarms which is affecting the other tests in longevity workflow. Set expectation for `TestInbandPathToSflowCollector` test Change breakout tests to run on only copper ports.

### DIFF
--- a/tests/sflow/sflow_test.h
+++ b/tests/sflow/sflow_test.h
@@ -80,7 +80,8 @@ struct SflowMirrorTestParams {
   thinkit::SSHClient* ssh_client;
   std::string sut_gnmi_config;
   std::string control_gnmi_config;
-  p4::config::v1::P4Info p4_info;
+  p4::config::v1::P4Info sut_p4_info;
+  p4::config::v1::P4Info control_p4_info;
 
   // Used for port breakout test.
   std::string platform_json_path;
@@ -97,10 +98,14 @@ class SflowMirrorTestFixture
   void SetUp() override;
 
   void TearDown() override;
-  const p4::config::v1::P4Info& GetP4Info() { return GetParam().p4_info; }
-  const pdpi::IrP4Info& GetIrP4Info() { return ir_p4_info_; }
 
-  pdpi::IrP4Info ir_p4_info_;
+  p4::config::v1::P4Info GetSutP4Info() { return sut_p4_info_; }
+  p4::config::v1::P4Info GetControlP4Info() { return control_p4_info_; }
+  pdpi::IrP4Info GetSutIrP4Info() { return sut_ir_p4_info_; }
+  pdpi::IrP4Info GetControlIrP4Info() { return control_ir_p4_info_; }
+
+  p4::config::v1::P4Info sut_p4_info_, control_p4_info_;
+  pdpi::IrP4Info sut_ir_p4_info_, control_ir_p4_info_;
   std::unique_ptr<pdpi::P4RuntimeSession> sut_p4_session_;
   std::unique_ptr<pdpi::P4RuntimeSession> control_p4_session_;
   std::unique_ptr<gnmi::gNMI::StubInterface> sut_gnmi_stub_;


### PR DESCRIPTION
Key_word Check:

```
~/pins_upstream/sonic-buildimage/src/sonic-p4rt/sonic-pins/tests/sflow$ ~/tools/keyword_checks.sh .
Keyword check Passed.

```

Build result:

```
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 645 targets (0 packages loaded, 0 targets configured).
INFO: Found 645 targets...
INFO: Elapsed time: 0.360s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

```


Test result:

```
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 645 targets (0 packages loaded, 371 targets configured).
INFO: Found 430 targets and 216 test targets...
INFO: Elapsed time: 161.596s, Critical Path: 115.71s
INFO: 269 processes: 325 linux-sandbox, 18 local.
INFO: Build completed successfully, 269 total actions
//dvaas:port_id_map_test                                                 PASSED in 1.4s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 0.9s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.2s
//thinkit:bazel_test_environment_test                                    PASSED in 1.2s
//thinkit:generic_testbed_test                                           PASSED in 2.0s
//thinkit:mock_control_device_test                                       PASSED in 0.8s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.8s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.4s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 1.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.3s
  Stats over 5 runs: max = 1.3s, min = 1.0s, avg = 1.2s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 44.6s
  Stats over 50 runs: max = 44.6s, min = 1.2s, avg = 4.5s, dev = 10.2s

Executed 216 out of 216 tests: 215 tests pass.
INFO: Build completed successfully, 269 total actions

```