### PR TITLE
[Dvaas]Implement and apply `GetPacketTraces` in `ValidateDataplane` to print the expected packet trace to the user.

### DIFF
--- a/dvaas/BUILD.bazel
+++ b/dvaas/BUILD.bazel
@@ -39,6 +39,7 @@ cc_library(
     deps = [
         ":output_writer",
         ":packet_injection",
+        ":packet_trace_cc_proto",
         ":port_id_map",
         ":switch_api",
         ":test_run_validation",
@@ -63,8 +64,7 @@ cc_library(
         "@com_github_gnmi//proto/gnmi:gnmi_cc_proto",
         "@com_github_google_glog//:glog",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
@@ -176,7 +176,14 @@ cc_library(
 
 proto_library(
     name = "packet_trace_proto",
+    testonly = False,
     srcs = ["packet_trace.proto"],
+)
+
+cc_proto_library(
+    name = "packet_trace_cc_proto",
+    testonly = False,
+    deps = [":packet_trace_proto"],
 )
 
 proto_library(

--- a/dvaas/dataplane_validation.cc
+++ b/dvaas/dataplane_validation.cc
@@ -17,6 +17,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"
@@ -26,6 +27,7 @@
 #include "absl/strings/string_view.h"
 #include "dvaas/output_writer.h"
 #include "dvaas/packet_injection.h"
+#include "dvaas/packet_trace.pb.h"
 #include "dvaas/port_id_map.h"
 #include "dvaas/switch_api.h"
 #include "dvaas/test_run_validation.h"
@@ -303,27 +305,50 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
         ValidateTestRun(test_run, params.switch_output_diff_params);
   }
 
-  ValidationResult validation_result(
-      test_outcomes, generate_test_vectors_result.packet_synthesis_result);
-  RETURN_IF_ERROR(writer->AppendToTestArtifact(
-      "test_vector_failures.txt",
-      absl::StrJoin(validation_result.GetAllFailures(), "\n\n")));
-
   // Store the packet trace for the first failed test packet (if any).
   ASSIGN_OR_RETURN(P4Specification p4_spec,
                    InferP4Specification(params, *backend_, sut));
   ASSIGN_OR_RETURN(pdpi::IrP4Info ir_p4info, pdpi::GetIrP4Info(*sut.p4rt));
-  for (const dvaas::PacketTestOutcome& test_outcome :
-       test_outcomes.outcomes()) {
+  for (dvaas::PacketTestOutcome& test_outcome :
+       *test_outcomes.mutable_outcomes()) {
     if (test_outcome.test_result().has_failure()) {
       LOG(INFO) << "Storing packet trace for the first failed test packet";
       const SwitchInput& switch_input =
           test_outcome.test_run().test_vector().input();
-      RETURN_IF_ERROR(backend_->StorePacketTrace(p4_spec.bmv2_config, ir_p4info,
+      ASSIGN_OR_RETURN(auto packet_traces,
+                       backend_->GetPacketTraces(p4_spec.bmv2_config, ir_p4info,
                                                  entities, switch_input));
+      const std::string packet_hex =
+          test_outcome.test_run().test_vector().input().packet().hex();
+
+      if (!packet_traces.contains(packet_hex) ||
+          packet_traces[packet_hex].empty()) {
+        return absl::InternalError(
+            absl::StrCat("Packet trace not found for packet ", packet_hex));
+      }
+
+      std::string bmv2_textual_log =
+          packet_traces[packet_hex][0].bmv2_textual_log();
+
+      test_outcome.mutable_test_result()->mutable_failure()->set_description(
+          absl::StrCat(test_outcome.test_result().failure().description(),
+                       "\n== P4 SIMULATION PACKET TRACE "
+                       "==================================================\n",
+                       bmv2_textual_log));
+
+      RETURN_IF_ERROR(writer->AppendToTestArtifact(
+          "packet_" + packet_hex.substr(packet_hex.length() - 8) + ".trace.txt",
+          bmv2_textual_log));
       break;
     }
   }
+
+  ValidationResult validation_result(
+      std::move(test_outcomes),
+      generate_test_vectors_result.packet_synthesis_result);
+  RETURN_IF_ERROR(writer->AppendToTestArtifact(
+      "test_vector_failures.txt",
+      absl::StrJoin(validation_result.GetAllFailures(), "\n\n")));
 
   return validation_result;
 }

--- a/dvaas/dataplane_validation.h
+++ b/dvaas/dataplane_validation.h
@@ -26,14 +26,14 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
+#include "absl/container/btree_map.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "dvaas/output_writer.h"
 #include "dvaas/packet_injection.h"
+#include "dvaas/packet_trace.pb.h"
 #include "dvaas/port_id_map.h"
 #include "dvaas/switch_api.h"
 #include "dvaas/test_run_validation.h"
@@ -283,6 +283,15 @@ public:
   // Stores the P4 simulation packet trace for the given config, entries, and
   // input packet.
   virtual absl::Status StorePacketTrace(
+      const p4::v1::ForwardingPipelineConfig& bmv2_compatible_config,
+      const pdpi::IrP4Info& ir_p4info, const pdpi::IrEntities& ir_entities,
+      const SwitchInput& switch_input) const = 0;
+
+  // Gets the P4 simulation packet trace for the given config, entries, and
+  // input packet.
+  virtual absl::StatusOr<
+      absl::btree_map<std::string, std::vector<dvaas::PacketTrace>>>
+  GetPacketTraces(
       const p4::v1::ForwardingPipelineConfig& bmv2_compatible_config,
       const pdpi::IrP4Info& ir_p4info, const pdpi::IrEntities& ir_entities,
       const SwitchInput& switch_input) const = 0;

--- a/dvaas/test_run_validation.cc
+++ b/dvaas/test_run_validation.cc
@@ -312,7 +312,6 @@ static constexpr absl::string_view kActualBanner =
 static constexpr absl::string_view kExpectationBanner =
     "== EXPECTED OUTPUT "
     "=============================================================";
-
 }  // namespace
 
 PacketTestValidationResult ValidateTestRun(


### PR DESCRIPTION
### Keyword Check
### Bazel build logs
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
DEBUG: Rule 'com_github_bazelbuild_buildtools' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "e3bb0dc8b0274ea1aca75f1f8c0c835adbe589708ea89bf698069d0790701ea3"
DEBUG: Repository com_github_bazelbuild_buildtools instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:42:16: in <toplevel>
  /sonic/src/sonic-p4rt/sonic-pins/pins_infra_deps.bzl:17:21: in pins_infra_deps
Repository rule http_archive defined at:
  /var/jaanahg/.cache/bazel/_bazel_jaanahg/5fd88bad78ef03829a4685c83637a020/external/bazel_tools/tools/build_defs/repo/http.bzl:355:31: in <toplevel>
INFO: Analyzed 728 targets (1 packages loaded, 145 targets configured).
INFO: Found 728 targets...
INFO: From Compiling dvaas/dataplane_validation.cc:
In file included from ./gutil/proto.h:26,
                 from dvaas/dataplane_validation.cc:39:
dvaas/dataplane_validation.cc: In member function 'absl::lts_20230802::StatusOr<dvaas::ValidationResult> dvaas::DataplaneValidator::ValidateDataplane(thinkit::MirrorTestbed&, const dvaas::DataplaneValidationParams&)':
dvaas/dataplane_validation.cc:378:44: warning: 'absl::lts_20230802::Status pdpi::ClearTableEntries(P4RuntimeSession*)' is deprecated: Use ClearEntities instead. [-Wdeprecated-declarations]
  378 |     RETURN_IF_ERROR(pdpi::ClearTableEntries(control_switch.p4rt.get()));
      |                     ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
./gutil/status.h:275:30: note: in definition of macro 'RETURN_IF_ERROR'
  275 |   for (absl::Status status = expr; !status.ok();)                              \
      |                              ^~~~
In file included from ./dvaas/packet_injection.h:27,
                 from ./dvaas/dataplane_validation.h:35,
                 from dvaas/dataplane_validation.cc:15:
./p4_pdpi/p4_runtime_session.h:392:14: note: declared here
  392 | absl::Status ClearTableEntries(P4RuntimeSession *session);
      |              ^~~~~~~~~~~~~~~~~
INFO: From Compiling tests/forwarding/ouroboros_test.cc:
In file included from tests/forwarding/ouroboros_test.cc:37:
tests/forwarding/ouroboros_test.cc: In function 'absl::lts_20230802::Status pins_test::{anonymous}::OutputTableEntriesToArtifact(dvaas::SwitchApi&, thinkit::TestEnvironment&, absl::lts_20230802::string_view, int)':
tests/forwarding/ouroboros_test.cc:83:50: warning: 'absl::lts_20230802::StatusOr<pdpi::IrTableEntries> pdpi::ReadIrTableEntriesSorted(P4RuntimeSession&)' is deprecated: Prefer ReadIrEntitiesSorted instead. [-Wdeprecated-declarations]
   83 |                    pdpi::ReadIrTableEntriesSorted(*sut.p4rt));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
./gutil/status.h:286:43: note: in definition of macro '__ASSIGN_OR_RETURN'
  286 |   auto __ASSIGN_OR_RETURN_VAL(__LINE__) = expr;                                \
      |                                           ^~~~
tests/forwarding/ouroboros_test.cc:82:3: note: in expansion of macro 'ASSIGN_OR_RETURN'
   82 |   ASSIGN_OR_RETURN(pdpi::IrTableEntries entries,
      |   ^~~~~~~~~~~~~~~~
In file included from tests/forwarding/ouroboros_test.cc:51:
./p4_pdpi/p4_runtime_session_extras.h:132:32: note: declared here
  132 | absl::StatusOr<IrTableEntries> ReadIrTableEntriesSorted(P4RuntimeSession &p4rt);
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~
tests/forwarding/ouroboros_test.cc: In function 'absl::lts_20230802::StatusOr<std::pair<dvaas::SwitchApi, dvaas::SwitchApi> > pins_test::{anonymous}::ConfigureMirrorTestbed(thinkit::MirrorTestbed&, bool, std::optional<std::__cxx11::basic_string<char> >, std::optional<p4::config::v1::P4Info>)':
tests/forwarding/ouroboros_test.cc:124:55: warning: 'absl::lts_20230802::StatusOr<std::pair<std::unique_ptr<pdpi::P4RuntimeSession>, std::unique_ptr<pdpi::P4RuntimeSession> > > pins_test::ConfigureSwitchPairAndReturnP4RuntimeSessionPair(thinkit::Switch&, thinkit::Switch&, const std::optional<std::basic_string_view<char> >&, const std::optional<p4::config::v1::P4Info>&, const pdpi::P4RuntimeSessionOptionalArgs&)' is deprecated: Use `ConfigureSwitchPair` instead, since this function works only for mirror testbeds. [-Wdeprecated-declarations]
  124 |       ConfigureSwitchPairAndReturnP4RuntimeSessionPair(
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  125 |           testbed.Sut(), testbed.ControlSwitch(), gnmi_config, p4info));
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./gutil/status.h:286:43: note: in definition of macro '__ASSIGN_OR_RETURN'
  286 |   auto __ASSIGN_OR_RETURN_VAL(__LINE__) = expr;                                \
      |                                           ^~~~
tests/forwarding/ouroboros_test.cc:122:3: note: in expansion of macro 'ASSIGN_OR_RETURN'
  122 |   ASSIGN_OR_RETURN(
      |   ^~~~~~~~~~~~~~~~
In file included from tests/forwarding/ouroboros_test.cc:55:
./tests/lib/switch_test_setup_helpers.h:132:1: note: declared here
  132 | ConfigureSwitchPairAndReturnP4RuntimeSessionPair(
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO: Elapsed time: 11.718s, Critical Path: 11.00s
INFO: 14 processes: 3 internal, 11 linux-sandbox.
INFO: Build completed successfully, 14 total actions
### Bazel test logs
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
DEBUG: Rule 'com_github_bazelbuild_buildtools' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "e3bb0dc8b0274ea1aca75f1f8c0c835adbe589708ea89bf698069d0790701ea3"
DEBUG: Repository com_github_bazelbuild_buildtools instantiated at:
  /sonic/src/sonic-p4rt/sonic-pins/WORKSPACE.bazel:42:16: in <toplevel>
  /sonic/src/sonic-p4rt/sonic-pins/pins_infra_deps.bzl:17:21: in pins_infra_deps
Repository rule http_archive defined at:
  /var/jaanahg/.cache/bazel/_bazel_jaanahg/5fd88bad78ef03829a4685c83637a020/external/bazel_tools/tools/build_defs/repo/http.bzl:355:31: in <toplevel>
INFO: Analyzed 728 targets (0 packages loaded, 10 targets configured).
INFO: Found 502 targets and 226 test targets...
INFO: Elapsed time: 170.854s, Critical Path: 125.19s
INFO: 283 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 283 total actions
//dvaas:port_id_map_test                                                 PASSED in 1.7s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.4s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.2s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.2s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//gutil:collections_test                                                 PASSED in 0.9s
//gutil:io_test                                                          PASSED in 0.8s
//gutil:proto_matchers_test                                              PASSED in 1.0s
//gutil:proto_ordering_test                                              PASSED in 1.3s
//gutil:proto_test                                                       PASSED in 0.9s
//gutil:status_matchers_test                                             PASSED in 1.1s
//gutil:test_artifact_writer_test                                        PASSED in 1.3s
//gutil:testing_test                                                     PASSED in 1.1s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 3.4s
//lib:basic_switch_test                                                  PASSED in 1.6s
//lib:ixia_helper_test                                                   PASSED in 2.3s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 1.5s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 15.6s
//lib/gnmi:gnmi_helper_test                                              PASSED in 3.7s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.1s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.9s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 1.5s
//lib/utils:generic_testbed_utils_test                                   PASSED in 2.4s
//lib/utils:json_utils_test                                              PASSED in 0.8s
//lib/validator:validator_backend_test                                   PASSED in 1.1s
//lib/validator:validator_lib_test                                       PASSED in 26.2s
//p4_fuzzer:constraints_test                                             PASSED in 5.1s
//p4_fuzzer:fuzz_util_test                                               PASSED in 125.1s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 1.5s
//p4_fuzzer:oracle_util_test                                             PASSED in 4.8s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 3.7s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 3.8s
//p4_fuzzer:switch_state_test                                            PASSED in 2.0s
//p4_pdpi:built_ins_test                                                 PASSED in 1.1s
//p4_pdpi:entity_keys_test                                               PASSED in 0.9s
//p4_pdpi:ir_properties_test                                             PASSED in 0.9s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.2s
//p4_pdpi:ir_tools_test                                                  PASSED in 1.4s
//p4_pdpi:names_test                                                     PASSED in 1.2s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.1s
//p4_pdpi:reference_annotations_test                                     PASSED in 1.2s
//p4_pdpi:references_test                                                PASSED in 1.3s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.9s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.2s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.9s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.0s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 18.8s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.9s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 6.2s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 0.9s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.1s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.9s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.1s
//p4_pdpi/testing:info_test                                              PASSED in 0.2s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 0.9s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.2s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.2s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:references_test                                        PASSED in 0.2s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.3s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 1.5s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 0.8s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.0s
//p4_symbolic:z3_util_test                                               PASSED in 1.1s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 1.8s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 2.0s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 1.8s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 1.6s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 1.8s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 1.9s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 1.8s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.2s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.1s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.1s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.0s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.1s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.1s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 0.8s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 12.4s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 7.5s
//p4_symbolic/sai:sai_test                                               PASSED in 5.1s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 2.7s
//p4_symbolic/symbolic:parser_test                                       PASSED in 1.3s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.0s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:reflector_test_packets                            PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 1.9s
//p4_symbolic/symbolic:util_test                                         PASSED in 1.4s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.0s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 4.7s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 9.4s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.8s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 2.0s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 2.2s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 1.7s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 2.0s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 1.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.8s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 1.5s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 0.9s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 1.4s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.1s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 2.2s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 1.7s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 1.6s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.0s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 1.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 1.5s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 1.1s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.1s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.0s
//p4rt_app/sonic:response_handler_test                                   PASSED in 1.6s
//p4rt_app/sonic:state_verification_test                                 PASSED in 1.3s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 0.9s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 1.1s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.5s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.7s
//p4rt_app/tests:action_set_test                                         PASSED in 1.3s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.0s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.2s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 5.6s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.9s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.0s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.2s
//p4rt_app/tests:packetio_test                                           PASSED in 4.1s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.4s
//p4rt_app/tests:resource_limits_test                                    PASSED in 3.5s
//p4rt_app/tests:response_path_test                                      PASSED in 4.3s
//p4rt_app/tests:role_test                                               PASSED in 1.3s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.4s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.0s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 1.1s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.9s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.2s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.5s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.0s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 4.8s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.0s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 5.6s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.1s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.3s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.4s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.1s
//tests/lib:p4info_helper_test                                           PASSED in 2.0s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.5s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.2s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.2s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.6s
//thinkit:bazel_test_environment_test                                    PASSED in 1.2s
//thinkit:generic_testbed_test                                           PASSED in 2.0s
//thinkit:mock_control_device_test                                       PASSED in 0.8s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.2s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.0s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.0s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.4s
//tests/lib:packet_generator_test                                        PASSED in 66.0s
  Stats over 4 runs: max = 66.0s, min = 64.6s, avg = 65.1s, dev = 0.5s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.7s
  Stats over 5 runs: max = 1.7s, min = 1.2s, avg = 1.5s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 46.5s
  Stats over 50 runs: max = 46.5s, min = 1.3s, avg = 5.4s, dev = 12.1s

Executed 226 out of 226 tests: 226 tests pass.
INFO: Build completed successfully, 283 total actions
