### PR TITLE
[Comb] Add basic support for recirculate action.

### DIFF
--- a/p4_symbolic/bmv2/bmv2.proto
+++ b/p4_symbolic/bmv2/bmv2.proto
@@ -415,6 +415,8 @@ enum StatementOp {
   exit = 6;
   // Assign a header instance to another of the same type.
   assign_header = 7;
+  // Recirculate the packet.
+  recirculate = 8;
 }
 
 // This specifies the exact expressions that are supported by our ir.

--- a/p4_symbolic/ir/ir.proto
+++ b/p4_symbolic/ir/ir.proto
@@ -328,6 +328,7 @@ message Statement {
     HashStatement hash = 5;
     ExitStatement exit = 6;
     HeaderAssignmentStatement header_assignment = 7;
+    RecirculateStatement recirculate = 8;
   }
 }
 
@@ -350,6 +351,14 @@ message CloneStatement {
   // 1. We only support one version of cloning: ingree to egress
   // 2. The session id is not know at parsing time.
   // 3. We do not support clone calls preserving custom fields.
+}
+
+// A statement recirculating egress packet to ingress, corresponds to
+// `recirculate`.
+message RecirculateStatement {
+  // We do not care about the arguments to recirculate as we do not currently
+  // fully model recirculation. We only set the kGotRecirculated pseudo field
+  // to true when recirculate is called.
 }
 
 // Hashing statement to modify a selected field based on a hash calculation.

--- a/p4_symbolic/sai/BUILD.bazel
+++ b/p4_symbolic/sai/BUILD.bazel
@@ -40,7 +40,9 @@ cc_test(
     srcs = ["sai_test.cc"],
     deps = [
         ":sai",
+        "//gutil:proto",
         "//gutil:status_matchers",
+        "//gutil:test_artifact_writer",
         "//gutil:testing",
         "//p4_pdpi:ir",
         "//p4_pdpi:pd",
@@ -49,6 +51,7 @@ cc_test(
         "//sai_p4/instantiations/google:sai_nonstandard_platforms_cc",
         "//sai_p4/instantiations/google:sai_pd_cc_proto",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_github_z3prover_z3//:api",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",

--- a/p4_symbolic/symbolic/action.cc
+++ b/p4_symbolic/symbolic/action.cc
@@ -59,6 +59,10 @@ absl::Status EvaluateStatement(const ir::Statement &statement,
       return headers.Set(std::string(kGotClonedPseudoField),
                          state.context.z3_context->bool_val(true), guard);
     }
+    case ir::Statement::kRecirculate: {
+      return headers.Set(std::string(kGotRecirculatedPseudoField),
+                         state.context.z3_context->bool_val(true), guard);
+    }
     case ir::Statement::kDrop: {
       // https://github.com/p4lang/p4c/blob/7ee76d16da63883c5092ab0c28321f04c2646759/p4include/v1model.p4#L435
       z3::context &z3_context = *state.context.z3_context;

--- a/p4_symbolic/symbolic/expected/basic.smt2
+++ b/p4_symbolic/symbolic/expected/basic.smt2
@@ -1,4 +1,5 @@
 (ingress) $got_cloned$: false
+(ingress) $got_recirculated$: false
 (ingress) ethernet.$extracted$: false
 (ingress) ethernet.$valid$: (ite true true false)
 (ingress) ethernet.dstAddr: ethernet.dstAddr
@@ -41,6 +42,7 @@
 (ingress) standard_metadata.priority: #b000
 
 (parsed) $got_cloned$: false
+(parsed) $got_recirculated$: false
 (parsed) ethernet.$extracted$: (ite true true false)
 (parsed) ethernet.$valid$: (ite true true false)
 (parsed) ethernet.dstAddr: ethernet.dstAddr
@@ -87,6 +89,7 @@
 (parsed) standard_metadata.priority: #b000
 
 (egress) $got_cloned$: false
+(egress) $got_recirculated$: false
 (egress) ethernet.$extracted$: (ite true true false)
 (egress) ethernet.$valid$: (ite true true false)
 (egress) ethernet.dstAddr: (let ((a!1 (ite (and true (= (concat #x0 #x800) ethernet.etherType)) true false))

--- a/p4_symbolic/symbolic/expected/basic.txt
+++ b/p4_symbolic/symbolic/expected/basic.txt
@@ -16,6 +16,7 @@ MyIngress.ipv4_lpm => was matched on entry 0
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -59,6 +60,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -102,6 +104,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -156,6 +159,7 @@ MyIngress.ipv4_lpm => was matched on entry 1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -199,6 +203,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -242,6 +247,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -296,6 +302,7 @@ MyIngress.ipv4_lpm => was matched on entry 2
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -339,6 +346,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -382,6 +390,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x00000000000a
@@ -436,6 +445,7 @@ MyIngress.ipv4_lpm => was matched on entry 3
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -479,6 +489,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -522,6 +533,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x160000000016

--- a/p4_symbolic/symbolic/expected/conditional.smt2
+++ b/p4_symbolic/symbolic/expected/conditional.smt2
@@ -1,4 +1,5 @@
 (ingress) $got_cloned$: false
+(ingress) $got_recirculated$: false
 (ingress) ethernet.$extracted$: false
 (ingress) ethernet.$valid$: (ite true true false)
 (ingress) ethernet.dst_addr: ethernet.dst_addr
@@ -27,6 +28,7 @@
 (ingress) standard_metadata.priority: #b000
 
 (parsed) $got_cloned$: false
+(parsed) $got_recirculated$: false
 (parsed) ethernet.$extracted$: (ite true true false)
 (parsed) ethernet.$valid$: (ite true true false)
 (parsed) ethernet.dst_addr: ethernet.dst_addr
@@ -55,6 +57,7 @@
 (parsed) standard_metadata.priority: #b000
 
 (egress) $got_cloned$: false
+(egress) $got_recirculated$: false
 (egress) ethernet.$extracted$: (ite true true false)
 (egress) ethernet.$valid$: (ite true true false)
 (egress) ethernet.dst_addr: (ite (and true true (= ethernet.dst_addr #x000000000001))

--- a/p4_symbolic/symbolic/expected/conditional.txt
+++ b/p4_symbolic/symbolic/expected/conditional.txt
@@ -12,6 +12,7 @@ MyIngress.t_3 => was matched on entry 0
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000001
@@ -41,6 +42,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000001
@@ -70,6 +72,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000002
@@ -112,6 +115,7 @@ MyIngress.t_3 => was matched on entry 0
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000001
@@ -141,6 +145,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000001
@@ -170,6 +175,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000002
@@ -218,6 +224,7 @@ MyIngress.t_3 => was matched on entry 0
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000001
@@ -247,6 +254,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000001
@@ -276,6 +284,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000002

--- a/p4_symbolic/symbolic/expected/conditional_nonlattice.smt2
+++ b/p4_symbolic/symbolic/expected/conditional_nonlattice.smt2
@@ -1,4 +1,5 @@
 (ingress) $got_cloned$: false
+(ingress) $got_recirculated$: false
 (ingress) ethernet.$extracted$: false
 (ingress) ethernet.$valid$: (ite true true false)
 (ingress) ethernet.dst_addr: ethernet.dst_addr
@@ -27,6 +28,7 @@
 (ingress) standard_metadata.priority: #b000
 
 (parsed) $got_cloned$: false
+(parsed) $got_recirculated$: false
 (parsed) ethernet.$extracted$: (ite true true false)
 (parsed) ethernet.$valid$: (ite true true false)
 (parsed) ethernet.dst_addr: ethernet.dst_addr
@@ -55,6 +57,7 @@
 (parsed) standard_metadata.priority: #b000
 
 (egress) $got_cloned$: false
+(egress) $got_recirculated$: false
 (egress) ethernet.$extracted$: (ite true true false)
 (egress) ethernet.$valid$: (ite true true false)
 (egress) ethernet.dst_addr: (ite (and true true (= ethernet.dst_addr #x000000000001))

--- a/p4_symbolic/symbolic/expected/conditional_nonlattice.txt
+++ b/p4_symbolic/symbolic/expected/conditional_nonlattice.txt
@@ -12,6 +12,7 @@ MyIngress.t_3 => was matched on entry 0
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000001
@@ -41,6 +42,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000001
@@ -70,6 +72,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000002
@@ -112,6 +115,7 @@ MyIngress.t_3 => was matched on entry 0
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000001
@@ -141,6 +145,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000001
@@ -170,6 +175,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000002
@@ -218,6 +224,7 @@ MyIngress.t_3 => was matched on entry 0
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000001
@@ -247,6 +254,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000001
@@ -276,6 +284,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000002

--- a/p4_symbolic/symbolic/expected/conditional_sequence.smt2
+++ b/p4_symbolic/symbolic/expected/conditional_sequence.smt2
@@ -1,4 +1,5 @@
 (ingress) $got_cloned$: false
+(ingress) $got_recirculated$: false
 (ingress) h1.$extracted$: false
 (ingress) h1.$valid$: (ite true true false)
 (ingress) h1.f1: h1.f1
@@ -34,6 +35,7 @@
 (ingress) standard_metadata.priority: #b000
 
 (parsed) $got_cloned$: false
+(parsed) $got_recirculated$: false
 (parsed) h1.$extracted$: (ite true true false)
 (parsed) h1.$valid$: (ite true true false)
 (parsed) h1.f1: h1.f1
@@ -69,6 +71,7 @@
 (parsed) standard_metadata.priority: #b000
 
 (egress) $got_cloned$: false
+(egress) $got_recirculated$: false
 (egress) h1.$extracted$: (ite true true false)
 (egress) h1.$valid$: (ite true true false)
 (egress) h1.f1: h1.f1

--- a/p4_symbolic/symbolic/expected/conditional_sequence.txt
+++ b/p4_symbolic/symbolic/expected/conditional_sequence.txt
@@ -26,6 +26,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x02
@@ -62,6 +63,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x02
@@ -98,6 +100,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x02
@@ -161,6 +164,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -197,6 +201,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -233,6 +238,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -296,6 +302,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -332,6 +339,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -368,6 +376,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -431,6 +440,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -467,6 +477,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -503,6 +514,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -566,6 +578,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -602,6 +615,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -638,6 +652,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -701,6 +716,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -737,6 +753,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -773,6 +790,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -836,6 +854,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -872,6 +891,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -908,6 +928,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -971,6 +992,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1007,6 +1029,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1043,6 +1066,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1106,6 +1130,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1142,6 +1167,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1178,6 +1204,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1241,6 +1268,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1277,6 +1305,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1313,6 +1342,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1376,6 +1406,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1412,6 +1443,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1448,6 +1480,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1511,6 +1544,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1547,6 +1581,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1583,6 +1618,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1646,6 +1682,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1682,6 +1719,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1718,6 +1756,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1781,6 +1820,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1817,6 +1857,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1853,6 +1894,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1916,6 +1958,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1952,6 +1995,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -1988,6 +2032,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -2051,6 +2096,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -2087,6 +2133,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -2123,6 +2170,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -2186,6 +2234,7 @@ MyIngress.t => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -2222,6 +2271,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -2258,6 +2308,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -2321,6 +2372,7 @@ MyIngress.t => was matched on entry 0
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -2357,6 +2409,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -2393,6 +2446,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00

--- a/p4_symbolic/symbolic/expected/hardcoded.smt2
+++ b/p4_symbolic/symbolic/expected/hardcoded.smt2
@@ -1,4 +1,5 @@
 (ingress) $got_cloned$: false
+(ingress) $got_recirculated$: false
 (ingress) scalars.$extracted$: false
 (ingress) scalars.$valid$: false
 (ingress) standard_metadata.$extracted$: false
@@ -22,6 +23,7 @@
 (ingress) standard_metadata.priority: #b000
 
 (parsed) $got_cloned$: false
+(parsed) $got_recirculated$: false
 (parsed) scalars.$extracted$: false
 (parsed) scalars.$valid$: false
 (parsed) standard_metadata.$extracted$: false
@@ -45,6 +47,7 @@
 (parsed) standard_metadata.priority: #b000
 
 (egress) $got_cloned$: false
+(egress) $got_recirculated$: false
 (egress) scalars.$extracted$: false
 (egress) scalars.$valid$: false
 (egress) standard_metadata.$extracted$: false

--- a/p4_symbolic/symbolic/expected/hardcoded.txt
+++ b/p4_symbolic/symbolic/expected/hardcoded.txt
@@ -11,6 +11,7 @@ tbl_hardcoded57 => was not matched!
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 standard_metadata.$extracted$ = false
@@ -35,6 +36,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 standard_metadata.$extracted$ = false
@@ -59,6 +61,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 standard_metadata.$extracted$ = false
@@ -95,6 +98,7 @@ tbl_hardcoded57 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 standard_metadata.$extracted$ = false
@@ -119,6 +123,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 standard_metadata.$extracted$ = false
@@ -143,6 +148,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 standard_metadata.$extracted$ = false

--- a/p4_symbolic/symbolic/expected/reflector.smt2
+++ b/p4_symbolic/symbolic/expected/reflector.smt2
@@ -1,4 +1,5 @@
 (ingress) $got_cloned$: false
+(ingress) $got_recirculated$: false
 (ingress) scalars.$extracted$: false
 (ingress) scalars.$valid$: false
 (ingress) standard_metadata.$extracted$: false
@@ -22,6 +23,7 @@
 (ingress) standard_metadata.priority: #b000
 
 (parsed) $got_cloned$: false
+(parsed) $got_recirculated$: false
 (parsed) scalars.$extracted$: false
 (parsed) scalars.$valid$: false
 (parsed) standard_metadata.$extracted$: false
@@ -45,6 +47,7 @@
 (parsed) standard_metadata.priority: #b000
 
 (egress) $got_cloned$: false
+(egress) $got_recirculated$: false
 (egress) scalars.$extracted$: false
 (egress) scalars.$valid$: false
 (egress) standard_metadata.$extracted$: false

--- a/p4_symbolic/symbolic/expected/reflector.txt
+++ b/p4_symbolic/symbolic/expected/reflector.txt
@@ -10,6 +10,7 @@ tbl_reflector54 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 standard_metadata.$extracted$ = false
@@ -34,6 +35,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 standard_metadata.$extracted$ = false
@@ -58,6 +60,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 standard_metadata.$extracted$ = false

--- a/p4_symbolic/symbolic/expected/string_optional.smt2
+++ b/p4_symbolic/symbolic/expected/string_optional.smt2
@@ -1,4 +1,5 @@
 (ingress) $got_cloned$: false
+(ingress) $got_recirculated$: false
 (ingress) scalars.$extracted$: false
 (ingress) scalars.$valid$: false
 (ingress) scalars._padding_0: scalars._padding_0
@@ -24,6 +25,7 @@
 (ingress) standard_metadata.priority: #b000
 
 (parsed) $got_cloned$: false
+(parsed) $got_recirculated$: false
 (parsed) scalars.$extracted$: false
 (parsed) scalars.$valid$: false
 (parsed) scalars._padding_0: scalars._padding_0
@@ -49,6 +51,7 @@
 (parsed) standard_metadata.priority: #b000
 
 (egress) $got_cloned$: false
+(egress) $got_recirculated$: false
 (egress) scalars.$extracted$: false
 (egress) scalars.$valid$: false
 (egress) scalars._padding_0: scalars._padding_0

--- a/p4_symbolic/symbolic/expected/string_optional.txt
+++ b/p4_symbolic/symbolic/expected/string_optional.txt
@@ -18,6 +18,7 @@ tbl_program92 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -44,6 +45,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -70,6 +72,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -109,6 +112,7 @@ tbl_program92 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -135,6 +139,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -161,6 +166,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -206,6 +212,7 @@ tbl_program92 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -232,6 +239,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -258,6 +266,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -297,6 +306,7 @@ tbl_program92 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -323,6 +333,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -349,6 +360,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -388,6 +400,7 @@ tbl_program92 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -414,6 +427,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -440,6 +454,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -479,6 +494,7 @@ tbl_program92 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -505,6 +521,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000
@@ -531,6 +548,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 scalars._padding_0 = #b0000000

--- a/p4_symbolic/symbolic/expected/table.smt2
+++ b/p4_symbolic/symbolic/expected/table.smt2
@@ -1,4 +1,5 @@
 (ingress) $got_cloned$: false
+(ingress) $got_recirculated$: false
 (ingress) scalars.$extracted$: false
 (ingress) scalars.$valid$: false
 (ingress) standard_metadata.$extracted$: false
@@ -22,6 +23,7 @@
 (ingress) standard_metadata.priority: #b000
 
 (parsed) $got_cloned$: false
+(parsed) $got_recirculated$: false
 (parsed) scalars.$extracted$: false
 (parsed) scalars.$valid$: false
 (parsed) standard_metadata.$extracted$: false
@@ -45,6 +47,7 @@
 (parsed) standard_metadata.priority: #b000
 
 (egress) $got_cloned$: false
+(egress) $got_recirculated$: false
 (egress) scalars.$extracted$: false
 (egress) scalars.$valid$: false
 (egress) standard_metadata.$extracted$: false

--- a/p4_symbolic/symbolic/expected/table.txt
+++ b/p4_symbolic/symbolic/expected/table.txt
@@ -16,6 +16,7 @@ MyIngress.ports_exact => was matched on entry 0
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 standard_metadata.$extracted$ = false
@@ -40,6 +41,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 standard_metadata.$extracted$ = false
@@ -64,6 +66,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 standard_metadata.$extracted$ = false
@@ -99,6 +102,7 @@ MyIngress.ports_exact => was matched on entry 1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 standard_metadata.$extracted$ = false
@@ -123,6 +127,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 standard_metadata.$extracted$ = false
@@ -147,6 +152,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 scalars.$extracted$ = false
 scalars.$valid$ = false
 standard_metadata.$extracted$ = false

--- a/p4_symbolic/symbolic/expected/table_hit_1.smt2
+++ b/p4_symbolic/symbolic/expected/table_hit_1.smt2
@@ -1,4 +1,5 @@
 (ingress) $got_cloned$: false
+(ingress) $got_recirculated$: false
 (ingress) ethernet.$extracted$: false
 (ingress) ethernet.$valid$: (ite true true false)
 (ingress) ethernet.dst_addr: ethernet.dst_addr
@@ -27,6 +28,7 @@
 (ingress) standard_metadata.priority: #b000
 
 (parsed) $got_cloned$: false
+(parsed) $got_recirculated$: false
 (parsed) ethernet.$extracted$: (ite true true false)
 (parsed) ethernet.$valid$: (ite true true false)
 (parsed) ethernet.dst_addr: ethernet.dst_addr
@@ -55,6 +57,7 @@
 (parsed) standard_metadata.priority: #b000
 
 (egress) $got_cloned$: false
+(egress) $got_recirculated$: false
 (egress) ethernet.$extracted$: (ite true true false)
 (egress) ethernet.$valid$: (ite true true false)
 (egress) ethernet.dst_addr: (let ((a!1 (distinct (ite (and true true (= ethernet.ether_type #x0010))

--- a/p4_symbolic/symbolic/expected/table_hit_1.txt
+++ b/p4_symbolic/symbolic/expected/table_hit_1.txt
@@ -17,6 +17,7 @@ MyIngress.t_2 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000000
@@ -46,6 +47,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000000
@@ -75,6 +77,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000002
@@ -116,6 +119,7 @@ MyIngress.t_2 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000000
@@ -145,6 +149,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000000
@@ -174,6 +179,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000002
@@ -215,6 +221,7 @@ MyIngress.t_2 => was matched on entry 0
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000000
@@ -244,6 +251,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000000
@@ -273,6 +281,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dst_addr = #x000000000003

--- a/p4_symbolic/symbolic/expected/table_hit_2.smt2
+++ b/p4_symbolic/symbolic/expected/table_hit_2.smt2
@@ -1,4 +1,5 @@
 (ingress) $got_cloned$: false
+(ingress) $got_recirculated$: false
 (ingress) h1.$extracted$: false
 (ingress) h1.$valid$: (ite true true false)
 (ingress) h1.f1: h1.f1
@@ -28,6 +29,7 @@
 (ingress) standard_metadata.priority: #b000
 
 (parsed) $got_cloned$: false
+(parsed) $got_recirculated$: false
 (parsed) h1.$extracted$: (ite true true false)
 (parsed) h1.$valid$: (ite true true false)
 (parsed) h1.f1: h1.f1
@@ -57,6 +59,7 @@
 (parsed) standard_metadata.priority: #b000
 
 (egress) $got_cloned$: false
+(egress) $got_recirculated$: false
 (egress) h1.$extracted$: (ite true true false)
 (egress) h1.$valid$: (ite true true false)
 (egress) h1.f1: h1.f1

--- a/p4_symbolic/symbolic/expected/table_hit_2.txt
+++ b/p4_symbolic/symbolic/expected/table_hit_2.txt
@@ -14,6 +14,7 @@ tbl_table_hit_2l83 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x00
@@ -44,6 +45,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -74,6 +76,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x00
@@ -119,6 +122,7 @@ tbl_table_hit_2l83 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #xff
@@ -149,6 +153,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #xff
@@ -179,6 +184,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #xff
@@ -224,6 +230,7 @@ tbl_table_hit_2l83 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #xff
@@ -254,6 +261,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #xff
@@ -284,6 +292,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #xff
@@ -329,6 +338,7 @@ tbl_table_hit_2l83 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #xff
@@ -359,6 +369,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #xff
@@ -389,6 +400,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #xff
@@ -434,6 +446,7 @@ tbl_table_hit_2l83 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x7f
@@ -464,6 +477,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x7f
@@ -494,6 +508,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x7f
@@ -539,6 +554,7 @@ tbl_table_hit_2l83 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x7f
@@ -569,6 +585,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x7f
@@ -599,6 +616,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x7f
@@ -644,6 +662,7 @@ tbl_table_hit_2l83 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x7f
@@ -674,6 +693,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x7f
@@ -704,6 +724,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x7f
@@ -749,6 +770,7 @@ tbl_table_hit_2l83 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = false
 h1.$valid$ = true
 h1.f1 = #x7f
@@ -779,6 +801,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x7f
@@ -809,6 +832,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 h1.$extracted$ = true
 h1.$valid$ = true
 h1.f1 = #x7f

--- a/p4_symbolic/symbolic/expected/vrf.smt2
+++ b/p4_symbolic/symbolic/expected/vrf.smt2
@@ -1,4 +1,5 @@
 (ingress) $got_cloned$: false
+(ingress) $got_recirculated$: false
 (ingress) ethernet.$extracted$: false
 (ingress) ethernet.$valid$: (ite true true false)
 (ingress) ethernet.dstAddr: ethernet.dstAddr
@@ -44,6 +45,7 @@
 (ingress) standard_metadata.priority: #b000
 
 (parsed) $got_cloned$: false
+(parsed) $got_recirculated$: false
 (parsed) ethernet.$extracted$: (ite true true false)
 (parsed) ethernet.$valid$: (ite true true false)
 (parsed) ethernet.dstAddr: ethernet.dstAddr
@@ -93,6 +95,7 @@
 (parsed) standard_metadata.priority: #b000
 
 (egress) $got_cloned$: false
+(egress) $got_recirculated$: false
 (egress) ethernet.$extracted$: (ite true true false)
 (egress) ethernet.$valid$: (ite true true false)
 (egress) ethernet.dstAddr: (let ((a!1 (ite (and true (= (concat #x0 #x800) ethernet.eth_type)) true false))

--- a/p4_symbolic/symbolic/expected/vrf.txt
+++ b/p4_symbolic/symbolic/expected/vrf.txt
@@ -18,6 +18,7 @@ tbl_vrf133 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -64,6 +65,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -110,6 +112,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -169,6 +172,7 @@ tbl_vrf133 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -215,6 +219,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -261,6 +266,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -320,6 +326,7 @@ tbl_vrf133 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -366,6 +373,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -412,6 +420,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x00000000000a
@@ -471,6 +480,7 @@ tbl_vrf133 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -517,6 +527,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -563,6 +574,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x160000000016
@@ -622,6 +634,7 @@ tbl_vrf133 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -668,6 +681,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -714,6 +728,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -773,6 +788,7 @@ tbl_vrf133 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -819,6 +835,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -865,6 +882,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x160000000016
@@ -924,6 +942,7 @@ tbl_vrf133 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -970,6 +989,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -1016,6 +1036,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x00000000000a
@@ -1075,6 +1096,7 @@ tbl_vrf133 => was matched on entry -1
 
 ingress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = false
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -1121,6 +1143,7 @@ standard_metadata.priority = #b000
 
 parsed_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x000000000000
@@ -1167,6 +1190,7 @@ standard_metadata.priority = #b000
 
 egress_headers:
 $got_cloned$ = false
+$got_recirculated$ = false
 ethernet.$extracted$ = true
 ethernet.$valid$ = true
 ethernet.dstAddr = #x00000000000a

--- a/p4_symbolic/symbolic/symbolic.h
+++ b/p4_symbolic/symbolic/symbolic.h
@@ -67,6 +67,10 @@ constexpr absl::string_view kExtractedPseudoField = "$extracted$";
 // gets cloned. Not an actual header field, but convenient for analysis.
 constexpr absl::string_view kGotClonedPseudoField = "$got_cloned$";
 
+// Boolean pseudo header field that is set to true by p4-symbolic if the packet
+// gets recirculated. Not an actual header field, but convenient for analysis.
+constexpr absl::string_view kGotRecirculatedPseudoField = "$got_recirculated$";
+
 // The overall state of our symbolic solver/interpreter.
 // This is returned by our main analysis/interpration function, and is used
 // to find concrete test packets and for debugging.

--- a/p4_symbolic/symbolic/util.cc
+++ b/p4_symbolic/symbolic/util.cc
@@ -111,6 +111,10 @@ absl::StatusOr<absl::btree_map<std::string, z3::expr>> FreeSymbolicHeaders(
       std::string(kGotClonedPseudoField),
       z3_context.bool_val(false),
   });
+  symbolic_headers.insert({
+      std::string(kGotRecirculatedPseudoField),
+      z3_context.bool_val(false),
+  });
 
   return symbolic_headers;
 }

--- a/sai_p4/fixed/BUILD.bazel
+++ b/sai_p4/fixed/BUILD.bazel
@@ -29,6 +29,7 @@ filegroup(
         "ingress_cloning.p4",
         "ipv4_checksum.p4",
         "l3_admit.p4",
+        "loopback.p4",
         "metadata.p4",
         "minimum_guaranteed_sizes.p4",
         "mirroring.p4",

--- a/sai_p4/fixed/loopback.p4
+++ b/sai_p4/fixed/loopback.p4
@@ -1,0 +1,48 @@
+#ifndef SAI_LOOPBACK_P4_
+#define SAI_LOOPBACK_P4_
+
+#include <v1model.p4>
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+#include "bmv2_intrinsics.h"
+
+
+control egress_port_loopback(inout headers_t headers,
+                        inout local_metadata_t local_metadata,
+                        inout standard_metadata_t standard_metadata) {
+  @id(EGRESS_LOOPBACK_ACTION_ID)
+  action egress_loopback() {
+    local_metadata.loopback_port = standard_metadata.egress_port;
+    recirculate_preserving_field_list((bit<8>)PreservedFieldList.RECIRCULATE);
+  }
+
+  // This table models SAI_PORT_LOOPBACK_MODE_MAC on front panel ports: an entry
+  // in this table matching on an `out_port` P indicates that a packet going
+  // out of P will be recirculated back as an input packet.
+  // This table is only used in v1model targets (e.g. BMv2). Note that in GPINS
+  // the loopback mode is configured via gNMI config for the port rather than
+  // P4.
+  @id(EGRESS_PORT_LOOPBACK_TABLE_ID)
+  @p4runtime_role(P4RUNTIME_ROLE_V1MODEL_AUXILIARY_CONTROLLER)
+  // TODO: Remove @unsupported once we can ignore this table
+  // in P4Info verification
+  @unsupported
+  table egress_port_loopback_table {
+    key = {
+      (port_id_t)standard_metadata.egress_port: exact
+          @id(1) @name("out_port");
+    }
+    actions = {
+      @proto_id(1) egress_loopback;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+  }
+
+  apply {
+    egress_port_loopback_table.apply();
+  }
+}  // control egress_port_loopback
+
+#endif  // SAI_LOOPBACK_P4_

--- a/sai_p4/fixed/metadata.p4
+++ b/sai_p4/fixed/metadata.p4
@@ -10,7 +10,8 @@
 // The field list numbers used in @field_list annotations to identify the fields
 // that need to be preserved during clone/recirculation/etc. operations.
 enum bit<8> PreservedFieldList {
-  MIRROR_AND_PACKET_IN_COPY = 8w1
+  MIRROR_AND_PACKET_IN_COPY = 8w1,
+  RECIRCULATE = 8w2
 };
 
 // -- Translated Types ---------------------------------------------------------
@@ -248,6 +249,15 @@ struct local_metadata_t {
   @field_list(PreservedFieldList.MIRROR_AND_PACKET_IN_COPY)
   bit<16> mirror_encap_udp_dst_port;
   // -- end of mirroring related fields ----------------------------------------
+
+  // If a packet is send to a port that is designated as a loopback port,
+  // the port is stored in this field and reciculated (see loopback.p4).
+  // This field (which is preserved during recirculation) will be used to set
+  // the ingress port to the loopback port after recirculation (as opposed to
+  // our hardware targets, this does NOT happen by default in v1model targets
+  // such as BMv2).
+  @field_list(PreservedFieldList.RECIRCULATE)
+  bit<PORT_BITWIDTH> loopback_port;
 
   // Packet-in related fields, which we can't group into a struct, because BMv2
   // doesn't support passing structs in clone3.

--- a/sai_p4/instantiations/google/BUILD.bazel
+++ b/sai_p4/instantiations/google/BUILD.bazel
@@ -174,7 +174,10 @@ p4_pd_proto(
     # Do not access directly. Use checked in sai_pd.proto instead.
     out = "generated/sai_pd.proto",
     package = "sai",
-    roles = ["sdn_controller"],
+    roles = [
+        "sdn_controller",
+        "v1model_auxiliary_controller",
+    ],
 )
 
 # -- P4Info --------------------------------------------------------------------

--- a/sai_p4/instantiations/google/test_tools/table_entry_generator.cc
+++ b/sai_p4/instantiations/google/test_tools/table_entry_generator.cc
@@ -282,7 +282,7 @@ TableEntryGenerator MulticastRouterInterfaceTableGenerator(
 }
 
 const absl::flat_hash_set<std::string>& KnownUnsupportedTables() {
-  static const auto* const kUnsupportedTables =
+  static const auto *const kUnsupportedTables =
       new absl::flat_hash_set<std::string>({
           "vrf_table",
           "neighbor_table",
@@ -290,8 +290,9 @@ const absl::flat_hash_set<std::string>& KnownUnsupportedTables() {
           "tunnel_table",
           "nexthop_table",
           "wcmp_group_table",
-          // Logical table that is not supported by the switch.
+          // Logical tables that are not supported by the switch.
           "ingress_clone_table",
+          "egress_port_loopback_table",
           // TODO: Add support for this table once the switch
           // supports it.
           "acl_ingress_mirror_and_redirect_table",

--- a/sai_p4/instantiations/google/tests/sai_p4_bmv2_loopback_test.cc
+++ b/sai_p4/instantiations/google/tests/sai_p4_bmv2_loopback_test.cc
@@ -1,0 +1,139 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <optional>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/log/check.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "gutil/testing.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4_pdpi/p4_runtime_session_extras.h"
+#include "p4_pdpi/packetlib/packetlib.h"
+#include "p4_pdpi/packetlib/packetlib.pb.h"
+#include "platforms/networking/p4/p4_infra/bmv2/bmv2.h"
+#include "sai_p4/instantiations/google/instantiations.h"
+#include "sai_p4/instantiations/google/sai_p4info.h"
+#include "sai_p4/instantiations/google/sai_pd.pb.h"
+#include "sai_p4/instantiations/google/test_tools/set_up_bmv2.h"
+#include "sai_p4/instantiations/google/test_tools/test_entries.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace pins {
+namespace {
+
+using ::orion::p4::test::Bmv2;
+using ::testing::ElementsAre;
+using ::testing::Key;
+
+using PacketsByPort = absl::flat_hash_map<int, packetlib::Packets>;
+
+void PreparePacketOrDie(packetlib::Packet &packet) {
+  CHECK_OK(packetlib::PadPacketToMinimumSize(packet).status()); // Crash OK.
+  CHECK_OK(
+      packetlib::UpdateMissingComputedFields(packet).status()); // Crash OK.
+}
+
+packetlib::Packet GetIpv4PacketOrDie() {
+  auto packet = gutil::ParseProtoOrDie<packetlib::Packet>(R"pb(
+    headers {
+      ethernet_header {
+        ethernet_destination: "02:03:04:05:06:07"
+        ethernet_source: "00:01:02:03:04:05"
+        ethertype: "0x0800"  # IPv4
+      }
+    }
+    headers {
+      ipv4_header {
+        version: "0x4"
+        ihl: "0x5"
+        dscp: "0x1c"
+        ecn: "0x0"
+        identification: "0x0000"
+        flags: "0x0"
+        fragment_offset: "0x0000"
+        ttl: "0x20"
+        protocol: "0xfe"
+        ipv4_source: "192.168.100.2"
+        ipv4_destination: "192.168.100.1"
+      }
+    }
+    payload: "Untagged IPv4 packet."
+  )pb");
+  PreparePacketOrDie(packet);
+  return packet;
+}
+
+TEST(ExperimentalTorLoopbackTest, PacketsSentToLoopbackPortsGetRecirculated) {
+  const sai::Instantiation kInstantiation =
+      sai::Instantiation::kExperimentalTor;
+  const pdpi::IrP4Info kIrP4Info = sai::GetIrP4Info(kInstantiation);
+  ASSERT_OK_AND_ASSIGN(Bmv2 bmv2, sai::SetUpBmv2ForSaiP4(kInstantiation));
+
+  constexpr int kIngressPort = 4;
+  constexpr int kLoobackPort = 5;
+  constexpr int kEgressPort = 6;
+  constexpr absl::string_view kLoobackPortProto = "\005";
+  constexpr absl::string_view kEgressPortProto = "\006";
+
+  constexpr absl::string_view kRedirectNexthopId = "redirect-nexthop";
+
+  {
+    // Install entries to send packets to kLoobackPort.
+    // For packets ingressing from the kLoobackPort, send them to kEgressPort.
+    // However, do NOT yet install the entry to make kLoobackPort a loopback
+    // port.
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<p4::v1::Entity> pi_entities,
+        sai::EntryBuilder()
+            .AddEntriesForwardingIpPacketsToGivenPort(kLoobackPortProto)
+            .AddIngressAclEntryRedirectingToNexthop(
+                kRedirectNexthopId,
+                /*in_port_match=*/kLoobackPortProto)
+            .AddNexthopRifNeighborEntries(kRedirectNexthopId, kEgressPortProto)
+            .LogPdEntries()
+            .GetDedupedPiEntities(kIrP4Info, /*allow_unsupported=*/true));
+    ASSERT_OK(pdpi::InstallPiEntities(bmv2.P4RuntimeSession(), pi_entities));
+
+    // Inject a test packet to kIngressPort.
+    ASSERT_OK_AND_ASSIGN(PacketsByPort output_by_port,
+                         bmv2.SendPacket(kIngressPort, GetIpv4PacketOrDie()));
+    // The packet must be forwarded to kLoobackPort.
+    ASSERT_THAT(output_by_port, ElementsAre(Key(kLoobackPort)));
+  }
+
+  {
+    // Now install an entry to make kLoobackPort a loopback port.
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<p4::v1::Entity> pi_entities,
+        sai::EntryBuilder()
+            .AddEgressPortLoopbackEntry(kLoobackPortProto)
+            .LogPdEntries()
+            .GetDedupedPiEntities(kIrP4Info, /*allow_unsupported=*/true));
+    ASSERT_OK(pdpi::InstallPiEntities(bmv2.P4RuntimeSession(), pi_entities));
+
+    // Inject a test packet to kIngressPort.
+    ASSERT_OK_AND_ASSIGN(PacketsByPort output_by_port,
+                         bmv2.SendPacket(kIngressPort, GetIpv4PacketOrDie()));
+    // The packet must be (looped back and eventually) forwarded to kEgressPort.
+    ASSERT_THAT(output_by_port, ElementsAre(Key(kEgressPort)));
+  }
+}
+
+} // namespace
+} // namespace pins


### PR DESCRIPTION
Keyword Check:
~/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.




Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Build options --copt, --cxxopt, --host_copt, and 1 more have changed, discarding analysis cache.
INFO: Analyzed 689 targets (0 packages loaded, 22835 targets configured).
INFO: Found 689 targets...
INFO: From Compiling src/google/protobuf/generated_message_tctable_lite.cc:
In file included from bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/generated_message_tctable_decl.h:45,
                 from external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:37:
bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/parse_context.h:1150:1: warning: 'always_inline' function might not be inlinable [-Wattributes]
 1150 | ParseContext::ParseLengthDelimitedInlined(const char* ptr, const Func& func) {
      | ^~~~~~~~~~~~
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:871:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
  871 | PROTOBUF_ALWAYS_INLINE const char* TcParser::FastVarintS1(
      |                                    ^~~~~~~~
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:871:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
INFO: From Compiling src/google/protobuf/compiler/retention.cc:
external/com_google_protobuf/src/google/protobuf/compiler/retention.cc: In function 'void google::protobuf::compiler::{anonymous}::StripSourceCodeInfo(std::vector<std::vector<int> >&, google::protobuf::SourceCodeInfo&)':
external/com_google_protobuf/src/google/protobuf/compiler/retention.cc:216:21: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<google::protobuf::SourceCodeInfo_Location*>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  216 |   for (int i = 0; i < old_locations.size(); ++i) {
      |                   ~~^~~~~~~~~~~~~~~~~~~~~~
INFO: From Compiling src/google/protobuf/compiler/retention.cc [for host]:
external/com_google_protobuf/src/google/protobuf/compiler/retention.cc: In function 'void google::protobuf::compiler::{anonymous}::StripSourceCodeInfo(std::vector<std::vector<int> >&, google::protobuf::SourceCodeInfo&)':
external/com_google_protobuf/src/google/protobuf/compiler/retention.cc:216:21: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<google::protobuf::SourceCodeInfo_Location*>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  216 |   for (int i = 0; i < old_locations.size(); ++i) {
      |                   ~~^~~~~~~~~~~~~~~~~~~~~~
INFO: From Compiling src/google/protobuf/generated_message_tctable_lite.cc [for host]:
In file included from bazel-out/host/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/generated_message_tctable_decl.h:45,
                 from external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:37:
bazel-out/host/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/parse_context.h:1150:1: warning: 'always_inline' function might not be inlinable [-Wattributes]
 1150 | ParseContext::ParseLengthDelimitedInlined(const char* ptr, const Func& func) {
      | ^~~~~~~~~~~~
INFO: From Compiling src/core/lib/channel/connected_channel.cc:
In file included from external/com_github_grpc_grpc/src/core/lib/channel/connected_channel.cc:64:
external/com_github_grpc_grpc/src/core/lib/promise/loop.h:124:31: warning: attribute ignored in declaration of 'union grpc_core::promise_detail::Loop<F>::<unnamed>' [-Wattributes]
  124 |   GPR_NO_UNIQUE_ADDRESS union {
      |                               ^
external/com_github_grpc_grpc/src/core/lib/promise/loop.h:124:31: note: attribute for 'union grpc_core::promise_detail::Loop<F>::<unnamed>' must follow the 'union' keyword
external/com_github_grpc_grpc/src/core/lib/channel/connected_channel.cc: In lambda function:
external/com_github_grpc_grpc/src/core/lib/channel/connected_channel.cc:551:21: warning: unused variable 'r' [-Wunused-variable]
  551 |           if (auto* r = p.value_if_ready()) {
      |                     ^
INFO: From Compiling src/core/lib/channel/server_call_tracer_filter.cc:
In file included from external/com_github_grpc_grpc/src/core/lib/channel/server_call_tracer_filter.cc:26:
external/com_github_grpc_grpc/src/core/lib/channel/call_tracer.h:45:1: warning: multi-line comment [-Wcomment]
   45 | //                      /          \
      | ^
external/com_github_grpc_grpc/src/core/lib/channel/call_tracer.h:47:1: warning: multi-line comment [-Wcomment]
   47 | //                                /             \
      | ^
INFO: From Compiling src/core/lib/iomgr/grpc_if_nametoindex_posix.cc:
external/com_github_grpc_grpc/src/core/lib/iomgr/grpc_if_nametoindex_posix.cc:42:9: warning: multi-line comment [-Wcomment]
   42 | #endif  // GRPC_IF_NAMETOINDEX == 1 && \
      |         ^
INFO: From Compiling src/google/protobuf/generated_message_tctable_lite.cc:
In file included from bazel-out/k8-fastbuild/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/generated_message_tctable_decl.h:45,
                 from external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:37:
bazel-out/k8-fastbuild/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/parse_context.h:1150:1: warning: 'always_inline' function might not be inlinable [-Wattributes]
 1150 | ParseContext::ParseLengthDelimitedInlined(const char* ptr, const Func& func) {
      | ^~~~~~~~~~~~
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:871:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
  871 | PROTOBUF_ALWAYS_INLINE const char* TcParser::FastVarintS1(
      |                                    ^~~~~~~~
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:871:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
INFO: From Compiling p4_pdpi/p4info_union_lib.cc:
p4_pdpi/p4info_union_lib.cc:66:10: warning: 'uint32_t pdpi::{anonymous}::GetId(const Param&)' defined but not used [-Wunused-function]
   66 | uint32_t GetId(const p4::config::v1::Action::Param& field) {
      |          ^~~~~
p4_pdpi/p4info_union_lib.cc:62:10: warning: 'uint32_t pdpi::{anonymous}::GetId(const Metadata&)' defined but not used [-Wunused-function]
   62 | uint32_t GetId(
      |          ^~~~~
INFO: Elapsed time: 441.502s, Critical Path: 64.55s
INFO: 2436 processes: 3 internal, 2433 linux-sandbox.
INFO: Build completed successfully, 2436 total actions




Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 689 targets (0 packages loaded, 374 targets configured).
INFO: Found 471 targets and 218 test targets...
INFO: From Compiling p4_symbolic/sai/sai_test.cc:
In file included from ./p4_symbolic/z3_util.h:26,
                 from ./p4_symbolic/symbolic/symbolic.h:36,
                 from ./p4_symbolic/sai/sai.h:25,
                 from p4_symbolic/sai/sai_test.cc:14:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   55 |     for (int i = 0; i < bytes.size(); i++) {
      |                     ~~^~~~~~~~~~~~~~
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.3s
//p4rt_app/tests:response_path_test                                      PASSED in 6.0s
//p4rt_app/tests:role_test                                               PASSED in 1.5s
//p4rt_app/tests:state_verification_test                                 PASSED in 3.0s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.6s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.6s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.4s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.9s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 3.5s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 1.1s
//tests/lib:p4info_helper_test                                           PASSED in 0.8s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 0.7s
//tests/lib:packet_generator_test                                        PASSED in 26.8s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.1s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 6.8s
//thinkit:bazel_test_environment_test                                    PASSED in 2.6s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.9s
  Stats over 5 runs: max = 0.9s, min = 0.7s, avg = 0.7s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 44.3s
  Stats over 50 runs: max = 44.3s, min = 0.8s, avg = 2.8s, dev = 8.5s

Executed 218 out of 218 tests: 218 tests pass.
INFO: Build completed successfully, 275 total actions




 