### PR TITLE
[P4_Symbolic] Use table and action aliases as keys in the synthesized table entries to be compatible with PDPI. Move `GetIrTable` to `symbolic/util.cc` to increase code sharing. Implement `AddConstraintsToForbidVrfZero` to avoid synthesizing table entries with values of VRF 0. Add constraints for `acl_pre_ingress_table` to respect the entry restrictions. Add `GetTableEntryPriorityType` to obtain the priority type.

### DIFF
--- a/p4_symbolic/sai/BUILD.bazel
+++ b/p4_symbolic/sai/BUILD.bazel
@@ -23,6 +23,9 @@ cc_library(
     hdrs = ["sai.h"],
     deps = [
         "//gutil:status",
+        "//p4_pdpi:ir_cc_proto",
+        "//p4_pdpi/internal:ordered_map",
+        "//p4_symbolic/ir:ir_cc_proto",
         "//p4_symbolic/symbolic",
         "@com_github_z3prover_z3//:api",
         "@com_google_absl//absl/container:flat_hash_set",

--- a/p4_symbolic/sai/sai.h
+++ b/p4_symbolic/sai/sai.h
@@ -21,6 +21,7 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "p4_symbolic/symbolic/context.h"
 #include "p4_symbolic/symbolic/symbolic.h"
 
 namespace p4_symbolic {
@@ -54,6 +55,25 @@ absl::StatusOr<std::string> GetUserMetadataFieldName(
 absl::StatusOr<std::string> GetLocalMetadataIngressPortFromModel(
     const symbolic::SolverState& solver_state);
 
-} // namespace p4_symbolic
+// Adds solver constraints for entry restrictions.
+// Right now only the entry restrictions of "vrf_table" and
+// "acl_pre_ingress_table" are implemented.
+// TODO: Note that this is for testing only and is not needed once
+// P4-Constraints is integrated with P4-Symbolic.
+absl::Status AddConstraintsForP4ConstraintsAnnotations(
+    symbolic::SolverState& state);
 
-#endif  // PINS_INFRA_P4_SYMBOLIC_SAI_SAI_H_
+// Adds solver constraints for each symbolic variable of type "vrf_id_t" to
+// avoid synthesizing values of VRF 0.
+// TODO: Note that this is for testing only and is not needed once
+// P4-Constraints is integrated with P4-Symbolic.
+absl::Status AddConstraintsToForbidVrfZero(symbolic::SolverState& state);
+
+// Adds solver constraints for "acl_pre_ingress_table".
+// TODO: Note that this is for testing only and is not needed once
+// P4-Constraints is integrated with P4-Symbolic.
+absl::Status AddConstraintsForAclPreIngressTable(symbolic::SolverState& state);
+
+}  // namespace p4_symbolic
+
+#endif  // PINS_P4_SYMBOLIC_SAI_SAI_H_

--- a/p4_symbolic/symbolic/table.h
+++ b/p4_symbolic/symbolic/table.h
@@ -31,8 +31,25 @@ namespace p4_symbolic {
 namespace symbolic {
 namespace table {
 
+// Determines how table entries are prioritized based on the table match types.
+enum class TableEntryPriorityType {
+  kPositivePriority,           // The table has a range, ternary, or optional
+                               // match, where the entry priority field must be
+                               // positive.
+  kPriorityZeroWithSingleLpm,  // The table has no range, ternary, or optional
+                               // matches, and has exactly one LPM match with
+                               // zero or more exact matches. The entry priority
+                               // field must be zero and the prefix length of
+                               // the LPM match must be positive.
+  kPriorityZero,               // None of the above. (I.e., the table has only
+                               // exact matches.) The entry priority field must
+                               // be zero.
+};
+
 // P4-Symbolic models the default action as an entry with index -1.
 constexpr int kDefaultActionEntryIndex = -1;
+
+TableEntryPriorityType GetTableEntryPriorityType(const ir::Table &table);
 
 absl::StatusOr<SymbolicTableMatches> EvaluateTable(
     const ir::Table &table, SolverState &state, SymbolicPerPacketState &headers,

--- a/p4_symbolic/symbolic/table_entry.cc
+++ b/p4_symbolic/symbolic/table_entry.cc
@@ -653,6 +653,44 @@ absl::StatusOr<z3::expr> TableEntry::GetActionParameter(
                              action_param.bitwidth);
 }
 
+void TableEntry::ConvertToTableAndActionAliases(const ir::P4Program &program) {
+  // Check if the table specified by the table name exists.
+  const std::string &table_name = GetTableName();
+  auto it = program.tables().find(table_name);
+  // If the table cannot be found with the table name, it may have been
+  // converted to the alias already.
+  if (it == program.tables().end()) return;
+  const ir::Table &table = it->second;
+
+  pdpi::IrTableEntry &pdpi_ir_entry =
+      IsConcrete() ? *ir_entry_.mutable_concrete_entry()
+                   : *ir_entry_.mutable_symbolic_entry()->mutable_sketch();
+
+  // Set table name that is compatible with PDPI.
+  pdpi_ir_entry.set_table_name(table.table_definition().preamble().alias());
+
+  // Set action name that is compatible with PDPI.
+  auto convert_action_name = [&program](
+                                 pdpi::IrActionInvocation &action_invocation) {
+    const std::string &action_name = action_invocation.name();
+    auto it = program.actions().find(action_name);
+    // If the action cannot be found with the action name, it may have been
+    // converted to the alias already.
+    if (it == program.actions().end()) return;
+    const ir::Action &action = it->second;
+    action_invocation.set_name(action.action_definition().preamble().alias());
+  };
+
+  if (pdpi_ir_entry.has_action()) {
+    convert_action_name(*pdpi_ir_entry.mutable_action());
+  } else if (pdpi_ir_entry.has_action_set()) {
+    for (pdpi::IrActionSetInvocation &action :
+         *pdpi_ir_entry.mutable_action_set()->mutable_actions()) {
+      convert_action_name(*action.mutable_action());
+    }
+  }
+}
+
 absl::StatusOr<ir::TableEntry> CreateSymbolicIrTableEntry(
     const ir::Table &table, int priority, std::optional<size_t> prefix_length) {
   // Build a symbolic table entry in P4-Symbolic IR.
@@ -815,12 +853,8 @@ absl::StatusOr<TableEntry> ExtractConcreteEntryFromModel(
 
   // Check if the table specified by the symbolic entry exists.
   const std::string &table_name = entry.GetTableName();
-  auto it = program.tables().find(table_name);
-  if (it == program.tables().end()) {
-    return gutil::NotFoundErrorBuilder()
-           << "Table '" << table_name << "' not found.";
-  }
-  const ir::Table &table = it->second;
+  ASSIGN_OR_RETURN(const ir::Table *table,
+                   util::GetIrTable(program, table_name));
 
   // Get the symbolic sketch.
   const pdpi::IrTableEntry &sketch = entry.GetPdpiIrTableEntry();
@@ -849,11 +883,11 @@ absl::StatusOr<TableEntry> ExtractConcreteEntryFromModel(
     // Evaluate and set match values.
     ASSIGN_OR_RETURN(
         SymbolicMatchVariables match_variables,
-        entry.GetMatchValues(match_name, table, program, z3_context));
+        entry.GetMatchValues(match_name, *table, program, z3_context));
     ASSIGN_OR_RETURN(std::string field_name,
-                     util::GetFieldNameFromMatch(match_name, table));
+                     util::GetFieldNameFromMatch(match_name, *table));
     ASSIGN_OR_RETURN(pdpi::IrMatchFieldDefinition match_definition,
-                     util::GetMatchDefinition(match_name, table));
+                     util::GetMatchDefinition(match_name, *table));
     const std::string &type_name =
         match_definition.match_field().type_name().name();
     ASSIGN_OR_RETURN(pdpi::IrValue value,
@@ -914,7 +948,7 @@ absl::StatusOr<TableEntry> ExtractConcreteEntryFromModel(
   }
 
   // Check if the table is a WCMP table.
-  if (table.table_definition().has_action_profile_id()) {
+  if (table->table_definition().has_action_profile_id()) {
     return gutil::UnimplementedErrorBuilder()
            << "Table entries with symbolic action sets are not supported "
               "at the moment.";
@@ -923,10 +957,11 @@ absl::StatusOr<TableEntry> ExtractConcreteEntryFromModel(
   // Set the invoked action of the entry.
   std::optional<std::string> previous_action_applied;
 
-  for (const auto &action_ref : table.table_definition().entry_actions()) {
+  for (const auto &action_ref : table->table_definition().entry_actions()) {
     const std::string &action_name = action_ref.action().preamble().name();
-    ASSIGN_OR_RETURN(z3::expr action_invocation,
-                     entry.GetActionInvocation(action_name, table, z3_context));
+    ASSIGN_OR_RETURN(
+        z3::expr action_invocation,
+        entry.GetActionInvocation(action_name, *table, z3_context));
     ASSIGN_OR_RETURN(bool action_applied, EvalZ3Bool(action_invocation, model));
     if (!action_applied) continue;
 
@@ -960,7 +995,7 @@ absl::StatusOr<TableEntry> ExtractConcreteEntryFromModel(
       // Set action parameter value.
       ASSIGN_OR_RETURN(
           z3::expr param,
-          entry.GetActionParameter(param_name, action, table, z3_context));
+          entry.GetActionParameter(param_name, action, *table, z3_context));
       ASSIGN_OR_RETURN(
           pdpi::IrValue value,
           EvalZ3BitvectorToIrValue(param, model, /*field_name=*/std::nullopt,

--- a/p4_symbolic/symbolic/table_entry.h
+++ b/p4_symbolic/symbolic/table_entry.h
@@ -101,6 +101,14 @@ class TableEntry {
                                               const ir::Table &table,
                                               z3::context &z3_context) const;
 
+  // Translates the table and action names back to the aliases.
+  // This should be called when synthesizing concrete entries used on other
+  // target platforms. PDPI maps are keyed by the alias names. This function
+  // makes the table entry compatible with PDPI formats.
+  // TODO: Consider removing this function if we switch to using
+  // aliases as table/action names in P4-Symbolic.
+  void ConvertToTableAndActionAliases(const ir::P4Program &program);
+
  private:
   int index_;                // The original index of the entry in the table.
   ir::TableEntry ir_entry_;  // Entry in P4-Symbolic IR.

--- a/p4_symbolic/symbolic/util.h
+++ b/p4_symbolic/symbolic/util.h
@@ -87,6 +87,12 @@ absl::StatusOr<std::string> GetFieldNameFromMatch(absl::string_view match_name,
 absl::StatusOr<pdpi::IrMatchFieldDefinition> GetMatchDefinition(
     absl::string_view match_name, const ir::Table &table);
 
+// Returns a pointer to the P4-Symbolic IR table with the given `table_name`
+// from the `program` IR. The returned pointer would not be null when the status
+// is ok.
+absl::StatusOr<const ir::Table *> GetIrTable(const ir::P4Program &program,
+                                             absl::string_view table_name);
+
 }  // namespace util
 }  // namespace symbolic
 }  // namespace p4_symbolic


### PR DESCRIPTION
Keyword Check:
~/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.





Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 687 targets (0 packages loaded, 0 targets configured).
INFO: Found 687 targets...
INFO: From Compiling p4_symbolic/symbolic/control.cc [for host]:
In file included from ./p4_symbolic/z3_util.h:26,
                 from ./p4_symbolic/symbolic/symbolic.h:36,
                 from ./p4_symbolic/symbolic/control.h:64,
                 from p4_symbolic/symbolic/control.cc:21:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   55 |     for (int i = 0; i < bytes.size(); i++) {
      |                     ~~^~~~~~~~~~~~~~
./p4_pdpi/string_encodings/bit_string.h: In instantiation of 'void pdpi::BitString::AppendBits(const std::bitset<_Nb>&) [with long unsigned int num_bits = 8]':
./p4_pdpi/string_encodings/bit_string.h:41:50:   required from here
./p4_pdpi/string_encodings/bit_string.h:49:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   49 |     for (int i = 0; i < num_bits; i++) {
      |                     ~~^~~~~~~~~~
INFO: From Compiling p4_symbolic/symbolic/control.cc:
In file included from ./p4_symbolic/z3_util.h:26,
                 from ./p4_symbolic/symbolic/symbolic.h:36,
                 from ./p4_symbolic/symbolic/control.h:64,
                 from p4_symbolic/symbolic/control.cc:21:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   55 |     for (int i = 0; i < bytes.size(); i++) {
      |                     ~~^~~~~~~~~~~~~~
./p4_pdpi/string_encodings/bit_string.h: In instantiation of 'void pdpi::BitString::AppendBits(const std::bitset<_Nb>&) [with long unsigned int num_bits = 8]':
./p4_pdpi/string_encodings/bit_string.h:41:50:   required from here
./p4_pdpi/string_encodings/bit_string.h:49:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   49 |     for (int i = 0; i < num_bits; i++) {
      |                     ~~^~~~~~~~~~
INFO: From Compiling p4_symbolic/symbolic/table.cc:
./p4_pdpi/string_encodings/bit_string.h: In instantiation of 'void pdpi::BitString::AppendBits(const std::bitset<_Nb>&) [with long unsigned int num_bits = 8]':
./p4_pdpi/string_encodings/bit_string.h:41:50:   required from here
./p4_pdpi/string_encodings/bit_string.h:49:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   49 |     for (int i = 0; i < num_bits; i++) {
      |                     ~~^~~~~~~~~~
INFO: From Compiling p4_symbolic/symbolic/table.cc [for host]:
In file included from ./p4_symbolic/z3_util.h:26,
                 from ./p4_symbolic/symbolic/symbolic.h:36,
                 from ./p4_symbolic/symbolic/table.h:27,
                 from p4_symbolic/symbolic/table.cc:21:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   55 |     for (int i = 0; i < bytes.size(); i++) {
      |                     ~~^~~~~~~~~~~~~~
./p4_pdpi/string_encodings/bit_string.h: In instantiation of 'void pdpi::BitString::AppendBits(const std::bitset<_Nb>&) [with long unsigned int num_bits = 8]':
./p4_pdpi/string_encodings/bit_string.h:41:50:   required from here
./p4_pdpi/string_encodings/bit_string.h:49:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   49 |     for (int i = 0; i < num_bits; i++) {
      |                     ~~^~~~~~~~~~
INFO: Elapsed time: 8.842s, Critical Path: 7.58s
INFO: 24 processes: 2 internal, 22 linux-sandbox.
INFO: Build completed successfully, 24 total actions





Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 687 targets (0 packages loaded, 0 targets configured).
INFO: Found 469 targets and 218 test targets...
INFO: Elapsed time: 184.556s, Critical Path: 119.95s
INFO: 272 processes: 327 linux-sandbox, 18 local.
INFO: Build completed successfully, 272 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.8s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 0.7s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 0.7s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.1s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.6s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//p4rt_app/tests:response_path_test                                      PASSED in 6.7s
//p4rt_app/tests:role_test                                               PASSED in 1.7s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.7s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.6s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.2s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.5s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.0s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 3.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.8s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 1.2s
//tests/lib:p4info_helper_test                                           PASSED in 0.8s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 0.9s
//tests/lib:packet_generator_test                                        PASSED in 27.8s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.1s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.0s
//tests/sflow:sflow_util_test                                            PASSED in 6.9s
//thinkit:bazel_test_environment_test                                    PASSED in 0.6s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.9s
  Stats over 5 runs: max = 0.9s, min = 0.7s, avg = 0.8s, dev = 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 6.4s
  Stats over 50 runs: max = 6.4s, min = 0.8s, avg = 1.1s, dev = 1.1s

Executed 218 out of 218 tests: 218 tests pass.
INFO: Build completed successfully, 272 total actions
