### PR TITLE
[P4_Symbolic] Eliminate symbolic::TableEntry and use ir::TableEntry instead.

### DIFF
--- a/p4_symbolic/ir/BUILD.bazel
+++ b/p4_symbolic/ir/BUILD.bazel
@@ -50,6 +50,7 @@ cc_library(
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
     ],
 )
@@ -93,12 +94,15 @@ cc_library(
         ":ir_cc_proto",
         ":table_entries",
         "//gutil:status",
+        "//p4_pdpi:ir_cc_proto",
         "//p4_symbolic/bmv2:bmv2_cc_proto",
+        "@com_github_google_glog//:glog",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:node_hash_map",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/p4_symbolic/ir/expected/basic.txt
+++ b/p4_symbolic/ir/expected/basic.txt
@@ -801,114 +801,125 @@ deparsers {
 =====MyIngress.ipv4_lpm Entries=====
 
 concrete_entry {
-  table_name: "MyIngress.ipv4_lpm"
-  matches {
-    name: "hdr.ipv4.dstAddr"
-    lpm {
-      value {
-        ipv4: "10.10.0.0"
-      }
-      prefix_length: 16
-    }
-  }
-  action {
-    name: "MyIngress.ipv4_forward"
-    params {
-      name: "dstAddr"
-      value {
-        hex_str: "0x000000000000"
+  pdpi_ir_entry {
+    table_name: "MyIngress.ipv4_lpm"
+    matches {
+      name: "hdr.ipv4.dstAddr"
+      lpm {
+        value {
+          ipv4: "10.10.0.0"
+        }
+        prefix_length: 16
       }
     }
-    params {
-      name: "port"
-      value {
-        hex_str: "0x000"
+    action {
+      name: "MyIngress.ipv4_forward"
+      params {
+        name: "dstAddr"
+        value {
+          hex_str: "0x000000000000"
+        }
       }
-    }
-  }
-}
-
-concrete_entry {
-  table_name: "MyIngress.ipv4_lpm"
-  matches {
-    name: "hdr.ipv4.dstAddr"
-    lpm {
-      value {
-        ipv4: "10.10.0.0"
-      }
-      prefix_length: 32
-    }
-  }
-  action {
-    name: "MyIngress.ipv4_forward"
-    params {
-      name: "dstAddr"
-      value {
-        hex_str: "0x000000000000"
-      }
-    }
-    params {
-      name: "port"
-      value {
-        hex_str: "0x001"
+      params {
+        name: "port"
+        value {
+          hex_str: "0x000"
+        }
       }
     }
   }
 }
 
 concrete_entry {
-  table_name: "MyIngress.ipv4_lpm"
-  matches {
-    name: "hdr.ipv4.dstAddr"
-    lpm {
-      value {
-        ipv4: "10.0.0.0"
+  pdpi_ir_entry {
+    table_name: "MyIngress.ipv4_lpm"
+    matches {
+      name: "hdr.ipv4.dstAddr"
+      lpm {
+        value {
+          ipv4: "10.10.0.0"
+        }
+        prefix_length: 32
       }
-      prefix_length: 8
+    }
+    action {
+      name: "MyIngress.ipv4_forward"
+      params {
+        name: "dstAddr"
+        value {
+          hex_str: "0x000000000000"
+        }
+      }
+      params {
+        name: "port"
+        value {
+          hex_str: "0x001"
+        }
+      }
     }
   }
-  action {
-    name: "MyIngress.ipv4_forward"
-    params {
-      name: "dstAddr"
-      value {
-        hex_str: "0x00000000000a"
-      }
-    }
-    params {
-      name: "port"
-      value {
-        hex_str: "0x001"
-      }
-    }
-  }
+  index: 1
 }
 
 concrete_entry {
-  table_name: "MyIngress.ipv4_lpm"
-  matches {
-    name: "hdr.ipv4.dstAddr"
-    lpm {
-      value {
-        ipv4: "20.20.0.0"
+  pdpi_ir_entry {
+    table_name: "MyIngress.ipv4_lpm"
+    matches {
+      name: "hdr.ipv4.dstAddr"
+      lpm {
+        value {
+          ipv4: "10.0.0.0"
+        }
+        prefix_length: 8
       }
-      prefix_length: 16
+    }
+    action {
+      name: "MyIngress.ipv4_forward"
+      params {
+        name: "dstAddr"
+        value {
+          hex_str: "0x00000000000a"
+        }
+      }
+      params {
+        name: "port"
+        value {
+          hex_str: "0x001"
+        }
+      }
     }
   }
-  action {
-    name: "MyIngress.ipv4_forward"
-    params {
-      name: "dstAddr"
-      value {
-        hex_str: "0x160000000016"
+  index: 2
+}
+
+concrete_entry {
+  pdpi_ir_entry {
+    table_name: "MyIngress.ipv4_lpm"
+    matches {
+      name: "hdr.ipv4.dstAddr"
+      lpm {
+        value {
+          ipv4: "20.20.0.0"
+        }
+        prefix_length: 16
       }
     }
-    params {
-      name: "port"
-      value {
-        hex_str: "0x001"
+    action {
+      name: "MyIngress.ipv4_forward"
+      params {
+        name: "dstAddr"
+        value {
+          hex_str: "0x160000000016"
+        }
+      }
+      params {
+        name: "port"
+        value {
+          hex_str: "0x001"
+        }
       }
     }
   }
+  index: 3
 }
 

--- a/p4_symbolic/ir/expected/table.txt
+++ b/p4_symbolic/ir/expected/table.txt
@@ -420,40 +420,45 @@ deparsers {
 =====MyIngress.ports_exact Entries=====
 
 concrete_entry {
-  table_name: "MyIngress.ports_exact"
-  matches {
-    name: "standard_metadata.ingress_port"
-    exact {
-      hex_str: "0x000"
+  pdpi_ir_entry {
+    table_name: "MyIngress.ports_exact"
+    matches {
+      name: "standard_metadata.ingress_port"
+      exact {
+        hex_str: "0x000"
+      }
     }
-  }
-  action {
-    name: "MyIngress.set_egress_spec"
-    params {
-      name: "port"
-      value {
-        hex_str: "0x001"
+    action {
+      name: "MyIngress.set_egress_spec"
+      params {
+        name: "port"
+        value {
+          hex_str: "0x001"
+        }
       }
     }
   }
 }
 
 concrete_entry {
-  table_name: "MyIngress.ports_exact"
-  matches {
-    name: "standard_metadata.ingress_port"
-    exact {
-      hex_str: "0x001"
+  pdpi_ir_entry {
+    table_name: "MyIngress.ports_exact"
+    matches {
+      name: "standard_metadata.ingress_port"
+      exact {
+        hex_str: "0x001"
+      }
     }
-  }
-  action {
-    name: "MyIngress.set_egress_spec"
-    params {
-      name: "port"
-      value {
-        hex_str: "0x000"
+    action {
+      name: "MyIngress.set_egress_spec"
+      params {
+        name: "port"
+        value {
+          hex_str: "0x000"
+        }
       }
     }
   }
+  index: 1
 }
 

--- a/p4_symbolic/ir/ir.h
+++ b/p4_symbolic/ir/ir.h
@@ -19,13 +19,17 @@
 #ifndef P4_SYMBOLIC_IR_IR_H_
 #define P4_SYMBOLIC_IR_IR_H_
 
+#include <string>
+
 #include "absl/status/statusor.h"
+#include "glog/logging.h"
+#include "google/protobuf/repeated_ptr_field.h"
+#include "p4_pdpi/ir.pb.h"
 #include "p4_symbolic/bmv2/bmv2.pb.h"
 #include "p4_symbolic/ir/ir.pb.h"
 #include "p4_symbolic/ir/table_entries.h"
 
-namespace p4_symbolic {
-namespace ir {
+namespace p4_symbolic::ir {
 
 // The dataplane configuration of the switch.
 // Used as input to our symbolic pipeline.
@@ -55,10 +59,29 @@ inline std::string TableHitAction() { return "__HIT__"; }
 inline std::string TableMissAction() { return "__MISS__"; }
 
 // Transforms bmv2 protobuf and pdpi protobuf into our IR protobuf.
-absl::StatusOr<P4Program> Bmv2AndP4infoToIr(const bmv2::P4Program &bmv2,
-                                            const pdpi::IrP4Info &pdpi);
+absl::StatusOr<P4Program> Bmv2AndP4infoToIr(const bmv2::P4Program& bmv2,
+                                            const pdpi::IrP4Info& pdpi);
 
-} // namespace ir
-} // namespace p4_symbolic
+// Returns a reference to the `ir::TableEntry` contained in the given `entry`.
+const pdpi::IrTableEntry& GetPdpiIrEntryOrSketch(const ir::TableEntry& entry);
 
-#endif // P4_SYMBOLIC_IR_IR_H_
+int GetIndex(const TableEntry& entry);
+
+const std::string& GetTableName(const TableEntry& entry);
+const std::string& GetTableName(const ConcreteTableEntry& entry);
+const std::string& GetTableName(const SymbolicTableEntry& entry);
+
+int GetPriority(const TableEntry& entry);
+int GetPriority(const ConcreteTableEntry& entry);
+int GetPriority(const SymbolicTableEntry& entry);
+
+const google::protobuf::RepeatedPtrField<pdpi::IrMatch>& GetMatches(
+    const TableEntry& entry);
+const google::protobuf::RepeatedPtrField<pdpi::IrMatch>& GetMatches(
+    const ConcreteTableEntry& entry);
+const google::protobuf::RepeatedPtrField<pdpi::IrMatch>& GetMatches(
+    const SymbolicTableEntry& entry);
+
+}  // namespace p4_symbolic::ir
+
+#endif  // P4_SYMBOLIC_IR_IR_H_

--- a/p4_symbolic/ir/ir.proto
+++ b/p4_symbolic/ir/ir.proto
@@ -517,8 +517,30 @@ message BuiltinExpression {
   repeated RValue arguments = 2;
 }
 
+// A concrete table entry, i.e., a table entry where all fields have concrete
+// values.
+message ConcreteTableEntry {
+  // The entry in PDPI IR representation, but using fully qualified names for
+  // tables, actions, etc., instead of aliases like in PDPI.
+  pdpi.IrTableEntry pdpi_ir_entry = 1;
+
+  // The original index of this entry within the user-provided list of entries,
+  // restricted to entries in the same table only.
+  // Useful as a unique ID in formula generation and in user-facing messages.
+  //
+  // Not hoisted to `TableEntry` so it is available to functions operating only
+  // on `ConcreteTableEntry`, not the super type `TableEntry`.
+  int32 index = 2;
+}
+
+// A symbolic table entry, i.e., a table entry where some fields may be
+// symbolic, i.e., are treated like algebraic variables with an unknown value.
 message SymbolicTableEntry {
   // We reuse the PDPI IR table entry to constrain a symbolic table entry.
+  //
+  // Uses fully qualified names for tables, action, etc., instead of aliases
+  // like in PDPI.
+  //
   // General semantics:
   //   - If a field is not set, it is treated as symbolic.
   //   - If a field is set, the concrete value is used to construct an equality
@@ -548,12 +570,20 @@ message SymbolicTableEntry {
   // In the future, we may copy the fields over from the PDPI IR to have more
   // flexbility if needed.
   pdpi.IrTableEntry sketch = 1;
+
+  // The original index of this entry within the user-provided list of entries,
+  // restricted to entries in the same table only.
+  // Useful as a unique ID in formula generation and in user-facing messages.
+  //
+  // Not hoisted to `TableEntry` so it is available to functions operating only
+  // on `SymbolicTableEntry`, not the super type `TableEntry`.
+  int32 index = 3;
 }
 
 // Describes a table entry, which may be concrete or symbolic.
 message TableEntry {
   oneof entry {
-    pdpi.IrTableEntry concrete_entry = 1;
+    ConcreteTableEntry concrete_entry = 1;
     SymbolicTableEntry symbolic_entry = 2;
   }
 }

--- a/p4_symbolic/packet_synthesizer/criteria_generator.cc
+++ b/p4_symbolic/packet_synthesizer/criteria_generator.cc
@@ -84,7 +84,7 @@ GenerateSynthesisCriteriaFor(const EntryCoverageGoal& goal,
     bool table_is_empty = true;
     auto it = solver_state.context.table_entries.find(table_name);
     if (it != solver_state.context.table_entries.end()) {
-      const std::vector<symbolic::TableEntry>& entries = it->second;
+      const std::vector<ir::TableEntry>& entries = it->second;
       if (!entries.empty()) table_is_empty = false;
       for (int i = 0; i < entries.size(); i++) {
         criteria.mutable_table_entry_reachability_criteria()->set_match_index(

--- a/p4_symbolic/sai/BUILD.bazel
+++ b/p4_symbolic/sai/BUILD.bazel
@@ -25,6 +25,7 @@ cc_library(
         "//gutil:status",
         "//p4_pdpi:ir_cc_proto",
         "//p4_pdpi/internal:ordered_map",
+        "//p4_symbolic/ir",
         "//p4_symbolic/ir:ir_cc_proto",
         "//p4_symbolic/symbolic",
         "@com_github_z3prover_z3//:api",

--- a/p4_symbolic/symbolic/BUILD.bazel
+++ b/p4_symbolic/symbolic/BUILD.bazel
@@ -214,6 +214,7 @@ cc_test(
     ],
     deps = [
         ":symbolic",
+        "//gutil:proto_matchers",
         "//gutil:status",
         "//gutil:status_matchers",
         "//p4_pdpi:ir_cc_proto",

--- a/p4_symbolic/symbolic/action.h
+++ b/p4_symbolic/symbolic/action.h
@@ -111,13 +111,13 @@ absl::Status EvaluateConcreteAction(
 // parameters of the given `entry`.
 // This applies the action with symbolic parameters on the symbolic `headers`.
 absl::Status EvaluateSymbolicAction(const ir::Action &action,
-                                    const TableEntry &entry, SolverState &state,
+                                    const ir::SymbolicTableEntry &entry,
+                                    SolverState &state,
                                     SymbolicPerPacketState &headers,
                                     const z3::expr &guard);
 
+}  // namespace action
+}  // namespace symbolic
+}  // namespace p4_symbolic
 
-} // namespace action
-} // namespace symbolic
-} // namespace p4_symbolic
-
-#endif // P4_SYMBOLIC_SYMBOLIC_ACTION_H_
+#endif  // P4_SYMBOLIC_SYMBOLIC_ACTION_H_

--- a/p4_symbolic/symbolic/context.h
+++ b/p4_symbolic/symbolic/context.h
@@ -17,10 +17,11 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "absl/container/btree_map.h"
+#include "p4_symbolic/ir/table_entries.h"
 #include "p4_symbolic/symbolic/guarded_map.h"
-#include "p4_symbolic/symbolic/table_entry.h"
 #include "z3++.h"
 
 namespace p4_symbolic {
@@ -105,7 +106,9 @@ struct ConcreteContext {
   ConcretePerPacketState egress_headers;
   std::string serialized_ingress_headers;
   std::string serialized_egress_headers;
-  TableEntries table_entries;
+  // We use an ordered map to ensure deterministic traversals.
+  absl::btree_map<std::string, std::vector<ir::ConcreteTableEntry>>
+      table_entries;
   ConcreteTrace trace;  // Expected trace in the program.
 
   std::string to_string(bool verbose = false) const;
@@ -133,7 +136,7 @@ class SymbolicContext {
   SymbolicPerPacketState ingress_headers;
   SymbolicPerPacketState parsed_headers;
   SymbolicPerPacketState egress_headers;
-  TableEntries table_entries;
+  ir::TableEntries table_entries;
   SymbolicTrace trace;
 };
 

--- a/p4_symbolic/symbolic/table_entry.h
+++ b/p4_symbolic/symbolic/table_entry.h
@@ -39,115 +39,49 @@ struct SymbolicMatchVariables {
   z3::expr mask;
 };
 
-// Contains the symbolic variable names and bit-width of the symbolic match of a
-// table entry.
-struct SymbolicMatchInfo {
-  p4::config::v1::MatchField::MatchType match_type;
-  int bitwidth;
-  // Value variable name of the symbolic match. It looks like
-  // "<table_name>_entry_<index>_<match_name>_<match_type>_value".
-  std::string value_variable_name;
-  // Value variable name of the symbolic match. It looks like
-  // "<table_name>_entry_<index>_<match_name>_<match_type>_mask".
-  std::string mask_variable_name;
+struct TableEntryPriorityParams {
+  // Must be set to a non-zero value if and only if the match key includes a
+  // P4Runtime optional, ternary, or range match.
+  int priority = 0;
+  // Must be set if and only if `priority == 0` and the match key includes
+  // exactly 1 P4Runtime LPM match. If set, must have a non-negative value.
+  std::optional<size_t> prefix_length;
 };
 
-// Contains the symbolic variable name and bit-width of the symbolic action
-// parameter of a table entry.
-struct SymbolicActionParameterInfo {
-  // Variable name of the symbolic action parameter. It looks like
-  // "<table_name>_entry_<index>_<action_name>_<param_name>".
-  std::string variable_name;
-  int bitwidth;
-};
+// Returns the symbolic variable of the action parameter with the given
+// `param_name` in the `action`. Returns an error if this is not a symbolic
+// entry.
+absl::StatusOr<z3::expr> GetSymbolicActionParameter(
+    const ir::SymbolicTableEntry &symbolic_entry, absl::string_view param_name,
+    const ir::Action &action, const ir::Table &table, z3::context &z3_context);
 
-class TableEntry {
- public:
-  // Constructs a table entry object, where the `index` is the original index of
-  // the entry in the table and the `ir_entry` is the entry in P4-Symbolic IR.
-  TableEntry(int index, ir::TableEntry ir_entry);
+// Returns the symbolic variable of the action invocation with the given
+// `action_name`. Returns an error if this is not a symbolic entry.
+absl::StatusOr<z3::expr> GetSymbolicActionInvocation(
+    const ir::SymbolicTableEntry &symbolic_entry, absl::string_view action_name,
+    const ir::Table &table, z3::context &z3_context);
 
-  // Returns the original index of the entry as installed in the table.
-  int GetIndex() const;
-  // Returns true if the IR entry has a concrete entry.
-  bool IsConcrete() const;
-  // Returns true if the IR entry has a symbolic entry.
-  bool IsSymbolic() const;
-  // Returns the table name of the table to which the entry belongs.
-  const std::string &GetTableName() const;
-  // Returns the P4-Symbolic IR table entry.
-  const ir::TableEntry &GetP4SymbolicIrTableEntry() const;
-  // Returns the PDPI IR table entry, which may represent a concrete entry or
-  // the skeleton for a symbolic entry.
-  // Note: If symbolic, the returned entry may not be a well-formed PDPI IR
-  // entry. See p4_symbolic/ir/ir.proto for details.
-  const pdpi::IrTableEntry &GetPdpiIrTableEntry() const;
-
-  // Returns the symbolic variables of the symbolic match with the given
-  // `match_name`. Returns an error if this is not a symbolic entry.
-  absl::StatusOr<SymbolicMatchVariables> GetMatchValues(
-      absl::string_view match_name, const ir::Table &table,
-      const ir::P4Program &program, z3::context &z3_context) const;
-  // Returns the symbolic variable of the action invocation with the given
-  // `action_name`. Returns an error if this is not a symbolic entry.
-  absl::StatusOr<z3::expr> GetActionInvocation(absl::string_view action_name,
-                                               const ir::Table &table,
-                                               z3::context &z3_context) const;
-  // Returns the symbolic variable of the action parameter with the given
-  // `param_name` in the `action`. Returns an error if this is not a symbolic
-  // entry.
-  absl::StatusOr<z3::expr> GetActionParameter(absl::string_view param_name,
-                                              const ir::Action &action,
-                                              const ir::Table &table,
-                                              z3::context &z3_context) const;
-
-  // Translates the table and action names back to the aliases.
-  // This should be called when synthesizing concrete entries used on other
-  // target platforms. PDPI maps are keyed by the alias names. This function
-  // makes the table entry compatible with PDPI formats.
-  // TODO: Consider removing this function if we switch to using
-  // aliases as table/action names in P4-Symbolic.
-  void ConvertToTableAndActionAliases(const ir::P4Program &program);
-
- private:
-  int index_;                // The original index of the entry in the table.
-  ir::TableEntry ir_entry_;  // Entry in P4-Symbolic IR.
-
-  // Returns the symbolic variable names, the bit-width, and the match type of
-  // the symbolic match with the given `match_name`. An error is returned if
-  // this is not a symbolic entry, or if the given `match_name` is not found in
-  // the table definition.
-  absl::StatusOr<SymbolicMatchInfo> GetSymbolicMatchInfo(
-      absl::string_view match_name, const ir::Table &table,
-      const ir::P4Program &program) const;
-  // Returns the symbolic variable name of the action invocation with the given
-  // `action_name`. An error is returned if this is not a symbolic entry, or if
-  // the given `action_name` is not found in the table definition.
-  absl::StatusOr<std::string> GetActionChoiceSymbolicVariableName(
-      absl::string_view action_name, const ir::Table &table) const;
-  // Returns the symbolic variable name and the bit-width of the action
-  // parameter with the given `action_name` and `param_name`. An error is
-  // returned if this is not a symbolic entry, or if the given `action_name` and
-  // `param_name` are not found in the table and action definition.
-  absl::StatusOr<SymbolicActionParameterInfo> GetSymbolicActionParameterInfo(
-      absl::string_view param_name, const ir::Action &action,
-      const ir::Table &table) const;
-};
-
-using TableEntries = absl::btree_map<std::string, std::vector<TableEntry>>;
+// Returns the symbolic variables of the symbolic match with the given
+// `match_name`. Returns an error if this is not a symbolic entry.
+absl::StatusOr<SymbolicMatchVariables> GetSymbolicMatch(
+    const ir::SymbolicTableEntry &symbolic_entry, absl::string_view match_name,
+    const ir::Table &table, const ir::P4Program &program,
+    z3::context &z3_context);
 
 // Returns a fully symbolic IR table entry for the given `table`.
 // All matches will be specified as a symbolic match.
-// If the given `table` has ternary or optional matches, the `priority` must be
-// provided with a positive value, and it is set concretely in the table entry
-// for deterministic entry priority. Otherwise the `priority` must be 0.
-// If the given `table` has no ternary or optional matches, and has exactly 1
-// LPM match with zero or more exact matches, the `prefix_length` must be
-// provided with a non-negative value, and it is set concretely in the table
-// entry for deterministic entry priority.
-absl::StatusOr<ir::TableEntry> CreateSymbolicIrTableEntry(
-    const ir::Table &table, int priority = 0,
-    std::optional<size_t> prefix_length = std::nullopt);
+// If the given `table` has ternary or optional matches,
+// `priority_params.priority` must be provided with a positive value, and it is
+// set concretely in the table entry for deterministic entry priority. Otherwise
+// the priority must be 0. If the given `table` has no ternary or optional
+// matches, and has exactly 1 LPM match with zero or more exact matches,
+// `priority_params.prefix_length` must be provided with a non-negative value,
+// and it is set concretely in the table entry for deterministic entry priority.
+//
+// TODO: This should probably live in ir/ir.h instead.
+absl::StatusOr<ir::SymbolicTableEntry> CreateSymbolicIrTableEntry(
+    int table_entry_index, const ir::Table &table,
+    const TableEntryPriorityParams &priority_params = {});
 
 // Creates symbolic variables and adds constraints for each field match of the
 // given `entry` in the given `table`. We don't create symbolic variables for
@@ -155,26 +89,22 @@ absl::StatusOr<ir::TableEntry> CreateSymbolicIrTableEntry(
 // based on the P4Runtime specification. If those symbolic variables are needed
 // later, calling the `GetMatchValues` function will automatically create the
 // corresponding variables for the entry match.
-absl::Status InitializeSymbolicMatches(const TableEntry &entry,
-                                       const ir::Table &table,
-                                       const ir::P4Program &program,
-                                       z3::context &z3_context,
-                                       z3::solver &solver,
-                                       values::P4RuntimeTranslator &translator);
+absl::Status InitializeSymbolicMatches(
+    const ir::SymbolicTableEntry &symbolic_entry, const ir::Table &table,
+    const ir::P4Program &program, z3::context &z3_context, z3::solver &solver,
+    values::P4RuntimeTranslator &translator);
 
 // Creates symbolic variables and adds constraints for the given `entry`, for
 // each action and each action parameter in the given `table`.
-absl::Status InitializeSymbolicActions(const TableEntry &entry,
-                                       const ir::Table &table,
-                                       const ir::P4Program &program,
-                                       z3::context &z3_context,
-                                       z3::solver &solver,
-                                       values::P4RuntimeTranslator &translator);
+absl::Status InitializeSymbolicActions(
+    const ir::SymbolicTableEntry &symbolic_entry, const ir::Table &table,
+    const ir::P4Program &program, z3::context &z3_context, z3::solver &solver,
+    values::P4RuntimeTranslator &translator);
 
 // Returns a concrete table entry extracted from the given `symbolic_entry`
 // based on the given `model` and `translator`.
-absl::StatusOr<TableEntry> ExtractConcreteEntryFromModel(
-    const TableEntry &symbolic_entry, const z3::model &model,
+absl::StatusOr<ir::ConcreteTableEntry> ExtractConcreteEntryFromModel(
+    const ir::SymbolicTableEntry &symbolic_entry, const z3::model &model,
     const ir::P4Program &program, const values::P4RuntimeTranslator &translator,
     z3::context &z3_context);
 

--- a/p4_symbolic/symbolic/table_entry_test.cc
+++ b/p4_symbolic/symbolic/table_entry_test.cc
@@ -27,6 +27,7 @@
 #include "gmock/gmock.h"
 #include "google/protobuf/util/message_differencer.h"
 #include "gtest/gtest.h"
+#include "gutil/proto_matchers.h"
 #include "gutil/status.h"
 #include "gutil/status_matchers.h"
 #include "p4/config/v1/p4info.pb.h"
@@ -90,45 +91,41 @@ class IPv4RoutingTableEntriesTest : public testing::Test {
 
 TEST_F(IPv4RoutingTableEntriesTest, SymbolicEntryWithGetterFunctions) {
   constexpr int entry_index = 0;
-  constexpr int priority = 0;
-  constexpr int prefix_length = 16;
+  constexpr auto priority_params = TableEntryPriorityParams{
+      .priority = 0,
+      .prefix_length = 16,
+  };
 
   // Construct a symbolic table entry.
   ASSERT_OK_AND_ASSIGN(ir::Table table, GetTable());
   ASSERT_OK_AND_ASSIGN(
-      ir::TableEntry ir_entry,
-      CreateSymbolicIrTableEntry(table, priority, prefix_length));
-  TableEntry entry(entry_index, std::move(ir_entry));
-
+      ir::SymbolicTableEntry symbolic_entry,
+      CreateSymbolicIrTableEntry(entry_index, table, priority_params));
 
   // Test all basic getter functions.
-  EXPECT_EQ(entry.GetIndex(), entry_index);
-  EXPECT_FALSE(entry.IsConcrete());
-  EXPECT_TRUE(entry.IsSymbolic());
-  EXPECT_EQ(entry.GetTableName(), "MyIngress.ipv4_lpm");
-  EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
-      entry.GetP4SymbolicIrTableEntry().symbolic_entry().sketch(),
-      entry.GetPdpiIrTableEntry()));
-  EXPECT_EQ(entry.GetPdpiIrTableEntry().matches_size(), 1);
-  EXPECT_TRUE(entry.GetPdpiIrTableEntry().matches(0).has_lpm());
-  EXPECT_EQ(entry.GetPdpiIrTableEntry().matches(0).lpm().prefix_length(),
-            prefix_length);
+  EXPECT_EQ(symbolic_entry.index(), entry_index);
+  EXPECT_EQ(ir::GetTableName(symbolic_entry), "MyIngress.ipv4_lpm");
+  ASSERT_THAT(ir::GetMatches(symbolic_entry), testing::SizeIs(1));
+  ASSERT_TRUE(ir::GetMatches(symbolic_entry).Get(0).has_lpm());
+  EXPECT_EQ(ir::GetMatches(symbolic_entry).Get(0).lpm().prefix_length(),
+            priority_params.prefix_length);
 }
 
 TEST_F(IPv4RoutingTableEntriesTest, MatchVariablesOfSymbolicEntry) {
   constexpr int entry_index = 0;
-  constexpr int priority = 0;
-  constexpr int prefix_length = 16;
+  constexpr auto priority_params = TableEntryPriorityParams{
+      .priority = 0,
+      .prefix_length = 16,
+  };
 
   // Construct a symbolic table entry.
   ASSERT_OK_AND_ASSIGN(ir::Table table, GetTable());
   ASSERT_OK_AND_ASSIGN(
-      ir::TableEntry ir_entry,
-      CreateSymbolicIrTableEntry(table, priority, prefix_length));
-  TableEntry entry(entry_index, std::move(ir_entry));
+      ir::SymbolicTableEntry symbolic_entry,
+      CreateSymbolicIrTableEntry(entry_index, table, priority_params));
 
   // Test the symbolic variables of the symbolic LPM match.
-  const std::string &match_name = entry.GetPdpiIrTableEntry().matches(0).name();
+  const std::string &match_name = ir::GetMatches(symbolic_entry).Get(0).name();
   int bitwidth = table.table_definition()
                      .match_fields_by_name()
                      .begin()
@@ -136,9 +133,10 @@ TEST_F(IPv4RoutingTableEntriesTest, MatchVariablesOfSymbolicEntry) {
                      .bitwidth();
   constexpr absl::string_view variable_prefix =
       "MyIngress.ipv4_lpm_entry_0_hdr.ipv4.dstAddr_lpm_";
-  ASSERT_OK_AND_ASSIGN(SymbolicMatchVariables match_variables,
-                       entry.GetMatchValues(match_name, table, state_->program,
-                                            *state_->context.z3_context));
+  ASSERT_OK_AND_ASSIGN(
+      SymbolicMatchVariables match_variables,
+      GetSymbolicMatch(symbolic_entry, match_name, table, state_->program,
+                       *state_->context.z3_context));
   EXPECT_EQ(match_variables.match_type, MatchType::MatchField_MatchType_LPM);
   z3::expr expected_value_expr = state_->context.z3_context->bv_const(
       absl::StrCat(variable_prefix, "value").c_str(), bitwidth);
@@ -150,23 +148,24 @@ TEST_F(IPv4RoutingTableEntriesTest, MatchVariablesOfSymbolicEntry) {
 
 TEST_F(IPv4RoutingTableEntriesTest, ActionInvocationVariablesOfSymbolicEntry) {
   constexpr int entry_index = 0;
-  constexpr int priority = 0;
-  constexpr int prefix_length = 16;
+  constexpr auto priority_params = TableEntryPriorityParams{
+      .priority = 0,
+      .prefix_length = 16,
+  };
 
   // Construct a symbolic table entry.
   ASSERT_OK_AND_ASSIGN(ir::Table table, GetTable());
   ASSERT_OK_AND_ASSIGN(
-      ir::TableEntry ir_entry,
-      CreateSymbolicIrTableEntry(table, priority, prefix_length));
-  TableEntry entry(entry_index, std::move(ir_entry));
+      ir::SymbolicTableEntry symbolic_entry,
+      CreateSymbolicIrTableEntry(entry_index, table, priority_params));
 
   // Test the symbolic variables of the symbolic action invocations.
-
   for (const auto &action_ref : table.table_definition().entry_actions()) {
     const std::string &action_name = action_ref.action().preamble().name();
-    ASSERT_OK_AND_ASSIGN(z3::expr action_invocation,
-                         entry.GetActionInvocation(
-                             action_name, table, *state_->context.z3_context));
+    ASSERT_OK_AND_ASSIGN(
+        z3::expr action_invocation,
+        GetSymbolicActionInvocation(symbolic_entry, action_name, table,
+                                    *state_->context.z3_context));
     z3::expr expected_action_invocation =
         state_->context.z3_context->bool_const(
             absl::StrCat("MyIngress.ipv4_lpm_entry_0_", action_name,
@@ -178,15 +177,16 @@ TEST_F(IPv4RoutingTableEntriesTest, ActionInvocationVariablesOfSymbolicEntry) {
 
 TEST_F(IPv4RoutingTableEntriesTest, ActionParameterVariablesOfSymbolicEntry) {
   constexpr int entry_index = 0;
-  constexpr int priority = 0;
-  constexpr int prefix_length = 16;
+  constexpr auto priority_params = TableEntryPriorityParams{
+      .priority = 0,
+      .prefix_length = 16,
+  };
 
   // Construct a symbolic table entry.
   ASSERT_OK_AND_ASSIGN(ir::Table table, GetTable());
   ASSERT_OK_AND_ASSIGN(
-      ir::TableEntry ir_entry,
-      CreateSymbolicIrTableEntry(table, priority, prefix_length));
-  TableEntry entry(entry_index, std::move(ir_entry));
+      ir::SymbolicTableEntry symbolic_entry,
+      CreateSymbolicIrTableEntry(entry_index, table, priority_params));
 
   // Test the symbolic variables of the symbolic action parameters.
   for (const auto &action_ref : table.table_definition().entry_actions()) {
@@ -196,9 +196,10 @@ TEST_F(IPv4RoutingTableEntriesTest, ActionParameterVariablesOfSymbolicEntry) {
 
     for (const auto &[param_name, param_definition] :
          action_ref.action().params_by_name()) {
-      ASSERT_OK_AND_ASSIGN(z3::expr param, entry.GetActionParameter(
-                                               param_name, action, table,
-                                               *state_->context.z3_context));
+      ASSERT_OK_AND_ASSIGN(
+          z3::expr param,
+          GetSymbolicActionParameter(symbolic_entry, param_name, action, table,
+                                     *state_->context.z3_context));
       z3::expr expected_param = state_->context.z3_context->bv_const(
           absl::StrCat("MyIngress.ipv4_lpm_entry_0_", action_name, "_",
                        param_name)
@@ -211,45 +212,45 @@ TEST_F(IPv4RoutingTableEntriesTest, ActionParameterVariablesOfSymbolicEntry) {
 
 TEST_F(IPv4RoutingTableEntriesTest, ErrorWithNonExistentMatch) {
   constexpr int entry_index = 0;
-  constexpr int priority = 0;
-  constexpr int prefix_length = 16;
+  constexpr auto priority_params = TableEntryPriorityParams{
+      .priority = 0,
+      .prefix_length = 16,
+  };
 
   // Construct a symbolic table entry.
   ASSERT_OK_AND_ASSIGN(ir::Table table, GetTable());
   ASSERT_OK_AND_ASSIGN(
-      ir::TableEntry ir_entry,
-      CreateSymbolicIrTableEntry(table, priority, prefix_length));
-  TableEntry entry(entry_index, std::move(ir_entry));
+      ir::SymbolicTableEntry symbolic_entry,
+      CreateSymbolicIrTableEntry(entry_index, table, priority_params));
 
   // Test getting the symbolic variables of a non-existent match.
   constexpr absl::string_view non_existent_match_name = "non_existent_match";
-  EXPECT_THAT(
-      entry.GetMatchValues(non_existent_match_name, table, state_->program,
-                           *state_->context.z3_context),
-      StatusIs(absl::StatusCode::kNotFound,
-               "Match 'non_existent_match' not found in table "
-               "'MyIngress.ipv4_lpm'"));
+  EXPECT_THAT(GetSymbolicMatch(symbolic_entry, non_existent_match_name, table,
+                               state_->program, *state_->context.z3_context),
+              StatusIs(absl::StatusCode::kNotFound,
+                       "Match 'non_existent_match' not found in table "
+                       "'MyIngress.ipv4_lpm'"));
 }
 
 TEST_F(IPv4RoutingTableEntriesTest, ErrorWithWildcardMatch) {
   constexpr int entry_index = 0;
-  constexpr int priority = 0;
-  constexpr int prefix_length = 16;
+  constexpr auto priority_params = TableEntryPriorityParams{
+      .priority = 0,
+      .prefix_length = 16,
+  };
 
   // Construct a symbolic table entry with all wildcard matches.
   ASSERT_OK_AND_ASSIGN(ir::Table table, GetTable());
   ASSERT_OK_AND_ASSIGN(
-      ir::TableEntry ir_entry,
-      CreateSymbolicIrTableEntry(table, priority, prefix_length));
-  TableEntry non_wildcard_entry(entry_index, ir_entry);
-  ir_entry.mutable_symbolic_entry()->mutable_sketch()->clear_matches();
-  TableEntry entry(entry_index, ir_entry);
+      ir::SymbolicTableEntry wildcard_entry,
+      CreateSymbolicIrTableEntry(entry_index, table, priority_params));
+  wildcard_entry.mutable_sketch()->clear_matches();
 
   // Test getting the symbolic variables of an all-wildcard symbolic entry.
   constexpr absl::string_view match_name = "hdr.ipv4.dstAddr";
   EXPECT_THAT(
-      entry.GetMatchValues(match_name, table, state_->program,
-                           *state_->context.z3_context),
+      GetSymbolicMatch(wildcard_entry, match_name, table, state_->program,
+                       *state_->context.z3_context),
       StatusIs(absl::StatusCode::kInvalidArgument,
                testing::StartsWith(absl::StrCat(
                    "Match '", match_name, "' is an explicit wildcard."))));
@@ -257,23 +258,25 @@ TEST_F(IPv4RoutingTableEntriesTest, ErrorWithWildcardMatch) {
 
 TEST_F(IPv4RoutingTableEntriesTest, ErrorWithNonExistentAction) {
   constexpr int entry_index = 0;
-  constexpr int priority = 0;
-  constexpr int prefix_length = 16;
+  constexpr auto priority_params = TableEntryPriorityParams{
+      .priority = 0,
+      .prefix_length = 16,
+  };
 
   // Construct a symbolic table entry.
   ASSERT_OK_AND_ASSIGN(ir::Table table, GetTable());
   ASSERT_OK_AND_ASSIGN(
-      ir::TableEntry ir_entry,
-      CreateSymbolicIrTableEntry(table, priority, prefix_length));
-  TableEntry entry(entry_index, std::move(ir_entry));
+      ir::SymbolicTableEntry symbolic_entry,
+      CreateSymbolicIrTableEntry(entry_index, table, priority_params));
 
   // Test getting the symbolic variables of a non-existent action.
   constexpr absl::string_view non_existent_action_name = "non_existent_action";
-  EXPECT_THAT(entry.GetActionInvocation(non_existent_action_name, table,
-                                        *state_->context.z3_context),
-              StatusIs(absl::StatusCode::kNotFound,
-                       "Action 'non_existent_action' not found in table "
-                       "'MyIngress.ipv4_lpm'"));
+  EXPECT_THAT(
+      GetSymbolicActionInvocation(symbolic_entry, non_existent_action_name,
+                                  table, *state_->context.z3_context),
+      StatusIs(absl::StatusCode::kNotFound,
+               "Action 'non_existent_action' not found in table "
+               "'MyIngress.ipv4_lpm'"));
 
   constexpr absl::string_view param_name = "dstAddr";
   const std::string &valid_action_name = table.table_definition()
@@ -288,8 +291,9 @@ TEST_F(IPv4RoutingTableEntriesTest, ErrorWithNonExistentAction) {
   ir::Action non_existent_action = valid_action;
   non_existent_action.mutable_action_definition()->mutable_preamble()->set_name(
       non_existent_action_name);
-  EXPECT_THAT(entry.GetActionParameter(param_name, non_existent_action, table,
-                                       *state_->context.z3_context),
+  EXPECT_THAT(GetSymbolicActionParameter(symbolic_entry, param_name,
+                                         non_existent_action, table,
+                                         *state_->context.z3_context),
               StatusIs(absl::StatusCode::kNotFound,
                        "Action 'non_existent_action' not found in table "
                        "'MyIngress.ipv4_lpm'"));
@@ -297,15 +301,16 @@ TEST_F(IPv4RoutingTableEntriesTest, ErrorWithNonExistentAction) {
 
 TEST_F(IPv4RoutingTableEntriesTest, ErrorWithNonExistentActionParameter) {
   constexpr int entry_index = 0;
-  constexpr int priority = 0;
-  constexpr int prefix_length = 16;
+  constexpr auto priority_params = TableEntryPriorityParams{
+      .priority = 0,
+      .prefix_length = 16,
+  };
 
   // Construct a symbolic table entry.
   ASSERT_OK_AND_ASSIGN(ir::Table table, GetTable());
   ASSERT_OK_AND_ASSIGN(
-      ir::TableEntry ir_entry,
-      CreateSymbolicIrTableEntry(table, priority, prefix_length));
-  TableEntry entry(entry_index, std::move(ir_entry));
+      ir::SymbolicTableEntry symbolic_entry,
+      CreateSymbolicIrTableEntry(entry_index, table, priority_params));
 
   // Test getting the symbolic variables of a non-existent action parameter.
   constexpr absl::string_view non_existent_param_name = "non_existent_param";
@@ -314,8 +319,8 @@ TEST_F(IPv4RoutingTableEntriesTest, ErrorWithNonExistentActionParameter) {
     ASSERT_TRUE(state_->program.actions().contains(action_name));
     const ir::Action &action = state_->program.actions().at(action_name);
     EXPECT_THAT(
-        entry.GetActionParameter(non_existent_param_name, action, table,
-                                 *state_->context.z3_context),
+        GetSymbolicActionParameter(symbolic_entry, non_existent_param_name,
+                                   action, table, *state_->context.z3_context),
         StatusIs(absl::StatusCode::kNotFound,
                  absl::StrCat("Action parameter 'non_existent_param' not found "
                               "in implementation of action '",
@@ -326,71 +331,17 @@ TEST_F(IPv4RoutingTableEntriesTest, ErrorWithNonExistentActionParameter) {
 TEST_F(IPv4RoutingTableEntriesTest, ConcreteEntriesWithGetterFunctions) {
   for (const auto &[table_name, per_table_ir_entries] : ir_entries_) {
     for (size_t index = 0; index < per_table_ir_entries.size(); ++index) {
-      // For each concrete IR entry, create a table entry object.
-      const ir::TableEntry &ir_entry = per_table_ir_entries[index];
-      TableEntry entry(index, ir_entry);
+      const ir::TableEntry &entry = per_table_ir_entries[index];
 
       // Test all basic getter functions.
-      EXPECT_EQ(entry.GetIndex(), index);
-      EXPECT_TRUE(entry.IsConcrete());
-      EXPECT_FALSE(entry.IsSymbolic());
-      EXPECT_EQ(entry.GetTableName(), table_name);
-      EXPECT_EQ(entry.GetTableName(), "MyIngress.ipv4_lpm");
-      EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
-          entry.GetP4SymbolicIrTableEntry().concrete_entry(),
-          entry.GetPdpiIrTableEntry()));
-      EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
-          entry.GetP4SymbolicIrTableEntry(), ir_entry));
-      EXPECT_EQ(entry.GetPdpiIrTableEntry().matches_size(), 1);
-      EXPECT_TRUE(entry.GetPdpiIrTableEntry().matches(0).has_lpm());
-    }
-  }
-}
-
-TEST_F(IPv4RoutingTableEntriesTest,
-       ErrorGettingSymbolicVariablesWithConcreteEntries) {
-  for (const auto &[table_name, per_table_ir_entries] : ir_entries_) {
-    for (size_t index = 0; index < per_table_ir_entries.size(); ++index) {
-      // For each concrete IR entry, create a table entry object.
-      const ir::TableEntry &ir_entry = per_table_ir_entries[index];
-      TableEntry entry(index, ir_entry);
-
-      // Test getting the symbolic variables of a concrete entry.
-      ASSERT_EQ(state_->program.tables_size(), 1);
-      const ir::Table &table = state_->program.tables().begin()->second;
-      ASSERT_EQ(entry.GetPdpiIrTableEntry().matches_size(), 1);
-      const std::string &match_name =
-          entry.GetPdpiIrTableEntry().matches(0).name();
-      ASSERT_TRUE(entry.GetPdpiIrTableEntry().has_action());
-      const std::string &action_name =
-          entry.GetPdpiIrTableEntry().action().name();
-      ASSERT_TRUE(state_->program.actions().contains(action_name));
-      const ir::Action &action = state_->program.actions().at(action_name);
-
-      EXPECT_THAT(
-          entry.GetMatchValues(match_name, table, state_->program,
-                               *state_->context.z3_context),
-          StatusIs(
-              absl::StatusCode::kInvalidArgument,
-              absl::StrCat("Entry ", index,
-                           " of table 'MyIngress.ipv4_lpm' is not symbolic.")));
-      EXPECT_THAT(
-          entry.GetActionInvocation(action_name, table,
-                                    *state_->context.z3_context),
-          StatusIs(
-              absl::StatusCode::kInvalidArgument,
-              absl::StrCat("Entry ", index,
-                           " of table 'MyIngress.ipv4_lpm' is not symbolic.")));
-
-      for (const auto &param : entry.GetPdpiIrTableEntry().action().params()) {
-        EXPECT_THAT(
-            entry.GetActionParameter(param.name(), action, table,
-                                     *state_->context.z3_context),
-            StatusIs(absl::StatusCode::kInvalidArgument,
-                     absl::StrCat(
-                         "Entry ", index,
-                         " of table 'MyIngress.ipv4_lpm' is not symbolic.")));
-      }
+      EXPECT_EQ(ir::GetIndex(entry), index);
+      EXPECT_THAT(entry, gutil::HasOneofCase<ir::TableEntry>(
+                             "entry", ir::TableEntry::kConcreteEntry));
+      EXPECT_EQ(ir::GetTableName(entry), table_name);
+      EXPECT_EQ(ir::GetTableName(entry), "MyIngress.ipv4_lpm");
+      EXPECT_THAT(ir::GetPdpiIrEntryOrSketch(entry),
+                  gutil::EqualsProto(entry.concrete_entry().pdpi_ir_entry()));
+      EXPECT_THAT(ir::GetMatches(entry), testing::SizeIs(1));
     }
   }
 }


### PR DESCRIPTION
Keyword Check:
~/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.






Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 690 targets (0 packages loaded, 0 targets configured).
INFO: Found 690 targets...
INFO: From Compiling p4_symbolic/ir/cfg.cc:
In file included from p4_symbolic/ir/cfg.cc:15:
./p4_symbolic/ir/cfg.h:79:3: warning: multi-line comment [-Wcomment]
   79 |   //             /             \
      |   ^
p4_symbolic/ir/cfg.cc:349:5: warning: multi-line comment [-Wcomment]
  349 |     //      /  \
      |     ^
p4_symbolic/ir/cfg.cc:388:7: warning: multi-line comment [-Wcomment]
  388 |       //      /  \
      |       ^
p4_symbolic/ir/cfg.cc: In function 'p4_symbolic::ir::ControlPath p4_symbolic::ir::{anonymous}::LongestCommonPrefix(const ControlPath&, const ControlPath&)':
p4_symbolic/ir/cfg.cc:101:16: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<std::__cxx11::basic_string<char> >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  101 |   while (index < l.size() && index < r.size() && l[index] == r[index]) {
      |          ~~~~~~^~~~~~~~~~
p4_symbolic/ir/cfg.cc:101:36: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<std::__cxx11::basic_string<char> >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  101 |   while (index < l.size() && index < r.size() && l[index] == r[index]) {
      |                              ~~~~~~^~~~~~~~~~
INFO: From Compiling p4_symbolic/sai/sai.cc:
In file included from ./p4_symbolic/z3_util.h:26,
                 from ./p4_symbolic/symbolic/symbolic.h:36,
INFO: From Compiling p4_symbolic/ir/cfg.cc [for host]:
In file included from p4_symbolic/ir/cfg.cc:15:
./p4_symbolic/ir/cfg.h:79:3: warning: multi-line comment [-Wcomment]
   79 |   //             /             \
      |   ^
p4_symbolic/ir/cfg.cc:349:5: warning: multi-line comment [-Wcomment]
  349 |     //      /  \
      |     ^
p4_symbolic/ir/cfg.cc:388:7: warning: multi-line comment [-Wcomment]
  388 |       //      /  \
      |       ^
p4_symbolic/ir/cfg.cc: In function 'p4_symbolic::ir::ControlPath p4_symbolic::ir::{anonymous}::LongestCommonPrefix(const ControlPath&, const ControlPath&)':
p4_symbolic/ir/cfg.cc:101:16: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<std::__cxx11::basic_string<char> >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  101 |   while (index < l.size() && index < r.size() && l[index] == r[index]) {
      |          ~~~~~~^~~~~~~~~~
p4_symbolic/ir/cfg.cc:101:36: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<std::__cxx11::basic_string<char> >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  101 |   while (index < l.size() && index < r.size() && l[index] == r[index]) {
      |                              ~~~~~~^~~~~~~~~~
INFO: From Compiling p4_symbolic/ir/ir.cc [for host]:
In file included from p4_symbolic/ir/ir.cc:37:
./p4_symbolic/ir/cfg.h:79:3: warning: multi-line comment [-Wcomment]
   79 |   //             /             \
      |   ^
INFO: Elapsed time: 54.973s, Critical Path: 9.15s
INFO: 52 processes: 1 internal, 51 linux-sandbox.
INFO: Build completed successfully, 52 total actions






Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 690 targets (0 packages loaded, 0 targets configured).
INFO: Found 472 targets and 218 test targets...
INFO: Elapsed time: 205.554s, Critical Path: 119.33s
INFO: 272 processes: 327 linux-sandbox, 18 local.
INFO: Build completed successfully, 272 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.7s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 0.6s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.0s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.0s
//dvaas:test_vector_stats_test                                           PASSED in 0.0s
//dvaas:test_vector_test                                                 PASSED in 0.6s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.1s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 0.6s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.7s
//p4rt_app/tests:resource_limits_test                                    PASSED in 2.8s
//p4rt_app/tests:response_path_test                                      PASSED in 5.8s
//p4rt_app/tests:role_test                                               PASSED in 1.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.8s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.8s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 2.8s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.0s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 3.4s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.8s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.8s
//tests/lib:p4info_helper_test                                           PASSED in 0.9s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 0.7s
//tests/lib:packet_generator_test                                        PASSED in 27.0s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.1s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.2s
//tests/sflow:sflow_util_test                                            PASSED in 7.0s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.9s
  Stats over 5 runs: max = 0.9s, min = 0.7s, avg = 0.8s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 44.0s
  Stats over 50 runs: max = 44.0s, min = 0.8s, avg = 3.1s, dev = 8.5s

Executed 218 out of 218 tests: 218 tests pass.
INFO: Build completed successfully, 272 total actions
