### PR TITLE
Updated Workspace name to match the repo.

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-workspace(name = "com_github_google_pins_infra")
+workspace(name = "com_github_sonic_net_sonic_pins")
 
 # -- Load buildifier -----------------------------------------------------------
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/pins_infra_deps.bzl
+++ b/pins_infra_deps.bzl
@@ -133,7 +133,7 @@ def pins_infra_deps():
             strip_prefix = "gnmi-0.10.0",
             patch_args = ["-p1"],
             patches = [
-                "@com_github_google_pins_infra//:bazel/patches/gnmi-001-fix_virtual_proto_import.patch",
+                "@com_github_sonic_net_sonic_pins//:bazel/patches/gnmi-001-fix_virtual_proto_import.patch",
             ],
             sha256 = "2231e1cc398a523fa840810fa6fdb8960639f7b91b57bb8f12ed8681e0142a67",
         )


### PR DESCRIPTION
Keyword Check:
~/sk/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.




Build Result:
sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 710 targets (1 packages loaded, 1135 targets configured).
INFO: Found 710 targets...
./gutil/status_matchers.h:63:43: note: in definition of macro 'ASSERT_OK_AND_ASSIGN'
   63 |   auto __ASSIGN_OR_RETURN_VAL(__LINE__) = expression;                          \
      |                                           ^~~~~~~~~~
In file included from p4_pdpi/ir_tools_test.cc:18:
./p4_pdpi/pd.h:292:30: note: declared here
  292 | absl::StatusOr<IrTableEntry> PartialPdTableEntryToIrTableEntry(
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
p4_pdpi/ir_tools_test.cc:49:57: warning: 'absl::lts_20230802::StatusOr<pdpi::IrTableEntry> pdpi::PartialPdTableEntryToIrTableEntry(const IrP4Info&, const google::protobuf::Message&, const TranslationOptions&)' is deprecated: Use PdTableEntryToIrEntity instead [-Wdeprecated-declarations]
   49 |                        PartialPdTableEntryToIrTableEntry(
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
   50 |                            info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   51 |                              one_match_field_table_entry {
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   52 |                                match { id: "another_string" }
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   53 |                                action { do_thing_4 {} }
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~  
   54 |                              }
      |                              ~                           
   55 |                            )pb")));
      |                            ~~~~~~                        
./gutil/status_matchers.h:63:43: note: in definition of macro 'ASSERT_OK_AND_ASSIGN'
   63 |   auto __ASSIGN_OR_RETURN_VAL(__LINE__) = expression;                          \
      |                                           ^~~~~~~~~~
./p4_pdpi/pd.h:292:30: note: declared here
  292 | absl::StatusOr<IrTableEntry> PartialPdTableEntryToIrTableEntry(
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
p4_pdpi/ir_tools_test.cc: In member function 'virtual void pdpi::{anonymous}::TransformValuesOfTypeTest_RewriteActionStrings_Test::TestBody()':
p4_pdpi/ir_tools_test.cc:70:57: warning: 'absl::lts_20230802::StatusOr<pdpi::IrTableEntry> pdpi::PartialPdTableEntryToIrTableEntry(const IrP4Info&, const google::protobuf::Message&, const TranslationOptions&)' is deprecated: Use PdTableEntryToIrEntity instead [-Wdeprecated-declarations]
   70 |                        PartialPdTableEntryToIrTableEntry(
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
   71 |                            info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   72 |                              referring_by_action_table_entry {
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   73 |                                match { val: "0x001" }
      |                                ~~~~~~~~~~~~~~~~~~~~~~    
   74 |                                action {
      |                                ~~~~~~~~                  
   75 |                                  referring_to_two_match_fields_action {
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   76 |                                    referring_id_1: "string1",
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~
   77 |                                    referring_id_2: "0x004",
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~
   78 |                                  }
      |                                  ~                       
   79 |                                }
      |                                ~                         
   80 |                              }
      |                              ~                           
   81 |                            )pb")));
      |                            ~~~~~~                        
./gutil/status_matchers.h:63:43: note: in definition of macro 'ASSERT_OK_AND_ASSIGN'
   63 |   auto __ASSIGN_OR_RETURN_VAL(__LINE__) = expression;                          \
      |                                           ^~~~~~~~~~
./p4_pdpi/pd.h:292:30: note: declared here
  292 | absl::StatusOr<IrTableEntry> PartialPdTableEntryToIrTableEntry(
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
p4_pdpi/ir_tools_test.cc:84:57: warning: 'absl::lts_20230802::StatusOr<pdpi::IrTableEntry> pdpi::PartialPdTableEntryToIrTableEntry(const IrP4Info&, const google::protobuf::Message&, const TranslationOptions&)' is deprecated: Use PdTableEntryToIrEntity instead [-Wdeprecated-declarations]
   84 |                        PartialPdTableEntryToIrTableEntry(
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
   85 |                            info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   86 |                              referring_by_action_table_entry {
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   87 |                                match { val: "0x001" }
      |                                ~~~~~~~~~~~~~~~~~~~~~~    
   88 |                                action {
      |                                ~~~~~~~~                  
   89 |                                  referring_to_two_match_fields_action {
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   90 |                                    referring_id_1: "another_string1",
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   91 |                                    referring_id_2: "0x004",
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~
   92 |                                  }
      |                                  ~                       
   93 |                                }
      |                                ~                         
   94 |                              }
      |                              ~                           
   95 |                            )pb")));
      |                            ~~~~~~                        
./gutil/status_matchers.h:63:43: note: in definition of macro 'ASSERT_OK_AND_ASSIGN'
   63 |   auto __ASSIGN_OR_RETURN_VAL(__LINE__) = expression;                          \
      |                                           ^~~~~~~~~~
./p4_pdpi/pd.h:292:30: note: declared here
  292 | absl::StatusOr<IrTableEntry> PartialPdTableEntryToIrTableEntry(
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
p4_pdpi/ir_tools_test.cc: In member function 'virtual void pdpi::{anonymous}::VisitValuesOfTypeTest_CollectStrings_Test::TestBody()':
p4_pdpi/ir_tools_test.cc:110:57: warning: 'absl::lts_20230802::StatusOr<pdpi::IrTableEntry> pdpi::PartialPdTableEntryToIrTableEntry(const IrP4Info&, const google::protobuf::Message&, const TranslationOptions&)' is deprecated: Use PdTableEntryToIrEntity instead [-Wdeprecated-declarations]
  110 |                        PartialPdTableEntryToIrTableEntry(
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  111 |                            info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  112 |                              one_match_field_table_entry {
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  113 |                                match { id: "string1" }
      |                                ~~~~~~~~~~~~~~~~~~~~~~~   
  114 |                                action { do_thing_4 {} }
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~  
  115 |                              }
      |                              ~                           
  116 |                            )pb")));
      |                            ~~~~~~                        
./gutil/status_matchers.h:63:43: note: in definition of macro 'ASSERT_OK_AND_ASSIGN'
   63 |   auto __ASSIGN_OR_RETURN_VAL(__LINE__) = expression;                          \
      |                                           ^~~~~~~~~~
./p4_pdpi/pd.h:292:30: note: declared here
  292 | absl::StatusOr<IrTableEntry> PartialPdTableEntryToIrTableEntry(
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
p4_pdpi/ir_tools_test.cc:118:57: warning: 'absl::lts_20230802::StatusOr<pdpi::IrTableEntry> pdpi::PartialPdTableEntryToIrTableEntry(const IrP4Info&, const google::protobuf::Message&, const TranslationOptions&)' is deprecated: Use PdTableEntryToIrEntity instead [-Wdeprecated-declarations]
  118 |                        PartialPdTableEntryToIrTableEntry(
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  119 |                            info, gutil::ParseProtoOrDie<TableEntry>(R"pb(
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  120 |                              referring_by_action_table_entry {
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  121 |                                match { val: "0x001" }
      |                                ~~~~~~~~~~~~~~~~~~~~~~    
  122 |                                action {
      |                                ~~~~~~~~                  
  123 |                                  referring_to_two_match_fields_action {
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  124 |                                    referring_id_1: "string2",
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~
  125 |                                    referring_id_2: "0x003",
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~
  126 |                                  }
      |                                  ~                       
  127 |                                }
      |                                ~                         
  128 |                              }
      |                              ~                           
  129 |                            )pb")));
      |                            ~~~~~~                        
./gutil/status_matchers.h:63:43: note: in definition of macro 'ASSERT_OK_AND_ASSIGN'
   63 |   auto __ASSIGN_OR_RETURN_VAL(__LINE__) = expression;                          \
      |                                           ^~~~~~~~~~
./p4_pdpi/pd.h:292:30: note: declared here
  292 | absl::StatusOr<IrTableEntry> PartialPdTableEntryToIrTableEntry(
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO: From Compiling p4_symbolic/ir/cfg_test.cc:
In file included from p4_symbolic/ir/cfg_test.cc:1:
./p4_symbolic/ir/cfg.h:79:3: warning: multi-line comment [-Wcomment]
   79 |   //             /             \
      |   ^
INFO: Elapsed time: 2832.429s, Critical Path: 1160.70s
INFO: 10051 processes: 3152 internal, 6899 linux-sandbox.
INFO: Build completed successfully, 10051 total actions





Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 710 targets (1 packages loaded, 697 targets configured).
INFO: Found 488 targets and 222 test targets...
INFO: Elapsed time: 221.019s, Critical Path: 114.92s
INFO: 279 processes: 336 linux-sandbox, 18 local.
INFO: Build completed successfully, 279 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.8s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 0.6s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.0s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.0s
//dvaas:test_vector_test                                                 PASSED in 0.6s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.1s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//gutil:status_matchers_test                                             PASSED in 0.5s
//gutil:test_artifact_writer_test                                        PASSED in 0.6s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:timer_test                                                       PASSED in 5.0s
//gutil:version_test                                                     PASSED in 1.0s
//lib:basic_switch_test                                                  PASSED in 0.8s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.5s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.9s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 3.3s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 1.2s
//tests/forwarding:hash_statistics_util_test                             PASSED in 0.9s
//tests/lib:p4info_helper_test                                           PASSED in 0.8s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 0.7s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 1.2s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.2s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 6.9s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.8s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.8s
//tests/lib:packet_generator_test                                        PASSED in 62.3s
  Stats over 4 runs: max = 62.3s, min = 59.4s, avg = 61.0s, dev = 1.1s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
  Stats over 5 runs: max = 0.8s, min = 0.7s, avg = 0.7s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 43.9s
  Stats over 50 runs: max = 43.9s, min = 0.8s, avg = 2.0s, dev = 6.1s

Executed 222 out of 222 tests: 222 tests pass.
INFO: Build completed successfully, 279 total actions
