### PR TITLE
[P4RT] Calculate hash config deltas during P4Reconcile.

### DIFF
--- a/p4rt_app/p4runtime/BUILD.bazel
+++ b/p4rt_app/p4runtime/BUILD.bazel
@@ -401,3 +401,17 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "p4info_reconcile",
+    srcs = ["p4info_reconcile.cc"],
+    hdrs = ["p4info_reconcile.h"],
+    deps = [
+        "//gutil:status",
+        "//p4_pdpi:ir_cc_proto",
+        "//p4rt_app/sonic:hashing",
+        "@com_google_absl//absl/container:btree",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)

--- a/p4rt_app/p4runtime/p4info_reconcile.cc
+++ b/p4rt_app/p4runtime/p4info_reconcile.cc
@@ -1,0 +1,126 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "p4rt_app/p4runtime/p4info_reconcile.h"
+
+#include <string>
+#include <vector>
+
+#include "absl/container/btree_set.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gutil/status.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4rt_app/sonic/hashing.h"
+
+namespace p4rt_app {
+namespace {
+
+template <typename T>
+struct SetDifference {
+  std::vector<T> deleted;
+  std::vector<T> added;
+  std::vector<T> intersection;
+};
+
+template <typename T>
+SetDifference<T> CalculateSetDifference(const absl::btree_set<T>& from,
+                                        const absl::btree_set<T>& to) {
+  SetDifference<T> difference;
+  auto from_iter = from.begin();
+  auto to_iter = to.begin();
+  while (from_iter != from.end() && to_iter != to.end()) {
+    if (*from_iter == *to_iter) {
+      difference.intersection.push_back(*from_iter);
+      ++from_iter;
+      ++to_iter;
+    } else if (*from_iter < *to_iter) {
+      difference.deleted.push_back(*from_iter);
+      ++from_iter;
+    } else {  // *from_iter > *to_iter
+      difference.added.push_back(*to_iter);
+      ++to_iter;
+    }
+  }
+  while (from_iter != from.end()) {
+    difference.deleted.push_back(*from_iter);
+    ++from_iter;
+  }
+  while (to_iter != to.end()) {
+    difference.added.push_back(*to_iter);
+    ++to_iter;
+  }
+  return difference;
+}
+
+absl::Status CalculateHashingDifference(const pdpi::IrP4Info& from,
+                                        const pdpi::IrP4Info& to,
+                                        P4InfoReconcileTransition& transition) {
+  auto from_hash_packet_fields = sonic::ExtractHashPacketFieldConfigs(from);
+  if (!from_hash_packet_fields.ok()) {
+    return gutil::InternalErrorBuilder()
+           << "Failed to calculate hash packets fields from existing P4Info: "
+           << from_hash_packet_fields.status().message();
+  }
+  auto from_hash_parameters = sonic::ExtractHashParamConfigs(from);
+  if (!from_hash_parameters.ok()) {
+    return gutil::InternalErrorBuilder()
+           << "Failed to calculate hash parameter fields from existing P4Info: "
+           << from_hash_parameters.status().message();
+  }
+
+  ASSIGN_OR_RETURN(auto to_hash_packet_fields,
+                   sonic::ExtractHashPacketFieldConfigs(to),
+                   _.SetPrepend() << "Failed to calculate hash packet fields "
+                                  << "from new forwarding pipeline config. ");
+  ASSIGN_OR_RETURN(auto to_hash_parameters, sonic::ExtractHashParamConfigs(to),
+                   _.SetPrepend() << "failed to calculate hash parameters from "
+                                  << "new forwarding pipeline config. ");
+
+  // calculate packet field config diffs.
+  SetDifference packet_field_diff =
+      CalculateSetDifference(*from_hash_packet_fields, to_hash_packet_fields);
+  absl::btree_set<std::string> to_packet_field_keys;
+  for (const sonic::HashPacketFieldConfig& config : to_hash_packet_fields) {
+    to_packet_field_keys.insert(to_packet_field_keys.end(), config.key);
+  }
+  for (const sonic::HashPacketFieldConfig& config : packet_field_diff.deleted) {
+    // Skip delete of keys that we will replace.
+    if (!to_packet_field_keys.contains(config.key)) {
+      transition.hashing_packet_field_configs_to_delete.push_back(config.key);
+    }
+  }
+  for (const sonic::HashPacketFieldConfig& config : packet_field_diff.added) {
+    transition.hashing_packet_field_configs_to_set.push_back(config.key);
+  }
+
+  // Calculate whether the switch table is different.
+  transition.update_switch_table =
+      !transition.hashing_packet_field_configs_to_delete.empty() ||
+      !transition.hashing_packet_field_configs_to_set.empty() ||
+      *from_hash_parameters != to_hash_parameters;
+
+  return absl::OkStatus();
+}
+
+}  // namespace
+
+absl::StatusOr<P4InfoReconcileTransition> CalculateTransition(
+    const pdpi::IrP4Info& from, const pdpi::IrP4Info& to) {
+  P4InfoReconcileTransition transition;
+  RETURN_IF_ERROR(CalculateHashingDifference(from, to, transition));
+  return transition;
+}
+
+}  // namespace p4rt_app

--- a/p4rt_app/p4runtime/p4info_reconcile.h
+++ b/p4rt_app/p4runtime/p4info_reconcile.h
@@ -1,0 +1,47 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PINS_P4RT_APP_P4RUNTIME_P4INFO_RECONCILE_H_
+#define PINS_P4RT_APP_P4RUNTIME_P4INFO_RECONCILE_H_
+
+#include <string>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "p4_pdpi/ir.pb.h"
+
+namespace p4rt_app {
+
+// This struct represents the actions that must be taken to reconcile a new
+// p4info from the current one.
+struct P4InfoReconcileTransition {
+  // Hashing
+  std::vector<std::string> hashing_packet_field_configs_to_delete;
+  std::vector<std::string> hashing_packet_field_configs_to_set;
+  bool update_switch_table = false;
+
+  // ACL (Currently unused).
+  std::vector<std::string> acl_tables_to_delete;
+  std::vector<std::string> acl_tables_to_add;
+  std::vector<std::string> acl_tables_to_modify;
+};
+
+// Returns the transition steps for migrating to a new P4Info.
+// Returns an error if there is an unreconcilable difference.
+absl::StatusOr<P4InfoReconcileTransition> CalculateTransition(
+    const pdpi::IrP4Info& from, const pdpi::IrP4Info& to);
+
+}  // namespace p4rt_app
+
+#endif  // PINS_P4RT_APP_P4RUNTIME_P4INFO_RECONCILE_H_


### PR DESCRIPTION
### Keyword Check:
upstream/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_check.sh  .
Keyword check Passed.

### Build Result:
  ./p4_pdpi/string_encodings/bit_string.h: In instantiation of 'void pdpi::BitString::AppendBits(const std::bitset<_Nb>&) [with long unsigned int num_bits = 8]':
./p4_pdpi/string_encodings/bit_string.h:41:24:   required from here
./p4_pdpi/string_encodings/bit_string.h:49:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   49 |     for (int i = 0; i < num_bits; i++) {
      |                     ~~^~~~~~~~~~
INFO: Elapsed time: 349.078s, Critical Path: 342.43s
INFO: 758 processes: 202 internal, 556 linux-sandbox.
INFO: Build completed successfully, 758 total actions
INFO: Build completed successfully, 758 total actions

### Test Result:
jaanahg@cd1dec8cc649:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 712 targets (1 packages loaded, 697 targets configured).
INFO: Found 490 targets and 222 test targets...
INFO: Elapsed time: 179.949s, Critical Path: 128.35s
INFO: 279 processes: 336 linux-sandbox, 18 local.
INFO: Build completed successfully, 279 total actions
//dvaas:port_id_map_test                                                 PASSED in 1.5s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.2s
//dvaas:test_run_validation_test                                         PASSED in 1.1s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.0s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.4s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.3s
//gutil:collections_test                                                 PASSED in 0.9s
//gutil:io_test                                                          PASSED in 1.0s
//gutil:proto_matchers_test                                              PASSED in 1.7s
//gutil:proto_ordering_test                                              PASSED in 1.5s
//gutil:proto_test                                                       PASSED in 1.2s
//gutil:status_matchers_test                                             PASSED in 0.9s
//gutil:test_artifact_writer_test                                        PASSED in 1.3s
//gutil:testing_test                                                     PASSED in 0.8s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 4.0s
//lib:basic_switch_test                                                  PASSED in 1.9s
//lib:ixia_helper_test                                                   PASSED in 2.1s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 1.7s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 16.2s
//lib/gnmi:gnmi_helper_test                                              PASSED in 3.7s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.1s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.9s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 2.2s
//lib/utils:generic_testbed_utils_test                                   PASSED in 2.4s
//lib/utils:json_utils_test                                              PASSED in 1.5s
//lib/validator:validator_backend_test                                   PASSED in 1.0s
//lib/validator:validator_lib_test                                       PASSED in 26.3s
//p4_fuzzer:constraints_test                                             PASSED in 6.2s
//p4_fuzzer:fuzz_util_test                                               PASSED in 128.3s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 1.8s
//p4_fuzzer:oracle_util_test                                             PASSED in 5.1s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 3.9s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 3.9s
//p4_fuzzer:switch_state_test                                            PASSED in 1.7s
//p4_pdpi:built_ins_test                                                 PASSED in 1.2s
//p4_pdpi:entity_keys_test                                               PASSED in 1.0s
//p4_pdpi:ir_properties_test                                             PASSED in 1.3s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.1s
//p4_pdpi:ir_tools_test                                                  PASSED in 1.4s
//p4_pdpi:names_test                                                     PASSED in 1.2s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.7s
//p4_pdpi:reference_annotations_test                                     PASSED in 1.0s
//p4_pdpi:references_test                                                PASSED in 1.0s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.1s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.2s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.3s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.9s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 24.2s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.0s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 8.0s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.9s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.4s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.2s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.7s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.2s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.2s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.2s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.3s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:references_test                                        PASSED in 0.3s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.3s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.3s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.3s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.2s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 1.3s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.3s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.1s
//p4_symbolic:z3_util_test                                               PASSED in 0.9s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 1.6s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 1.9s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 2.1s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 1.8s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 1.8s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 1.9s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 1.2s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.0s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.1s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.1s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.1s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.1s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.0s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.1s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.0s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 0.9s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 11.4s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 7.6s
//p4_symbolic/sai:sai_test                                               PASSED in 3.9s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 2.5s
//p4_symbolic/symbolic:parser_test                                       PASSED in 1.6s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:reflector_test_packets                            PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 2.0s
//p4_symbolic/symbolic:util_test                                         PASSED in 1.9s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.1s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 4.6s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 10.0s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.8s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 2.2s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 2.1s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 2.1s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 2.4s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 2.3s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 2.3s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.9s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 1.4s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 1.3s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.6s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 2.1s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 1.9s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 2.0s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.3s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 1.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 1.7s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 1.5s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.2s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 1.4s
//p4rt_app/sonic:state_verification_test                                 PASSED in 1.5s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.5s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.9s
//p4rt_app/tests:action_set_test                                         PASSED in 1.4s
//p4rt_app/tests:api_access_test                                         PASSED in 1.1s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.2s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.2s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.2s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.8s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 6.1s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.2s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.1s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.5s
//p4rt_app/tests:packetio_test                                           PASSED in 4.3s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.7s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.2s
//p4rt_app/tests:response_path_test                                      PASSED in 4.6s
//p4rt_app/tests:role_test                                               PASSED in 1.5s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.7s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.2s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 1.3s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.1s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.3s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.4s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.2s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.9s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 6.3s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.6s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 7.1s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.3s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.6s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.5s
//tests/forwarding:hash_statistics_util_test                             PASSED in 1.6s
//tests/lib:p4info_helper_test                                           PASSED in 2.2s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 2.1s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.2s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.2s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 8.2s
//thinkit:bazel_test_environment_test                                    PASSED in 1.1s
//thinkit:generic_testbed_test                                           PASSED in 1.7s
//thinkit:mock_control_device_test                                       PASSED in 1.0s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.6s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.3s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.4s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 1.8s
//tests/lib:packet_generator_test                                        PASSED in 71.3s
  Stats over 4 runs: max = 71.3s, min = 69.5s, avg = 70.4s, dev = 0.6s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.8s
  Stats over 5 runs: max = 1.8s, min = 1.4s, avg = 1.6s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 51.3s
  Stats over 50 runs: max = 51.3s, min = 1.2s, avg = 3.0s, dev = 7.0s

Executed 222 out of 222 tests: 222 tests pass.
INFO: Build completed successfully, 279 total actions
