### PR TITLE
[P4_PDPI] [P4 Infra] Support CloneSessionEntry translation between PI <-> IR.

### DIFF
--- a/p4_pdpi/ir.proto
+++ b/p4_pdpi/ir.proto
@@ -481,6 +481,7 @@ message IrTableEntries {
 message IrPacketReplicationEngineEntry {
   oneof type {
     IrMulticastGroupEntry multicast_group_entry = 1;
+    IrCloneSessionEntry clone_session_entry = 2;
   }
 }
 
@@ -492,6 +493,13 @@ message IrReplica {
 message IrMulticastGroupEntry {
   uint32 multicast_group_id = 1;
   repeated IrReplica replicas = 2;
+}
+
+message IrCloneSessionEntry {
+  uint32 session_id = 1;
+  repeated IrReplica replicas = 2;
+  uint32 class_of_service = 3;
+  int32 packet_length_bytes = 4;
 }
 
 // -- Packet IO ----------------------------------------------------------------

--- a/p4_pdpi/names.cc
+++ b/p4_pdpi/names.cc
@@ -56,6 +56,8 @@ absl::StatusOr<std::string> EntityToTableName(const IrEntity& entity) {
       switch (entity.packet_replication_engine_entry().type_case()) {
         case IrPacketReplicationEngineEntry::kMulticastGroupEntry:
           return GetMulticastGroupTableName();
+        case IrPacketReplicationEngineEntry::kCloneSessionEntry:
+          return GetCloneSessionTableName();
         case IrPacketReplicationEngineEntry::TYPE_NOT_SET:
           break;
       }

--- a/p4_pdpi/pd.cc
+++ b/p4_pdpi/pd.cc
@@ -1560,15 +1560,20 @@ absl::Status IrMulticastGroupEntryToPd(
 absl::Status IrPacketReplicationEngineEntryToPd(
     const IrP4Info &info, const IrPacketReplicationEngineEntry &ir,
     google::protobuf::Message *pd, const TranslationOptions &options) {
-  const absl::StatusOr<google::protobuf::Message *> pd_multicast =
-      GetMutableMessage(pd, "multicast_group_table_entry");
-  if (!pd_multicast.ok()) {
-    return absl::InternalError(GenerateFormattedError(
-        "MulticastGroupEntry",
-        absl::StrCat(kNewBullet, pd_multicast.status().message())));
+  if (ir.has_multicast_group_entry()) {
+    const absl::StatusOr<google::protobuf::Message *> pd_multicast =
+        GetMutableMessage(pd, "multicast_group_table_entry");
+    if (!pd_multicast.ok()) {
+      return absl::InternalError(GenerateFormattedError(
+          "MulticastGroupEntry",
+          absl::StrCat(kNewBullet, pd_multicast.status().message())));
+    }
+    return IrMulticastGroupEntryToPd(info, ir.multicast_group_entry(),
+                                     *pd_multicast, options);
   }
-  return IrMulticastGroupEntryToPd(info, ir.multicast_group_entry(),
-                                   *pd_multicast, options);
+  return absl::UnimplementedError(
+      absl::StrCat("PacketReplicationEngineEntry is not supported: ",
+                   gutil::PrintShortTextProto(ir)));
 }
 
 absl::Status IrEntityToPdTableEntry(const IrP4Info &info, const IrEntity &ir,

--- a/p4_pdpi/testing/table_entry_gunit_test.cc
+++ b/p4_pdpi/testing/table_entry_gunit_test.cc
@@ -97,6 +97,24 @@ absl::StatusOr<IrEntities> ValidIrEntities() {
 
 using VectorTranslationTest = testing::TestWithParam<pdpi::TranslationOptions>;
 
+TEST(CloneSessionTest, IrToPdCloneSessionEntryTranslationFails) {
+  ASSERT_OK_AND_ASSIGN(pdpi::IrEntity ir_entity,
+                       gutil::ParseTextProto<pdpi::IrEntity>(R"pb(
+                         packet_replication_engine_entry {
+                           clone_session_entry {
+                             session_id: 7
+                             replicas { port: "some_port" instance: 1 }
+                             replicas { port: "some_port" instance: 2 }
+                             replicas { port: "some_other_port" instance: 1 }
+                           }
+                         }
+                       )pb"));
+  TableEntry clone_session_pd;
+  EXPECT_THAT(
+      IrEntityToPdTableEntry(GetTestIrP4Info(), ir_entity, &clone_session_pd),
+      StatusIs(absl::StatusCode::kUnimplemented));
+}
+
 TEST_P(VectorTranslationTest,
        FooTableEntriesToBarPointWiseEqualFooTableEntryToBar) {
   const TranslationOptions options = GetParam();

--- a/p4_pdpi/testing/testdata/table_entry.expected
+++ b/p4_pdpi/testing/testdata/table_entry.expected
@@ -1387,6 +1387,127 @@ packet_replication_engine_entry {
 
 
 =========================================================================
+valid clone session group entry
+=========================================================================
+
+--- PI (Input):
+packet_replication_engine_entry {
+  clone_session_entry {
+    session_id: 7
+    replicas {
+      instance: 1
+      port: "some_port"
+    }
+    replicas {
+      instance: 2
+      port: "some_port"
+    }
+    replicas {
+      instance: 1
+      port: "some_other_port"
+    }
+    class_of_service: 2
+    packet_length_bytes: 200
+  }
+}
+
+--- IR:
+packet_replication_engine_entry {
+  clone_session_entry {
+    session_id: 7
+    replicas {
+      port: "some_port"
+      instance: 1
+    }
+    replicas {
+      port: "some_port"
+      instance: 2
+    }
+    replicas {
+      port: "some_other_port"
+      instance: 1
+    }
+    class_of_service: 2
+    packet_length_bytes: 200
+  }
+}
+
+
+=========================================================================
+clone session group entry with duplicate replica
+=========================================================================
+
+--- PI (Input):
+packet_replication_engine_entry {
+  clone_session_entry {
+    session_id: 7
+    replicas {
+      instance: 1
+      port: "some_port"
+    }
+    replicas {
+      instance: 1
+      port: "some_port"
+    }
+    class_of_service: 2
+    packet_length_bytes: 200
+  }
+}
+
+--- IR:
+packet_replication_engine_entry {
+  clone_session_entry {
+    session_id: 7
+    replicas {
+      port: "some_port"
+      instance: 1
+    }
+    replicas {
+      port: "some_port"
+      instance: 1
+    }
+    class_of_service: 2
+    packet_length_bytes: 200
+  }
+}
+
+
+=========================================================================
+valid clone session entry without explicit instance
+=========================================================================
+
+--- PI (Input):
+packet_replication_engine_entry {
+  clone_session_entry {
+    session_id: 7
+    replicas {
+      port: "some_port"
+    }
+    replicas {
+      port: "some_other_port"
+    }
+    class_of_service: 2
+    packet_length_bytes: 200
+  }
+}
+
+--- IR:
+packet_replication_engine_entry {
+  clone_session_entry {
+    session_id: 7
+    replicas {
+      port: "some_port"
+    }
+    replicas {
+      port: "some_other_port"
+    }
+    class_of_service: 2
+    packet_length_bytes: 200
+  }
+}
+
+
+=========================================================================
 empty IR (IR -> PI)
 =========================================================================
 
@@ -3539,6 +3660,127 @@ multicast_group_table_entry {
         instance: "0x0000"
       }
     }
+  }
+}
+
+
+=========================================================================
+clone session entry with duplicate replica (IR -> PI)
+=========================================================================
+
+--- IR (Input):
+packet_replication_engine_entry {
+  clone_session_entry {
+    session_id: 7
+    replicas {
+      port: "some_port"
+      instance: 1
+    }
+    replicas {
+      port: "some_port"
+      instance: 1
+    }
+    class_of_service: 2
+    packet_length_bytes: 200
+  }
+}
+
+--- PI:
+packet_replication_engine_entry {
+  clone_session_entry {
+    session_id: 7
+    replicas {
+      instance: 1
+      port: "some_port"
+    }
+    replicas {
+      instance: 1
+      port: "some_port"
+    }
+    class_of_service: 2
+    packet_length_bytes: 200
+  }
+}
+
+
+=========================================================================
+valid clone session group entry (IR -> PI)
+=========================================================================
+
+--- IR (Input):
+packet_replication_engine_entry {
+  clone_session_entry {
+    session_id: 7
+    replicas {
+      port: "some_port"
+      instance: 1
+    }
+    replicas {
+      port: "some_port"
+      instance: 2
+    }
+    replicas {
+      port: "some_other_port"
+      instance: 1
+    }
+    class_of_service: 2
+    packet_length_bytes: 200
+  }
+}
+
+--- PI:
+packet_replication_engine_entry {
+  clone_session_entry {
+    session_id: 7
+    replicas {
+      instance: 1
+      port: "some_port"
+    }
+    replicas {
+      instance: 2
+      port: "some_port"
+    }
+    replicas {
+      instance: 1
+      port: "some_other_port"
+    }
+    class_of_service: 2
+    packet_length_bytes: 200
+  }
+}
+
+
+=========================================================================
+valid clone session entry without explicit instance (IR -> PI)
+=========================================================================
+
+--- IR (Input):
+packet_replication_engine_entry {
+  clone_session_entry {
+    session_id: 7
+    replicas {
+      port: "some_port"
+    }
+    replicas {
+      port: "some_other_port"
+    }
+    class_of_service: 2
+    packet_length_bytes: 200
+  }
+}
+
+--- PI:
+packet_replication_engine_entry {
+  clone_session_entry {
+    session_id: 7
+    replicas {
+      port: "some_port"
+    }
+    replicas {
+      port: "some_other_port"
+    }
+    class_of_service: 2
+    packet_length_bytes: 200
   }
 }
 


### PR DESCRIPTION
Keyword Check Result:
~/tools/keyword_check.sh ./p4_pdpi/ .
Keyword check Passed.

Bazel Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 727 targets (260 packages loaded, 22923 targets configured).
INFO: Found 727 targets...
INFO: From Compiling p4_pdpi/pd.cc:
In file included from ./p4_pdpi/pd.h:25,
                 from p4_pdpi/pd.cc:15:
p4_pdpi/pd.cc: In function 'absl::lts_20230802::StatusOr<p4::v1::TableEntry> pdpi::PartialPdTableEntryToPiTableEntry(const IrP4Info&, const google::protobuf::Message&, const TranslationOptions&)':
INFO: From Executing genrule //p4_symbolic/ir:partial_icmp_test_parse:
WARNING: Logging before InitGoogleLogging() is written to STDERR
W20250516 13:30:52.988552     3 ir.cc:218] Fixing incomplete definition of the ICMP header, missing 'rest_of_header'
INFO: Elapsed time: 645.589s, Critical Path: 66.05s
INFO: 542 processes: 17 internal, 525 linux-sandbox.
INFO: Build completed successfully, 542 total actions

Bazel Test Result:

bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 727 targets (0 packages loaded, 382 targets configured).
INFO: Found 501 targets and 226 test targets...
[1,266 / 1,285] 207 / 226 tests;  1 action; last test: ...teria_generator_test
INFO: Elapsed time: 240.814s, Critical Path: 119.21s
INFO: 283 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 283 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.8s
  Stats over 4 runs: max = 61.2s, min = 60.0s, avg = 60.7s, dev = 0.5s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 0.8s
  Stats over 5 runs: max = 0.8s, min = 0.7s, avg = 0.7s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 43.5s
  Stats over 50 runs: max = 43.5s, min = 0.8s, avg = 6.7s, dev = 13.6s

Executed 226 out of 226 tests: 226 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeoutINFO: Build completed successfully, 283 total actions
