### PR TITLE
[Comb] Ensuring the Correct usage of Protobuf DebugString APIs.

### DIFF
--- a/lib/gnmi/BUILD.bazel
+++ b/lib/gnmi/BUILD.bazel
@@ -81,6 +81,7 @@ cc_test(
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/lib/gnmi/gnmi_helper.cc
+++ b/lib/gnmi/gnmi_helper.cc
@@ -49,6 +49,7 @@
 #include "github.com/openconfig/gnoi/types/types.pb.h"
 #include "glog/logging.h"
 #include "google/protobuf/any.pb.h"
+#include "google/protobuf/text_format.h"
 #include "grpcpp/client_context.h"
 #include "gutil/collections.h"
 #include "gutil/proto.h"

--- a/lib/gnmi/gnmi_helper_test.cc
+++ b/lib/gnmi/gnmi_helper_test.cc
@@ -32,6 +32,7 @@
 #include "absl/types/span.h"
 #include "glog/logging.h"
 #include "gmock/gmock.h"
+#include "google/protobuf/text_format.h"
 #include "grpcpp/support/status.h"
 #include "gtest/gtest.h"
 #include "gutil/proto_matchers.h"
@@ -392,6 +393,9 @@ TEST(ParseAlarms, InvalidInput) {
 // path and the `gnmi_config` as the response value.
 gnmi::GetResponse ConstructResponse(absl::string_view oc_path,
                                     absl::string_view gnmi_config) {
+  std::string path_textproto;
+  google::protobuf::TextFormat::PrintToString(ConvertOCStringToPath(oc_path),
+                                              &path_textproto);
   std::string response = absl::Substitute(
       R"pb(notification {
              timestamp: 1620348032128305716
@@ -401,7 +405,7 @@ gnmi::GetResponse ConstructResponse(absl::string_view oc_path,
                val { json_ietf_val: "$1" }
              }
            })pb",
-      ConvertOCStringToPath(oc_path).DebugString(), absl::CEscape(gnmi_config));
+      path_textproto, absl::CEscape(gnmi_config));
   return gutil::ParseProtoOrDie<gnmi::GetResponse>(response);
 }
 

--- a/p4_pdpi/reference_annotations.cc
+++ b/p4_pdpi/reference_annotations.cc
@@ -160,8 +160,14 @@ absl::StatusOr<IrActionField> CreateIrBuiltInActionField(
 
 }  // namespace
 
+bool FieldIsOptional(const IrP4MatchField &p4_match_field) {
+  return p4_match_field.is_optional();
+}
+bool FieldIsOptional(const IrMatchField &match_field) {
+  return FieldIsOptional(match_field.p4_match_field());
+}
 bool FieldIsOptional(const IrField &field) {
-  return field.match_field().p4_match_field().is_optional();
+  return FieldIsOptional(field.match_field());
 }
 
 absl::StatusOr<IrTable> CreateIrTable(absl::string_view table_name,

--- a/p4_pdpi/reference_annotations.h
+++ b/p4_pdpi/reference_annotations.h
@@ -105,6 +105,8 @@ absl::StatusOr<std::string> GetNameOfAction(const IrActionField &field);
 // Returns true if `field` is optional. Only IrP4MatchFields can be optional.
 // All other fields (including unset fields) will return false.
 bool FieldIsOptional(const IrField &field);
+bool FieldIsOptional(const IrMatchField &match_field);
+bool FieldIsOptional(const IrP4MatchField &p4_match_field);
 
 } // namespace pdpi
 

--- a/p4_pdpi/reference_annotations_test.cc
+++ b/p4_pdpi/reference_annotations_test.cc
@@ -393,7 +393,7 @@ TEST(CreateIrActionField, FailsForUnknownP4Param) {
 
 // -- FieldIsOptional Test -----------------------------------------------------
 
-TEST(FieldIsOptional, OnlyReturnsTrueForP4OptionalMatchField) {
+TEST(FieldIsOptional, OnlyReturnsTrueIfIrFieldHoldsP4OptionalMatchField) {
   // Under-specified protos return false.
   EXPECT_FALSE(FieldIsOptional(ParseProtoOrDie<IrField>(R"pb()pb")));
   EXPECT_FALSE(FieldIsOptional(ParseProtoOrDie<IrField>(R"pb(
@@ -424,6 +424,34 @@ TEST(FieldIsOptional, OnlyReturnsTrueForP4OptionalMatchField) {
   // Optional p4 match field returns true.
   EXPECT_TRUE(FieldIsOptional(ParseProtoOrDie<IrField>(R"pb(
     match_field { p4_match_field { is_optional: true } }
+  )pb")));
+}
+
+TEST(FieldIsOptional, OnlyReturnsTrueIfIrMatchFieldHoldsP4OptionalMatchField) {
+  // Built-in match field returns false.
+  EXPECT_FALSE(FieldIsOptional(ParseProtoOrDie<IrMatchField>(R"pb(
+    built_in_match_field: BUILT_IN_MATCH_FIELD_UNSPECIFIED
+  )pb")));
+
+  // Non-optional p4 match field returns false.
+  EXPECT_FALSE(FieldIsOptional(ParseProtoOrDie<IrMatchField>(R"pb(
+    p4_match_field {}
+  )pb")));
+
+  // Optional p4 match field returns true.
+  EXPECT_TRUE(FieldIsOptional(ParseProtoOrDie<IrMatchField>(R"pb(
+    p4_match_field { is_optional: true }
+  )pb")));
+}
+
+TEST(FieldIsOptional, OnlyReturnsTrueIfIrP4MatchFieldHoldsOptionalMatchField) {
+  // Non-optional p4 match field returns false.
+  EXPECT_FALSE(FieldIsOptional(ParseProtoOrDie<IrP4MatchField>(R"pb(
+  )pb")));
+
+  // Optional p4 match field returns true.
+  EXPECT_TRUE(FieldIsOptional(ParseProtoOrDie<IrP4MatchField>(R"pb(
+    is_optional: true
   )pb")));
 }
 

--- a/p4rt_app/sonic/app_db_acl_def_table_manager_test.cc
+++ b/p4rt_app/sonic/app_db_acl_def_table_manager_test.cc
@@ -737,8 +737,8 @@ TEST_P(WhitespaceTest, MatchField) {
                        pdpi::IPV4)
           .entry_action(IrActionDefinitionBuilder().preamble(
               R"pb(alias: "action"
-                   annotations: "@sai_action(SAI_PACKET_ACTION_DROP)")pb"))()
-          .DebugString());
+                   annotations: "@sai_action(SAI_PACKET_ACTION_DROP)")pb"))
+          .GetTableAsTextProto());
 
   switch (GetParam()) {
     case WhitespaceCase::kNone:
@@ -771,8 +771,8 @@ TEST_P(WhitespaceTest, Stage) {
               pdpi::IPV6)
           .entry_action(IrActionDefinitionBuilder().preamble(
               R"pb(alias: "action"
-                   annotations: "@sai_action(SAI_PACKET_ACTION_DROP)")pb"))()
-          .DebugString());
+                   annotations: "@sai_action(SAI_PACKET_ACTION_DROP)")pb"))
+          .GetTableAsTextProto());
 
   switch (GetParam()) {
     case WhitespaceCase::kNone:
@@ -800,8 +800,8 @@ TEST_P(WhitespaceTest, UncoloredAction) {
               )pb",
               pdpi::STRING)
           .entry_action(IrActionDefinitionBuilder().preamble(
-              R"pb(alias: "action" annotations: "@sai_action($0)")pb"))()
-          .DebugString());
+              R"pb(alias: "action" annotations: "@sai_action($0)")pb"))
+          .GetTableAsTextProto());
 
   switch (GetParam()) {
     case WhitespaceCase::kNone:
@@ -834,8 +834,8 @@ TEST_P(WhitespaceTest, UdfBase) {
               pdpi::IPV4)
           .entry_action(IrActionDefinitionBuilder().preamble(
               R"pb(alias: "action"
-                   annotations: "@sai_action(SAI_PACKET_ACTION_DROP)")pb"))()
-          .DebugString());
+                   annotations: "@sai_action(SAI_PACKET_ACTION_DROP)")pb"))
+          .GetTableAsTextProto());
 
   switch (GetParam()) {
     case WhitespaceCase::kNone:
@@ -867,8 +867,8 @@ TEST_P(WhitespaceTest, UdfOffset) {
               pdpi::IPV4)
           .entry_action(IrActionDefinitionBuilder().preamble(
               R"pb(alias: "action"
-                   annotations: "@sai_action(SAI_PACKET_ACTION_DROP)")pb"))()
-          .DebugString());
+                   annotations: "@sai_action(SAI_PACKET_ACTION_DROP)")pb"))
+          .GetTableAsTextProto());
 
   switch (GetParam()) {
     case WhitespaceCase::kNone:
@@ -898,8 +898,8 @@ TEST_P(WhitespaceTest, UdfLength) {
               pdpi::IPV4)
           .entry_action(IrActionDefinitionBuilder().preamble(
               R"pb(alias: "action"
-                   annotations: "@sai_action(SAI_PACKET_ACTION_DROP)")pb"))()
-          .DebugString());
+                   annotations: "@sai_action(SAI_PACKET_ACTION_DROP)")pb"))
+          .GetTableAsTextProto());
 
   switch (GetParam()) {
     case WhitespaceCase::kNone:
@@ -939,8 +939,8 @@ TEST_P(ActionColorWhitespaceTest, Action) {
                    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT)")pb",
               pdpi::STRING)
           .entry_action(IrActionDefinitionBuilder().preamble(
-              R"pb(alias: "action" annotations: "@sai_action($0)")pb"))()
-          .DebugString());
+              R"pb(alias: "action" annotations: "@sai_action($0)")pb"))
+          .GetTableAsTextProto());
 
   WhitespaceCase inner_padding = std::get<0>(GetParam());
   WhitespaceCase outer_padding = std::get<1>(GetParam());

--- a/p4rt_app/utils/ir_builder.h
+++ b/p4rt_app/utils/ir_builder.h
@@ -300,6 +300,11 @@ public:
     table_.set_is_unsupported(false);
     return *this;
   }
+  std::string GetTableAsTextProto() const {
+    std::string textproto;
+    google::protobuf::TextFormat::PrintToString(table_, &textproto);
+    return textproto;
+  }
 
 private:
   pdpi::IrTableDefinition table_;

--- a/sai_p4/instantiations/google/BUILD.bazel
+++ b/sai_p4/instantiations/google/BUILD.bazel
@@ -213,6 +213,7 @@ cc_test(
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:variant",
         "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/sai_p4/instantiations/google/sai_p4info_test.cc
+++ b/sai_p4/instantiations/google/sai_p4info_test.cc
@@ -6,6 +6,7 @@
 #include "absl/types/optional.h"
 #include "absl/types/variant.h"
 #include "gmock/gmock.h"
+#include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
 #include "gutil/proto_matchers.h"
 #include "gutil/status_matchers.h"
@@ -49,11 +50,13 @@ TEST_P(InstantiationTest, GetIrP4InfoDoesNotCrash) {
 
 TEST_P(InstantiationTest, GetP4InfoWithHashSeedReplacesHashSeed) {
   constexpr uint32_t kHashSeed = 1966175594;
-  std::string p4info = GetP4Info(GetParam()).ShortDebugString();
+  std::string p4info_textproto;
+  google::protobuf::TextFormat::PrintToString(GetP4Info(GetParam()),
+                                              &p4info_textproto);
   absl::StrReplaceAll({{"@sai_hash_seed(0)", "@sai_hash_seed(1966175594)"}},
-                      &p4info);
+                      &p4info_textproto);
   EXPECT_THAT(GetP4InfoWithHashSeed(GetParam(), kHashSeed),
-              gutil::EqualsProto(p4info));
+              gutil::EqualsProto(p4info_textproto));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/sai_p4/instantiations/google/versions.h
+++ b/sai_p4/instantiations/google/versions.h
@@ -42,20 +42,22 @@
 // Indicates the switch supports multiple WCMP members with the same Nexthop.
 #define SAI_P4_PKGINFO_VERSION_HAS_DUPLICATE_WCMP_MEMBER_SUPPORT "1.6.1"
 
-// Indicates the switch executes batched updates in order, aborting every update
-// after the first failed one.
-#define SAI_P4_PKGINFO_VERSION_USES_FAIL_ON_FIRST "1.6.2"
-
 // Indicates that switch respects ingress ACL resource guarantees.
-#define SAI_P4_PKGINFO_VERSION_FIXED_INGRESS_ACL_RESOURCE                      \
-  SAI_P4_PKGINFO_VERSION_USES_FAIL_ON_FIRST
+#define SAI_P4_PKGINFO_VERSION_FIXED_INGRESS_ACL_RESOURCE "1.6.2"
 
 // Indicates that the program does not support the `set_nexthop` action.
 #define SAI_P4_PKGINFO_VERSION_HAS_NO_SET_NEXTHOP_SUPPORT "2.0.0"
 
+// Indicates the switch supports P4Info ReconcileAndCommit for most cases.
+#define SAI_P4_PKGINFO_VERSION_SUPPORTS_RECONCILE "2.1.0"
+
 // Indicates that the program supports ternary rather than optional route
 // metadata in the acl_ingress_table.
 #define SAI_P4_PKGINFO_VERSION_USES_TERNARY_ROUTE_METADATA "3.0.0"
+
+// Indicates the switch executes batched updates in order, aborting every update
+// after the first failed one.
+#define SAI_P4_PKGINFO_VERSION_USES_FAIL_ON_FIRST "3.1.0"
 
 // Macro that always points to the latest SAI P4 version.
 #define SAI_P4_PKGINFO_VERSION_LATEST \


### PR DESCRIPTION
Keyword Check:
sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.


Build Result:
sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 727 targets (260 packages loaded, 22923 targets configured).
INFO: Found 727 targets...
tests/qos/cpu_qos_test.cc:1191:5: note: in expansion of macro 'ASSERT_OK'
 1191 |     ASSERT_OK(pdpi::ClearTableEntries(sut_p4rt_session.get()));
      |     ^~~~~~~~~
./p4_pdpi/p4_runtime_session.h:392:14: note: declared here
  392 | absl::Status ClearTableEntries(P4RuntimeSession *session);
      |              ^~~~~~~~~~~~~~~~~
tests/qos/cpu_qos_test.cc: In member function 'virtual void pins_test::{anonymous}::CpuQosTestWithoutIxia_P4CpuQueueMappingByNameIsCorrect_Test::TestBody()':
tests/qos/cpu_qos_test.cc:1299:66: warning: 'absl::lts_20230802::StatusOr<std::pair<std::unique_ptr<pdpi::P4RuntimeSession>, std::unique_ptr<pdpi::P4RuntimeSession> > > pins_test::ConfigureSwitchPairAndReturnP4RuntimeSessionPair(thinkit::Switch&, thinkit::Switch&, const std::optional<std::basic_string_view<char> >&, const std::optional<p4::config::v1::P4Info>&, const pdpi::P4RuntimeSessionOptionalArgs&)' is deprecated: Use `ConfigureSwitchPair` instead, since this function works only for mirror testbeds. [-Wdeprecated-declarations]
 1299 |       pins_test::ConfigureSwitchPairAndReturnP4RuntimeSessionPair(
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 1300 |           Sut(), ControlSwitch(), GetParam().gnmi_config, p4info));
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
./gutil/status_matchers.h:63:43: note: in definition of macro 'ASSERT_OK_AND_ASSIGN'
   63 |   auto __ASSIGN_OR_RETURN_VAL(__LINE__) = expression;                          \
      |                                           ^~~~~~~~~~
./tests/lib/switch_test_setup_helpers.h:132:1: note: declared here
  132 | ConfigureSwitchPairAndReturnP4RuntimeSessionPair(
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tests/qos/cpu_qos_test.cc: At global scope:
tests/qos/cpu_qos_test.cc:473:36: warning: 'absl::lts_20230802::StatusOr<p4::v1::TableEntry> pins_test::{anonymous}::MakeRouterInterface(absl::lts_20230802::string_view, absl::lts_20230802::string_view, const netaddr::MacAddress&, const pdpi::IrP4Info&)' defined but not used [-Wunused-function]
  473 | absl::StatusOr<p4::v1::TableEntry> MakeRouterInterface(
      |                                    ^~~~~~~~~~~~~~~~~~~
tests/qos/cpu_qos_test.cc:414:35: warning: 'absl::lts_20230802::StatusOr<packetlib::Packet> pins_test::{anonymous}::MakeIpv6PacketWithDscp(const netaddr::MacAddress&, const netaddr::Ipv6Address&, int)' defined but not used [-Wunused-function]
  414 | absl::StatusOr<packetlib::Packet> MakeIpv6PacketWithDscp(
      |                                   ^~~~~~~~~~~~~~~~~~~~~~
tests/qos/cpu_qos_test.cc:381:35: warning: 'absl::lts_20230802::StatusOr<packetlib::Packet> pins_test::{anonymous}::MakeIpv4PacketWithDscp(const netaddr::MacAddress&, const netaddr::Ipv4Address&, int)' defined but not used [-Wunused-function]
  381 | absl::StatusOr<packetlib::Packet> MakeIpv4PacketWithDscp(
      |                                   ^~~~~~~~~~~~~~~~~~~~~~
INFO: Elapsed time: 39.464s, Critical Path: 29.28s
INFO: 25 processes: 1 internal, 24 linux-sandbox.
INFO: Build completed successfully, 25 total actions



Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 727 targets (0 packages loaded, 66 targets configured).
INFO: Found 501 targets and 226 test targets...
INFO: Elapsed time: 226.859s, Critical Path: 111.65s
INFO: 283 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 283 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.7s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 0.6s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.0s
//dvaas:test_vector_stats_test                                           PASSED in 0.0s
//dvaas:test_vector_test                                                 PASSED in 0.6s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.1s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.3s
//gutil:collections_test                                                 PASSED in 0.5s
//gutil:io_test                                                          PASSED in 0.5s
//gutil:proto_matchers_test                                              PASSED in 0.6s
//gutil:proto_ordering_test                                              PASSED in 0.5s
//gutil:proto_test                                                       PASSED in 0.5s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 0.8s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 1.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 0.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.1s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 3.8s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 3.4s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 0.7s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 1.1s
//tests/forwarding:hash_statistics_util_test                             PASSED in 0.8s
//tests/lib:p4info_helper_test                                           PASSED in 0.8s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 0.7s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.1s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.0s
//tests/sflow:sflow_util_test                                            PASSED in 6.9s
//thinkit:bazel_test_environment_test                                    PASSED in 0.5s
//thinkit:generic_testbed_test                                           PASSED in 0.9s
//thinkit:mock_control_device_test                                       PASSED in 0.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//tests/lib:packet_generator_test                                        PASSED in 61.9s
  Stats over 4 runs: max = 61.9s, min = 59.4s, avg = 60.8s, dev = 1.0s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
  Stats over 5 runs: max = 0.8s, min = 0.7s, avg = 0.7s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 44.6s
  Stats over 50 runs: max = 44.6s, min = 0.8s, avg = 3.9s, dev = 10.3s

Executed 226 out of 226 tests: 226 tests pass.
INFO: Build completed successfully, 283 total actions
