### PR TITLE
[P4_Symbolic] Create symbolic variables and add constraints for symbolic table entries.

### DIFF
--- a/p4_symbolic/ir/ir.proto
+++ b/p4_symbolic/ir/ir.proto
@@ -512,6 +512,9 @@ message SymbolicTableEntry {
   //     https://p4.org/p4-spec/p4runtime/v1.3.0/P4Runtime-Spec.html#sec-match-format
   //   - To specify a symbolic match, provide a concrete match name without any
   //     values.
+  //   - For the prefix lengths in symbolic LPM matches, any negative value
+  //     denotes a symbolic prefix length and a non-negative value represents a
+  //     concrete prefix length value.
   //   - The `priority` must be concrete. It must be strictly positive if there
   //     are range, ternary, or optional matches, and must be zero if there are
   //     only LPM or exact matches.

--- a/p4_symbolic/symbolic/table_entry.cc
+++ b/p4_symbolic/symbolic/table_entry.cc
@@ -20,16 +20,22 @@
 #include <string>
 #include <utility>
 
+#include "absl/container/btree_map.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
+#include "gutil/collections.h"
 #include "gutil/status.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "p4_pdpi/internal/ordered_map.h"
 #include "p4_pdpi/ir.pb.h"
 #include "p4_symbolic/ir/ir.pb.h"
+#include "p4_symbolic/symbolic/operators.h"
 #include "p4_symbolic/symbolic/util.h"
+#include "p4_symbolic/symbolic/values.h"
 #include "z3++.h"
 
 namespace p4_symbolic::symbolic {
@@ -45,6 +51,285 @@ const absl::flat_hash_map<MatchType, std::string> match_type_to_str = {
     {MatchType::MatchField_MatchType_TERNARY, "ternary"},
     {MatchType::MatchField_MatchType_OPTIONAL, "optional"},
 };
+
+// Translates the given `value` read from the `match` of an entry in the given
+// `table` into a Z3 expression.
+absl::StatusOr<z3::expr> GetZ3Value(const pdpi::IrValue &value,
+                                    const p4::config::v1::MatchField &match,
+                                    const ir::Table &table,
+                                    z3::context &z3_context,
+                                    values::P4RuntimeTranslator &translator) {
+  const google::protobuf::Map<std::string, ir::FieldValue>
+      &match_name_to_field = table.table_implementation().match_name_to_field();
+  const auto it = match_name_to_field.find(match.name());
+  if (it == match_name_to_field.end()) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Match key with name '" << match.name()
+           << "' was not found in implementation of table '"
+           << table.table_definition().preamble().name() << "'";
+  }
+  const ir::FieldValue &matched_field = it->second;
+  std::string field_name = absl::StrFormat("%s.%s", matched_field.header_name(),
+                                           matched_field.field_name());
+  return values::FormatP4RTValue(field_name, match.type_name().name(), value,
+                                 match.bitwidth(), z3_context, translator);
+}
+
+// Adds constraints for the specific match types for encoding them as ternary
+// values and masks.
+absl::Status AddMatchTypeConstraintsForSymbolicMatch(
+    const SymbolicMatchVariables &variables, z3::context &z3_context,
+    z3::solver &solver) {
+  // Add type constraints on the symbolic match variables.
+  switch (variables.match_type) {
+    case p4::config::v1::MatchField::EXACT: {
+      // For exact matches, the mask bit-vector must be all-1s.
+      int bitwidth = variables.mask.get_sort().bv_size();
+      z3::expr all_ones = z3_context.bv_val((1UL << bitwidth) - 1, bitwidth);
+      ASSIGN_OR_RETURN(z3::expr mask_constraint,
+                       operators::Eq(variables.mask, all_ones));
+      solver.add(mask_constraint);
+      break;
+    }
+    case p4::config::v1::MatchField::LPM: {
+      // For LPM matches, the mask bit-vector must comply with the LPM format.
+      // I.e. (~lpm_mask) & (~lpm_mask + 1) == 0
+      int bitwidth = variables.mask.get_sort().bv_size();
+      ASSIGN_OR_RETURN(z3::expr negated_mask,
+                       operators::BitNeg(variables.mask));
+      ASSIGN_OR_RETURN(
+          z3::expr negated_mask_plus_one,
+          operators::Plus(negated_mask, z3_context.bv_val(1, bitwidth)));
+      ASSIGN_OR_RETURN(z3::expr result,
+                       operators::BitAnd(negated_mask, negated_mask_plus_one));
+      ASSIGN_OR_RETURN(z3::expr mask_constraint,
+                       operators::Eq(result, z3_context.bv_val(0, bitwidth)));
+      solver.add(mask_constraint);
+      break;
+    }
+    case p4::config::v1::MatchField::OPTIONAL: {
+      // For optional matches, the mask bit-vector must be either all-1s
+      // (present) or all-0s (don't-care).
+      int bitwidth = variables.mask.get_sort().bv_size();
+      z3::expr all_ones = z3_context.bv_val((1UL << bitwidth) - 1, bitwidth);
+      z3::expr all_zeroes = z3_context.bv_val(0, bitwidth);
+      ASSIGN_OR_RETURN(z3::expr mask_is_all_ones,
+                       operators::Eq(variables.mask, all_ones));
+      ASSIGN_OR_RETURN(z3::expr mask_is_all_zeroes,
+                       operators::Eq(variables.mask, all_zeroes));
+      ASSIGN_OR_RETURN(z3::expr mask_constraint,
+                       operators::Or(mask_is_all_ones, mask_is_all_zeroes));
+      solver.add(mask_constraint);
+      break;
+    }
+    case p4::config::v1::MatchField::TERNARY: {
+      // No type constraint is required for ternary matches.
+      break;
+    }
+    default: {
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Unsupported match type: " << variables.match_type
+             << ". Expected: EXACT, LPM, TERNARY, or OPTIONAL";
+    }
+  }
+
+  return absl::OkStatus();
+}
+
+// Adds canonicity constraints for P4Runtime updates.
+// Since the P4Runtime API rejects entry updates where the non-masked bits are
+// not zero, here we add the constraint to avoid synthesizing such entries.
+// Namely, "(value & mask == value)".
+absl::Status AddCanonicityConstraintForSymbolicMatch(
+    const SymbolicMatchVariables &variables, z3::solver &solver) {
+  ASSIGN_OR_RETURN(z3::expr masked_value,
+                   operators::BitAnd(variables.value, variables.mask));
+  ASSIGN_OR_RETURN(z3::expr constraint,
+                   operators::Eq(masked_value, variables.value));
+  solver.add(constraint);
+  return absl::OkStatus();
+}
+
+// Adds equality constraints on the given `variables` corresponding to the
+// concrete parts of the given symbolic `ir_match` of a table entry in the given
+// `table`.
+absl::Status AddConstraintsForConcretePartsOfSymbolicMatch(
+    const SymbolicMatchVariables &variables, const pdpi::IrMatch &ir_match,
+    const ir::Table &table, z3::context &z3_context, z3::solver &solver,
+    values::P4RuntimeTranslator &translator) {
+  // If the symbolic variables are created successfully, it means that a
+  // match with the match name exists in the table definition, so no
+  // exception will be thrown here.
+  const p4::config::v1::MatchField &pi_match = table.table_definition()
+                                                   .match_fields_by_name()
+                                                   .at(ir_match.name())
+                                                   .match_field();
+
+  // Add equality constraints if a match value is set.
+  // If no concrete value is specified, no equality constraint is asserted.
+  if (ir_match.has_exact()) {
+    ASSIGN_OR_RETURN(
+        z3::expr concrete_exact_value,
+        GetZ3Value(ir_match.exact(), pi_match, table, z3_context, translator));
+    ASSIGN_OR_RETURN(z3::expr constraint,
+                     operators::Eq(variables.value, concrete_exact_value));
+    solver.add(constraint);
+  } else if (ir_match.has_lpm()) {
+    if (ir_match.lpm().has_value()) {
+      ASSIGN_OR_RETURN(z3::expr concrete_lpm_value,
+                       GetZ3Value(ir_match.lpm().value(), pi_match, table,
+                                  z3_context, translator));
+      ASSIGN_OR_RETURN(z3::expr value_constraint,
+                       operators::Eq(variables.value, concrete_lpm_value));
+      solver.add(value_constraint);
+    }
+    if (ir_match.lpm().prefix_length() >= 0) {
+      int bitwidth = variables.value.get_sort().bv_size();
+      int prefix_length = ir_match.lpm().prefix_length();
+      if (prefix_length < 0 || prefix_length > bitwidth) {
+        return gutil::InvalidArgumentErrorBuilder()
+               << "Prefix length of match '" << ir_match.name()
+               << "' must fall in the range [0, " << bitwidth
+               << "]. Found: " << ir_match.DebugString();
+      }
+      z3::expr ones =
+          z3_context.bv_val((1UL << prefix_length) - 1, prefix_length);
+      z3::expr zeroes = z3_context.bv_val(0, bitwidth - prefix_length);
+      z3::expr concrete_lpm_mask = z3::concat(ones, zeroes);
+
+      // Constrain the symbolic variables of the LPM match to be equal to
+      // the specified concrete values.
+      ASSIGN_OR_RETURN(z3::expr mask_constraint,
+                       operators::Eq(variables.mask, concrete_lpm_mask));
+      solver.add(mask_constraint);
+    }
+  } else if (ir_match.has_ternary()) {
+    if (ir_match.ternary().has_value()) {
+      ASSIGN_OR_RETURN(z3::expr concrete_ternary_value,
+                       GetZ3Value(ir_match.ternary().value(), pi_match, table,
+                                  z3_context, translator));
+      ASSIGN_OR_RETURN(z3::expr value_constraint,
+                       operators::Eq(variables.value, concrete_ternary_value));
+      solver.add(value_constraint);
+    }
+    if (ir_match.ternary().has_mask()) {
+      ASSIGN_OR_RETURN(z3::expr concrete_ternary_mask,
+                       GetZ3Value(ir_match.ternary().mask(), pi_match, table,
+                                  z3_context, translator));
+      ASSIGN_OR_RETURN(z3::expr mask_constraint,
+                       operators::Eq(variables.mask, concrete_ternary_mask));
+      solver.add(mask_constraint);
+    }
+  } else if (ir_match.has_optional() && ir_match.optional().has_value()) {
+    ASSIGN_OR_RETURN(z3::expr concrete_optional_value,
+                     GetZ3Value(ir_match.optional().value(), pi_match, table,
+                                z3_context, translator));
+    ASSIGN_OR_RETURN(z3::expr value_constraint,
+                     operators::Eq(variables.value, concrete_optional_value));
+    solver.add(value_constraint);
+  }
+
+  return absl::OkStatus();
+}
+
+// Add constraints enforcing exactly one action to be chosen for a symbolic
+// action, for entries in a direct match table.
+void AddSingleActionChoiceConstraintForSymbolicAction(
+    const absl::btree_map<std::string, z3::expr> &action_choices_by_name,
+    z3::context &z3_context, z3::solver &solver) {
+  z3::expr overall_constraint = z3_context.bool_val(false);
+
+  for (const auto &[applied_action_name, applied_action] :
+       action_choices_by_name) {
+    z3::expr assignment_constraint =
+        (applied_action == z3_context.bool_val(true));
+
+    for (const auto &[action_name, action] : action_choices_by_name) {
+      if (action_name != applied_action_name) {
+        assignment_constraint =
+            (assignment_constraint && (action == z3_context.bool_val(false)));
+      }
+    }
+
+    overall_constraint = overall_constraint || assignment_constraint;
+  }
+
+  solver.add(overall_constraint);
+}
+
+// Adds equality constraints to the solver according to the given `ir_action`.
+absl::Status AddConstraintsForConcretePartsOfSymbolicAction(
+    const pdpi::IrActionInvocation &ir_action,
+    const absl::btree_map<std::string, z3::expr> &action_invocations_by_name,
+    const absl::flat_hash_map<std::string,
+                              absl::flat_hash_map<std::string, z3::expr>>
+        &action_params_by_name,
+    const ir::P4Program &program, z3::context &z3_context, z3::solver &solver,
+    values::P4RuntimeTranslator &translator) {
+  // If the action name of the invocation is empty, it is treated as an
+  // unconstrained symbolic action. No constraint is asserted and no concrete
+  // parameters should be specified.
+  if (ir_action.name().empty()) {
+    if (!ir_action.params().empty()) {
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Action parameters must not be specified in a fully "
+                "symbolic action. Found: "
+             << ir_action.DebugString();
+    }
+    return absl::OkStatus();
+  }
+
+  // Check if the specified action name is valid.
+  if (!action_invocations_by_name.contains(ir_action.name()) ||
+      !action_params_by_name.contains(ir_action.name())) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Invalid action name: '" << ir_action.name() << "'";
+  }
+
+  // Check if the specified action parameter names are valid.
+  for (const auto &param : ir_action.params()) {
+    if (!action_params_by_name.at(ir_action.name()).contains(param.name())) {
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Invalid action parameter name: '" << param.name() << "'";
+    }
+  }
+
+  // Constrain the symbolic action invocation with the specified action name to
+  // true and all other action invocations to false.
+  solver.add(action_invocations_by_name.at(ir_action.name()) ==
+             z3_context.bool_val(true));
+
+  for (const auto &[action_name, action] : action_invocations_by_name) {
+    if (action_name != ir_action.name()) {
+      solver.add(action == z3_context.bool_val(false));
+    }
+  }
+
+  // Add equality constraints on the symbolic action parameters with the
+  // specified concrete parameter values.
+  for (const auto &param : ir_action.params()) {
+    z3::expr action_param =
+        action_params_by_name.at(ir_action.name()).at(param.name());
+    ASSIGN_OR_RETURN(const pdpi::IrActionDefinition::IrActionParamDefinition
+                         *param_definition,
+                     gutil::FindPtrOrStatus(program.actions()
+                                                .at(ir_action.name())
+                                                .action_definition()
+                                                .params_by_name(),
+                                            param.name()));
+    ASSIGN_OR_RETURN(
+        z3::expr concrete_param_value,
+        values::FormatP4RTValue(
+            /*field_name=*/"", param_definition->param().type_name().name(),
+            param.value(), param_definition->param().bitwidth(), z3_context,
+            translator));
+    ASSIGN_OR_RETURN(z3::expr param_constraint,
+                     operators::Eq(action_param, concrete_param_value));
+    solver.add(param_constraint);
+  }
+
+  return absl::OkStatus();
+}
 
 }  // namespace
 
@@ -371,6 +656,89 @@ absl::StatusOr<ir::TableEntry> CreateSymbolicIrTableEntry(
   sketch.set_priority(has_ternary_or_optional ? priority : 0);
 
   return ir_entry;
+}
+
+absl::Status InitializeSymbolicMatches(
+    const TableEntry &entry, const ir::Table &table,
+    const ir::P4Program &program, z3::context &z3_context, z3::solver &solver,
+    values::P4RuntimeTranslator &translator) {
+  for (const pdpi::IrMatch &match : entry.GetPdpiIrTableEntry().matches()) {
+    if (match.name().empty()) {
+      return gutil::InvalidArgumentErrorBuilder()
+             << "The match name must not be empty. Found: "
+             << match.DebugString();
+    }
+
+    // Create symbolic variables for the symbolic match.
+    ASSIGN_OR_RETURN(
+        SymbolicMatchVariables variables,
+        entry.GetMatchValues(match.name(), table, program, z3_context));
+    // Add various constraints for the symbolic match.
+    RETURN_IF_ERROR(
+        AddMatchTypeConstraintsForSymbolicMatch(variables, z3_context, solver));
+    RETURN_IF_ERROR(AddCanonicityConstraintForSymbolicMatch(variables, solver));
+    RETURN_IF_ERROR(AddConstraintsForConcretePartsOfSymbolicMatch(
+        variables, match, table, z3_context, solver, translator));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status InitializeSymbolicActions(
+    const TableEntry &entry, const ir::Table &table,
+    const ir::P4Program &program, z3::context &z3_context, z3::solver &solver,
+    values::P4RuntimeTranslator &translator) {
+  absl::btree_map<std::string, z3::expr> action_choices_by_name;
+  absl::flat_hash_map<std::string, absl::flat_hash_map<std::string, z3::expr>>
+      action_params_by_name;
+
+  // Create symbolic variables for each valid action of the table.
+  for (const pdpi::IrActionReference &action_ref :
+       table.table_definition().entry_actions()) {
+    const std::string &action_name = action_ref.action().preamble().name();
+
+    // Check if the action referred by the table definition exists.
+    auto it = program.actions().find(action_name);
+    if (it == program.actions().end()) {
+      return gutil::NotFoundErrorBuilder()
+             << "Action not found: '" << action_name << "'";
+    }
+    const ir::Action &action = it->second;
+
+    // Create a symbolic variable for the action invocation.
+    ASSIGN_OR_RETURN(z3::expr action_invocation,
+                     entry.GetActionInvocation(action_name, table, z3_context));
+    action_choices_by_name.insert_or_assign(action_name, action_invocation);
+
+    // Create a symbolic variable for each action parameter.
+    for (const auto &[param_name, param_definition] :
+         Ordered(action.action_definition().params_by_name())) {
+      ASSIGN_OR_RETURN(
+          z3::expr action_param,
+          entry.GetActionParameter(param_name, action, table, z3_context));
+      action_params_by_name[action_name].insert_or_assign(param_name,
+                                                          action_param);
+    }
+  }
+
+  // Add well-formedness constraints for the symbolic actions of this entry.
+  AddSingleActionChoiceConstraintForSymbolicAction(action_choices_by_name,
+                                                   z3_context, solver);
+
+  // Add equality constraints for the symbolic actions if concrete values are
+  // specified.
+  const pdpi::IrTableEntry &ir_entry = entry.GetPdpiIrTableEntry();
+  if (ir_entry.has_action()) {
+    RETURN_IF_ERROR(AddConstraintsForConcretePartsOfSymbolicAction(
+        ir_entry.action(), action_choices_by_name, action_params_by_name,
+        program, z3_context, solver, translator));
+  } else if (ir_entry.has_action_set()) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Action set should not be specified in a direct match table. "
+              "Found: "
+           << ir_entry.DebugString();
+  }
+
+  return absl::OkStatus();
 }
 
 }  // namespace p4_symbolic::symbolic

--- a/p4_symbolic/symbolic/table_entry.h
+++ b/p4_symbolic/symbolic/table_entry.h
@@ -21,11 +21,13 @@
 #include <vector>
 
 #include "absl/container/btree_map.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "p4_pdpi/ir.pb.h"
 #include "p4_symbolic/ir/ir.pb.h"
+#include "p4_symbolic/symbolic/values.h"
 #include "z3++.h"
 
 namespace p4_symbolic::symbolic {
@@ -138,6 +140,28 @@ using TableEntries = absl::btree_map<std::string, std::vector<TableEntry>>;
 absl::StatusOr<ir::TableEntry> CreateSymbolicIrTableEntry(
     const ir::Table &table, int priority = 0,
     std::optional<size_t> prefix_length = std::nullopt);
+
+// Creates symbolic variables and adds constraints for each field match of the
+// given `entry` in the given `table`. We don't create symbolic variables for
+// omitted matches as the omitted matches are treated as explicit wildcards
+// based on the P4Runtime specification. If those symbolic variables are needed
+// later, calling the `GetMatchValues` function will automatically create the
+// corresponding variables for the entry match.
+absl::Status InitializeSymbolicMatches(const TableEntry &entry,
+                                       const ir::Table &table,
+                                       const ir::P4Program &program,
+                                       z3::context &z3_context,
+                                       z3::solver &solver,
+                                       values::P4RuntimeTranslator &translator);
+
+// Creates symbolic variables and adds constraints for the given `entry`, for
+// each action and each action parameter in the given `table`.
+absl::Status InitializeSymbolicActions(const TableEntry &entry,
+                                       const ir::Table &table,
+                                       const ir::P4Program &program,
+                                       z3::context &z3_context,
+                                       z3::solver &solver,
+                                       values::P4RuntimeTranslator &translator);
 
 }  // namespace p4_symbolic::symbolic
 

--- a/p4_symbolic/tests/BUILD.bazel
+++ b/p4_symbolic/tests/BUILD.bazel
@@ -32,3 +32,31 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "symbolic_table_entries_test",
+    srcs = ["symbolic_table_entries_test.cc"],
+    data = [
+        "//p4_symbolic/testdata:ipv4-routing/basic.config.json",
+        "//p4_symbolic/testdata:ipv4-routing/basic.p4info.pb.txt",
+        "//p4_symbolic/testdata:ipv4-routing/entries.pb.txt",
+    ],
+    deps = [
+        "//gutil:status_matchers",
+        "//p4_symbolic:test_util",
+        "//p4_symbolic/ir",
+        "//p4_symbolic/ir:ir_cc_proto",
+        "//p4_symbolic/ir:parser",
+        "//p4_symbolic/ir:table_entries",
+        "//p4_symbolic/sai",
+        "//p4_symbolic/symbolic",
+        "//thinkit:bazel_test_environment",
+        "//thinkit:test_environment",
+        "@com_github_google_glog//:glog",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/p4_symbolic/tests/symbolic_table_entries_test.cc
+++ b/p4_symbolic/tests/symbolic_table_entries_test.cc
@@ -1,0 +1,112 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "glog/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status_matchers.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_symbolic/ir/ir.h"
+#include "p4_symbolic/ir/ir.pb.h"
+#include "p4_symbolic/ir/parser.h"
+#include "p4_symbolic/ir/table_entries.h"
+#include "p4_symbolic/sai/sai.h"
+#include "p4_symbolic/symbolic/symbolic.h"
+#include "p4_symbolic/symbolic/table_entry.h"
+#include "p4_symbolic/symbolic/values.h"
+#include "p4_symbolic/test_util.h"
+#include "thinkit/bazel_test_environment.h"
+#include "thinkit/test_environment.h"
+
+namespace p4_symbolic {
+namespace {
+
+class SymbolicTableEntriesIPv4BasicTest : public testing::Test {
+ public:
+  thinkit::TestEnvironment& Environment() { return *environment_; }
+
+  void SetUp() override {
+    constexpr absl::string_view bmv2_json_path =
+        "p4_symbolic/testdata/ipv4-routing/"
+        "basic.config.json";
+    constexpr absl::string_view p4info_path =
+        "p4_symbolic/testdata/ipv4-routing/"
+        "basic.p4info.pb.txt";
+    constexpr absl::string_view entries_path =
+        "p4_symbolic/testdata/ipv4-routing/"
+        "entries.pb.txt";
+    ASSERT_OK_AND_ASSIGN(
+        p4::v1::ForwardingPipelineConfig config,
+        ParseToForwardingPipelineConfig(bmv2_json_path, p4info_path));
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<p4::v1::TableEntry> pi_entries,
+        GetPiTableEntriesFromPiUpdatesProtoTextFile(entries_path));
+    ASSERT_OK_AND_ASSIGN(ir::Dataplane dataplane,
+                         ir::ParseToIr(config, pi_entries));
+    program_ = std::move(dataplane.program);
+    ir_entries_ = std::move(dataplane.entries);
+  }
+
+ protected:
+  std::unique_ptr<thinkit::TestEnvironment> environment_ =
+      std::make_unique<thinkit::BazelTestEnvironment>(
+          /*mask_known_failures=*/true);
+  ir::P4Program program_;
+  ir::TableEntries ir_entries_;
+};
+
+TEST_F(SymbolicTableEntriesIPv4BasicTest, OneSymbolicEntryPerTable) {
+  constexpr int priority = 0;
+  constexpr int prefix_length = 16;
+
+  // Create a symbolic IR entry for each table.
+  ir_entries_.clear();
+  for (const auto& [table_name, table] : program_.tables()) {
+    ASSERT_OK_AND_ASSIGN(
+        ir::TableEntry ir_entry,
+        symbolic::CreateSymbolicIrTableEntry(table, priority, prefix_length));
+    ir_entries_[table_name].push_back(std::move(ir_entry));
+  }
+
+  // Symbolically evaluate the program with symbolic table entries.
+  std::vector<int> ports = {1, 2, 3, 4, 5};
+  symbolic::TranslationPerType translations;
+  translations[p4_symbolic::kPortIdTypeName] =
+      symbolic::values::TranslationData{
+          .static_mapping = {{"1", 1}, {"2", 2}, {"3", 3}, {"4", 4}, {"5", 5}},
+          .dynamic_translation = false,
+      };
+  translations[p4_symbolic::kVrfIdTypeName] = symbolic::values::TranslationData{
+      .static_mapping = {{"", 0}},
+      .dynamic_translation = true,
+  };
+  LOG(INFO) << "Building model ...";
+  absl::Time start_time = absl::Now();
+  EXPECT_THAT(
+      symbolic::EvaluateP4Program(program_, ir_entries_, ports, translations),
+      gutil::StatusIs(absl::StatusCode::kUnimplemented,
+                      "Symbolic entries are not supported at the moment."));
+  LOG(INFO) << "-> done in " << (absl::Now() - start_time);
+}
+
+}  // namespace
+}  // namespace p4_symbolic


### PR DESCRIPTION
Keyword Check:
~/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.






Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 671 targets (1 packages loaded, 4 targets configured).
INFO: Found 671 targets...
INFO: From Compiling p4_symbolic/sai/sai.cc:
In file included from ./p4_symbolic/z3_util.h:18,
                 from ./p4_symbolic/symbolic/symbolic.h:36,
                 from ./p4_symbolic/sai/sai.h:24,
                 from p4_symbolic/sai/sai.cc:15:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   55 |     for (int i = 0; i < bytes.size(); i++) {
      |                     ~~^~~~~~~~~~~~~~
./p4_pdpi/string_encodings/bit_string.h: In instantiation of 'void pdpi::BitString::AppendBits(const std::bitset<_Nb>&) [with long unsigned int num_bits = 8]':
./p4_pdpi/string_encodings/bit_string.h:41:50:   required from here
./p4_pdpi/string_encodings/bit_string.h:49:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   49 |     for (int i = 0; i < num_bits; i++) {
      |                     ~~^~~~~~~~~~
INFO: From Compiling p4_symbolic/symbolic/v1model.cc:
In file included from ./p4_symbolic/z3_util.h:18,
                 from ./p4_symbolic/symbolic/symbolic.h:36,
                 from ./p4_symbolic/symbolic/v1model.h:24,
                 from p4_symbolic/symbolic/v1model.cc:15:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   55 |     for (int i = 0; i < bytes.size(); i++) {
      |                     ~~^~~~~~~~~~~~~~
./p4_pdpi/string_encodings/bit_string.h: In instantiation of 'void pdpi::BitString::AppendBits(const std::bitset<_Nb>&) [with long unsigned int num_bits = 8]':
./p4_pdpi/string_encodings/bit_string.h:41:50:   required from here
./p4_pdpi/string_encodings/bit_string.h:49:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   49 |     for (int i = 0; i < num_bits; i++) {
      |                     ~~^~~~~~~~~~
INFO: From Compiling p4_symbolic/tests/symbolic_table_entries_test.cc:
In file included from ./p4_symbolic/z3_util.h:18,
                 from ./p4_symbolic/symbolic/symbolic.h:36,
                 from ./p4_symbolic/sai/sai.h:24,
                 from p4_symbolic/tests/symbolic_table_entries_test.cc:32:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
INFO: From Compiling p4_symbolic/symbolic/symbolic.cc [for host]:
In file included from ./p4_symbolic/z3_util.h:18,
                 from ./p4_symbolic/symbolic/symbolic.h:36,
                 from p4_symbolic/symbolic/symbolic.cc:15:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   55 |     for (int i = 0; i < bytes.size(); i++) {
      |                     ~~^~~~~~~~~~~~~~
./p4_pdpi/string_encodings/bit_string.h: In instantiation of 'void pdpi::BitString::AppendBits(const std::bitset<_Nb>&) [with long unsigned int num_bits = 8]':
./p4_pdpi/string_encodings/bit_string.h:41:50:   required from here
./p4_pdpi/string_encodings/bit_string.h:49:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   49 |     for (int i = 0; i < num_bits; i++) {
      |                     ~~^~~~~~~~~~
INFO: Elapsed time: 50.655s, Critical Path: 13.43s
INFO: 63 processes: 5 internal, 58 linux-sandbox.
INFO: Build completed successfully, 63 total actions






Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 671 targets (0 packages loaded, 2 targets configured).
INFO: Found 453 targets and 218 test targets...
INFO: Elapsed time: 200.011s, Critical Path: 114.61s
INFO: 272 processes: 327 linux-sandbox, 18 local.
INFO: Build completed successfully, 272 total actions
//dvaas:port_id_map_test                                                 PASSED in 1.3s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 0.8s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.0s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 0.6s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.4s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 0.6s
//gutil:io_test                                                          PASSED in 0.7s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//p4rt_app/tests:response_path_test                                      PASSED in 6.4s
//p4rt_app/tests:role_test                                               PASSED in 1.7s
//p4rt_app/tests:state_verification_test                                 PASSED in 3.6s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.9s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.8s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 0.8s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.2s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.5s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 3.1s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.0s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 3.5s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.8s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.9s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 1.2s
//tests/lib:p4info_helper_test                                           PASSED in 0.9s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 0.9s
//tests/lib:packet_generator_test                                        PASSED in 27.4s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 1.6s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.0s
//tests/sflow:sflow_util_test                                            PASSED in 7.0s
//thinkit:bazel_test_environment_test                                    PASSED in 0.6s
//thinkit:generic_testbed_test                                           PASSED in 1.0s
//thinkit:mock_control_device_test                                       PASSED in 0.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.8s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.8s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 0.8s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.0s
  Stats over 5 runs: max = 1.0s, min = 0.7s, avg = 0.8s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 44.0s
  Stats over 50 runs: max = 44.0s, min = 0.8s, avg = 3.0s, dev = 8.4s

Executed 218 out of 218 tests: 218 tests pass.
INFO: Build completed successfully, 272 total actions
