### PR TITLE
[P4_Symbolic] Remove and modify outdated comments. Make the order of creating symbolic header fields deterministic.Initialize standard metadata fields to 0.

### DIFF
--- a/p4_symbolic/symbolic/expected/conditional_sequence.txt
+++ b/p4_symbolic/symbolic/expected/conditional_sequence.txt
@@ -28,7 +28,7 @@ ingress_headers:
 $got_cloned$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
-h1.f1 = #x01
+h1.f1 = #x02
 h1.f2 = #x00
 h1.f3 = #x00
 h1.f4 = #x00
@@ -64,7 +64,7 @@ parsed_headers:
 $got_cloned$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
-h1.f1 = #x01
+h1.f1 = #x02
 h1.f2 = #x00
 h1.f3 = #x00
 h1.f4 = #x00
@@ -100,7 +100,7 @@ egress_headers:
 $got_cloned$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
-h1.f1 = #x01
+h1.f1 = #x02
 h1.f2 = #x00
 h1.f3 = #x00
 h1.f4 = #x00

--- a/p4_symbolic/symbolic/parser.cc
+++ b/p4_symbolic/symbolic/parser.cc
@@ -27,6 +27,7 @@
 #include "p4_symbolic/symbolic/operators.h"
 #include "p4_symbolic/symbolic/symbolic.h"
 #include "p4_symbolic/symbolic/util.h"
+#include "p4_symbolic/symbolic/v1model.h"
 #include "z3++.h"
 
 namespace p4_symbolic::symbolic::parser {
@@ -361,7 +362,7 @@ absl::Status SetParserError(const ir::P4Program &program,
                             const z3::expr &guard) {
   ASSIGN_OR_RETURN(z3::expr error_code,
                    GetErrorCodeExpression(program, error_name, z3_context));
-  return state.Set(kParserErrorField, std::move(error_code), guard);
+  return state.Set(v1model::kParserErrorField, std::move(error_code), guard);
 }
 
 // Evaluates the parse state with the given `state_name` in the given parser.
@@ -486,7 +487,7 @@ absl::StatusOr<z3::expr> GetErrorCodeExpression(const ir::P4Program &program,
 
   // Obtain the bitwidth of the `parser_error` field
   ASSIGN_OR_RETURN(unsigned int bitwidth,
-                   util::GetFieldBitwidth(kParserErrorField, program));
+                   util::GetFieldBitwidth(v1model::kParserErrorField, program));
 
   return z3_context.bv_val(error_code, bitwidth);
 }

--- a/p4_symbolic/symbolic/parser_test.cc
+++ b/p4_symbolic/symbolic/parser_test.cc
@@ -28,7 +28,6 @@
 #include "gutil/status_matchers.h"
 #include "p4_symbolic/ir/ir.h"
 #include "p4_symbolic/ir/ir.pb.h"
-#include "p4_symbolic/symbolic/symbolic.h"
 #include "p4_symbolic/symbolic/v1model.h"
 #include "z3++.h"
 
@@ -86,6 +85,9 @@ constexpr absl::string_view kHeaders = R"pb(
         key: "src_addr"
         value { name: "src_addr" bitwidth: 48 }
       }
+      ordered_fields_list: "dst_addr"
+      ordered_fields_list: "src_addr"
+      ordered_fields_list: "ether_type"
     }
   }
   headers {
@@ -153,6 +155,21 @@ constexpr absl::string_view kHeaders = R"pb(
         key: "version"
         value { name: "version" bitwidth: 4 }
       }
+      ordered_fields_list: "version"
+      ordered_fields_list: "ihl"
+      ordered_fields_list: "dscp"
+      ordered_fields_list: "ecn"
+      ordered_fields_list: "total_len"
+      ordered_fields_list: "identification"
+      ordered_fields_list: "reserved"
+      ordered_fields_list: "do_not_fragment"
+      ordered_fields_list: "more_fragments"
+      ordered_fields_list: "frag_offset"
+      ordered_fields_list: "ttl"
+      ordered_fields_list: "protocol"
+      ordered_fields_list: "header_checksum"
+      ordered_fields_list: "src_addr"
+      ordered_fields_list: "dst_addr"
     }
   }
   headers {
@@ -161,9 +178,90 @@ constexpr absl::string_view kHeaders = R"pb(
       name: "standard_metadata"
       id: 1
       fields {
+        key: "_padding"
+        value { name: "_padding" bitwidth: 3 }
+      }
+      fields {
+        key: "checksum_error"
+        value { name: "checksum_error" bitwidth: 1 }
+      }
+      fields {
+        key: "deq_qdepth"
+        value { name: "deq_qdepth" bitwidth: 19 }
+      }
+      fields {
+        key: "deq_timedelta"
+        value { name: "deq_timedelta" bitwidth: 32 }
+      }
+      fields {
+        key: "egress_global_timestamp"
+        value { name: "egress_global_timestamp" bitwidth: 48 }
+      }
+      fields {
+        key: "egress_port"
+        value { name: "egress_port" bitwidth: 9 }
+      }
+      fields {
+        key: "egress_rid"
+        value { name: "egress_rid" bitwidth: 16 }
+      }
+      fields {
+        key: "egress_spec"
+        value { name: "egress_spec" bitwidth: 9 }
+      }
+      fields {
+        key: "enq_qdepth"
+        value { name: "enq_qdepth" bitwidth: 19 }
+      }
+      fields {
+        key: "enq_timestamp"
+        value { name: "enq_timestamp" bitwidth: 32 }
+      }
+      fields {
+        key: "ingress_global_timestamp"
+        value { name: "ingress_global_timestamp" bitwidth: 48 }
+      }
+      fields {
+        key: "ingress_port"
+        value { name: "ingress_port" bitwidth: 9 }
+      }
+      fields {
+        key: "instance_type"
+        value { name: "instance_type" bitwidth: 32 }
+      }
+      fields {
+        key: "mcast_grp"
+        value { name: "mcast_grp" bitwidth: 16 }
+      }
+      fields {
+        key: "packet_length"
+        value { name: "packet_length" bitwidth: 32 }
+      }
+      fields {
         key: "parser_error"
         value { name: "parser_error" bitwidth: 32 }
       }
+      fields {
+        key: "priority"
+        value { name: "priority" bitwidth: 3 }
+      }
+      ordered_fields_list: "ingress_port"
+      ordered_fields_list: "egress_spec"
+      ordered_fields_list: "egress_port"
+      ordered_fields_list: "instance_type"
+      ordered_fields_list: "packet_length"
+      ordered_fields_list: "enq_timestamp"
+      ordered_fields_list: "enq_qdepth"
+      ordered_fields_list: "deq_timedelta"
+      ordered_fields_list: "deq_qdepth"
+      ordered_fields_list: "ingress_global_timestamp"
+      ordered_fields_list: "egress_global_timestamp"
+      ordered_fields_list: "mcast_grp"
+      ordered_fields_list: "egress_rid"
+      ordered_fields_list: "checksum_error"
+      ordered_fields_list: "parser_error"
+      ordered_fields_list: "priority"
+      ordered_fields_list: "_padding"
     }
   }
 )pb";
@@ -943,7 +1041,7 @@ std::vector<ParserTestParam> GetParserTestInstances() {
                                   ctx.bv_val(0x0800, 16))},
                 {"ipv4.$extracted$", (ctx.bv_const("ethernet.ether_type", 16) ==
                                       ctx.bv_val(0x0800, 16))},
-                {std::string(kParserErrorField),
+                {std::string(v1model::kParserErrorField),
                  z3::ite((ctx.bv_const("ethernet.ether_type", 16) !=
                           ctx.bv_val(0x0800, 16)),
                          ctx.bv_val(2, 32), ctx.bv_val(0, 32))},

--- a/p4_symbolic/symbolic/symbolic.h
+++ b/p4_symbolic/symbolic/symbolic.h
@@ -37,15 +37,19 @@ namespace symbolic {
 // A port reserved to encode dropping packets.
 // The value is arbitrary; we choose the same value as BMv2:
 // https://github.com/p4lang/behavioral-model/blob/main/docs/simple_switch.md#standard-metadata
-constexpr int kDropPort = 511; // 2^9 - 1.
+constexpr int kDropPort = 511;  // 2^9 - 1.
+
 // An arbitrary port we reserve for the CPU port (for PacketIO packets).
-constexpr int kCpuPort = 510; // 2^9 - 2.
+constexpr int kCpuPort = 510;  // 2^9 - 2.
+
+// Bit-width of port numbers.
 constexpr int kPortBitwidth = 9;
 
 // Boolean pseudo header field that is initialized to false, set to true when
 // the header is extracted, and set to true/false when `setValid`/`setInvalid`
 // is called, respectively.
 constexpr absl::string_view kValidPseudoField = "$valid$";
+
 // Boolean pseudo header field denoting that the header has been extracted by
 // the parser. It is initialized to false and set to true when the header is
 // extracted. This is necessary to distinguish between headers extracted and
@@ -53,14 +57,10 @@ constexpr absl::string_view kValidPseudoField = "$valid$";
 // example, a `packet_in` header may be set to valid but should never be
 // extracted from the input packet.
 constexpr absl::string_view kExtractedPseudoField = "$extracted$";
+
 // Boolean pseudo header field that is set to true by p4-symbolic if the packet
 // gets cloned. Not an actual header field, but convenient for analysis.
 constexpr absl::string_view kGotClonedPseudoField = "$got_cloned$";
-// 32-bit bit-vector field in standard metadata indicating whether there is a
-// parser error. The error code is defined in core.p4 and can be extended by the
-// P4 program. 0 means no error.
-constexpr absl::string_view kParserErrorField =
-    "standard_metadata.parser_error";
 
 // The overall state of our symbolic solver/interpreter.
 // This is returned by our main analysis/interpration function, and is used

--- a/p4_symbolic/symbolic/v1model.h
+++ b/p4_symbolic/symbolic/v1model.h
@@ -26,12 +26,24 @@ namespace p4_symbolic {
 namespace symbolic {
 namespace v1model {
 
+// Standard metadata header name.
+constexpr absl::string_view kStandardMetadataHeaderName = "standard_metadata";
+
+// 32-bit bit-vector field in standard metadata indicating whether there is a
+// parser error. The error code is defined in core.p4 and can be extended by the
+// P4 program. 0 means no error.
+constexpr absl::string_view kParserErrorField =
+    "standard_metadata.parser_error";
+
 // V1model's `mark_to_drop` primitive sets the `egress_spec` field to
 // `kDropPort` to indicate the packet should be dropped at the end of
 // ingress/egress processing. See v1model.p4 for details.
 z3::expr EgressSpecDroppedValue(z3::context &z3_context);
 
 // Initializes the ingress headers to appropriate values.
+// Here we initialize all standard metadata fields to zero for the ingress
+// packet. Local (user) metadata fields are intentionally left uninitialized
+// to align with the standard.
 absl::Status InitializeIngressHeaders(const ir::P4Program &program,
                                       SymbolicPerPacketState &ingress_headers,
                                       z3::context &z3_context);


### PR DESCRIPTION
Keyword Check:
~/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.





Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 669 targets (0 packages loaded, 0 targets configured).
INFO: Found 669 targets...
INFO: From Compiling p4_symbolic/symbolic/action.cc:
In file included from ./p4_symbolic/z3_util.h:18,
                 from ./p4_symbolic/symbolic/symbolic.h:31,
                 from p4_symbolic/symbolic/action.cc:26:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   55 |     for (int i = 0; i < bytes.size(); i++) {
      |                     ~~^~~~~~~~~~~~~~
./p4_pdpi/string_encodings/bit_string.h: In instantiation of 'void pdpi::BitString::AppendBits(const std::bitset<_Nb>&) [with long unsigned int num_bits = 8]':
./p4_pdpi/string_encodings/bit_string.h:41:50:   required from here
./p4_pdpi/string_encodings/bit_string.h:49:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   49 |     for (int i = 0; i < num_bits; i++) {
      |                     ~~^~~~~~~~~~
INFO: From Compiling p4_symbolic/symbolic/values.cc:
In file included from ./p4_symbolic/z3_util.h:18,
                 from ./p4_symbolic/symbolic/symbolic.h:31,
                 from p4_symbolic/symbolic/values.cc:45:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   55 |     for (int i = 0; i < bytes.size(); i++) {
      |                     ~~^~~~~~~~~~~~~~
./p4_pdpi/string_encodings/bit_string.h: In instantiation of 'void pdpi::BitString::AppendBits(const std::bitset<_Nb>&) [with long unsigned int num_bits = 8]':
./p4_pdpi/string_encodings/bit_string.h:41:50:   required from here
./p4_pdpi/string_encodings/bit_string.h:49:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   49 |     for (int i = 0; i < num_bits; i++) {
      |                     ~~^~~~~~~~~~
INFO: From Compiling p4_symbolic/symbolic/parser.cc:
In file included from ./p4_symbolic/z3_util.h:18,
                 from ./p4_symbolic/symbolic/symbolic.h:31,
                 from p4_symbolic/symbolic/parser.cc:28:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
INFO: From Compiling p4_symbolic/packet_synthesizer/util_test.cc:
In file included from ./p4_symbolic/z3_util.h:18,
                 from ./p4_symbolic/symbolic/symbolic.h:31,
                 from ./p4_symbolic/packet_synthesizer/util.h:19,
                 from p4_symbolic/packet_synthesizer/util_test.cc:15:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   55 |     for (int i = 0; i < bytes.size(); i++) {
      |                     ~~^~~~~~~~~~~~~~
./p4_pdpi/string_encodings/bit_string.h: In instantiation of 'void pdpi::BitString::AppendBits(const std::bitset<_Nb>&) [with long unsigned int num_bits = 8]':
./p4_pdpi/string_encodings/bit_string.h:41:50:   required from here
./p4_pdpi/string_encodings/bit_string.h:49:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   49 |     for (int i = 0; i < num_bits; i++) {
      |                     ~~^~~~~~~~~~
INFO: From Compiling p4_symbolic/main.cc:
In file included from ./p4_symbolic/z3_util.h:18,
                 from ./p4_symbolic/symbolic/symbolic.h:31,
                 from p4_symbolic/main.cc:33:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   55 |     for (int i = 0; i < bytes.size(); i++) {
      |                     ~~^~~~~~~~~~~~~~
./p4_pdpi/string_encodings/bit_string.h: In instantiation of 'void pdpi::BitString::AppendBits(const std::bitset<_Nb>&) [with long unsigned int num_bits = 8]':
./p4_pdpi/string_encodings/bit_string.h:41:50:   required from here
./p4_pdpi/string_encodings/bit_string.h:49:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   49 |     for (int i = 0; i < num_bits; i++) {
      |                     ~~^~~~~~~~~~
INFO: Elapsed time: 28.052s, Critical Path: 9.31s
INFO: 49 processes: 5 internal, 44 linux-sandbox.
INFO: Build completed successfully, 49 total actions










Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 669 targets (0 packages loaded, 0 targets configured).
INFO: Found 453 targets and 216 test targets...
INFO: Elapsed time: 210.289s, Critical Path: 117.18s
INFO: 271 processes: 326 linux-sandbox, 18 local.
INFO: Build completed successfully, 271 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.8s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.0s
//dvaas:test_run_validation_test                                         PASSED in 0.6s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.0s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.0s
//dvaas:test_vector_test                                                 PASSED in 0.6s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.1s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.6s
//gutil:proto_matchers_test                                              PASSED in 0.7s
//gutil:proto_ordering_test                                              PASSED in 0.6s
//p4rt_app/tests:response_path_test                                      PASSED in 6.5s
//p4rt_app/tests:role_test                                               PASSED in 1.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.9s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.7s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 0.8s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.2s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.4s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.0s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 3.4s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.8s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 1.1s
//tests/lib:p4info_helper_test                                           PASSED in 0.9s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 0.7s
//tests/lib:packet_generator_test                                        PASSED in 27.1s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.1s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.0s
//tests/sflow:sflow_util_test                                            PASSED in 6.9s
//thinkit:bazel_test_environment_test                                    PASSED in 0.6s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.0s
  Stats over 5 runs: max = 1.0s, min = 0.8s, avg = 0.9s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 43.8s
  Stats over 50 runs: max = 43.8s, min = 0.8s, avg = 2.5s, dev = 6.2s

Executed 216 out of 216 tests: 216 tests pass.
INFO: Build completed successfully, 271 total actions
