### PR TITLE
[Thinkit] Add Bursty Traffic test to the CPUQosWithIxia Test

### DIFF
--- a/tests/qos/cpu_qos_test.h
+++ b/tests/qos/cpu_qos_test.h
@@ -127,6 +127,8 @@ struct ParamsForTestsWithIxia {
   thinkit::GenericTestbedInterface* testbed_interface;
 
   p4::config::v1::P4Info p4info;
+  // Number of pipes supported by Vendor across which the Buffer is split.
+  int num_pipes;
   // This is be the minimum guaranteed bandwidth for control path to Tester in
   // the testbed. This is required to ensure the per queue rate limits to be
   // tested are within this guaranteed end to end bandwidth.

--- a/tests/qos/qos_test_util.h
+++ b/tests/qos/qos_test_util.h
@@ -214,7 +214,6 @@ struct QueueInfoByQueueName {
   int scheduler_be_pkts;              // Burst excess packets.
 };
 
-
 // Updates parameters of the buffer profile of the given name according to
 // `params_by_queue_name` and waits for the updated config to converge, or times
 // out with an Unavailable error if the state does not converge within the given


### PR DESCRIPTION
Key_word Check:

```
~/pins_upstream/sonic-buildimage/src/sonic-p4rt/sonic-pins/tests/sflow$ ~/tools/keyword_checks.sh .
Keyword check Passed.

```

Build result:

```
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ... 
INFO: Analyzed 710 targets (0 packages loaded, 0 targets configured).
INFO: Found 710 targets...
INFO: Elapsed time: 0.307s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

```


Test result:

```
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 710 targets (0 packages loaded, 2 targets configured).
INFO: Found 488 targets and 222 test targets...
INFO: Elapsed time: 167.310s, Critical Path: 122.26s
INFO: 279 processes: 336 linux-sandbox, 18 local.
INFO: Build completed successfully, 279 total actions
//dvaas:port_id_map_test                                                 PASSED in 1.3s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 0.9s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.2s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.3s
//dvaas:test_vector_stats_test                                           PASSED in 0.2s
//dvaas:test_vector_test                                                 PASSED in 1.4s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.4s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 0.8s
//tests/forwarding:hash_statistics_util_test                             PASSED in 1.8s
//tests/lib:p4info_helper_test                                           PASSED in 1.8s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.4s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.1s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.9s
//thinkit:bazel_test_environment_test                                    PASSED in 1.1s
//thinkit:generic_testbed_test                                           PASSED in 1.6s
//thinkit:mock_control_device_test                                       PASSED in 0.9s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.1s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.2s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 1.3s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.3s
//tests/lib:packet_generator_test                                        PASSED in 58.1s
  Stats over 4 runs: max = 58.1s, min = 56.4s, avg = 57.4s, dev = 0.6s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.6s
  Stats over 5 runs: max = 1.6s, min = 1.1s, avg = 1.3s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 50.4s
  Stats over 50 runs: max = 50.4s, min = 1.2s, avg = 6.3s, dev = 13.1s

Executed 222 out of 222 tests: 222 tests pass.
INFO: Build completed successfully, 279 total actions

```