### PR TITLE
[P4_Symbolic] Adding nested_conditional .p4 & .pb.txt files.

### DIFF
--- a/p4_symbolic/testdata/conditional/nested_conditional.p4
+++ b/p4_symbolic/testdata/conditional/nested_conditional.p4
@@ -1,0 +1,184 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This unit test is added to test the effect of multiple nested conditionals
+// on the symbolic expressions representing header fields' value at the
+// end of pipeline. The goal is to demonstrate the effect of guard-factorization
+// on the size of the expressions (go/p4-symbolic-guard-factorization).
+
+/* -*- P4_16 -*- */
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<9>  egress_spec_t;
+
+header header_t {
+    bit<8> fr;
+    bit<8> fw;
+    bit<8> f1;
+    bit<8> f2;
+    bit<8> f3;
+    bit<8> f4;
+    bit<8> f5;
+    bit<8> f6;
+    bit<8> f7;
+    bit<8> f8;
+}
+
+struct metadata {
+    /* empty */
+}
+
+struct headers {
+    header_t   h1;
+}
+
+parser MyParser(packet_in packet,
+                out headers hdr,
+                inout metadata meta,
+                inout standard_metadata_t standard_metadata) {
+
+    state start {
+        transition parse_h1;
+    }
+
+    state parse_h1 {
+        packet.extract(hdr.h1);
+        transition accept;
+    }
+}
+
+
+control MyIngress(inout headers hdr,
+                  inout metadata meta,
+                  inout standard_metadata_t standard_metadata) {
+    action a1(egress_spec_t port) {
+       hdr.h1.fw = 1;
+       standard_metadata.egress_port = port;
+    }
+    action a2(egress_spec_t port) {
+       hdr.h1.fw = 2;
+       standard_metadata.egress_port = port;
+    }
+    action a3(egress_spec_t port) {
+       hdr.h1.fw = 3;
+       standard_metadata.egress_port = port;
+    }
+    action a4(egress_spec_t port) {
+       standard_metadata.egress_port = port;
+    }
+
+    table i1 {key = {hdr.h1.fr: exact;} actions = {@proto_id(1) a1;}}
+    table i2 {key = {hdr.h1.fr: exact;} actions = {@proto_id(1) a2;}}
+    table e1 {key = {hdr.h1.fr: exact;} actions = {@proto_id(1) a3;}}
+    table e2 {key = {hdr.h1.fr: exact;} actions = {@proto_id(1) a4;}}
+
+    apply {
+        if (hdr.h1.f1 == 0) {
+            if (hdr.h1.f2 == 0) {
+                if (hdr.h1.f3 == 0) {
+                    if (hdr.h1.f4 == 0) {
+                        i1.apply();
+                    } else {
+                        i2.apply();
+                    }
+                }
+                else {
+                    if (hdr.h1.f4 == 0) {
+                        i2.apply();
+                    } else {
+                        i1.apply();
+                    }
+                }
+            } else {
+                if (hdr.h1.f3 == 0) {
+                    if (hdr.h1.f4 == 0) {
+                        i1.apply();
+                    } else {
+                        i2.apply();
+                    }
+                }
+                else {
+                    if (hdr.h1.f4 == 0) {
+                        i2.apply();
+                    } else {
+                        i1.apply();
+                    }
+                }
+            }
+        } else {
+            if (hdr.h1.f2 == 0) {
+                if (hdr.h1.f3 == 0) {
+                    if (hdr.h1.f4 == 0) {
+                        e1.apply();
+                    } else {
+                        e2.apply();
+                    }
+                }
+                else {
+                    if (hdr.h1.f4 == 0) {
+                        e2.apply();
+                    } else {
+                        e1.apply();
+                    }
+                }
+            } else {
+                if (hdr.h1.f3 == 0) {
+                    if (hdr.h1.f4 == 0) {
+                        e1.apply();
+                    } else {
+                        e2.apply();
+                    }
+                }
+                else {
+                    if (hdr.h1.f4 == 0) {
+                        e2.apply();
+                    } else {
+                        e1.apply();
+                    }
+                }
+            }
+        }
+    }
+}
+control MyEgress(inout headers hdr,
+                 inout metadata meta,
+                 inout standard_metadata_t standard_metadata) {
+    apply {  }
+}
+
+
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.h1);
+    }
+}
+
+control MyComputeChecksum(inout headers  hdr, inout metadata meta) {
+    apply { }
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {  }
+}
+
+V1Switch(
+MyParser(),
+MyVerifyChecksum(),
+MyIngress(),
+MyEgress(),
+MyComputeChecksum(),
+MyDeparser()
+) main;

--- a/p4_symbolic/testdata/conditional/nested_conditional_entries.pb.txt
+++ b/p4_symbolic/testdata/conditional/nested_conditional_entries.pb.txt
@@ -1,0 +1,96 @@
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 49487630  # MyIngress.i1
+      match {
+        field_id: 1  # hdr.h1.fr
+        exact {
+          value: "\xff"
+        }
+      }
+      action {
+        action {
+          action_id: 23754841  # MyIngress.a1
+          params {
+            param_id: 1  # port
+            value: "\01"
+          }
+        }
+      }
+    }
+  }
+}
+
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 45464723  # MyIngress.i2
+      match {
+        field_id: 1  # hdr.h1.fr
+        exact {
+          value: "\xff"
+        }
+      }
+      action {
+        action {
+          action_id: 24829050  # MyIngress.a2
+          params {
+            param_id: 1  # port
+            value: "\01"
+          }
+        }
+      }
+    }
+  }
+}
+
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 34124830  # MyIngress.e1
+      match {
+        field_id: 1  # hdr.h1.fr
+        exact {
+          value: "\xff"
+        }
+      }
+      action {
+        action {
+          action_id: 29110526  # MyIngress.a3
+          params {
+            param_id: 1  # port
+            value: "\01"
+          }
+        }
+      }
+    }
+  }
+}
+
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 38443170  # MyIngress.e2
+      match {
+        field_id: 1  # hdr.h1.fr
+        exact {
+          value: "\xff"
+        }
+      }
+      action {
+        action {
+          action_id: 30878518  # MyIngress.a4
+          params {
+            param_id: 1  # port
+            value: "\01"
+          }
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
### Keyword Check:
divyagayathris@divyagayathris-16:~/Apr11/sonic-buildimage/src/sonic-p4rt/sonic-pins/p4_symbolic$ ~/keyword_check.sh .
Keyword check Passed.

### Build Results:
divyagayathris@cae27f88848a:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 717 targets (0 packages loaded, 0 targets configured).
INFO: Found 717 targets...
...
./p4_pdpi/string_encodings/bit_string.h:49:23: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
49 | for (int i = 0; i < num_bits; i++) {
| ~~^~~~~~~~~~
INFO: Elapsed time: 535.510s, Critical Path: 385.20s
INFO: 10093 processes: 3174 internal, 6919 linux-sandbox.
INFO: Build completed successfully, 10093 total actions

### Test Results:
divyagayathris@cae27f88848a:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 717 targets (260 packages loaded, 22904 targets configured).
INFO: Found 492 targets and 225 test targets...
INFO: Elapsed time: 168.613s, Critical Path: 113.39s
INFO: 282 processes: 339 linux-sandbox, 18 local.
INFO: Build completed successfully, 282 total actions
//dvaas:port_id_map_test PASSED in 1.6s
//dvaas:test_run_validation_golden_test PASSED in 0.2s
//dvaas:test_run_validation_test PASSED in 1.0s
//dvaas:test_run_validation_test_runner PASSED in 0.1s
//dvaas:test_vector_stats_diff_test PASSED in 0.3s
//dvaas:test_vector_stats_test PASSED in 0.2s
//dvaas:test_vector_test PASSED in 1.0s
//dvaas:user_provided_packet_test_vector_diff_test PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test PASSED in 0.2s
//gutil:collections_test PASSED in 0.9s
//gutil:io_test PASSED in 0.9s
//gutil:proto_matchers_test PASSED in 1.4s
//gutil:proto_ordering_test PASSED in 0.9s
//gutil:proto_test PASSED in 1.2s
//gutil:status_matchers_test PASSED in 0.9s
//gutil:test_artifact_writer_test PASSED in 1.2s
//gutil:testing_test PASSED in 1.2s
//gutil:timer_test PASSED in 5.1s
//gutil:version_test PASSED in 1.3s
//lib:basic_switch_test PASSED in 1.5s
//lib:ixia_helper_test PASSED in 2.1s
//lib/basic_traffic:basic_p4rt_util_test PASSED in 1.9s
//lib/basic_traffic:basic_traffic_test PASSED in 16.4s
//lib/gnmi:gnmi_helper_test PASSED in 3.3s
//lib/gnoi:gnoi_helper_test PASSED in 1.2s
//lib/p4rt:p4rt_port_test PASSED in 1.1s
//lib/p4rt:p4rt_programming_context_test PASSED in 1.4s
//lib/utils:generic_testbed_utils_test PASSED in 2.2s
//lib/utils:json_utils_test PASSED in 1.5s
//lib/validator:validator_backend_test PASSED in 0.8s
//lib/validator:validator_lib_test PASSED in 26.4s
//p4_fuzzer:constraints_test PASSED in 3.7s
//p4_fuzzer:fuzz_util_test PASSED in 112.9s
//p4_fuzzer:fuzzer_config_test PASSED in 1.2s
//p4_fuzzer:oracle_util_test PASSED in 3.3s
//p4_fuzzer:switch_state_assert_entry_equality_test PASSED in 2.7s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner PASSED in 3.4s
//p4_fuzzer:switch_state_test PASSED in 1.6s
//p4_pdpi:built_ins_test PASSED in 0.9s
//p4_pdpi:entity_keys_test PASSED in 1.1s
//p4_pdpi:ir_properties_test PASSED in 1.1s
//p4_pdpi:ir_to_ir_test PASSED in 1.0s
//p4_pdpi:ir_tools_test PASSED in 1.8s
//p4_pdpi:names_test PASSED in 1.8s
//p4_pdpi:p4_runtime_matchers_test PASSED in 1.2s
//p4_pdpi:reference_annotations_test PASSED in 1.4s
//p4_pdpi:references_test PASSED in 1.3s
//p4_pdpi:sequencing_util_test PASSED in 0.9s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test PASSED in 1.0s
//p4_pdpi/netaddr:ipv6_address_test PASSED in 1.5s
//p4_pdpi/netaddr:mac_address_test PASSED in 1.0s
//p4_pdpi/packetlib:packetlib_fuzzer_test PASSED in 19.2s
//p4_pdpi/packetlib:packetlib_matchers_test PASSED in 0.9s
//p4_pdpi/packetlib:packetlib_test PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test PASSED in 1.1s
//p4_pdpi/string_encodings:bit_string_test PASSED in 1.0s
//p4_pdpi/string_encodings:byte_string_test PASSED in 1.0s
//p4_pdpi/string_encodings:decimal_string_test PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test_runner PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test_runner PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test PASSED in 0.9s
//p4_pdpi/testing:helper_function_test PASSED in 1.6s
//p4_pdpi/testing:info_test PASSED in 0.3s
//p4_pdpi/testing:info_test_runner PASSED in 0.2s
//p4_pdpi/testing:main_pd_test PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test PASSED in 1.2s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.2s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.2s
//p4_pdpi/testing:packet_io_test PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner PASSED in 0.2s
//p4_pdpi/testing:references_test PASSED in 0.3s
//p4_pdpi/testing:references_test_runner PASSED in 0.2s
//p4_pdpi/testing:rpc_test PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner PASSED in 0.2s
//p4_pdpi/testing:sequencing_test PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test_runner PASSED in 0.2s
//p4_pdpi/testing:table_entry_gunit_test PASSED in 1.4s
//p4_pdpi/testing:table_entry_test PASSED in 0.5s
//p4_pdpi/testing:table_entry_test_runner PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test PASSED in 1.0s
//p4_pdpi/utils:ir_test PASSED in 1.0s
//p4_symbolic:z3_util_test PASSED in 1.3s
//p4_symbolic/bmv2:ipv4_routing_exact_test PASSED in 0.2s
//p4_symbolic/bmv2:ipv4_routing_subset_test PASSED in 2.0s
//p4_symbolic/bmv2:port_hardcoded_exact_test PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test PASSED in 2.0s
//p4_symbolic/bmv2:port_table_exact_test PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test PASSED in 1.9s
//p4_symbolic/bmv2:reflector_exact_test PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test PASSED in 2.2s
//p4_symbolic/bmv2:set_invalid_exact_test PASSED in 0.0s
//p4_symbolic/bmv2:set_invalid_subset_test PASSED in 2.3s
//p4_symbolic/bmv2:table_hit_1_exact_test PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_1_subset_test PASSED in 2.2s
//p4_symbolic/bmv2:table_hit_2_exact_test PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_2_subset_test PASSED in 2.4s
//p4_symbolic/ir:cfg_test PASSED in 1.1s
//p4_symbolic/ir:complex_conditional_test PASSED in 0.1s
//p4_symbolic/ir:conditional_sequence_test PASSED in 0.0s
//p4_symbolic/ir:conditional_test PASSED in 0.2s
//p4_symbolic/ir:default_transition_test PASSED in 0.1s
//p4_symbolic/ir:extract_parser_operation_test PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test PASSED in 0.0s
//p4_symbolic/ir:partial_icmp_test PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test PASSED in 0.3s
//p4_symbolic/ir:port_table_test PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test PASSED in 0.3s
//p4_symbolic/ir:reflector_test PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test PASSED in 0.0s
//p4_symbolic/ir:set_invalid_test PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test PASSED in 0.0s
//p4_symbolic/ir:string_optional_test PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test PASSED in 0.0s
//p4_symbolic/ir:table_hit_2_test PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test PASSED in 1.4s
//p4_symbolic/sai:criteria_generator_test PASSED in 9.4s
//p4_symbolic/sai:packet_synthesizer_test PASSED in 4.6s
//p4_symbolic/sai:sai_test PASSED in 4.2s
//p4_symbolic/symbolic:conditional_sequence_test_packets PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test PASSED in 2.6s
//p4_symbolic/symbolic:parser_test PASSED in 2.1s
//p4_symbolic/symbolic:port_hardcoded_test_packets PASSED in 0.3s
//p4_symbolic/symbolic:port_table_test_packets PASSED in 0.1s
//p4_symbolic/symbolic:reflector_test_packets PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test PASSED in 1.9s
//p4_symbolic/symbolic:util_test PASSED in 1.1s
//p4_symbolic/symbolic:values_test PASSED in 1.4s
//p4_symbolic/tests:sai_p4_integration_test PASSED in 3.8s
//p4_symbolic/tests:symbolic_table_entries_test PASSED in 8.2s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test PASSED in 1.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 2.4s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test PASSED in 1.7s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test PASSED in 1.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test PASSED in 1.6s
//p4rt_app/event_monitoring:debug_data_dump_events_test PASSED in 2.2s
//p4rt_app/event_monitoring:state_verification_events_test PASSED in 1.9s
//p4rt_app/p4runtime:cpu_queue_translator_test PASSED in 1.0s
//p4rt_app/p4runtime:ir_translation_test PASSED in 1.8s
//p4rt_app/p4runtime:p4info_reconcile_test PASSED in 1.4s
//p4rt_app/p4runtime:p4info_verification_schema_test PASSED in 1.9s
//p4rt_app/p4runtime:p4info_verification_test PASSED in 1.5s
//p4rt_app/p4runtime:packetio_helpers_test PASSED in 2.4s
//p4rt_app/p4runtime:resource_utilization_test PASSED in 1.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test PASSED in 1.4s
//p4rt_app/sonic:app_db_manager_test PASSED in 1.5s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test PASSED in 2.0s
//p4rt_app/sonic:hashing_test PASSED in 1.7s
//p4rt_app/sonic:packet_replication_entry_translation_test PASSED in 1.8s
//p4rt_app/sonic:packetio_impl_test PASSED in 1.0s
//p4rt_app/sonic:packetio_port_test PASSED in 0.9s
//p4rt_app/sonic:response_handler_test PASSED in 1.4s
//p4rt_app/sonic:state_verification_test PASSED in 1.5s
//p4rt_app/sonic:swss_utils_test PASSED in 1.0s
//p4rt_app/sonic:vlan_entry_translation_test PASSED in 1.9s
//p4rt_app/sonic:vrf_entry_translation_test PASSED in 1.0s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test PASSED in 0.1s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test PASSED in 0.1s
//p4rt_app/tests:acl_table_test PASSED in 1.7s
//p4rt_app/tests:action_set_test PASSED in 1.3s
//p4rt_app/tests:api_access_test PASSED in 1.0s
//p4rt_app/tests:arbitration_test PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test PASSED in 2.0s
//p4rt_app/tests:debug_data_dump_test PASSED in 1.2s
//p4rt_app/tests:fixed_l3_tables_test PASSED in 3.6s
//p4rt_app/tests:forwarding_pipeline_config_test PASSED in 5.6s
//p4rt_app/tests:grpc_behavior_test PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test PASSED in 1.0s
//p4rt_app/tests:p4_constraints_test_runner PASSED in 0.4s
//p4rt_app/tests:p4_programs_test PASSED in 2.0s
//p4rt_app/tests:packet_replication_table_test PASSED in 2.3s
//p4rt_app/tests:packetio_test PASSED in 4.1s
//p4rt_app/tests:port_name_and_id_test PASSED in 3.5s
//p4rt_app/tests:resource_limits_test PASSED in 3.2s
//p4rt_app/tests:response_path_test PASSED in 4.2s
//p4rt_app/tests:role_test PASSED in 1.3s
//p4rt_app/tests:state_verification_test PASSED in 2.4s
//p4rt_app/tests:vrf_table_test PASSED in 2.0s
//p4rt_app/tests/lib:app_db_entry_builder_test PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test PASSED in 0.1s
//p4rt_app/utils:table_utility_test PASSED in 1.9s
//sai_p4/instantiations/google:clos_stage_test PASSED in 1.1s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.2s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test PASSED in 1.4s
//sai_p4/instantiations/google:sai_p4info_fetcher_test PASSED in 1.8s
//sai_p4/instantiations/google:sai_p4info_test PASSED in 1.9s
//sai_p4/instantiations/google:sai_pd_proto_test PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test PASSED in 1.2s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test PASSED in 0.5s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test PASSED in 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 1.2s
//sai_p4/instantiations/google/test_tools:test_entries_test PASSED in 1.4s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test PASSED in 4.1s
//sai_p4/tools:p4info_tools_test PASSED in 0.9s
//sai_p4/tools:packetio_tools_test PASSED in 1.4s
//tests:thinkit_gnmi_interface_util_tests PASSED in 1.8s
//tests/forwarding:hash_statistics_util_test PASSED in 1.5s
//tests/lib:p4info_helper_test PASSED in 1.2s
//tests/lib:p4rt_fixed_table_programming_helper_test PASSED in 1.2s
//tests/lib:switch_test_setup_helpers_golden_test PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner PASSED in 0.2s
//tests/qos:gnmi_parsers_test PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner PASSED in 0.1s
//tests/sflow:sflow_util_test PASSED in 8.4s
//thinkit:bazel_test_environment_test PASSED in 1.4s
//thinkit:generic_testbed_test PASSED in 2.0s
//thinkit:mock_control_device_test PASSED in 1.5s
//thinkit:mock_generic_testbed_test PASSED in 1.3s
//thinkit:mock_mirror_testbed_test PASSED in 1.4s
//thinkit:mock_ssh_client_test PASSED in 0.1s
//thinkit:mock_switch_test PASSED in 1.2s
//thinkit:mock_test_environment_test PASSED in 0.2s
//thinkit:switch_test PASSED in 1.8s
//tests/lib:packet_generator_test PASSED in 64.8s
Stats over 4 runs: max = 64.8s, min = 61.9s, avg = 63.6s, dev = 1.1s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test PASSED in 2.1s
Stats over 5 runs: max = 2.1s, min = 1.5s, avg = 1.8s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test PASSED in 45.3s
Stats over 50 runs: max = 45.3s, min = 1.6s, avg = 4.0s, dev = 8.5s

Executed 225 out of 225 tests: 225 tests pass.
INFO: Build completed successfully, 282 total actions