### PR TITLE
[P4RT] support action `set_port_and_src_mac_and_vlan_id`. For tests that testing internal requests handling during normal P4RT warm reboot shutdown, add code to verify that the warm-boot state is changed to FROZEN during the process of the internal request and then changed back to QUIESCENT. Calculate ACL table reconciliation for SetForwardingPipelineConfig[P4RT]

### DIFF
--- a/p4rt_app/p4runtime/BUILD.bazel
+++ b/p4rt_app/p4runtime/BUILD.bazel
@@ -409,7 +409,10 @@ cc_library(
     deps = [
         "//gutil:status",
         "//p4_pdpi:ir_cc_proto",
+        "//p4rt_app/sonic:app_db_acl_def_table_manager",
         "//p4rt_app/sonic:hashing",
+        "//p4rt_app/sonic:swss_utils",
+        "//p4rt_app/utils:table_utility",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
@@ -417,17 +420,18 @@ cc_library(
 )
 
 cc_test(
-     name = "p4info_reconcile_test",
-     srcs = ["p4info_reconcile_test.cc"],
-     deps = [
-         ":p4info_reconcile",
-         "//gutil:status_matchers",
-         "//p4_pdpi:ir_cc_proto",
-         "//p4rt_app/utils:ir_builder",
-         "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-         "@com_google_absl//absl/functional:any_invocable",
-         "@com_google_absl//absl/status",
-         "@com_google_absl//absl/strings",
-         "@com_google_googletest//:gtest_main",
-     ],
+    name = "p4info_reconcile_test",
+    srcs = ["p4info_reconcile_test.cc"],
+    deps = [
+        ":p4info_reconcile",
+        "//gutil:status_matchers",
+        "//p4_pdpi:ir_cc_proto",
+        "//p4rt_app/utils:ir_builder",
+        "//p4rt_app/utils:table_utility",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/functional:any_invocable",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
 )

--- a/p4rt_app/p4runtime/p4info_reconcile.h
+++ b/p4rt_app/p4runtime/p4info_reconcile.h
@@ -31,7 +31,7 @@ struct P4InfoReconcileTransition {
   std::vector<std::string> hashing_packet_field_configs_to_set;
   bool update_switch_table = false;
 
-  // ACL (Currently unused).
+  // ACL
   std::vector<std::string> acl_tables_to_delete;
   std::vector<std::string> acl_tables_to_add;
   std::vector<std::string> acl_tables_to_modify;

--- a/p4rt_app/p4runtime/p4info_verification_schema.pb.txt
+++ b/p4rt_app/p4runtime/p4info_verification_schema.pb.txt
@@ -164,6 +164,12 @@ tables {
     parameters { name: "port" format: STRING }
     parameters { name: "src_mac" format: MAC }
   }
+  actions {
+    name: "set_port_and_src_mac_and_vlan_id"
+    parameters { name: "port" format: STRING }
+    parameters { name: "src_mac" format: MAC }
+    parameters { name: "vlan_id" bitwidth: 12 }
+  }
 }
 tables {
   name: "tunnel_table"

--- a/p4rt_app/sonic/adapters/fake_warm_boot_state_adapter.cc
+++ b/p4rt_app/sonic/adapters/fake_warm_boot_state_adapter.cc
@@ -13,26 +13,49 @@
 // limitations under the License.
 #include "p4rt_app/sonic/adapters/fake_warm_boot_state_adapter.h"
 
+#include <vector>
+
 #include "swss/warm_restart.h"
 
 namespace p4rt_app {
 namespace sonic {
 
-FakeWarmBootStateAdapter::FakeWarmBootStateAdapter() {}
+FakeWarmBootStateAdapter::FakeWarmBootStateAdapter() {
+  states_.push_back(swss::WarmStart::WarmStartState::RECONCILED);
+}
 
 swss::WarmStart::WarmStartState FakeWarmBootStateAdapter::GetWarmBootState() {
-  return state_;
+  return states_.back();
+}
+
+std::vector<swss::WarmStart::WarmStartState>
+FakeWarmBootStateAdapter::GetWarmBootStateHistory() {
+  return states_;
 }
 
 void FakeWarmBootStateAdapter::SetWarmBootState(
     swss::WarmStart::WarmStartState state) {
-  state_ = state;
+  states_.push_back(state);
 }
 
 bool FakeWarmBootStateAdapter::IsWarmStart() { return is_warm_start_; }
 
 void FakeWarmBootStateAdapter::SetWarmStart(bool is_warm_start) {
   is_warm_start_ = is_warm_start;
+}
+
+void FakeWarmBootStateAdapter::SetWaitForUnfreeze(bool wait_for_unfreeze) {
+  wait_for_unfreeze_ = wait_for_unfreeze;
+}
+
+void FakeWarmBootStateAdapter::SetOrchAgentWarmBootState(
+    swss::WarmStart::WarmStartState state) {
+  oa_state_ = state;
+}
+
+swss::WarmStart::WarmStartState
+FakeWarmBootStateAdapter::GetOrchAgentWarmBootState() {
+  return oa_state_;
 }
 
 }  // namespace sonic

--- a/p4rt_app/sonic/adapters/fake_warm_boot_state_adapter.h
+++ b/p4rt_app/sonic/adapters/fake_warm_boot_state_adapter.h
@@ -24,13 +24,22 @@ public:
   explicit FakeWarmBootStateAdapter();
   swss::WarmStart::WarmStartState GetWarmBootState() override;
   void SetWarmBootState(swss::WarmStart::WarmStartState state) override;
+  swss::WarmStart::WarmStartState GetOrchAgentWarmBootState(void) override;
   bool IsWarmStart(void) override;
-  void SetWarmStart(bool is_warm_start);
 
-private:
-  swss::WarmStart::WarmStartState state_ =
-      swss::WarmStart::WarmStartState::WSUNKNOWN;
+  // Test-only accessors
+  std::vector<swss::WarmStart::WarmStartState> GetWarmBootStateHistory();
+  void SetWarmStart(bool is_warm_start);
+  void SetWaitForUnfreeze(bool wait_for_unfreeze);
+  void SetOrchAgentWarmBootState(swss::WarmStart::WarmStartState);
+
+ private:
+  // History of warm-boot states.
+  std::vector<swss::WarmStart::WarmStartState> states_;
   bool is_warm_start_ = false;
+  bool wait_for_unfreeze_ = false;
+  swss::WarmStart::WarmStartState oa_state_ =
+      swss::WarmStart::WarmStartState::WSUNKNOWN;
 };
 
 } // namespace sonic

--- a/p4rt_app/sonic/adapters/fake_warm_boot_state_adapter_test.cc
+++ b/p4rt_app/sonic/adapters/fake_warm_boot_state_adapter_test.cc
@@ -24,7 +24,7 @@ namespace {
 TEST(FakeWarmBootStateAdapterTest, GetWarmBootStateDefault) {
   FakeWarmBootStateAdapter adapter;
   EXPECT_THAT(adapter.GetWarmBootState(),
-              swss::WarmStart::WarmStartState::WSUNKNOWN);
+              swss::WarmStart::WarmStartState::RECONCILED);
 }
 
 TEST(FakeWarmBootStateAdapterTest, SetWarmBootState) {

--- a/p4rt_app/sonic/adapters/warm_boot_state_adapter.cc
+++ b/p4rt_app/sonic/adapters/warm_boot_state_adapter.cc
@@ -36,5 +36,13 @@ bool WarmBootStateAdapter::IsWarmStart() {
   return swss::WarmStart::isWarmStart();
 }
 
+swss::WarmStart::WarmStartState
+WarmBootStateAdapter::GetOrchAgentWarmBootState() {
+  swss::WarmStart::WarmStartState state;
+  swss::WarmStart::getWarmStartState("orchagent", state);
+
+  return state;
+}
+
 }  // namespace sonic
 }  // namespace p4rt_app

--- a/p4rt_app/sonic/adapters/warm_boot_state_adapter.h
+++ b/p4rt_app/sonic/adapters/warm_boot_state_adapter.h
@@ -29,6 +29,8 @@ public:
   virtual swss::WarmStart::WarmStartState GetWarmBootState();
   virtual void SetWarmBootState(swss::WarmStart::WarmStartState state);
   virtual bool IsWarmStart(void);
+  // Get OrchAgent WarmBoot state.
+  virtual swss::WarmStart::WarmStartState GetOrchAgentWarmBootState(void);
 };
 
 } // namespace sonic

--- a/p4rt_app/sonic/app_db_acl_def_table_manager.cc
+++ b/p4rt_app/sonic/app_db_acl_def_table_manager.cc
@@ -809,28 +809,6 @@ absl::Status VerifyConstDefaultActionInIrTable(
   return absl::OkStatus();
 }
 
-// Example AppDB Table
-//  P4RT_ACL_TABLE_DEFINITION:P4RT_ACL_PUNT_TABLE
-//    "stage" = "INGRESS"
-//    "match/ether_type" = "SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE"
-//    "match/ether_dst" = "SAI_ACL_ENTRY_ATTR_FIELD_DST_MAC"
-//    "match/ipv6_dst" = "SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6"
-//    "match/ipv6_next_header" = "SAI_ACL_ENTRY_ATTR_FIELD_IPV6_NEXT_HEADER"
-//    "match/ttl" = "SAI_ACL_ENTRY_ATTR_FIELD_TTL"
-//    "match/icmp_type" = "SAI_ACL_ENTRY_ATTR_FIELD_ICMP_TYPE"
-//    "match/l4_dst_port" = "SAI_ACL_ENTRY_ATTR_FIELD_L4_DST_PORT"
-//    "action/copy_and_set_tc" = JsonToString([
-//      {"action": "SAI_PACKET_ACTION_COPY"},
-//      {"action": "SAI_ACL_ENTRY_ATTR_ACTION_SET_TC", "param": "traffic_class"}
-//    ])
-//    "action/punt_and_set_tc" = JsonToString([
-//      {"action": "SAI_PACKET_ACTION_PUNT"},
-//      {"action": "SAI_ACL_ENTRY_ATTR_ACTION_SET_TC", "param": "traffic_class"}
-//    ])
-//    "meter/unit" = "BYTES"
-//    "counter/unit" = "PACKETS"
-//    "size" = "123"
-//    "priority" = "234"
 StatusOr<std::vector<swss::FieldValueTuple>> GenerateSonicDbValuesFromIrTable(
     const IrTableDefinition& ir_table) {
   std::vector<swss::FieldValueTuple> values;
@@ -908,9 +886,13 @@ StatusOr<std::vector<swss::FieldValueTuple>> GenerateSonicDbValuesFromIrTable(
 
 }  // namespace
 
-Status VerifyAclTableDefinition(const IrTableDefinition& ir_table) {
-  RETURN_IF_ERROR(GenerateSonicDbKeyFromIrTable(ir_table).status());
-  return GenerateSonicDbValuesFromIrTable(ir_table).status();
+StatusOr<swss::KeyOpFieldsValuesTuple> AppDbAclTableDefinition(
+    const pdpi::IrTableDefinition& ir_table) {
+  swss::KeyOpFieldsValuesTuple kfv;
+  ASSIGN_OR_RETURN(kfvKey(kfv), GenerateSonicDbKeyFromIrTable(ir_table));
+  ASSIGN_OR_RETURN(kfvFieldsValues(kfv),
+                   GenerateSonicDbValuesFromIrTable(ir_table));
+  return kfv;
 }
 
 StatusOr<std::string> InsertAclTableDefinition(


### PR DESCRIPTION
~/upstream/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_check.sh .
Keyword check Passed.

Build Logs:
========
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...                
INFO: Analyzed 715 targets (2 packages loaded, 497 targets configured).
INFO: Found 715 targets...
INFO: Elapsed time: 0.726s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action


Build Test Log:
===========
jaanahg@cd1dec8cc649:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ... 2> build_test.log
//dvaas:port_id_map_test                                                 PASSED in 1.5s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.1s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.6s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.3s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//gutil:collections_test                                                 PASSED in 0.9s
//gutil:io_test                                                          PASSED in 0.9s
//gutil:proto_matchers_test                                              PASSED in 0.9s
//gutil:proto_ordering_test                                              PASSED in 0.9s
//gutil:proto_test                                                       PASSED in 0.8s
//gutil:status_matchers_test                                             PASSED in 1.0s
//gutil:test_artifact_writer_test                                        PASSED in 0.9s
//gutil:testing_test                                                     PASSED in 1.4s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 3.8s
//lib:basic_switch_test                                                  PASSED in 1.4s
//lib:ixia_helper_test                                                   PASSED in 2.2s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 1.8s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 16.0s
//lib/gnmi:gnmi_helper_test                                              PASSED in 3.4s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.0s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.8s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 1.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 2.4s
//lib/utils:json_utils_test                                              PASSED in 1.2s
//lib/validator:validator_backend_test                                   PASSED in 1.1s
//lib/validator:validator_lib_test                                       PASSED in 26.5s
//p4_fuzzer:constraints_test                                             PASSED in 4.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 135.0s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 1.6s
//p4_fuzzer:oracle_util_test                                             PASSED in 4.6s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 3.6s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 3.0s
//p4_fuzzer:switch_state_test                                            PASSED in 1.8s
//p4_pdpi:built_ins_test                                                 PASSED in 1.1s
//p4_pdpi:entity_keys_test                                               PASSED in 0.9s
//p4_pdpi:ir_properties_test                                             PASSED in 1.0s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.0s
//p4_pdpi:ir_tools_test                                                  PASSED in 1.2s
//p4_pdpi:names_test                                                     PASSED in 1.2s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.0s
//p4_pdpi:reference_annotations_test                                     PASSED in 1.5s
//p4_pdpi:references_test                                                PASSED in 1.3s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.0s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.2s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.0s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.3s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 24.3s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.1s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 7.7s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.1s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.0s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.2s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.3s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.5s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.2s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.2s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:references_test                                        PASSED in 0.2s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.3s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 2.3s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.4s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.0s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.4s
//p4_symbolic:z3_util_test                                               PASSED in 1.6s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 2.1s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 2.1s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 2.0s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 1.3s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 1.8s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 1.8s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 1.8s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.3s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.1s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.0s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.0s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.1s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.1s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.1s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 13.7s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 7.2s
//p4_symbolic/sai:sai_test                                               PASSED in 4.9s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 2.4s
//p4_symbolic/symbolic:parser_test                                       PASSED in 1.7s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:reflector_test_packets                            PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 1.5s
//p4_symbolic/symbolic:util_test                                         PASSED in 1.1s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.6s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 5.4s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 8.0s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.7s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 2.4s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.7s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 2.2s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 2.5s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 2.5s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 2.1s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 1.0s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 1.3s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 1.2s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 1.5s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.3s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 1.6s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 1.3s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 1.5s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 1.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 1.6s
//p4rt_app/sonic:hashing_test                                            PASSED in 1.1s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 1.4s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.0s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.0s
//p4rt_app/sonic:response_handler_test                                   PASSED in 1.3s
//p4rt_app/sonic:state_verification_test                                 PASSED in 1.5s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.1s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.3s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.5s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.9s
//p4rt_app/tests:action_set_test                                         PASSED in 1.4s
//p4rt_app/tests:api_access_test                                         PASSED in 1.1s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.2s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.3s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.3s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.9s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 6.4s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.5s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.0s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.1s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.4s
//p4rt_app/tests:packetio_test                                           PASSED in 4.3s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.8s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.5s
//p4rt_app/tests:response_path_test                                      PASSED in 4.6s
//p4rt_app/tests:role_test                                               PASSED in 1.4s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.6s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.2s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 1.3s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.8s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.3s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.5s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.8s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 5.5s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.6s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 4.4s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.3s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.3s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.5s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.3s
//tests/lib:p4info_helper_test                                           PASSED in 1.4s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.4s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.3s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.8s
//thinkit:bazel_test_environment_test                                    PASSED in 1.2s
//thinkit:generic_testbed_test                                           PASSED in 1.6s
//thinkit:mock_control_device_test                                       PASSED in 1.4s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.1s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.3s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.4s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.6s
//tests/lib:packet_generator_test                                        PASSED in 71.4s
  Stats over 4 runs: max = 71.4s, min = 70.0s, avg = 70.6s, dev = 0.6s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.8s
  Stats over 5 runs: max = 1.8s, min = 1.1s, avg = 1.5s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 53.3s
  Stats over 50 runs: max = 53.3s, min = 1.2s, avg = 5.0s, dev = 12.0s

Executed 224 out of 224 tests: 224 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.


