### PR TITLE
[Thinkit] Dynamic buffer test for multicast

### DIFF
--- a/tests/qos/BUILD.bazel
+++ b/tests/qos/BUILD.bazel
@@ -109,6 +109,7 @@ cc_library(
         "//p4_pdpi:ir",
         "//p4_pdpi:ir_cc_proto",
         "//p4_pdpi:p4_runtime_session",
+	"//p4_pdpi:p4_runtime_session_extras",
         "//p4_pdpi:pd",
         "//p4_pdpi/internal:ordered_map",
         "//p4_pdpi/netaddr:ipv4_address",


### PR DESCRIPTION
### **PR Description:**
Dynamic buffer test for multicast

### **Keyword Check:**
bibhuprasad@bibhuprasad9136:~/Sonic_Build_20_11/sonic-buildimage/src/sonic-p4rt/sonic-pins$ sh ~/keyword_check.sh ./
Keyword check Passed.

### **Build Results:**
bibhuprasad@abe92661eacf:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 696 targets (0 packages loaded, 0 targets configured).
INFO: Found 696 targets...
INFO: Elapsed time: 0.411s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### **UT Results:**
bibhuprasad@abe92661eacf:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 696 targets (0 packages loaded, 0 targets configured).
INFO: Found 478 targets and 218 test targets...
INFO: Elapsed time: 161.584s, Critical Path: 116.26s
INFO: 275 processes: 330 linux-sandbox, 18 local.
INFO: Build completed successfully, 275 total actions
//dvaas:port_id_map_test                                                 PASSED in 1.3s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.2s
//dvaas:test_run_validation_test                                         PASSED in 1.2s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.1s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.1s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 1.0s
//gutil:io_test                                                          PASSED in 1.1s
//gutil:proto_matchers_test                                              PASSED in 1.0s
//gutil:proto_ordering_test                                              PASSED in 0.8s
//gutil:proto_test                                                       PASSED in 1.0s
//gutil:status_matchers_test                                             PASSED in 1.1s
//gutil:test_artifact_writer_test                                        PASSED in 1.3s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:timer_test                                                       PASSED in 5.3s
//gutil:version_test                                                     PASSED in 3.6s
//lib:basic_switch_test                                                  PASSED in 1.2s
//lib:ixia_helper_test                                                   PASSED in 1.8s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 1.8s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 16.0s
//lib/gnmi:gnmi_helper_test                                              PASSED in 3.2s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.8s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 1.3s
//lib/utils:generic_testbed_utils_test                                   PASSED in 2.5s
//lib/utils:json_utils_test                                              PASSED in 1.3s
//lib/validator:validator_backend_test                                   PASSED in 0.7s
//lib/validator:validator_lib_test                                       PASSED in 26.2s
//p4_fuzzer:constraints_test                                             PASSED in 3.8s
//p4_fuzzer:fuzz_util_test                                               PASSED in 116.1s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 1.5s
//p4_fuzzer:oracle_util_test                                             PASSED in 4.0s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 3.4s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 3.3s
//p4_fuzzer:switch_state_test                                            PASSED in 1.8s
//p4_pdpi:built_ins_test                                                 PASSED in 0.9s
//p4_pdpi:entity_keys_test                                               PASSED in 0.8s
//p4_pdpi:ir_properties_test                                             PASSED in 1.0s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 0.8s
//p4_pdpi:ir_tools_test                                                  PASSED in 0.8s
//p4_pdpi:names_test                                                     PASSED in 1.3s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.1s
//p4_pdpi:reference_annotations_test                                     PASSED in 1.1s
//p4_pdpi:references_test                                                PASSED in 0.9s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.0s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.9s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.0s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.8s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 16.6s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.7s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 4.5s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 0.8s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.7s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.2s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.8s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.2s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.1s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:references_test                                        PASSED in 0.1s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.3s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 0.9s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.2s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.8s
//p4_pdpi/utils:ir_test                                                  PASSED in 0.9s
//p4_symbolic:z3_util_test                                               PASSED in 1.2s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 3.3s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 3.5s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 3.6s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 3.5s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 3.4s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 3.6s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 3.6s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.3s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.1s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.1s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.1s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.1s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.3s
//p4_symbolic/packet_synthesizer:util_test                               PASSED in 6.3s
//p4_symbolic/sai:sai_test                                               PASSED in 4.1s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:parser_test                                       PASSED in 1.1s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:reflector_test_packets                            PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 1.7s
//p4_symbolic/symbolic:util_test                                         PASSED in 1.2s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.1s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 4.5s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 7.4s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.4s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.4s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.6s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 1.2s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.3s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 2.4s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.8s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 1.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 1.6s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.2s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 1.8s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 1.3s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 1.5s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 1.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 1.6s
//p4rt_app/sonic:hashing_test                                            PASSED in 1.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 1.6s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.1s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.2s
//p4rt_app/sonic:response_handler_test                                   PASSED in 1.6s
//p4rt_app/sonic:state_verification_test                                 PASSED in 1.5s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.5s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.8s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.7s
//p4rt_app/tests:action_set_test                                         PASSED in 1.3s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.1s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.2s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 5.6s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.6s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.3s
//p4rt_app/tests:p4_programs_test                                        PASSED in 1.9s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.2s
//p4rt_app/tests:packetio_test                                           PASSED in 4.1s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.5s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.9s
//p4rt_app/tests:response_path_test                                      PASSED in 4.2s
//p4rt_app/tests:role_test                                               PASSED in 1.3s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.4s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.0s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 1.5s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.1s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.3s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.2s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.2s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.2s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.0s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.3s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 3.5s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.8s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 3.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.0s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.1s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.4s
//tests/forwarding:hash_statistics_util_test                             PASSED in 1.4s
//tests/lib:p4info_helper_test                                           PASSED in 2.0s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.8s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.1s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.5s
//thinkit:bazel_test_environment_test                                    PASSED in 1.1s
//thinkit:generic_testbed_test                                           PASSED in 1.8s
//thinkit:mock_control_device_test                                       PASSED in 1.3s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.5s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.9s
//thinkit:mock_ssh_client_test                                           PASSED in 0.2s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.1s
//tests/lib:packet_generator_test                                        PASSED in 57.9s
  Stats over 4 runs: max = 57.9s, min = 56.1s, avg = 57.2s, dev = 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.4s
  Stats over 5 runs: max = 1.4s, min = 0.9s, avg = 1.2s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 48.6s
  Stats over 50 runs: max = 48.6s, min = 1.1s, avg = 3.7s, dev = 8.9s

Executed 218 out of 218 tests: 218 tests pass.
INFO: Build completed successfully, 275 total actions