### PR TITLE
[P4_PDPI]Disable PSP reserved field since it causes issues with DVaaS.Add CSIG header support to packetlib.

### DIFF
--- a/p4_pdpi/packetlib/bit_widths.h
+++ b/p4_pdpi/packetlib/bit_widths.h
@@ -33,6 +33,7 @@ constexpr int kSaiP4BMv2PacketInHeaderBitwidth = 24;
 constexpr int kIpfixHeaderBitwidth = 128;
 constexpr int kPsampHeaderBitwidth = 224;
 constexpr int kPtpHeaderBitwidth = 272;
+constexpr int kPspHeaderBitwidth = 128;
 
 // Ethernet constants.
 constexpr int kEthernetEthertypeBitwidth = 16;
@@ -135,6 +136,21 @@ constexpr int kPtpSourcePortIdentityBitwidth = 80;
 constexpr int kPtpSequenceIdBitwidth = 16;
 constexpr int kPtpControlFieldBitwidth = 8;
 constexpr int kPtpLogMessageIntervalBitwidth = 8;
+
+// PSP constants
+// NOTE: There is an optional virtualization_cookie field that we do not model
+// since we do not yet have a use-case.
+constexpr int kPspNextHeaderBitwidth = 8;
+constexpr int kPspHeaderExtLengthBitwidth = 8;
+constexpr int kPspReserved0Bitwidth = 2;
+constexpr int kPspCryptOffsetBitwidth = 6;
+constexpr int kPspSampleBitwidth = 1;
+constexpr int kPspDropBitwidth = 1;
+constexpr int kPspVersionBitwidth = 4;
+constexpr int kPspVirtualizationCookieBitwidth = 1;
+constexpr int kPspReserved1Bitwidth = 1;
+constexpr int kPspSecurityParametersIndexBitwidth = 32;
+constexpr int kPspInitializationVectorBitwidth = 64;
 
 } // namespace packetlib
 

--- a/p4_pdpi/packetlib/packetlib.cc
+++ b/p4_pdpi/packetlib/packetlib.cc
@@ -16,6 +16,7 @@
 #include <bitset>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -132,6 +133,8 @@ absl::StatusOr<NextHeader> GetNextHeader(const UdpHeader& header) {
     return Header::kIpfixHeader;
   if (dest_port == 319)
     return Header::kPtpHeader;
+  if (dest_port == 1000)
+    return Header::kPspHeader;
   return Header::HEADER_NOT_SET;
 }
 absl::StatusOr<NextHeader> GetNextHeader(const TcpHeader& header) {
@@ -150,6 +153,19 @@ absl::StatusOr<NextHeader> GetNextHeader(const PsampHeader& header) {
   return Header::HEADER_NOT_SET;
 }
 absl::StatusOr<NextHeader> GetNextHeader(const PtpHeader &header) {
+  return Header::HEADER_NOT_SET;
+}
+absl::StatusOr<NextHeader> GetNextHeader(const PspHeader &header) {
+  if (header.virtualization_cookie_present() == "0x1") {
+    return UnsupportedNextHeader{
+        .reason = "psp_header virtualization_cookie is not supported.",
+    };
+  }
+  // Only parse the UDP header if we have enough unencrypted bits.
+  ASSIGN_OR_RETURN(int crypt_offset,
+                   pdpi::HexStringToInt32(header.crypt_offset()));
+  if (header.next_header() == "0x11" && crypt_offset * 32 >= kUdpHeaderBitwidth)
+    return Header::kUdpHeader;
   return Header::HEADER_NOT_SET;
 }
 absl::StatusOr<NextHeader> GetNextHeader(const Header& header) {
@@ -180,6 +196,8 @@ absl::StatusOr<NextHeader> GetNextHeader(const Header& header) {
       return GetNextHeader(header.psamp_header());
     case Header::kPtpHeader:
       return GetNextHeader(header.ptp_header());
+    case Header::kPspHeader:
+      return GetNextHeader(header.psp_header());
     case Header::HEADER_NOT_SET:
       return Header::HEADER_NOT_SET;
   }
@@ -557,6 +575,33 @@ absl::StatusOr<PtpHeader> ParsePtpHeader(pdpi::BitString &data) {
   return header;
 }
 
+absl::StatusOr<PspHeader> ParsePspHeader(pdpi::BitString &data) {
+  if (data.size() < kPspHeaderBitwidth) {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "Packet is too short to parse a PSP header next. Only "
+           << data.size() << " bits left, need at least " << kPspHeaderBitwidth
+           << ".";
+  }
+  PspHeader header;
+
+  header.set_next_header(ParseBits(data, kPspNextHeaderBitwidth));
+  header.set_header_ext_length(ParseBits(data, kPspHeaderExtLengthBitwidth));
+  header.set_reserved0(ParseBits(data, kPspReserved0Bitwidth));
+  header.set_crypt_offset(ParseBits(data, kPspCryptOffsetBitwidth));
+  header.set_sample_bit(ParseBits(data, kPspSampleBitwidth));
+  header.set_drop_bit(ParseBits(data, kPspDropBitwidth));
+  header.set_version(ParseBits(data, kPspVersionBitwidth));
+  header.set_virtualization_cookie_present(
+      ParseBits(data, kPspVirtualizationCookieBitwidth));
+  header.set_reserved1(ParseBits(data, kPspReserved1Bitwidth));
+  header.set_security_parameters_index(
+      ParseBits(data, kPspSecurityParametersIndexBitwidth));
+  header.set_initialization_vector(
+      ParseBits(data, kPspInitializationVectorBitwidth));
+
+  return header;
+}
+
 absl::StatusOr<Header> ParseHeader(Header::HeaderCase header_case,
                                    pdpi::BitString& data) {
   Header result;
@@ -613,6 +658,10 @@ absl::StatusOr<Header> ParseHeader(Header::HeaderCase header_case,
     }
     case Header::kPtpHeader: {
       ASSIGN_OR_RETURN(*result.mutable_ptp_header(), ParsePtpHeader(data));
+      return result;
+    }
+    case Header::kPspHeader: {
+      ASSIGN_OR_RETURN(*result.mutable_psp_header(), ParsePspHeader(data));
       return result;
     }
     case Header::HEADER_NOT_SET:
@@ -985,6 +1034,21 @@ void Ipv6HeaderInvalidReasons(const Ipv6Header& header,
   }
 }
 
+// The UDP checksum is allowed to be zero for tunneling packets:
+//   https://datatracker.ietf.org/doc/html/rfc6935.
+// IpFix should enable UDP checksums, but we make an exception here:
+//   https://datatracker.ietf.org/doc/html/rfc5153
+bool AllowZeroChecksumForUdp(Packet packet, int udp_header_index) {
+  if (udp_header_index + 1 >= packet.headers_size()) {
+    return false;
+  }
+
+  Header::HeaderCase next_header =
+      packet.headers(udp_header_index + 1).header_case();
+  return next_header == Header::kPspHeader ||
+         next_header == Header::kIpfixHeader;
+}
+
 void UdpHeaderInvalidReasons(const UdpHeader& header,
                              const std::string& field_prefix,
                              const Packet& packet, int header_index,
@@ -1023,7 +1087,8 @@ void UdpHeaderInvalidReasons(const UdpHeader& header,
         "defined; found no header instead"));
   } else if (auto previous = packet.headers(header_index - 1).header_case();
              previous != Header::kIpv4Header &&
-             previous != Header::kIpv6Header) {
+             previous != Header::kIpv6Header &&
+             previous != Header::kPspHeader) {
     output.push_back(absl::StrCat(
         field_prefix,
         "checksum: UDP header must be preceded by IP header for checksum to be "
@@ -1037,19 +1102,16 @@ void UdpHeaderInvalidReasons(const UdpHeader& header,
           field_prefix, "checksum: Couldn't compute expected checksum: ",
           checksum.status().ToString()));
     } else if (packet.headers_size() > header_index + 1) {
-      // UDP is not the latest header.
-      if (packet.headers(header_index + 1).header_case() ==
-              Header::kIpfixHeader &&
-          header.checksum() != UdpChecksum(0)) {
-        // UDP checksum is defaulted to zero in case of Ipfix.
+      if (header.checksum() != UdpChecksum(0) &&
+          AllowZeroChecksumForUdp(packet, header_index)) {
         output.push_back(absl::StrCat(field_prefix,
                                       "checksum: Must be 0, but was ",
                                       header.checksum(), " instead."));
       }
-    } else {
-      std::string expected =
-          pdpi::BitsetToHexString(std::bitset<kUdpChecksumBitwidth>(*checksum));
-      if (header.checksum() != expected) {
+    } else if (checksum->has_value()) {
+      if (std::string expected = pdpi::BitsetToHexString(
+              std::bitset<kUdpChecksumBitwidth>(checksum->value()));
+          header.checksum() != expected) {
         output.push_back(absl::StrCat(field_prefix, "checksum: Must be ",
                                       expected, ", but was ", header.checksum(),
                                       " instead."));
@@ -1549,6 +1611,50 @@ void PtpHeaderInvalidReasons(const PtpHeader &header,
   }
 }
 
+void PspHeaderInvalidReasons(const PspHeader &header,
+                             const std::string &field_prefix,
+                             std::vector<std::string> &output) {
+  HexStringInvalidReasons<kPspNextHeaderBitwidth>(
+      header.next_header(), absl::StrCat(field_prefix, "next_header"), output);
+  HexStringInvalidReasons<kPspHeaderExtLengthBitwidth>(
+      header.header_ext_length(),
+      absl::StrCat(field_prefix, "header_ext_length"), output);
+  HexStringInvalidReasons<kPspCryptOffsetBitwidth>(
+      header.crypt_offset(), absl::StrCat(field_prefix, "crypt_offset"),
+      output);
+  HexStringInvalidReasons<kPspSampleBitwidth>(
+      header.sample_bit(), absl::StrCat(field_prefix, "sample_bit"), output);
+  HexStringInvalidReasons<kPspDropBitwidth>(
+      header.drop_bit(), absl::StrCat(field_prefix, "drop_bit"), output);
+  HexStringInvalidReasons<kPspVersionBitwidth>(
+      header.version(), absl::StrCat(field_prefix, "version"), output);
+  HexStringInvalidReasons<kPspVirtualizationCookieBitwidth>(
+      header.virtualization_cookie_present(),
+      absl::StrCat(field_prefix, "virtualization_cookie_present"), output);
+  HexStringInvalidReasons<kPspSecurityParametersIndexBitwidth>(
+      header.security_parameters_index(),
+      absl::StrCat(field_prefix, "security_parameters_index"), output);
+  HexStringInvalidReasons<kPspInitializationVectorBitwidth>(
+      header.initialization_vector(),
+      absl::StrCat(field_prefix, "initialization_vector"), output);
+
+  // Verify that the reserved fields are correct per the PSP spec.
+  bool reserved0_invalid = HexStringInvalidReasons<kPspReserved0Bitwidth>(
+      header.reserved0(), absl::StrCat(field_prefix, "reserved0"), output);
+  if (!reserved0_invalid && header.reserved0() != "0x0") {
+    output.push_back(absl::StrCat(field_prefix,
+                                  "reserved0: Must be 0x0, but was ",
+                                  header.reserved0(), " instead."));
+  }
+  bool reserved1_invalid = HexStringInvalidReasons<kPspReserved1Bitwidth>(
+      header.reserved1(), absl::StrCat(field_prefix, "reserved1"), output);
+  if (!reserved1_invalid && header.reserved1() != "0x1") {
+    output.push_back(absl::StrCat(field_prefix,
+                                  "reserved1: Must be 0x1, but was ",
+                                  header.reserved1(), " instead."));
+  }
+}
+
 }  // namespace
 
 std::string HeaderCaseName(Header::HeaderCase header_case) {
@@ -1579,6 +1685,8 @@ std::string HeaderCaseName(Header::HeaderCase header_case) {
       return "PsampHeader";
     case Header::kPtpHeader:
       return "PtpHeader";
+    case Header::kPspHeader:
+      return "PspHeader";
     case Header::HEADER_NOT_SET:
       return "HEADER_NOT_SET";
   }
@@ -1673,6 +1781,10 @@ std::vector<std::string> PacketInvalidReasons(const Packet& packet) {
       case Header::kPtpHeader: {
         PtpHeaderInvalidReasons(header.ptp_header(), error_prefix, packet,
                                 index, result);
+        break;
+      }
+      case Header::kPspHeader: {
+        PspHeaderInvalidReasons(header.psp_header(), error_prefix, result);
         break;
       }
       case Header::HEADER_NOT_SET:
@@ -1976,6 +2088,31 @@ absl::Status SerializePtpHeader(const PtpHeader &header,
   return absl::OkStatus();
 }
 
+absl::Status SerializePspHeader(const PspHeader &header,
+                                pdpi::BitString &output) {
+  RETURN_IF_ERROR(
+      SerializeBits<kPspNextHeaderBitwidth>(header.next_header(), output));
+  RETURN_IF_ERROR(SerializeBits<kPspHeaderExtLengthBitwidth>(
+      header.header_ext_length(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kPspReserved0Bitwidth>(header.reserved0(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kPspCryptOffsetBitwidth>(header.crypt_offset(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kPspSampleBitwidth>(header.sample_bit(), output));
+  RETURN_IF_ERROR(SerializeBits<kPspDropBitwidth>(header.drop_bit(), output));
+  RETURN_IF_ERROR(SerializeBits<kPspVersionBitwidth>(header.version(), output));
+  RETURN_IF_ERROR(SerializeBits<kPspVirtualizationCookieBitwidth>(
+      header.virtualization_cookie_present(), output));
+  RETURN_IF_ERROR(
+      SerializeBits<kPspReserved1Bitwidth>(header.reserved1(), output));
+  RETURN_IF_ERROR(SerializeBits<kPspSecurityParametersIndexBitwidth>(
+      header.security_parameters_index(), output));
+  RETURN_IF_ERROR(SerializeBits<kPspInitializationVectorBitwidth>(
+      header.initialization_vector(), output));
+  return absl::OkStatus();
+}
+
 absl::Status SerializeHeader(const Header& header, pdpi::BitString& output) {
   switch (header.header_case()) {
     case Header::kEthernetHeader:
@@ -2005,6 +2142,8 @@ absl::Status SerializeHeader(const Header& header, pdpi::BitString& output) {
           header.sai_p4_bmv2_packet_in_header(), output);
     case Header::kPtpHeader:
       return SerializePtpHeader(header.ptp_header(), output);
+    case Header::kPspHeader:
+      return SerializePspHeader(header.psp_header(), output);
     case Header::HEADER_NOT_SET:
       return gutil::InvalidArgumentErrorBuilder()
              << "Found invalid HEADER_NOT_SET in header.";
@@ -2156,11 +2295,15 @@ absl::StatusOr<bool> UpdateComputedFields(Packet& packet, bool overwrite) {
           changes = true;
         }
         if (udp_header.checksum().empty() || overwrite) {
-          ASSIGN_OR_RETURN(int checksum,
+          ASSIGN_OR_RETURN(std::optional<int> checksum,
                            UdpHeaderChecksum(packet, header_index),
                            _.SetPrepend() << error_prefix << "checksum: ");
-          udp_header.set_checksum(pdpi::BitsetToHexString(
-              std::bitset<kUdpChecksumBitwidth>(checksum)));
+          if (checksum.has_value()) {
+            udp_header.set_checksum(pdpi::BitsetToHexString(
+                std::bitset<kUdpChecksumBitwidth>(*checksum)));
+          } else {
+            udp_header.set_checksum(UdpChecksum(0));
+          }
           changes = true;
         }
         break;
@@ -2225,9 +2368,6 @@ absl::StatusOr<bool> UpdateComputedFields(Packet& packet, bool overwrite) {
         }
         break;
       }
-      case Header::kVlanHeader:
-        // No computed fields.
-        break;
       case Header::kGreHeader: {
         GreHeader& gre_header = *header.mutable_gre_header();
         if (gre_header.checksum_present() == "0x1") {
@@ -2292,6 +2432,11 @@ absl::StatusOr<bool> UpdateComputedFields(Packet& packet, bool overwrite) {
         }
         break;
       }
+      case Header::kVlanHeader:
+      case Header::kPspHeader: {
+        // No computed fields.
+        break;
+      }
       case Header::HEADER_NOT_SET:
         return gutil::InvalidArgumentErrorBuilder()
                << "Invalid packet with HEADER_NOT_SET: "
@@ -2340,6 +2485,7 @@ absl::StatusOr<bool> PadPacketToMinimumSizeFromHeaderIndex(Packet& packet,
     case Header::kIpfixHeader:
     case Header::kPsampHeader:
     case Header::kPtpHeader:
+    case Header::kPspHeader:
       return PadPacketToMinimumSizeFromHeaderIndex(packet, header_index + 1);
     case Header::HEADER_NOT_SET:
       return false;
@@ -2444,6 +2590,9 @@ absl::StatusOr<int> PacketSizeInBits(const Packet& packet,
       case Header::kPtpHeader:
         size += kPtpHeaderBitwidth;
         break;
+      case Header::kPspHeader:
+        size += kPspHeaderBitwidth;
+        break;
       case Header::HEADER_NOT_SET:
         return gutil::InvalidArgumentErrorBuilder()
                << "Found invalid HEADER_NOT_SET in header.";
@@ -2491,7 +2640,8 @@ absl::StatusOr<int> Ipv4HeaderChecksum(Ipv4Header header) {
   return OnesComplementChecksum(std::move(data));
 }
 
-absl::StatusOr<int> UdpHeaderChecksum(Packet packet, int udp_header_index) {
+absl::StatusOr<std::optional<int>> UdpHeaderChecksum(Packet packet,
+                                                     int udp_header_index) {
   auto invalid_argument = gutil::InvalidArgumentErrorBuilder()
                           << "UdpHeaderChecksum(packet, udp_header_index = "
                           << udp_header_index << "): ";
@@ -2499,12 +2649,10 @@ absl::StatusOr<int> UdpHeaderChecksum(Packet packet, int udp_header_index) {
     return invalid_argument
            << "udp_header_index must be in [1, " << packet.headers().size()
            << ") since the given packet has " << packet.headers().size()
-           << " headers and the UDP header must be preceded by an IP header";
+           << " headers and the UDP header must be preceded by an IP or PSP "
+           << "header";
   }
-  // If the next header is PSAMP = checksum should be zero.
-  if (udp_header_index < packet.headers().size() - 1 &&
-      packet.headers(udp_header_index + 1).header_case() ==
-          Header::kIpfixHeader) {
+  if (AllowZeroChecksumForUdp(packet, udp_header_index)) {
     return 0;
   }
   const Header& preceding_header = packet.headers(udp_header_index - 1);
@@ -2514,15 +2662,15 @@ absl::StatusOr<int> UdpHeaderChecksum(Packet packet, int udp_header_index) {
                             << "] is a " << HeaderCaseName(header_case)
                             << ", expected UdpHeader";
   }
-  UdpHeader& udp_header =
+  UdpHeader &udp_header =
       *packet.mutable_headers(udp_header_index)->mutable_udp_header();
-  udp_header.set_checksum("0x0000");
 
   // Serialize "pseudo header" for checksum calculation, following
   // https://en.wikipedia.org/wiki/User_Datagram_Protocol#Checksum_computation.
   pdpi::BitString data;
   switch (preceding_header.header_case()) {
     case Header::kIpv4Header: {
+      udp_header.set_checksum("0x0000");
       auto& header = preceding_header.ipv4_header();
       RETURN_IF_ERROR(SerializeIpv4Address(header.ipv4_source(), data));
       RETURN_IF_ERROR(SerializeIpv4Address(header.ipv4_destination(), data));
@@ -2534,6 +2682,7 @@ absl::StatusOr<int> UdpHeaderChecksum(Packet packet, int udp_header_index) {
       break;
     }
     case Header::kIpv6Header: {
+      udp_header.set_checksum("0x0000");
       auto& header = preceding_header.ipv6_header();
       RETURN_IF_ERROR(SerializeIpv6Address(header.ipv6_source(), data));
       RETURN_IF_ERROR(SerializeIpv6Address(header.ipv6_destination(), data));
@@ -2545,9 +2694,12 @@ absl::StatusOr<int> UdpHeaderChecksum(Packet packet, int udp_header_index) {
           SerializeBits<kIpNextHeaderBitwidth>(header.next_header(), data));
       break;
     }
+    case Header::kPspHeader: {
+      return std::nullopt;
+    }
     default:
       return invalid_argument << "expected packet.headers[udp_header_index - "
-                                 "1] to be an IP header, got "
+                                 "1] to be an IP or PSP header, got "
                               << HeaderCaseName(preceding_header.header_case());
   }
   RETURN_IF_ERROR(RawSerializePacket(packet, udp_header_index, data));

--- a/p4_pdpi/packetlib/packetlib.h
+++ b/p4_pdpi/packetlib/packetlib.h
@@ -15,6 +15,7 @@
 #define GOOGLE_P4_PDPI_PACKETLIB_PACKETLIB_H_
 
 #include <cstdint>
+#include <optional>
 #include <string>
 
 #include "absl/numeric/bits.h"
@@ -134,10 +135,16 @@ absl::StatusOr<int> Ipv4HeaderChecksum(Ipv4Header header);
 
 // Computes the 16-bit UDP checksum for the given `packet` and
 // `udp_header_index`.
-// The header at the given index must be a UDP header, and it must be preceded
-// by an IP header. All fields in all headers following that IP header must be
-// set and valid except possibly the UDP checksum field, which is ignored.
-absl::StatusOr<int> UdpHeaderChecksum(Packet packet, int udp_header_index);
+// The header at the given index must be a UDP header. All fields in all headers
+// following the parent header must be set and valid except possibly the UDP
+// checksum field, which is ignored. Returning nullopt means the value cannot be
+// computed based on information in the packet (i.e. any value is allowed).
+//
+// NOTE: The nullopt case should not occur in the normal L4 UDP use case. It can
+// appear when the UDP header is nested deeper inside a packet. For example when
+// we are using tunnels (e.g. PSP).
+absl::StatusOr<std::optional<int>> UdpHeaderChecksum(Packet packet,
+                                                     int udp_header_index);
 
 // Computes the 16-bit ICMP checksum for the given `packet` and
 // `icmp_header_index`.

--- a/p4_pdpi/packetlib/packetlib.proto
+++ b/p4_pdpi/packetlib/packetlib.proto
@@ -67,6 +67,7 @@ message Header {
     IpfixHeader ipfix_header = 11;
     PsampHeader psamp_header = 12;
     PtpHeader ptp_header = 13;
+    PspHeader psp_header = 14;
   }
 }
 
@@ -246,4 +247,19 @@ message PtpHeader {
   string sequence_id = 12;
   string control_field = 13;
   string log_message_interval = 14;
+}
+
+// message PspHeader (https://github.com/google/psp)
+message PspHeader {
+  string next_header = 1;
+  string header_ext_length = 2;
+  string reserved0 = 3;
+  string crypt_offset = 4;
+  string sample_bit = 5;
+  string drop_bit = 6;
+  string version = 7;
+  string virtualization_cookie_present = 8;
+  string reserved1 = 9;
+  string security_parameters_index = 10;
+  string initialization_vector = 11;
 }

--- a/p4_pdpi/packetlib/packetlib_test_runner.cc
+++ b/p4_pdpi/packetlib/packetlib_test_runner.cc
@@ -1107,6 +1107,158 @@ void RunPacketParseTests() {
                        sequence_id: 0x0000
                        control_field: 0x00
                      )pb");
+  RunPacketParseTest("PSP packet unencrypted UDP (valid)",
+                     R"pb(
+                       # Ethernet header
+                       ethernet_destination: 0xaabbccddeeff
+                       ethernet_source: 0x112233445566
+                       ethertype: 0x86DD
+                       # IPv6 header.
+                       version: 0x6
+                       dscp: 0b000000
+                       ecn: 0b00
+                       flow_label: 0x12345
+                       payload_length: 0x0032
+                       next_header: 0x11  # UDP
+                       hop_limit: 0x42
+                       ipv6_source: 0x00001111222233334444555566667777
+                       ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+                       # UDP header
+                       source_port: 0x0014
+                       destination_port: 0x03e8  # 1000
+                       length: 0x0032
+                       checksum: 0x0000
+                       # PSP Header
+                       next_header: 0x11  # UDP
+                       header_ext_length: 0x00
+                       reserved0: 0b00
+                       crypt_offset: 0b000010
+                       sample_bit: 0b0
+                       drop_bit: 0b0
+                       version: 0x1
+                       virtualization_cookie_present: 0b0
+                       reserved1: 0b1
+                       security_parameters_index: 0x00000000
+                       initialization_vector: 0x0000000000000000
+                       # Inner UDP Header
+                       source_port: 0xbeef
+                       destination_port: 0xabcd
+                       length: 0x001a
+                       checksum: 0x0025
+                       # Payload - 18 octets
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22
+                     )pb");
+  RunPacketParseTest("PSP packet with encrypted UDP (valid)",
+                     R"pb(
+                       # Ethernet header
+                       ethernet_destination: 0xaabbccddeeff
+                       ethernet_source: 0x112233445566
+                       ethertype: 0x86DD
+                       # IPv6 header.
+                       version: 0x6
+                       dscp: 0b000000
+                       ecn: 0b00
+                       flow_label: 0x12345
+                       payload_length: 0x002a
+                       next_header: 0x11  # UDP
+                       hop_limit: 0x42
+                       ipv6_source: 0x00001111222233334444555566667777
+                       ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+                       # UDP header
+                       source_port: 0x0014
+                       destination_port: 0x03e8  # 1000
+                       length: 0x002a
+                       checksum: 0x0000
+                       # PSP Header
+                       next_header: 0x11  # UDP
+                       header_ext_length: 0x00
+                       reserved0: 0b00
+                       crypt_offset: 0b000000
+                       sample_bit: 0b0
+                       drop_bit: 0b0
+                       version: 0x1
+                       virtualization_cookie_present: 0b0
+                       reserved1: 0b1
+                       security_parameters_index: 0x00000000
+                       initialization_vector: 0x0000000000000000
+                       # Payload - 18 octets
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22
+                     )pb");
+  RunPacketParseTest("PSP packet with virtualization cookie (unsupported)",
+                     R"pb(
+                       # Ethernet header
+                       ethernet_destination: 0xaabbccddeeff
+                       ethernet_source: 0x112233445566
+                       ethertype: 0x86DD
+                       # IPv6 header.
+                       version: 0x6
+                       dscp: 0b000000
+                       ecn: 0b00
+                       flow_label: 0x12345
+                       payload_length: 0x002a
+                       next_header: 0x11  # UDP
+                       hop_limit: 0x42
+                       ipv6_source: 0x00001111222233334444555566667777
+                       ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+                       # UDP header
+                       source_port: 0x0014
+                       destination_port: 0x03e8  # 1000
+                       length: 0x002a
+                       checksum: 0x0000
+                       # PSP Header
+                       next_header: 0x04
+                       header_ext_length: 0x00
+                       reserved0: 0b00
+                       crypt_offset: 0b000000
+                       sample_bit: 0b0
+                       drop_bit: 0b0
+                       version: 0x1
+                       virtualization_cookie_present: 0b1
+                       reserved1: 0b1
+                       security_parameters_index: 0x00000000
+                       initialization_vector: 0x0000000000000000
+                       # Payload - 18 octets
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22
+                     )pb");
+  RunPacketParseTest("PSP packet that is too short (invalid)",
+                     R"pb(
+                       # Ethernet header
+                       ethernet_destination: 0xaabbccddeeff
+                       ethernet_source: 0x112233445566
+                       ethertype: 0x86DD
+                       # IPv6 header.
+                       version: 0x6
+                       dscp: 0b000000
+                       ecn: 0b00
+                       flow_label: 0x12345
+                       payload_length: 0x0010
+                       next_header: 0x11  # UDP
+                       hop_limit: 0x42
+                       ipv6_source: 0x00001111222233334444555566667777
+                       ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+                       # UDP header
+                       source_port: 0x0014
+                       destination_port: 0x03e8  # 1000
+                       length: 0x0010
+                       checksum: 0x0000
+                       # PSP Header
+                       next_header: 0x11  # UDP
+                       header_ext_length: 0x00
+                       reserved0: 0b00
+                       crypt_offset: 0b000000
+                       sample_bit: 0b0
+                       drop_bit: 0b0
+                       version: 0x1
+                       virtualization_cookie_present: 0b0
+                       reserved1: 0b1
+                       security_parameters_index: 0x00000000
+                     )pb");
 }  // NOLINT(readability/fn_size)
 
 void RunProtoPacketTests() {
@@ -2136,6 +2288,312 @@ void RunProtoPacketTests() {
                                   sequence_id: "0x0000"
                                   control_field: "0x00"
                                   log_message_interval: "0x00"
+                                }
+                              }
+                              payload: "ABCDABCDABCDABCDABCD"  # 20 octets
+                         )pb"));
+  RunProtoPacketTest("PSP packet with UDP port 1000 (valid)",
+                     gutil::ParseProtoOrDie<Packet>(
+                         R"pb(headers {
+                                ethernet_header {
+                                  ethernet_destination: "00:ee:dd:cc:bb:aa"
+                                  ethernet_source: "00:44:33:22:11:00"
+                                  ethertype: "0x86dd"
+                                }
+                              }
+                              headers {
+                                ipv6_header {
+                                  version: "0x6"
+                                  dscp: "0x00"
+                                  ecn: "0x0"
+                                  flow_label: "0x12345"
+                                  payload_length: "0x0034"
+                                  next_header: "0x11"  # UDP
+                                  hop_limit: "0x42"
+                                  ipv6_source: "2607:f8b0:11::"
+                                  ipv6_destination: "2607:f8b0:12::"
+                                }
+                              }
+                              headers {
+                                udp_header {
+                                  source_port: "0x08ae"       # 2222
+                                  destination_port: "0x03e8"  # 1000
+                                  length: "0x0034"
+                                  checksum: "0x0000"
+                                }
+                              }
+                              headers {
+                                psp_header {
+                                  next_header: "0x11"
+                                  header_ext_length: "0x00"
+                                  reserved0: "0x0"
+                                  crypt_offset: "0x02"
+                                  sample_bit: "0x0"
+                                  drop_bit: "0x0"
+                                  version: "0x1"
+                                  virtualization_cookie_present: "0x0"
+                                  reserved1: "0x1"
+                                  security_parameters_index: "0x00000000"
+                                  initialization_vector: "0x0000000000000000"
+                                }
+                              }
+                              headers {
+                                udp_header {
+                                  source_port: "0xbeef"
+                                  destination_port: "0xabcd"
+                                  length: "0x001c"
+                                  checksum: "0xfe85"
+                                }
+                              }
+                              payload: "ABCDABCDABCDABCDABCD"  # 20 octets
+                         )pb"));
+  RunProtoPacketTest("PSP packet with inner UDP checksum empty (valid)",
+                     gutil::ParseProtoOrDie<Packet>(
+                         R"pb(headers {
+                                ethernet_header {
+                                  ethernet_destination: "00:ee:dd:cc:bb:aa"
+                                  ethernet_source: "00:44:33:22:11:00"
+                                  ethertype: "0x86dd"
+                                }
+                              }
+                              headers {
+                                ipv6_header {
+                                  version: "0x6"
+                                  dscp: "0x00"
+                                  ecn: "0x0"
+                                  flow_label: "0x12345"
+                                  payload_length: "0x0034"
+                                  next_header: "0x11"  # UDP
+                                  hop_limit: "0x42"
+                                  ipv6_source: "2607:f8b0:11::"
+                                  ipv6_destination: "2607:f8b0:12::"
+                                }
+                              }
+                              headers {
+                                udp_header {
+                                  source_port: "0x08ae"       # 2222
+                                  destination_port: "0x03e8"  # 1000
+                                  length: "0x0034"
+                                  checksum: "0x0000"
+                                }
+                              }
+                              headers {
+                                psp_header {
+                                  next_header: "0x11"
+                                  header_ext_length: "0x00"
+                                  reserved0: "0x0"
+                                  crypt_offset: "0x02"
+                                  sample_bit: "0x0"
+                                  drop_bit: "0x0"
+                                  version: "0x1"
+                                  virtualization_cookie_present: "0x0"
+                                  reserved1: "0x1"
+                                  security_parameters_index: "0x00000000"
+                                  initialization_vector: "0x0000000000000000"
+                                }
+                              }
+                              headers {
+                                udp_header {
+                                  source_port: "0xbeef"
+                                  destination_port: "0xabcd"
+                                  length: "0x001c"
+                                }
+                              }
+                              payload: "ABCDABCDABCDABCDABCD"  # 20 octets
+                         )pb"));
+  RunProtoPacketTest("PSP packet with encrypted payload (valid)",
+                     gutil::ParseProtoOrDie<Packet>(
+                         R"pb(headers {
+                                ethernet_header {
+                                  ethernet_destination: "00:ee:dd:cc:bb:aa"
+                                  ethernet_source: "00:44:33:22:11:00"
+                                  ethertype: "0x86dd"
+                                }
+                              }
+                              headers {
+                                ipv6_header {
+                                  version: "0x6"
+                                  dscp: "0x00"
+                                  ecn: "0x0"
+                                  flow_label: "0x12345"
+                                  payload_length: "0x002c"
+                                  next_header: "0x11"  # UDP
+                                  hop_limit: "0x42"
+                                  ipv6_source: "2607:f8b0:11::"
+                                  ipv6_destination: "2607:f8b0:12::"
+                                }
+                              }
+                              headers {
+                                udp_header {
+                                  source_port: "0x08ae"       # 2222
+                                  destination_port: "0x03e8"  # 1000
+                                  length: "0x002c"
+                                  checksum: "0x0000"
+                                }
+                              }
+                              headers {
+                                psp_header {
+                                  next_header: "0x04"
+                                  header_ext_length: "0x00"
+                                  reserved0: "0x0"
+                                  crypt_offset: "0x00"
+                                  sample_bit: "0x0"
+                                  drop_bit: "0x0"
+                                  version: "0x1"
+                                  virtualization_cookie_present: "0x1"
+                                  reserved1: "0x1"
+                                  security_parameters_index: "0x00000000"
+                                  initialization_vector: "0x0000000000000000"
+                                }
+                              }
+                              payload: "ABCDABCDABCDABCDABCD"  # 20 octets
+                         )pb"));
+  RunProtoPacketTest(
+      "PSP packet with UDP payload but not crypt_offset (invalid)",
+      gutil::ParseProtoOrDie<Packet>(
+          R"pb(headers {
+                 ethernet_header {
+                   ethernet_destination: "00:ee:dd:cc:bb:aa"
+                   ethernet_source: "00:44:33:22:11:00"
+                   ethertype: "0x86dd"
+                 }
+               }
+               headers {
+                 ipv6_header {
+                   version: "0x6"
+                   dscp: "0x00"
+                   ecn: "0x0"
+                   flow_label: "0x12345"
+                   payload_length: "0x0034"
+                   next_header: "0x11"  # UDP
+                   hop_limit: "0x42"
+                   ipv6_source: "2607:f8b0:11::"
+                   ipv6_destination: "2607:f8b0:12::"
+                 }
+               }
+               headers {
+                 udp_header {
+                   source_port: "0x08ae"
+                   destination_port: "0x03e8"  # 1000
+                   length: "0x0034"
+                   checksum: "0x0000"
+                 }
+               }
+               headers {
+                 psp_header {
+                   next_header: "0x11"
+                   header_ext_length: "0x00"
+                   reserved0: "0x0"
+                   crypt_offset: "0x00"
+                   sample_bit: "0x0"
+                   drop_bit: "0x0"
+                   version: "0x1"
+                   virtualization_cookie_present: "0x0"
+                   reserved1: "0x1"
+                   security_parameters_index: "0x00000000"
+                   initialization_vector: "0x0000000000000000"
+                 }
+               }
+               headers {
+                 udp_header {
+                   source_port: "0xbeef"
+                   destination_port: "0xabcd"
+                   length: "0x001c"
+                   checksum: "0xfe85"
+                 }
+               }
+               payload: "ABCDABCDABCDABCDABCD"  # 20 octets
+          )pb"));
+  RunProtoPacketTest("PSP packet with UDP port 1001 (invalid)",
+                     gutil::ParseProtoOrDie<Packet>(
+                         R"pb(headers {
+                                ethernet_header {
+                                  ethernet_destination: "00:ee:dd:cc:bb:aa"
+                                  ethernet_source: "00:44:33:22:11:00"
+                                  ethertype: "0x86dd"
+                                }
+                              }
+                              headers {
+                                ipv6_header {
+                                  version: "0x6"
+                                  dscp: "0x00"
+                                  ecn: "0x0"
+                                  flow_label: "0x12345"
+                                  payload_length: "0x002c"
+                                  next_header: "0x11"  # UDP
+                                  hop_limit: "0x42"
+                                  ipv6_source: "2607:f8b0:11::"
+                                  ipv6_destination: "2607:f8b0:12::"
+                                }
+                              }
+                              headers {
+                                udp_header {
+                                  source_port: "0x08ae"       # 2222
+                                  destination_port: "0x03e9"  # 1001
+                                  length: "0x002c"
+                                  checksum: "0x0000"
+                                }
+                              }
+                              headers {
+                                psp_header {
+                                  next_header: "0x11"
+                                  header_ext_length: "0x00"
+                                  reserved0: "0x0"
+                                  crypt_offset: "0x00"
+                                  sample_bit: "0x0"
+                                  drop_bit: "0x0"
+                                  version: "0x1"
+                                  virtualization_cookie_present: "0x0"
+                                  reserved1: "0x1"
+                                  security_parameters_index: "0x00000000"
+                                  initialization_vector: "0x0000000000000000"
+                                }
+                              }
+                              payload: "ABCDABCDABCDABCDABCD"  # 20 octets
+                         )pb"));
+  RunProtoPacketTest("PSP packet with wrong reserved values (invalid)",
+                     gutil::ParseProtoOrDie<Packet>(
+                         R"pb(headers {
+                                ethernet_header {
+                                  ethernet_destination: "00:ee:dd:cc:bb:aa"
+                                  ethernet_source: "00:44:33:22:11:00"
+                                  ethertype: "0x86dd"
+                                }
+                              }
+                              headers {
+                                ipv6_header {
+                                  version: "0x6"
+                                  dscp: "0x00"
+                                  ecn: "0x0"
+                                  flow_label: "0x12345"
+                                  payload_length: "0x002c"
+                                  next_header: "0x11"  # UDP
+                                  hop_limit: "0x42"
+                                  ipv6_source: "2607:f8b0:11::"
+                                  ipv6_destination: "2607:f8b0:12::"
+                                }
+                              }
+                              headers {
+                                udp_header {
+                                  source_port: "0x08ae"       # 2222
+                                  destination_port: "0x03e8"  # 1000
+                                  length: "0x002c"
+                                  checksum: "0x0000"
+                                }
+                              }
+                              headers {
+                                psp_header {
+                                  next_header: "0x11"
+                                  header_ext_length: "0x00"
+                                  reserved0: "0x1"
+                                  crypt_offset: "0x00"
+                                  sample_bit: "0x0"
+                                  drop_bit: "0x0"
+                                  version: "0x1"
+                                  virtualization_cookie_present: "0x0"
+                                  reserved1: "0x0"
+                                  security_parameters_index: "0x00000000"
+                                  initialization_vector: "0x0000000000000000"
                                 }
                               }
                               payload: "ABCDABCDABCDABCDABCD"  # 20 octets

--- a/p4_pdpi/packetlib/packetlib_test_runner.expected
+++ b/p4_pdpi/packetlib/packetlib_test_runner.expected
@@ -2060,6 +2060,347 @@ UpdateAllComputedFields(packet) = true
 ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
 - headers[3]: header missing - expected PtpHeader
 ================================================================================
+Parsing test: PSP packet unencrypted UDP (valid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+# Ethernet header
+                       ethernet_destination: 0xaabbccddeeff
+                       ethernet_source: 0x112233445566
+                       ethertype: 0x86DD
+                       # IPv6 header.
+                       version: 0x6
+                       dscp: 0b000000
+                       ecn: 0b00
+                       flow_label: 0x12345
+                       payload_length: 0x0032
+                       next_header: 0x11  # UDP
+                       hop_limit: 0x42
+                       ipv6_source: 0x00001111222233334444555566667777
+                       ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+                       # UDP header
+                       source_port: 0x0014
+                       destination_port: 0x03e8  # 1000
+                       length: 0x0032
+                       checksum: 0x0000
+                       # PSP Header
+                       next_header: 0x11  # UDP
+                       header_ext_length: 0x00
+                       reserved0: 0b00
+                       crypt_offset: 0b000010
+                       sample_bit: 0b0
+                       drop_bit: 0b0
+                       version: 0x1
+                       virtualization_cookie_present: 0b0
+                       reserved1: 0b1
+                       security_parameters_index: 0x00000000
+                       initialization_vector: 0x0000000000000000
+                       # Inner UDP Header
+                       source_port: 0xbeef
+                       destination_port: 0xabcd
+                       length: 0x001a
+                       checksum: 0x0025
+                       # Payload - 18 octets
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22
+-- OUTPUT ----------------------------------------------------------------------
+headers {
+  ethernet_header {
+    ethernet_destination: "aa:bb:cc:dd:ee:ff"
+    ethernet_source: "11:22:33:44:55:66"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x0032"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "0:1111:2222:3333:4444:5555:6666:7777"
+    ipv6_destination: "8888:9999:aaaa:bbbb:cccc:dddd:eeee:ffff"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x0014"
+    destination_port: "0x03e8"
+    length: "0x0032"
+    checksum: "0x0000"
+  }
+}
+headers {
+  psp_header {
+    next_header: "0x11"
+    header_ext_length: "0x00"
+    reserved0: "0x0"
+    crypt_offset: "0x02"
+    sample_bit: "0x0"
+    drop_bit: "0x0"
+    version: "0x1"
+    virtualization_cookie_present: "0x0"
+    reserved1: "0x1"
+    security_parameters_index: "0x00000000"
+    initialization_vector: "0x0000000000000000"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0xbeef"
+    destination_port: "0xabcd"
+    length: "0x001a"
+    checksum: "0x0025"
+  }
+}
+payload: "\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\""
+
+================================================================================
+Parsing test: PSP packet with encrypted UDP (valid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+# Ethernet header
+                       ethernet_destination: 0xaabbccddeeff
+                       ethernet_source: 0x112233445566
+                       ethertype: 0x86DD
+                       # IPv6 header.
+                       version: 0x6
+                       dscp: 0b000000
+                       ecn: 0b00
+                       flow_label: 0x12345
+                       payload_length: 0x002a
+                       next_header: 0x11  # UDP
+                       hop_limit: 0x42
+                       ipv6_source: 0x00001111222233334444555566667777
+                       ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+                       # UDP header
+                       source_port: 0x0014
+                       destination_port: 0x03e8  # 1000
+                       length: 0x002a
+                       checksum: 0x0000
+                       # PSP Header
+                       next_header: 0x11  # UDP
+                       header_ext_length: 0x00
+                       reserved0: 0b00
+                       crypt_offset: 0b000000
+                       sample_bit: 0b0
+                       drop_bit: 0b0
+                       version: 0x1
+                       virtualization_cookie_present: 0b0
+                       reserved1: 0b1
+                       security_parameters_index: 0x00000000
+                       initialization_vector: 0x0000000000000000
+                       # Payload - 18 octets
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22
+-- OUTPUT ----------------------------------------------------------------------
+headers {
+  ethernet_header {
+    ethernet_destination: "aa:bb:cc:dd:ee:ff"
+    ethernet_source: "11:22:33:44:55:66"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x002a"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "0:1111:2222:3333:4444:5555:6666:7777"
+    ipv6_destination: "8888:9999:aaaa:bbbb:cccc:dddd:eeee:ffff"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x0014"
+    destination_port: "0x03e8"
+    length: "0x002a"
+    checksum: "0x0000"
+  }
+}
+headers {
+  psp_header {
+    next_header: "0x11"
+    header_ext_length: "0x00"
+    reserved0: "0x0"
+    crypt_offset: "0x00"
+    sample_bit: "0x0"
+    drop_bit: "0x0"
+    version: "0x1"
+    virtualization_cookie_present: "0x0"
+    reserved1: "0x1"
+    security_parameters_index: "0x00000000"
+    initialization_vector: "0x0000000000000000"
+  }
+}
+payload: "\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\""
+
+================================================================================
+Parsing test: PSP packet with virtualization cookie (unsupported)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+# Ethernet header
+                       ethernet_destination: 0xaabbccddeeff
+                       ethernet_source: 0x112233445566
+                       ethertype: 0x86DD
+                       # IPv6 header.
+                       version: 0x6
+                       dscp: 0b000000
+                       ecn: 0b00
+                       flow_label: 0x12345
+                       payload_length: 0x002a
+                       next_header: 0x11  # UDP
+                       hop_limit: 0x42
+                       ipv6_source: 0x00001111222233334444555566667777
+                       ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+                       # UDP header
+                       source_port: 0x0014
+                       destination_port: 0x03e8  # 1000
+                       length: 0x002a
+                       checksum: 0x0000
+                       # PSP Header
+                       next_header: 0x04
+                       header_ext_length: 0x00
+                       reserved0: 0b00
+                       crypt_offset: 0b000000
+                       sample_bit: 0b0
+                       drop_bit: 0b0
+                       version: 0x1
+                       virtualization_cookie_present: 0b1
+                       reserved1: 0b1
+                       security_parameters_index: 0x00000000
+                       initialization_vector: 0x0000000000000000
+                       # Payload - 18 octets
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22
+-- OUTPUT ----------------------------------------------------------------------
+headers {
+  ethernet_header {
+    ethernet_destination: "aa:bb:cc:dd:ee:ff"
+    ethernet_source: "11:22:33:44:55:66"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x002a"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "0:1111:2222:3333:4444:5555:6666:7777"
+    ipv6_destination: "8888:9999:aaaa:bbbb:cccc:dddd:eeee:ffff"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x0014"
+    destination_port: "0x03e8"
+    length: "0x002a"
+    checksum: "0x0000"
+  }
+}
+headers {
+  psp_header {
+    next_header: "0x04"
+    header_ext_length: "0x00"
+    reserved0: "0x0"
+    crypt_offset: "0x00"
+    sample_bit: "0x0"
+    drop_bit: "0x0"
+    version: "0x1"
+    virtualization_cookie_present: "0x1"
+    reserved1: "0x1"
+    security_parameters_index: "0x00000000"
+    initialization_vector: "0x0000000000000000"
+  }
+}
+payload: "\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\""
+reason_not_fully_parsed: "psp_header virtualization_cookie is not supported."
+
+================================================================================
+Parsing test: PSP packet that is too short (invalid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+# Ethernet header
+                       ethernet_destination: 0xaabbccddeeff
+                       ethernet_source: 0x112233445566
+                       ethertype: 0x86DD
+                       # IPv6 header.
+                       version: 0x6
+                       dscp: 0b000000
+                       ecn: 0b00
+                       flow_label: 0x12345
+                       payload_length: 0x0010
+                       next_header: 0x11  # UDP
+                       hop_limit: 0x42
+                       ipv6_source: 0x00001111222233334444555566667777
+                       ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+                       # UDP header
+                       source_port: 0x0014
+                       destination_port: 0x03e8  # 1000
+                       length: 0x0010
+                       checksum: 0x0000
+                       # PSP Header
+                       next_header: 0x11  # UDP
+                       header_ext_length: 0x00
+                       reserved0: 0b00
+                       crypt_offset: 0b000000
+                       sample_bit: 0b0
+                       drop_bit: 0b0
+                       version: 0x1
+                       virtualization_cookie_present: 0b0
+                       reserved1: 0b1
+                       security_parameters_index: 0x00000000
+-- OUTPUT ----------------------------------------------------------------------
+headers {
+  ethernet_header {
+    ethernet_destination: "aa:bb:cc:dd:ee:ff"
+    ethernet_source: "11:22:33:44:55:66"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x0010"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "0:1111:2222:3333:4444:5555:6666:7777"
+    ipv6_destination: "8888:9999:aaaa:bbbb:cccc:dddd:eeee:ffff"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x0014"
+    destination_port: "0x03e8"
+    length: "0x0010"
+    checksum: "0x0000"
+  }
+}
+payload: "\021\000\000\005\000\000\000\000"
+reasons_invalid: "Packet is too short to parse a PSP header next. Only 64 bits left, need at least 128."
+reasons_invalid: "in UdpHeader headers[2]: checksum: Must be 0xeacd, but was 0x0000 instead."
+reasons_invalid: "headers[3]: header missing - expected PspHeader"
+
+PadPacketToMinimumSize(packet) = false
+UpdateAllComputedFields(packet) = true
+ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- headers[3]: header missing - expected PspHeader
+================================================================================
 Proto packet test: UDP header not preceded by other header
 ================================================================================
 -- INPUT -----------------------------------------------------------------------
@@ -4042,3 +4383,436 @@ UpdateMissingComputedFields(packet) = false
 
 Serialize(Packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
 - in PtpHeader headers[3]: message_type: value '0x4' is invalid. expecting a value in the range [0x0,0x3]
+
+================================================================================
+Proto packet test: PSP packet with UDP port 1000 (valid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+packet =
+headers {
+  ethernet_header {
+    ethernet_destination: "00:ee:dd:cc:bb:aa"
+    ethernet_source: "00:44:33:22:11:00"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x0034"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "2607:f8b0:11::"
+    ipv6_destination: "2607:f8b0:12::"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x08ae"
+    destination_port: "0x03e8"
+    length: "0x0034"
+    checksum: "0x0000"
+  }
+}
+headers {
+  psp_header {
+    next_header: "0x11"
+    header_ext_length: "0x00"
+    reserved0: "0x0"
+    crypt_offset: "0x02"
+    sample_bit: "0x0"
+    drop_bit: "0x0"
+    version: "0x1"
+    virtualization_cookie_present: "0x0"
+    reserved1: "0x1"
+    security_parameters_index: "0x00000000"
+    initialization_vector: "0x0000000000000000"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0xbeef"
+    destination_port: "0xabcd"
+    length: "0x001c"
+    checksum: "0xfe85"
+  }
+}
+payload: "ABCDABCDABCDABCDABCD"
+
+-- OUTPUT ----------------------------------------------------------------------
+ValidatePacket(packet) = OK
+
+Serialize(Packet) = OK
+
+================================================================================
+Proto packet test: PSP packet with inner UDP checksum empty (valid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+packet =
+headers {
+  ethernet_header {
+    ethernet_destination: "00:ee:dd:cc:bb:aa"
+    ethernet_source: "00:44:33:22:11:00"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x0034"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "2607:f8b0:11::"
+    ipv6_destination: "2607:f8b0:12::"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x08ae"
+    destination_port: "0x03e8"
+    length: "0x0034"
+    checksum: "0x0000"
+  }
+}
+headers {
+  psp_header {
+    next_header: "0x11"
+    header_ext_length: "0x00"
+    reserved0: "0x0"
+    crypt_offset: "0x02"
+    sample_bit: "0x0"
+    drop_bit: "0x0"
+    version: "0x1"
+    virtualization_cookie_present: "0x0"
+    reserved1: "0x1"
+    security_parameters_index: "0x00000000"
+    initialization_vector: "0x0000000000000000"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0xbeef"
+    destination_port: "0xabcd"
+    length: "0x001c"
+  }
+}
+payload: "ABCDABCDABCDABCDABCD"
+
+-- OUTPUT ----------------------------------------------------------------------
+ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in UdpHeader headers[4]: checksum: missing
+
+PadPacketToMinimumSize(packet) = false
+
+UpdateMissingComputedFields(packet) = true
+packet =
+headers {
+  ethernet_header {
+    ethernet_destination: "00:ee:dd:cc:bb:aa"
+    ethernet_source: "00:44:33:22:11:00"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x0034"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "2607:f8b0:11::"
+    ipv6_destination: "2607:f8b0:12::"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x08ae"
+    destination_port: "0x03e8"
+    length: "0x0034"
+    checksum: "0x0000"
+  }
+}
+headers {
+  psp_header {
+    next_header: "0x11"
+    header_ext_length: "0x00"
+    reserved0: "0x0"
+    crypt_offset: "0x02"
+    sample_bit: "0x0"
+    drop_bit: "0x0"
+    version: "0x1"
+    virtualization_cookie_present: "0x0"
+    reserved1: "0x1"
+    security_parameters_index: "0x00000000"
+    initialization_vector: "0x0000000000000000"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0xbeef"
+    destination_port: "0xabcd"
+    length: "0x001c"
+    checksum: "0x0000"
+  }
+}
+payload: "ABCDABCDABCDABCDABCD"
+
+ValidatePacket(packet) = OK
+
+Serialize(Packet) = OK
+
+================================================================================
+Proto packet test: PSP packet with encrypted payload (valid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+packet =
+headers {
+  ethernet_header {
+    ethernet_destination: "00:ee:dd:cc:bb:aa"
+    ethernet_source: "00:44:33:22:11:00"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x002c"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "2607:f8b0:11::"
+    ipv6_destination: "2607:f8b0:12::"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x08ae"
+    destination_port: "0x03e8"
+    length: "0x002c"
+    checksum: "0x0000"
+  }
+}
+headers {
+  psp_header {
+    next_header: "0x04"
+    header_ext_length: "0x00"
+    reserved0: "0x0"
+    crypt_offset: "0x00"
+    sample_bit: "0x0"
+    drop_bit: "0x0"
+    version: "0x1"
+    virtualization_cookie_present: "0x1"
+    reserved1: "0x1"
+    security_parameters_index: "0x00000000"
+    initialization_vector: "0x0000000000000000"
+  }
+}
+payload: "ABCDABCDABCDABCDABCD"
+
+-- OUTPUT ----------------------------------------------------------------------
+ValidatePacket(packet) = OK
+
+Serialize(Packet) = OK
+
+================================================================================
+Proto packet test: PSP packet with UDP payload but not crypt_offset (invalid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+packet =
+headers {
+  ethernet_header {
+    ethernet_destination: "00:ee:dd:cc:bb:aa"
+    ethernet_source: "00:44:33:22:11:00"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x0034"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "2607:f8b0:11::"
+    ipv6_destination: "2607:f8b0:12::"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x08ae"
+    destination_port: "0x03e8"
+    length: "0x0034"
+    checksum: "0x0000"
+  }
+}
+headers {
+  psp_header {
+    next_header: "0x11"
+    header_ext_length: "0x00"
+    reserved0: "0x0"
+    crypt_offset: "0x00"
+    sample_bit: "0x0"
+    drop_bit: "0x0"
+    version: "0x1"
+    virtualization_cookie_present: "0x0"
+    reserved1: "0x1"
+    security_parameters_index: "0x00000000"
+    initialization_vector: "0x0000000000000000"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0xbeef"
+    destination_port: "0xabcd"
+    length: "0x001c"
+    checksum: "0xfe85"
+  }
+}
+payload: "ABCDABCDABCDABCDABCD"
+
+-- OUTPUT ----------------------------------------------------------------------
+ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in UdpHeader headers[4]: expected no header (because the previous header demands either no header or an unsupported header), got UdpHeader
+
+PadPacketToMinimumSize(packet) = false
+
+UpdateMissingComputedFields(packet) = false
+
+Serialize(Packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in UdpHeader headers[4]: expected no header (because the previous header demands either no header or an unsupported header), got UdpHeader
+
+================================================================================
+Proto packet test: PSP packet with UDP port 1001 (invalid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+packet =
+headers {
+  ethernet_header {
+    ethernet_destination: "00:ee:dd:cc:bb:aa"
+    ethernet_source: "00:44:33:22:11:00"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x002c"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "2607:f8b0:11::"
+    ipv6_destination: "2607:f8b0:12::"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x08ae"
+    destination_port: "0x03e9"
+    length: "0x002c"
+    checksum: "0x0000"
+  }
+}
+headers {
+  psp_header {
+    next_header: "0x11"
+    header_ext_length: "0x00"
+    reserved0: "0x0"
+    crypt_offset: "0x00"
+    sample_bit: "0x0"
+    drop_bit: "0x0"
+    version: "0x1"
+    virtualization_cookie_present: "0x0"
+    reserved1: "0x1"
+    security_parameters_index: "0x00000000"
+    initialization_vector: "0x0000000000000000"
+  }
+}
+payload: "ABCDABCDABCDABCDABCD"
+
+-- OUTPUT ----------------------------------------------------------------------
+ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in PspHeader headers[3]: expected no header (because the previous header demands either no header or an unsupported header), got PspHeader
+
+PadPacketToMinimumSize(packet) = false
+
+UpdateMissingComputedFields(packet) = false
+
+Serialize(Packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in PspHeader headers[3]: expected no header (because the previous header demands either no header or an unsupported header), got PspHeader
+
+================================================================================
+Proto packet test: PSP packet with wrong reserved values (invalid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+packet =
+headers {
+  ethernet_header {
+    ethernet_destination: "00:ee:dd:cc:bb:aa"
+    ethernet_source: "00:44:33:22:11:00"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x002c"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "2607:f8b0:11::"
+    ipv6_destination: "2607:f8b0:12::"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x08ae"
+    destination_port: "0x03e8"
+    length: "0x002c"
+    checksum: "0x0000"
+  }
+}
+headers {
+  psp_header {
+    next_header: "0x11"
+    header_ext_length: "0x00"
+    reserved0: "0x1"
+    crypt_offset: "0x00"
+    sample_bit: "0x0"
+    drop_bit: "0x0"
+    version: "0x1"
+    virtualization_cookie_present: "0x0"
+    reserved1: "0x0"
+    security_parameters_index: "0x00000000"
+    initialization_vector: "0x0000000000000000"
+  }
+}
+payload: "ABCDABCDABCDABCDABCD"
+
+-- OUTPUT ----------------------------------------------------------------------
+ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in PspHeader headers[3]: reserved0: Must be 0x0, but was 0x1 instead.
+- in PspHeader headers[3]: reserved1: Must be 0x1, but was 0x0 instead.
+
+PadPacketToMinimumSize(packet) = false
+
+UpdateMissingComputedFields(packet) = false
+
+Serialize(Packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in PspHeader headers[3]: reserved0: Must be 0x0, but was 0x1 instead.
+- in PspHeader headers[3]: reserved1: Must be 0x1, but was 0x0 instead.

--- a/tests/lib/packet_generator.cc
+++ b/tests/lib/packet_generator.cc
@@ -401,6 +401,10 @@ void SetFieldValue(Field field, int value, packetlib::Packet& packet) {
     case Field::kL4DstPort:
       // TODO: Re-allow PTP ports when traffic forwards.
       if (value > 318) value += 2;  // Skip PTP ports 319 & 320.
+      if (value > 999)
+        value += 1; // Skip PSP port 1000.
+      if (value > 4738)
+        value += 1; // Skip Ipfix port 4739.
       UdpHeader(packet).set_destination_port(packetlib::UdpPort(value));
       break;
   }
@@ -612,7 +616,7 @@ int Range(Field field, IpType ip_type) {
     case Field::kL4DstPort:
       // TODO: Re-allow PTP ports when traffic forwards.
       // Reserve PTP ports 319 & 320.
-      return BitwidthToInt(packetlib::kUdpPortBitwidth) - 2;
+      return BitwidthToInt(packetlib::kUdpPortBitwidth) - 4;
   }
   return 0;
 }


### PR DESCRIPTION
**Keycheck REsult:**

sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_check.sh ./p4_pdpi/ .
Keyword check Passed

**Bazel Build Result:**

/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 715 targets (0 packages loaded, 0 targets configured).
INFO: Found 715 targets...
INFO: From Compiling p4_pdpi/packetlib/packetlib.cc:
In file included from p4_pdpi/packetlib/packetlib.cc:43:
./p4_pdpi/string_encodings/bit_string.h: In member function 'void pdpi::BitString::AppendBytes(absl::lts_20230802::string_view)':
./p4_pdpi/string_encodings/bit_string.h:55:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string_view<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   55 |     for (int i = 0; i < bytes.size(); i++) {
      |                     ~~^~~~~~~~~~~~~~
p4_pdpi/packetlib/packetlib.cc: In function 'std::vector<std::__cxx11::basic_string<char> > packetlib::PacketInvalidReasons(const Packet&)':
p4_pdpi/packetlib/packetlib.cc:1750:22: warning: 'int google::protobuf::MessageLite::ByteSize() const' is deprecated: Please use ByteSizeLong() instead [-Wdeprecated-declarations]
 1750 |   if (packet.ByteSize() == 0) {
      |       ~~~~~~~~~~~~~~~^~

_synthesizer::PacketSynthesisCriteria>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   87 |   for (int i = 0; i < result.size(); i++) {
      |                   ~~^~~~~~~~~~~~~~~
INFO: Elapsed time: 156.705s, Critical Path: 84.39s
INFO: 85 processes: 4 internal, 81 linux-sandbox.
INFO: Build completed successfully, 85 total actions



**Bazel Test Result:**
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 715 targets (0 packages loaded, 0 targets configured).
INFO: Found 491 targets and 224 test targets...
[448 / 467] 205 / 224 tests;  1 action; last test: ...ble_entry_generator_test
INFO: Elapsed time: 262.092s, Critical Path: 119.51s
INFO: 281 processes: 338 linux-sandbox, 18 local.
INFO: Build completed successfully, 281 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.8s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 18.2s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 9.5s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 43.3s
  Stats over 50 runs: max = 43.3s, min = 0.8s, avg = 7.1s, dev = 14.6s

Executed 224 out of 224 tests: 224 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeoutINFO: Build completed successfully, 281 total actions

