### PR TITLE
[Thinkit] Update hard-coded dscp-to-queue mappings to match our configs, Configure switches sequentially with ConfigureSwitchPairAndReturnP4RuntimeSessionPair, Stop masking fixed bug, add helper methods for generating IPv6 and WCMP flows, Vlan tag test & gNMI port breakout tests.

### DIFF
--- a/tests/forwarding/l3_admit_test.cc
+++ b/tests/forwarding/l3_admit_test.cc
@@ -526,15 +526,7 @@ TEST_P(L3AdmitTestFixture, DISABLED_L3AdmitCanUseInPortToRestrictMacAddresses) {
   }
   LOG(INFO) << "Done collecting packets.";
 
-  if (GetMirrorTestbed().Environment().MaskKnownFailures()) {
-    // TODO: Reduce expected count by tolerance level.
-    const int kDropTolerance = 1;
-    int adjusted_good_packets = kNumberOfTestPacket - kDropTolerance;
-    EXPECT_GE(good_packet_count, adjusted_good_packets);
-    EXPECT_LE(good_packet_count, kNumberOfTestPacket);
-  } else {
-    EXPECT_EQ(good_packet_count, kNumberOfTestPacket);
-  }
+  EXPECT_EQ(good_packet_count, kNumberOfTestPacket);
   EXPECT_EQ(bad_packet_count, 0);
 }
 

--- a/tests/lib/p4rt_fixed_table_programming_helper.h
+++ b/tests/lib/p4rt_fixed_table_programming_helper.h
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef GOOGLE_TESTS_LIB_P4RT_FIXED_TABLE_PROGRAMMING_HELPER_H_
-#define GOOGLE_TESTS_LIB_P4RT_FIXED_TABLE_PROGRAMMING_HELPER_H_
+#ifndef PINS_TESTS_LIB_P4RT_FIXED_TABLE_PROGRAMMING_HELPER_H_
+#define PINS_TESTS_LIB_P4RT_FIXED_TABLE_PROGRAMMING_HELPER_H_
 #include <optional>
 #include <utility>
 #include <vector>
@@ -110,4 +110,4 @@ WcmpGroupTableUpdate(const pdpi::IrP4Info &ir_p4_info,
 
 } // namespace pins
 
-#endif // GOOGLE_TESTS_LIB_P4RT_FIXED_TABLE_PROGRAMMING_HELPER_H_
+#endif // PINS_TESTS_LIB_P4RT_FIXED_TABLE_PROGRAMMING_HELPER_H_

--- a/tests/qos/qos_test_util.cc
+++ b/tests/qos/qos_test_util.cc
@@ -198,7 +198,7 @@ ParseIpv4DscpToQueueMapping(absl::string_view gnmi_config) {
   for (int dscp = 16; dscp <= 19; ++dscp) queue_by_dscp[dscp] = "AF2";
   queue_by_dscp[21] = "LLQ2";
   for (int dscp = 24; dscp <= 27; ++dscp) queue_by_dscp[dscp] = "AF3";
-  for (int dscp = 32; dscp <= 35; ++dscp) queue_by_dscp[dscp] = "AF4";
+  for (int dscp = 32; dscp <= 39; ++dscp) queue_by_dscp[dscp] = "AF4";
   for (int dscp = 48; dscp <= 59; ++dscp) queue_by_dscp[dscp] = "NC1";
   return queue_by_dscp;
 }
@@ -212,16 +212,7 @@ ParseIpv6DscpToQueueMapping(absl::string_view gnmi_config) {
 absl::StatusOr<absl::flat_hash_map<int, std::string>> GetIpv4DscpToQueueMapping(
     absl::string_view port, gnmi::gNMI::StubInterface &gnmi_stub) {
   // TODO: Actually parse config -- hard-coded for now.
-  absl::flat_hash_map<int, std::string> queue_by_dscp;
-  for (int dscp = 0; dscp < 64; ++dscp) queue_by_dscp[dscp] = "BE1";
-  for (int dscp = 8; dscp <= 11; ++dscp) queue_by_dscp[dscp] = "AF1";
-  queue_by_dscp[13] = "LLQ1";
-  for (int dscp = 16; dscp <= 19; ++dscp) queue_by_dscp[dscp] = "AF2";
-  queue_by_dscp[21] = "LLQ2";
-  for (int dscp = 24; dscp <= 27; ++dscp) queue_by_dscp[dscp] = "AF3";
-  for (int dscp = 32; dscp <= 35; ++dscp) queue_by_dscp[dscp] = "AF4";
-  for (int dscp = 48; dscp <= 59; ++dscp) queue_by_dscp[dscp] = "NC1";
-  return queue_by_dscp;
+  return ParseIpv4DscpToQueueMapping(/*gnmi_config=*/"");
 }
 
 absl::StatusOr<absl::flat_hash_map<int, std::string>> GetIpv6DscpToQueueMapping(

--- a/tests/thinkit_gnmi_interface_util_tests.cc
+++ b/tests/thinkit_gnmi_interface_util_tests.cc
@@ -1790,53 +1790,25 @@ TEST_F(GNMIThinkitInterfaceUtilityTest,
   expected_port_info["Ethernet1/1/1"] =
       pins_test::PortBreakoutInfo{"[0,1,2,3,4,5,6,7]", pins_test::kStateUp};
   std::vector<std::string> non_existing_port_list;
-  gnmi::GetRequest oper_status_req;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      R"pb(prefix { origin: "openconfig" }
-           path {
-             elem { name: "interfaces" }
-             elem {
-               name: "interface"
-               key { key: "name" value: "Ethernet1/1/1" }
-             }
-             elem { name: "state" }
-             elem { name: "oper-status" }
-           }
-           type: STATE)pb",
-      &oper_status_req));
-  gnmi::GetResponse oper_status_resp;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      R"pb(notification {
-             timestamp: 1632102697699213032
-             prefix { origin: "openconfig" }
-             update {
-               path {
-                 elem { name: "interfaces" }
-                 elem {
-                   name: "interface"
-                   key { key: "name" value: "Ethernet1/1/1" }
-                 }
-                 elem { name: "state" }
-                 elem { name: "oper-status" }
-               }
-               val {
-                 json_ietf_val: "{\"openconfig-interfaces:oper-status\":\"DOWN\"}"
-               }
-             }
-           })pb",
-      &oper_status_resp));
-  EXPECT_CALL(*mock_gnmi_stub_ptr, Get(_, EqualsProto(oper_status_req), _))
-      .WillOnce(
-          DoAll(SetArgPointee<2>(oper_status_resp), Return(grpc::Status::OK)));
+  EXPECT_CALL(*mock_gnmi_stub_ptr, Get)
+      .WillOnce(DoAll(
+          SetArgPointee<2>(gutil::ParseProtoOrDie<gnmi::GetResponse>(
+              R"pb(notification {
+                     timestamp: 1620348032128305716
+                     prefix { origin: "openconfig" }
+                     update {
+                       path { elem { name: "interfaces" } }
+                       val {
+                         json_ietf_val: "{\"openconfig-interfaces:interfaces\":{\"interface\":[{\"name\":\"Ethernet1/1/1\",\"state\":{\"oper-status\":\"DOWN\"}}]}}"
+                       }
+                     }
+                   })pb")),
+          Return(grpc::Status::OK)));
   EXPECT_THAT(
       pins_test::ValidateBreakoutState(
           mock_gnmi_stub_ptr.get(), expected_port_info, non_existing_port_list),
-      StatusIs(
-          absl::StatusCode::kInternal,
-          HasSubstr(absl::StrCat(
-              "Port oper-status match failed for port Ethernet1/1/1. got: \"",
-              pins_test::kStateDown,
-              "\", want:", expected_port_info["Ethernet1/1/1"].oper_status))));
+      StatusIs(absl::StatusCode::kUnavailable,
+               HasSubstr("Some interfaces are not in the expected state UP")));
 }
 
 TEST_F(GNMIThinkitInterfaceUtilityTest,
@@ -1847,41 +1819,6 @@ TEST_F(GNMIThinkitInterfaceUtilityTest,
   expected_port_info["Ethernet1/1/1"] =
       pins_test::PortBreakoutInfo{"[0,1,2,3]", pins_test::kStateUp};
   std::vector<std::string> non_existing_port_list;
-  gnmi::GetRequest oper_status_req;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      R"pb(prefix { origin: "openconfig" }
-           path {
-             elem { name: "interfaces" }
-             elem {
-               name: "interface"
-               key { key: "name" value: "Ethernet1/1/1" }
-             }
-             elem { name: "state" }
-             elem { name: "oper-status" }
-           }
-           type: STATE)pb",
-      &oper_status_req));
-  gnmi::GetResponse oper_status_resp;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      R"pb(notification {
-             timestamp: 1632102697699213032
-             prefix { origin: "openconfig" }
-             update {
-               path {
-                 elem { name: "interfaces" }
-                 elem {
-                   name: "interface"
-                   key { key: "name" value: "Ethernet1/1/1" }
-                 }
-                 elem { name: "state" }
-                 elem { name: "oper-status" }
-               }
-               val {
-                 json_ietf_val: "{\"openconfig-interfaces:oper-status\":\"UP\"}"
-               }
-             }
-           })pb",
-      &oper_status_resp));
   gnmi::GetRequest physical_channels_req;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
       R"pb(prefix { origin: "openconfig" }
@@ -1917,9 +1854,20 @@ TEST_F(GNMIThinkitInterfaceUtilityTest,
              }
            })pb",
       &physical_channels_resp));
-  EXPECT_CALL(*mock_gnmi_stub_ptr, Get(_, EqualsProto(oper_status_req), _))
-      .WillOnce(
-          DoAll(SetArgPointee<2>(oper_status_resp), Return(grpc::Status::OK)));
+  EXPECT_CALL(*mock_gnmi_stub_ptr, Get)
+      .WillOnce(DoAll(
+          SetArgPointee<2>(gutil::ParseProtoOrDie<gnmi::GetResponse>(
+              R"pb(notification {
+                     timestamp: 1620348032128305716
+                     prefix { origin: "openconfig" }
+                     update {
+                       path { elem { name: "interfaces" } }
+                       val {
+                         json_ietf_val: "{\"openconfig-interfaces:interfaces\":{\"interface\":[{\"name\":\"Ethernet1/1/1\",\"state\":{\"oper-status\":\"UP\"}}]}}"
+                       }
+                     }
+                   })pb")),
+          Return(grpc::Status::OK)));
   EXPECT_CALL(*mock_gnmi_stub_ptr,
               Get(_, EqualsProto(physical_channels_req), _))
       .WillOnce(DoAll(SetArgPointee<2>(physical_channels_resp),
@@ -2012,9 +1960,22 @@ TEST_F(GNMIThinkitInterfaceUtilityTest,
              }
            })pb",
       &physical_channels_resp));
+  EXPECT_CALL(*mock_gnmi_stub_ptr, Get)
+      .WillOnce(DoAll(
+          SetArgPointee<2>(gutil::ParseProtoOrDie<gnmi::GetResponse>(
+              R"pb(notification {
+                     timestamp: 1620348032128305716
+                     prefix { origin: "openconfig" }
+                     update {
+                       path { elem { name: "interfaces" } }
+                       val {
+                         json_ietf_val: "{\"openconfig-interfaces:interfaces\":{\"interface\":[{\"name\":\"Ethernet1/1/1\",\"state\":{\"oper-status\":\"UP\"}}]}}"
+                       }
+                     }
+                   })pb")),
+          Return(grpc::Status::OK)));
   EXPECT_CALL(*mock_gnmi_stub_ptr, Get(_, EqualsProto(oper_status_req), _))
-      .Times(2)
-      .WillRepeatedly(
+      .WillOnce(
           DoAll(SetArgPointee<2>(oper_status_resp), Return(grpc::Status::OK)));
   EXPECT_CALL(*mock_gnmi_stub_ptr,
               Get(_, EqualsProto(physical_channels_req), _))
@@ -2035,41 +1996,6 @@ TEST_F(GNMIThinkitInterfaceUtilityTest, TestValidateBreakoutStateSuccess) {
   expected_port_info["Ethernet1/1/1"] =
       pins_test::PortBreakoutInfo{"[0,1,2,3,4,5,6,7]", pins_test::kStateUp};
   std::vector<std::string> non_existing_port_list{};
-  gnmi::GetRequest oper_status_req;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      R"pb(prefix { origin: "openconfig" }
-           path {
-             elem { name: "interfaces" }
-             elem {
-               name: "interface"
-               key { key: "name" value: "Ethernet1/1/1" }
-             }
-             elem { name: "state" }
-             elem { name: "oper-status" }
-           }
-           type: STATE)pb",
-      &oper_status_req));
-  gnmi::GetResponse oper_status_resp;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      R"pb(notification {
-             timestamp: 1632102697699213032
-             prefix { origin: "openconfig" }
-             update {
-               path {
-                 elem { name: "interfaces" }
-                 elem {
-                   name: "interface"
-                   key { key: "name" value: "Ethernet1/1/1" }
-                 }
-                 elem { name: "state" }
-                 elem { name: "oper-status" }
-               }
-               val {
-                 json_ietf_val: "{\"openconfig-interfaces:oper-status\":\"UP\"}"
-               }
-             }
-           })pb",
-      &oper_status_resp));
   gnmi::GetRequest physical_channels_req;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
       R"pb(prefix { origin: "openconfig" }
@@ -2105,9 +2031,20 @@ TEST_F(GNMIThinkitInterfaceUtilityTest, TestValidateBreakoutStateSuccess) {
              }
            })pb",
       &physical_channels_resp));
-  EXPECT_CALL(*mock_gnmi_stub_ptr, Get(_, EqualsProto(oper_status_req), _))
-      .WillOnce(
-          DoAll(SetArgPointee<2>(oper_status_resp), Return(grpc::Status::OK)));
+  EXPECT_CALL(*mock_gnmi_stub_ptr, Get)
+      .WillOnce(DoAll(
+          SetArgPointee<2>(gutil::ParseProtoOrDie<gnmi::GetResponse>(
+              R"pb(notification {
+                     timestamp: 1620348032128305716
+                     prefix { origin: "openconfig" }
+                     update {
+                       path { elem { name: "interfaces" } }
+                       val {
+                         json_ietf_val: "{\"openconfig-interfaces:interfaces\":{\"interface\":[{\"name\":\"Ethernet1/1/1\",\"state\":{\"oper-status\":\"UP\"}}]}}"
+                       }
+                     }
+                   })pb")),
+          Return(grpc::Status::OK)));
   EXPECT_CALL(*mock_gnmi_stub_ptr,
               Get(_, EqualsProto(physical_channels_req), _))
       .WillOnce(DoAll(SetArgPointee<2>(physical_channels_resp),


### PR DESCRIPTION
### Keyword Check:
divyagayathris@divyagayathris-16:~/Dec_23/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_check.sh tests/.
Keyword check Passed.

### Build & Test Results:
divyagayathris@25f33459dcdc:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 673 targets (0 packages loaded, 0 targets configured).
INFO: Found 673 targets...
INFO: Elapsed time: 33.450s, Critical Path: 32.96s
INFO: 6 processes: 2 internal, 4 linux-sandbox.
INFO: Build completed successfully, 6 total actions

divyagayathris@25f33459dcdc:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 673 targets (0 packages loaded, 0 targets configured).
INFO: Found 456 targets and 217 test targets...
INFO: Elapsed time: 163.251s, Critical Path: 117.53s
INFO: 275 processes: 331 linux-sandbox, 18 local.
INFO: Build completed successfully, 275 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.8s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.1s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.1s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.4s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 0.9s
//gutil:io_test                                                          PASSED in 0.8s
//gutil:proto_matchers_test                                              PASSED in 1.4s
//gutil:proto_ordering_test                                              PASSED in 1.2s
//gutil:proto_test                                                       PASSED in 1.0s
//gutil:status_matchers_test                                             PASSED in 0.9s
//gutil:test_artifact_writer_test                                        PASSED in 1.0s
//gutil:testing_test                                                     PASSED in 0.9s
//gutil:timer_test                                                       PASSED in 5.2s
//gutil:version_test                                                     PASSED in 1.3s
//lib:basic_switch_test                                                  PASSED in 1.4s
//lib:ixia_helper_test                                                   PASSED in 1.5s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 2.1s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 16.2s
//lib/gnmi:gnmi_helper_test                                              PASSED in 3.6s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.9s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.0s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 1.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 2.9s
//lib/utils:json_utils_test                                              PASSED in 1.1s
//lib/validator:validator_backend_test                                   PASSED in 0.9s
//lib/validator:validator_lib_test                                       PASSED in 26.3s
//p4_fuzzer:constraints_test                                             PASSED in 4.3s
//p4_fuzzer:fuzz_util_test                                               PASSED in 117.4s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 1.7s
//p4_fuzzer:oracle_util_test                                             PASSED in 4.4s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 3.3s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 3.2s
//p4_fuzzer:switch_state_test                                            PASSED in 1.5s
//p4_pdpi:built_ins_test                                                 PASSED in 1.0s
//p4_pdpi:entity_keys_test                                               PASSED in 1.2s
//p4_pdpi:ir_properties_test                                             PASSED in 1.0s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.2s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.9s
//p4_pdpi:names_test                                                     PASSED in 1.4s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.0s
//p4_pdpi:reference_annotations_test                                     PASSED in 1.5s
//p4_pdpi:references_test                                                PASSED in 1.3s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.7s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.8s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.6s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.9s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 1.5s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.9s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.6s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.0s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.0s
//p4_pdpi/testing:info_test                                              PASSED in 0.2s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.0s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.2s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.1s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:references_test                                        PASSED in 0.1s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 1.0s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.2s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.8s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.0s
//p4_symbolic:deparser_test                                              PASSED in 2.5s
//p4_symbolic:z3_util_test                                               PASSED in 0.9s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 3.2s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 3.3s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 3.3s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 3.3s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 3.2s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 3.3s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 3.2s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.3s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.1s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.1s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.1s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.0s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.1s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.0s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.1s
//p4_symbolic/packet_synthesizer:util_test                               PASSED in 6.5s
//p4_symbolic/sai:sai_test                                               PASSED in 4.0s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:ipv4_routing_test_packets                         PASSED in 0.1s
//p4_symbolic/symbolic:parser_test                                       PASSED in 1.6s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:reflector_test_packets                            PASSED in 0.1s
//p4_symbolic/symbolic:util_test                                         PASSED in 1.7s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.3s
//p4_symbolic/tests:sai_p4_component_test                                PASSED in 1.8s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 2.1s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.5s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 2.0s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.3s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.6s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 2.2s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 1.0s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 1.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 1.4s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 1.8s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 2.0s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 1.9s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 1.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.0s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 1.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 1.4s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 1.7s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.0s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 0.9s
//p4rt_app/sonic:response_handler_test                                   PASSED in 1.1s
//p4rt_app/sonic:state_verification_test                                 PASSED in 1.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.1s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.7s
//p4rt_app/tests:action_set_test                                         PASSED in 1.3s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.2s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.1s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.2s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 5.5s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.5s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.3s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.9s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.3s
//p4rt_app/tests:packetio_test                                           PASSED in 4.2s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.5s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.9s
//p4rt_app/tests:response_path_test                                      PASSED in 4.2s
//p4rt_app/tests:role_test                                               PASSED in 1.3s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.4s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.0s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 1.3s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.1s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.2s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.3s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.5s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.7s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.1s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.6s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.0s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 4.4s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.3s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.2s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.0s
//tests/lib:p4info_helper_test                                           PASSED in 1.7s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.5s
//tests/lib:packet_generator_test                                        PASSED in 28.0s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.1s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 8.0s
//thinkit:bazel_test_environment_test                                    PASSED in 0.9s
//thinkit:generic_testbed_test                                           PASSED in 1.7s
//thinkit:mock_control_device_test                                       PASSED in 0.9s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.4s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.3s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.1s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.3s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.7s
  Stats over 5 runs: max = 1.7s, min = 1.2s, avg = 1.4s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 44.2s
  Stats over 50 runs: max = 44.2s, min = 1.1s, avg = 2.7s, dev = 6.1s

Executed 217 out of 217 tests: 217 tests pass.
INFO: Build completed successfully, 275 total actions
divyagayathris@25f33459dcdc:/sonic/src/sonic-p4rt/sonic-pins$ 
