### PR TITLE
[Thinkit] Adding arriba_test in tests/forwarding/BUILD.bazel

### DIFF
--- a/tests/forwarding/BUILD.bazel
+++ b/tests/forwarding/BUILD.bazel
@@ -520,3 +520,23 @@ cc_library(
     ],
     deps = ["@com_google_absl//absl/strings"],
 )
+
+cc_library(
+    name = "arriba_test",
+    testonly = True,
+    srcs = ["arriba_test.cc"],
+    hdrs = ["arriba_test.h"],
+    linkstatic = True,
+    deps = [
+        "//dvaas:arriba_test_vector_validation",
+        "//dvaas:mirror_testbed_config",
+        "//dvaas:test_vector_cc_proto",
+        "//gutil:status",
+        "//gutil:status_matchers",
+        "//p4_pdpi:ir_cc_proto",
+        "//p4_pdpi:p4_runtime_session",
+        "//thinkit:mirror_testbed_fixture",
+        "@com_google_googletest//:gtest",
+    ],
+    alwayslink = True,
+)


### PR DESCRIPTION
Keyword Check:
/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.


Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 711 targets (1 packages loaded, 67 targets configured).
INFO: Found 711 targets...
tests/sflow/sflow_test.cc: In member function 'virtual void pins::SflowTestFixture::TearDown()':
tests/sflow/sflow_test.cc:1201:38: warning: 'absl::lts_20230802::Status pdpi::ClearTableEntries(P4RuntimeSession*)' is deprecated: Use ClearEntities instead. [-Wdeprecated-declarations]
 1201 |     EXPECT_OK(pdpi::ClearTableEntries(sut_p4_session_.get()));
      |               ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
tests/sflow/sflow_test.cc:1201:5: note: in expansion of macro 'EXPECT_OK'
 1201 |     EXPECT_OK(pdpi::ClearTableEntries(sut_p4_session_.get()));
      |     ^~~~~~~~~
./p4_pdpi/p4_runtime_session.h:392:14: note: declared here
  392 | absl::Status ClearTableEntries(P4RuntimeSession *session);
      |              ^~~~~~~~~~~~~~~~~
tests/sflow/sflow_test.cc: In member function 'virtual void pins::SflowTestFixture_VerifyIngressSamplesForP4rtPuntTraffic_Test::TestBody()':
tests/sflow/sflow_test.cc:1543:36: warning: 'absl::lts_20230802::Status pdpi::ClearTableEntries(P4RuntimeSession*)' is deprecated: Use ClearEntities instead. [-Wdeprecated-declarations]
 1543 |   EXPECT_OK(pdpi::ClearTableEntries(sut_p4_session_.get()));
      |             ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
tests/sflow/sflow_test.cc:1543:3: note: in expansion of macro 'EXPECT_OK'
 1543 |   EXPECT_OK(pdpi::ClearTableEntries(sut_p4_session_.get()));
      |   ^~~~~~~~~
./p4_pdpi/p4_runtime_session.h:392:14: note: declared here
  392 | absl::Status ClearTableEntries(P4RuntimeSession *session);
      |              ^~~~~~~~~~~~~~~~~
tests/sflow/sflow_test.cc: In function 'absl::lts_20230802::Status pins::{anonymous}::SetSwitchVrfForAllPackets(pdpi::P4RuntimeSession&, const pdpi::IrP4Info&, absl::lts_20230802::string_view)':
tests/sflow/sflow_test.cc:2020:46: warning: 'absl::lts_20230802::StatusOr<p4::v1::TableEntry> pdpi::PartialPdTableEntryToPiTableEntry(const IrP4Info&, const google::protobuf::Message&, const TranslationOptions&)' is deprecated: Use PdTableEntryToPiEntity instead [-Wdeprecated-declarations]
 2020 |       pdpi::PartialPdTableEntryToPiTableEntry(
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 2021 |           ir_p4info, gutil::ParseProtoOrDie<sai::TableEntry>(absl::Substitute(
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2022 |                          R"pb(
      |                          ~~~~~                
 2023 |                            vrf_table_entry {
      |                            ~~~~~~~~~~~~~~~~~  
 2024 |                              match { vrf_id: "$0" }
      |                              ~~~~~~~~~~~~~~~~~~~~~~
 2025 |                              action { no_action {} }
      |                              ~~~~~~~~~~~~~~~~~~~~~~~
 2026 |                            })pb",
      |                            ~~~~~~             
 2027 |                          vrf_id))));
      |                          ~~~~~~~~~            
./gutil/status.h:286:43: note: in definition of macro '__ASSIGN_OR_RETURN'
  286 |   auto __ASSIGN_OR_RETURN_VAL(__LINE__) = expr;                                \
      |                                           ^~~~
tests/sflow/sflow_test.cc:2018:3: note: in expansion of macro 'ASSIGN_OR_RETURN'
 2018 |   ASSIGN_OR_RETURN(
In file included from tests/qos/frontpanel_qos_test.cc:70:
./p4_pdpi/pd.h:142:36: note: declared here
  142 | absl::StatusOr<p4::v1::TableEntry> PartialPdTableEntryToPiTableEntry(
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tests/qos/frontpanel_qos_test.cc: In member function 'virtual void pins_test::FrontpanelQosTest_PacketsGetMappedToCorrectQueuesBasedOnDscpAndQueuePeakRatesAreEnforced_Test::TestBody()':
tests/qos/frontpanel_qos_test.cc:672:31: warning: loop variable 'kDscpsByQueueName' creates a copy from type 'const DscpsByQueueName' {aka 'const std::optional<absl::lts_20230802::flat_hash_map<std::__cxx11::basic_string<char>, std::vector<int> > >'} [-Wrange-loop-construct]
  672 |   for (const DscpsByQueueName kDscpsByQueueName :
      |                               ^~~~~~~~~~~~~~~~~
tests/qos/frontpanel_qos_test.cc:672:31: note: use reference type to prevent copying
  672 |   for (const DscpsByQueueName kDscpsByQueueName :
      |                               ^~~~~~~~~~~~~~~~~
      |                               &
In file included from external/com_google_googletest/googletest/include/gtest/gtest.h:387,
                 from ./thinkit/generic_testbed_fixture.h:28,
                 from ./tests/qos/frontpanel_qos_test.h:27:
tests/qos/frontpanel_qos_test.cc: In member function 'virtual void pins_test::FrontpanelQosTest_WeightedRoundRobinWeightsAreRespected_Test::TestBody()':
tests/qos/frontpanel_qos_test.cc:1249:36: warning: 'absl::lts_20230802::Status pdpi::ClearTableEntries(P4RuntimeSession*)' is deprecated: Use ClearEntities instead. [-Wdeprecated-declarations]
 1249 |   ASSERT_OK(pdpi::ClearTableEntries(sut_p4rt.get()));
      |             ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
tests/qos/frontpanel_qos_test.cc:1249:3: note: in expansion of macro 'ASSERT_OK'
 1249 |   ASSERT_OK(pdpi::ClearTableEntries(sut_p4rt.get()));
      |   ^~~~~~~~~
./p4_pdpi/p4_runtime_session.h:392:14: note: declared here
  392 | absl::Status ClearTableEntries(P4RuntimeSession *session);
      |              ^~~~~~~~~~~~~~~~~
INFO: Elapsed time: 292.980s, Critical Path: 115.75s
INFO: 34 processes: 3 internal, 31 linux-sandbox.
INFO: Build completed successfully, 34 total actions



Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 711 targets (0 packages loaded, 378 targets configured).
INFO: Found 489 targets and 222 test targets...
INFO: Elapsed time: 269.211s, Critical Path: 127.34s
INFO: 279 processes: 336 linux-sandbox, 18 local.
INFO: Build completed successfully, 279 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.8s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 0.6s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.4s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.2s
//dvaas:test_vector_test                                                 PASSED in 0.7s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 1.8s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 0.6s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.6s
//gutil:proto_test                                                       PASSED in 0.6s
//gutil:status_matchers_test                                             PASSED in 0.6s
//gutil:test_artifact_writer_test                                        PASSED in 0.6s
//gutil:testing_test                                                     PASSED in 0.5s
//gutil:timer_test                                                       PASSED in 5.3s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.2s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.3s
//p4rt_app/utils:table_utility_test                                      PASSED in 0.9s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.0s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 0.8s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 16.5s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.2s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.8s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.5s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 4.1s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.2s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 5.3s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.7s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.8s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.0s
//tests/forwarding:hash_statistics_util_test                             PASSED in 1.0s
//tests/lib:p4info_helper_test                                           PASSED in 0.9s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 2.5s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.1s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.6s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.0s
//tests/sflow:sflow_util_test                                            PASSED in 21.9s
//thinkit:bazel_test_environment_test                                    PASSED in 3.1s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.8s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 0.7s
//tests/lib:packet_generator_test                                        PASSED in 66.6s
  Stats over 4 runs: max = 66.6s, min = 64.8s, avg = 65.5s, dev = 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.5s
  Stats over 5 runs: max = 1.5s, min = 0.9s, avg = 1.2s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 44.9s
  Stats over 50 runs: max = 44.9s, min = 0.8s, avg = 2.2s, dev = 6.3s

Executed 222 out of 222 tests: 222 tests pass.
INFO: Build completed successfully, 279 total actions