### PR TITLE
[Thinkit] Use collector port from config by default. Add a test for transition into gNPSI config after NSF.Check for config convergence as part of SUT validation post NSF reboot.

### DIFF
--- a/tests/sflow/sflow_test.h
+++ b/tests/sflow/sflow_test.h
@@ -115,6 +115,11 @@ class SflowMirrorTestFixture
   std::unique_ptr<gnmi::gNMI::StubInterface> control_gnmi_stub_;
 
   std::string agent_address_;
+
+  // Used for setting gNMI collector config. It would be set to the same as the
+  // config collector port. If config does not have any collector config, it
+  // would be set to 6343.
+  int collector_port_;
 };
 
 class SflowRebootTestFixture : public SflowMirrorTestFixture {};


### PR DESCRIPTION
Keyword Check:
~/sk/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.




Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 710 targets (0 packages loaded, 0 targets configured).
INFO: Found 710 targets...
INFO: From Compiling tests/sflow/sflow_test.cc:
In file included from ./gutil/collections.h:29,
                 from tests/sflow/sflow_test.cc:51:
tests/sflow/sflow_test.cc: In function 'absl::lts_20230802::Status pins::{anonymous}::SetUpAclPunt(pdpi::P4RuntimeSession&, const pdpi::IrP4Info&, int)':
tests/sflow/sflow_test.cc:184:46: warning: 'absl::lts_20230802::StatusOr<p4::v1::TableEntry> pdpi::PartialPdTableEntryToPiTableEntry(const IrP4Info&, const google::protobuf::Message&, const TranslationOptions&)' is deprecated: Use PdTableEntryToPiEntity instead [-Wdeprecated-declarations]
  184 |       pdpi::PartialPdTableEntryToPiTableEntry(
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  185 |           ir_p4info,
      |           ~~~~~~~~~~                          
  186 |           gutil::ParseProtoOrDie<sai::TableEntry>(absl::Substitute(
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  187 |               R"pb(
      |               ~~~~~                           
  188 |                 acl_ingress_table_entry {
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~     
  189 |                   match {
      |                   ~~~~~~~                     
  190 |                     dst_mac { value: "$0" mask: "ff:ff:ff:ff:ff:ff" }
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  191 |                     is_ipv4 { value: "0x1" }
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~  
  192 |                     dst_ip { value: "$1" mask: "255.255.255.255" }
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  193 |                   }
      |                   ~                           
  194 |                   action { acl_trap { qos_queue: "0x7" } }
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  195 |                   priority: 1
      |                   ~~~~~~~~~~~                 
  196 |                 }
      |                 ~                             
  197 |               )pb",
      |               ~~~~~                           
  198 |               kDstMac.ToString(), GetDstIpv4AddrByPortId(port_id)))));
tests/sflow/sflow_test.cc:2396:5: note: in expansion of macro 'EXPECT_OK'
 2396 |     EXPECT_OK(pdpi::ClearTableEntries(control_p4_session_.get()));
      |     ^~~~~~~~~
./p4_pdpi/p4_runtime_session.h:392:14: note: declared here
  392 | absl::Status ClearTableEntries(P4RuntimeSession *session);
      |              ^~~~~~~~~~~~~~~~~
In file included from ./p4_pdpi/netaddr/network_address.h:28,
                 from ./p4_pdpi/netaddr/ipv4_address.h:22,
                 from ./lib/ixia_helper.h:30,
                 from tests/sflow/sflow_test.cc:56:
./p4_pdpi/string_encodings/hex_string.h: In instantiation of 'std::string pdpi::BitsetToHexString(const std::bitset<_Nb>&) [with long unsigned int num_bits = 48; std::string = std::__cxx11::basic_string<char>]':
./p4_pdpi/netaddr/network_address.h:85:67:   required from 'std::string netaddr::NetworkAddress<num_bits, T>::ToHexString() const [with long unsigned int num_bits = 48; T = netaddr::MacAddress; std::string = std::__cxx11::basic_string<char>]'
tests/sflow/sflow_test.cc:1271:43:   required from here
./p4_pdpi/string_encodings/hex_string.h:95:24: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   95 |       int kth_bit = (k < num_bits) ? bitset[k] : 0; // Implicit bits are 0.
      |                     ~~~^~~~~~~~~~~
tests/sflow/sflow_test.cc: At global scope:
tests/sflow/sflow_test.cc:637:29: warning: 'absl::lts_20230802::StatusOr<std::__cxx11::basic_string<char> > pins::{anonymous}::GetPortSpeed(absl::lts_20230802::string_view, gnmi::gNMI::StubInterface*)' defined but not used [-Wunused-function]
  637 | absl::StatusOr<std::string> GetPortSpeed(absl::string_view iface,
      |                             ^~~~~~~~~~~~
INFO: Elapsed time: 28.102s, Critical Path: 27.34s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions





Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 710 targets (0 packages loaded, 0 targets configured).
INFO: Found 488 targets and 222 test targets...
INFO: Elapsed time: 209.714s, Critical Path: 119.35s
INFO: 279 processes: 336 linux-sandbox, 18 local.
INFO: Build completed successfully, 279 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.7s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 0.6s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.0s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.0s
//dvaas:test_vector_test                                                 PASSED in 0.6s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.1s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.5s
//gutil:testing_test                                                     PASSED in 0.5s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.9s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.4s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.0s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.6s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 0.6s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.4s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.9s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 3.4s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 1.2s
//tests/forwarding:hash_statistics_util_test                             PASSED in 1.0s
//tests/lib:p4info_helper_test                                           PASSED in 0.9s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 0.7s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.1s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 6.9s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.8s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//tests/lib:packet_generator_test                                        PASSED in 62.1s
  Stats over 4 runs: max = 62.1s, min = 60.8s, avg = 61.2s, dev = 0.5s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.9s
  Stats over 5 runs: max = 0.9s, min = 0.7s, avg = 0.8s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 49.1s
  Stats over 50 runs: max = 49.1s, min = 0.8s, avg = 5.3s, dev = 13.1s

Executed 222 out of 222 tests: 222 tests pass.
INFO: Build completed successfully, 279 total actions