### PR TITLE
[P4RT]Update P4RT test to include on-SUT multicast programming,Port ID assignment and init time prior to performance testing.

### DIFF
--- a/p4rt_app/scripts/BUILD.bazel
+++ b/p4rt_app/scripts/BUILD.bazel
@@ -65,6 +65,7 @@ cc_binary(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/tests/lib/p4rt_fixed_table_programming_helper.h
+++ b/tests/lib/p4rt_fixed_table_programming_helper.h
@@ -72,6 +72,20 @@ struct IpTableOptions {
   std::optional<std::string> nexthop_id;
 };
 
+struct MulticastReplica {
+  std::string port;
+  int instance = 0;
+  std::string src_mac;
+  const std::string key;
+
+  MulticastReplica() = default;
+  MulticastReplica(std::string port, int instance, std::string src_mac)
+      : port(std::move(port)),
+        instance(instance),
+        src_mac(std::move(src_mac)),
+        key(absl::StrCat(this->port, "_", this->instance)) {}
+};
+
 absl::StatusOr<p4::v1::Update>
 Ipv4TableUpdate(const pdpi::IrP4Info &ir_p4_info, p4::v1::Update::Type type,
                 const IpTableOptions &ip_options);
@@ -79,6 +93,14 @@ Ipv4TableUpdate(const pdpi::IrP4Info &ir_p4_info, p4::v1::Update::Type type,
 absl::StatusOr<p4::v1::Update>
 Ipv6TableUpdate(const pdpi::IrP4Info &ir_p4_info, p4::v1::Update::Type type,
                 const IpTableOptions &ip_options);
+
+absl::StatusOr<p4::v1::Update> MulticastGroupUpdate(
+    const pdpi::IrP4Info& ir_p4_info, p4::v1::Update::Type type,
+    uint32_t group_id, absl::Span<MulticastReplica> replicas);
+
+absl::StatusOr<p4::v1::Update> MulticastRouterInterfaceTableUpdate(
+    const pdpi::IrP4Info& ir_p4_info, p4::v1::Update::Type type,
+    const MulticastReplica& replica);
 
 // The L3 admit table can optionally admit packets based on the ingress port.
 struct L3AdmitOptions {


### PR DESCRIPTION
**Keycheck Result:**

sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_check.sh ./p4rt_app/ .
Keyword check Passed.

**Bazel Build Output:**
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 717 targets (0 packages loaded, 0 targets configured).
INFO: Found 717 targets...
INFO: From Compiling p4rt_app/scripts/p4rt_route_measurement_test.cc:
p4rt_app/scripts/p4rt_route_measurement_test.cc: In function 'absl::lts_20230802::Status p4rt_app::{anonymous}::VerifyP4WriteRequestSizes(const P4WriteRequests&, uint32_t, uint32_t, bool)':
p4rt_app/scripts/p4rt_route_measurement_test.cc:307:21: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<p4::v1::WriteRequest>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  307 |   for (int i = 0; i < requests.inserts.size(); ++i) {
      |                   ~~^~~~~~~~~~~~~~~~~~~~~~~~~
p4rt_app/scripts/p4rt_route_measurement_test.cc:309:13: warning: comparison of integer expressions of different signedness: 'int' and 'uint32_t' {aka 'unsigned int'} [-Wsign-compare]
  309 |     if (got != expected_requests_per_batch) {
      |                                            ~~~~~~~~~~~~~~^~~~~~
INFO: Elapsed time: 45.445s, Critical Path: 44.42s
INFO: 6 processes: 2 internal, 4 linux-sandbox.
INFO: Build completed successfully, 6 total actions


**Bazel Test output:**

/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 717 targets (0 packages loaded, 0 targets configured).
INFO: Found 492 targets and 225 test targets...
INFO: Elapsed time: 216.208s, Critical Path: 121.44s
INFO: 282 processes: 339 linux-sandbox, 18 local.
INFO: Build completed successfully, 282 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.8s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//tests/lib:packet_generator_test                                        PASSED in 64.6s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 3.1s
//p4rt_app/tests:packetio_test                                           PASSED in 4.9s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.9s
  Stats over 4 runs: max = 64.6s, min = 61.9s, avg = 63.1s, dev = 1.0s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.9s
  Stats over 5 runs: max = 0.9s, min = 0.7s, avg = 0.8s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 46.0s
  Stats over 50 runs: max = 46.0s, min = 0.8s, avg = 1.9s, dev = 6.4s
Executed 225 out of 225 tests: 225 tests pass.
INFO: Build completed successfully, 282 total actions
