### PR TITLE
[Thinkit] Add multicast test using ACL redirect.Update expected error outputs for multicast tests

### DIFF
--- a/tests/forwarding/l3_multicast_test.h
+++ b/tests/forwarding/l3_multicast_test.h
@@ -45,13 +45,11 @@ class L3MulticastTestFixture
   void TearDown() override { GetParam().mirror_testbed->TearDown(); }
 
  protected:
-  // This test runs on a mirror testbed setup so we open a P4RT connection to
-  // both switches.
+  // This test runs on a mirror testbed setup, but we only need to configure
+  // the SUT.
   std::unique_ptr<pdpi::P4RuntimeSession> sut_p4rt_session_;
-  std::unique_ptr<pdpi::P4RuntimeSession> control_switch_p4rt_session_;
   pdpi::IrP4Info ir_p4info_;
 };
 
 }  // namespace pins_test
-
 #endif  // PINS_TESTS_FORWARDING_L3_MULTICAST_TEST_H_


### PR DESCRIPTION
Keyword Check:
~/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.



Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 695 targets (0 packages loaded, 0 targets configured).
INFO: Found 695 targets...
INFO: Elapsed time: 0.710s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action





UT Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 695 targets (0 packages loaded, 0 targets configured).
INFO: Found 477 targets and 218 test targets...
INFO: Elapsed time: 218.779s, Critical Path: 123.48s
INFO: 275 processes: 330 linux-sandbox, 18 local.
INFO: Build completed successfully, 275 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.8s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 0.6s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.0s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.0s
//dvaas:test_vector_test                                                 PASSED in 0.6s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.1s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 0.6s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//p4rt_app/tests:role_test                                               PASSED in 1.5s
//p4rt_app/tests:state_verification_test                                 PASSED in 3.4s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.6s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.4s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.0s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 3.4s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.8s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 1.2s
//tests/forwarding:hash_statistics_util_test                             PASSED in 0.9s
//tests/lib:p4info_helper_test                                           PASSED in 0.9s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 0.7s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.2s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.0s
//thinkit:bazel_test_environment_test                                    PASSED in 0.6s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.8s
//tests/lib:packet_generator_test                                        PASSED in 58.7s
  Stats over 4 runs: max = 58.7s, min = 54.9s, avg = 56.3s, dev = 1.5s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
  Stats over 5 runs: max = 0.8s, min = 0.7s, avg = 0.7s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 44.3s
  Stats over 50 runs: max = 44.3s, min = 0.8s, avg = 6.4s, dev = 13.8s

Executed 218 out of 218 tests: 218 tests pass.
INFO: Build completed successfully, 275 total actions
