### PR TITLE
P4_Symbolic] Add related table entry information to synthesis criteria. Generalize from p4.v1.TableEntry to p4.v1.Entity to support multicast. Rename "sai_p4_component_test" to "sai_p4_integration_test", since it is an integration test.remove obsolete TODO.Add default coverage goals for SAI.

### DIFF
--- a/p4_symbolic/packet_synthesizer/criteria_generator.cc
+++ b/p4_symbolic/packet_synthesizer/criteria_generator.cc
@@ -89,6 +89,10 @@ GenerateSynthesisCriteriaFor(const EntryCoverageGoal& goal,
         criteria.mutable_table_entry_reachability_criteria()->set_match_index(
             i);
         criteria_list.push_back(criteria);
+        criteria_list.back()
+            .mutable_metadata()
+            ->mutable_covered_entity_debug_strings()
+            ->Add(entries[i].ShortDebugString());
       }
     }
 

--- a/p4_symbolic/packet_synthesizer/packet_synthesis_criteria.cc
+++ b/p4_symbolic/packet_synthesizer/packet_synthesis_criteria.cc
@@ -187,6 +187,15 @@ absl::StatusOr<PacketSynthesisCriteria> MakeConjunction(
           lhs.ShortDebugString(), rhs.ShortDebugString()));
     }
   }
+
+  if (lhs.has_metadata() || rhs.has_metadata()) {
+    *merged_criteria.mutable_metadata() = lhs.metadata();
+    merged_criteria.mutable_metadata()
+        ->mutable_covered_entity_debug_strings()
+        ->Add(rhs.metadata().covered_entity_debug_strings().begin(),
+              rhs.metadata().covered_entity_debug_strings().end());
+  }
+
   return merged_criteria;
 }
 

--- a/p4_symbolic/packet_synthesizer/packet_synthesis_criteria.proto
+++ b/p4_symbolic/packet_synthesizer/packet_synthesis_criteria.proto
@@ -80,6 +80,12 @@ message PacketSynthesisCriteria {
   TableEntryReachabilityCriteria table_entry_reachability_criteria = 4;
   PayloadCriteria payload_criteria = 5;
   PortCriteria ingress_port_criteria = 6;
+
+  // Axiluary information about the criteria, for debugging purposes only.
+  Metadata metadata = 7;
+  message Metadata {
+    repeated string covered_entity_debug_strings = 1;
+  }
 }
 // LINT.ThenChange(
 //  :criteria_variant,

--- a/p4_symbolic/packet_synthesizer/packet_synthesizer.cc
+++ b/p4_symbolic/packet_synthesizer/packet_synthesizer.cc
@@ -229,14 +229,8 @@ absl::StatusOr<std::unique_ptr<PacketSynthesizer>> PacketSynthesizer::Create(
 
   // Extract data from params.
   const p4::v1::ForwardingPipelineConfig& config = params.pipeline_config();
-  std::vector<p4::v1::Entity> entities;
-  {
-    entities.reserve(params.pi_entries().size());
-    // TODO: Add support for entities that are not table entries.
-    for (const auto& entry : params.pi_entries()) {
-      *entities.emplace_back().mutable_table_entry() = entry;
-    }
-  }
+  std::vector<p4::v1::Entity> entities(params.pi_entities().begin(),
+                                       params.pi_entities().end());
   std::vector<int> physical_ports(params.physical_port().begin(),
                                   params.physical_port().end());
   symbolic::TranslationPerType translation_per_type;

--- a/p4_symbolic/packet_synthesizer/packet_synthesizer.proto
+++ b/p4_symbolic/packet_synthesizer/packet_synthesizer.proto
@@ -35,8 +35,7 @@ message TranslationData {
 // PacketSynthesizer to build the initial SMT formula.
 message PacketSynthesisParams {
   p4.v1.ForwardingPipelineConfig pipeline_config = 1;
-  // TODO: Add support for entities that are not table entries.
-  repeated p4.v1.TableEntry pi_entries = 2;
+  repeated p4.v1.Entity pi_entities = 2;
   repeated int32 physical_port = 3;
   map<string, TranslationData> translation_per_type = 4;
 }

--- a/p4_symbolic/sai/BUILD.bazel
+++ b/p4_symbolic/sai/BUILD.bazel
@@ -36,6 +36,16 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "sai_coverage_goals",
+    testonly = True,
+    hdrs = ["sai_coverage_goals.h"],
+    deps = [
+        "//gutil:testing",
+        "//p4_symbolic/packet_synthesizer:coverage_goal_cc_proto",
+    ],
+)
+
 cc_test(
     name = "sai_test",
     srcs = ["sai_test.cc"],

--- a/p4_symbolic/sai/packet_synthesizer_test.cc
+++ b/p4_symbolic/sai/packet_synthesizer_test.cc
@@ -65,7 +65,7 @@ PacketSynthesisParams GetParams(
       pdpi::PartialPdTableEntryToPiTableEntry(ir_p4info, pd_entry);
 
   CHECK_OK(pi_entry.status());
-  *params.mutable_pi_entries()->Add() = *pi_entry;
+  *params.add_pi_entities()->mutable_table_entry() = *pi_entry;
 
   return params;
 }

--- a/p4_symbolic/sai/sai_coverage_goals.h
+++ b/p4_symbolic/sai/sai_coverage_goals.h
@@ -1,0 +1,80 @@
+#ifndef PINS_P4_SYMBOLIC_SAI_SAI_COVERAGE_GOALS_H_
+#define PINS_P4_SYMBOLIC_SAI_SAI_COVERAGE_GOALS_H_
+
+#include "gutil/testing.h"
+#include "p4_symbolic/packet_synthesizer/coverage_goal.pb.h"
+
+namespace p4_symbolic::packet_synthesizer {
+
+inline CoverageGoals SaiDefaultCoverageGoals() {
+  return gutil::ParseProtoOrDie<CoverageGoals>(
+      R"pb(
+        coverage_goals {
+          # TODO: Restore header coverage when performance is
+          # improved.
+          # header_coverage {
+          #  headers { patterns: [ "*" ] }
+          #  header_exclusions {
+          #    patterns: [
+          #      # Optimization: do not need to target ethernet individually.
+          #      All
+          #      # valid packets for SAI-P4 will have the ethernet header.
+          #      "ethernet"
+          #    ]
+          #    patterns: [
+          #      # PacketIO is currently handled differently in dataplane tests.
+          #      "packet_in_header",
+          #      "packet_out_header"
+          #    ]
+          #    patterns: [
+          #      # The following are not satisfiable anyway (because the headers
+          #      # will never be valid in ingress).
+          #      "erspan_ipv4",
+          #      "erspan_gre",
+          #      "erspan_ethernet",
+          #      "tunnel_encap_ipv6",
+          #      "tunnel_encap_gre"
+          #    ]
+          #  }
+          #  headers_to_prevent_unless_explicitly_covered {
+          #    patterns: [ "vlan" ]
+          #  }
+          #  include_wildcard_header: true
+          # }
+          packet_fate_coverage { fates: [ DROP, NOT_DROP ] }
+          entry_coverage {
+            tables { patterns: [ "*" ] }
+            table_exclusions {
+              # TODO: Excluding tables that are covered by covering
+              # other tables and for which packet synthesis is expensive.
+              patterns: [
+                "ingress.routing_resolution.neighbor_table",
+                "ingress.routing_resolution.nexthop_table",
+                "ingress.routing_resolution.router_interface_table",
+                "ingress.routing_resolution.wcmp_group_table",
+                "ingress.routing_resolution.tunnel_table",
+                # TODO: Remove the following when PINS releases no
+                # longer include the tables.
+                "ingress.routing.neighbor_table",
+                "ingress.routing.nexthop_table",
+                "ingress.routing.router_interface_table",
+                "ingress.routing.wcmp_group_table",
+                "ingress.routing.tunnel_table"
+              ]
+            }
+            cover_default_actions: true
+            # TODO: Currently must ignore cover for default
+            # action of empty tables due to the limitation of
+            # packet_util::SynthesizePackets's return type
+            # (TestPacketsByTargetEntry).
+            # TODO: Also covering these tables is
+            # expensive. Remove when these limitations are addressed.
+            exclude_empty_tables: true
+          }
+        }
+      )pb");
+}
+
+}  // namespace p4_symbolic::packet_synthesizer
+
+#endif  // PINS_P4_SYMBOLIC_SAI_SAI_COVERAGE_GOALS_H_

--- a/p4_symbolic/tests/BUILD.bazel
+++ b/p4_symbolic/tests/BUILD.bazel
@@ -4,9 +4,9 @@ package(
 )
 
 cc_test(
-    name = "sai_p4_component_test",
+    name = "sai_p4_integration_test",
     timeout = "long",
-    srcs = ["sai_p4_component_test.cc"],
+    srcs = ["sai_p4_integration_test.cc"],
     deps = [
         "//gutil:status_matchers",
         "//gutil:testing",

--- a/p4_symbolic/tests/sai_p4_integration_test.cc
+++ b/p4_symbolic/tests/sai_p4_integration_test.cc
@@ -96,7 +96,7 @@ constexpr absl::string_view kTableEntries = R"pb(
   }
 )pb";
 
-class P4SymbolicComponentTest : public testing::Test {
+class P4SymbolicIntegrationTest : public testing::Test {
  public:
   thinkit::TestEnvironment& Environment() { return *environment_; }
 
@@ -122,7 +122,7 @@ absl::StatusOr<std::string> GenerateSmtForSaiPiplelineWithSimpleEntries() {
 
 // Generate SMT constraints for the SAI pipeline from scratch multiple times and
 // make sure the results remain the same.
-TEST_F(P4SymbolicComponentTest,
+TEST_F(P4SymbolicIntegrationTest,
        DISABLED_ConstraintGenerationIsDeterministicForSai) {
   constexpr int kNumberOfRuns = 5;
   ASSERT_OK_AND_ASSIGN(const std::string reference_smt_formula,
@@ -135,7 +135,7 @@ TEST_F(P4SymbolicComponentTest,
   }
 }
 
-TEST_F(P4SymbolicComponentTest, CanGenerateTestPacketsForSimpleSaiP4Entries) {
+TEST_F(P4SymbolicIntegrationTest, CanGenerateTestPacketsForSimpleSaiP4Entries) {
   // Some constants.
   auto env = thinkit::BazelTestEnvironment(/*mask_known_failures=*/false);
   const auto config = sai::GetNonstandardForwardingPipelineConfig(


### PR DESCRIPTION
Keyword Check:
~/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.



Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 691 targets (2 packages loaded, 11 targets configured).
INFO: Found 691 targets...
INFO: From Compiling p4_symbolic/symbolic/table.cc:
In file included from ./p4_symbolic/z3_util.h:26,
                 from ./p4_symbolic/symbolic/symbolic.h:36,
                 from ./p4_symbolic/symbolic/table.h:27,
                 from p4_symbolic/symbolic/table.cc:21:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   55 |     for (int i = 0; i < bytes.size(); i++) {
      |                     ~~^~~~~~~~~~~~~~
./p4_pdpi/string_encodings/bit_string.h: In instantiation of 'void pdpi::BitString::AppendBits(const std::bitset<_Nb>&) [with long unsigned int num_bits = 8]':
./p4_pdpi/string_encodings/bit_string.h:41:50:   required from here
./p4_pdpi/string_encodings/bit_string.h:49:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   49 |     for (int i = 0; i < num_bits; i++) {
      |                     ~~^~~~~~~~~~
INFO: From Compiling p4_symbolic/symbolic/table.cc [for host]:
In file included from ./p4_symbolic/z3_util.h:26,
                 from ./p4_symbolic/symbolic/symbolic.h:36,
                 from ./p4_symbolic/symbolic/table.h:27,
                 from p4_symbolic/symbolic/table.cc:21:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   55 |     for (int i = 0; i < bytes.size(); i++) {
      |                     ~~^~~~~~~~~~~~~~
./p4_pdpi/string_encodings/bit_string.h: In instantiation of 'void pdpi::BitString::AppendBits(const std::bitset<_Nb>&) [with long unsigned int num_bits = 8]':
./p4_pdpi/string_encodings/bit_string.h:41:50:   required from here
./p4_pdpi/string_encodings/bit_string.h:49:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   49 |     for (int i = 0; i < num_bits; i++) {
      |                     ~~^~~~~~~~~~
INFO: Elapsed time: 7.766s, Critical Path: 6.88s
INFO: 3 processes: 1 internal, 2 linux-sandbox.
INFO: Build completed successfully, 3 total actions







Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 691 targets (0 packages loaded, 3 targets configured).
INFO: Found 473 targets and 218 test targets...
INFO: Elapsed time: 184.874s, Critical Path: 120.58s
INFO: 272 processes: 327 linux-sandbox, 18 local.
INFO: Build completed successfully, 272 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.8s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 0.6s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.0s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.0s
//dvaas:test_vector_test                                                 PASSED in 0.6s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.1s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.7s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.3s
//p4rt_app/tests:response_path_test                                      PASSED in 6.4s
//p4rt_app/tests:role_test                                               PASSED in 1.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 3.1s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.7s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 2.0s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.0s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 3.5s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.8s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 1.1s
//tests/lib:p4info_helper_test                                           PASSED in 0.9s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 0.9s
//tests/lib:packet_generator_test                                        PASSED in 27.2s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.1s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.0s
//tests/sflow:sflow_util_test                                            PASSED in 6.9s
//thinkit:bazel_test_environment_test                                    PASSED in 0.6s
//thinkit:generic_testbed_test                                           PASSED in 1.0s
//thinkit:mock_control_device_test                                       PASSED in 0.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.9s
  Stats over 5 runs: max = 0.9s, min = 0.7s, avg = 0.7s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 85.1s
  Stats over 50 runs: max = 85.1s, min = 0.8s, avg = 6.6s, dev = 16.1s

Executed 218 out of 218 tests: 218 tests pass.
INFO: Build completed successfully, 272 total actions