### PR TITLE
[Dvaas] Added refactor packet_trace.proto and print all failed test outcomes traces to file

### DIFF
--- a/dvaas/BUILD.bazel
+++ b/dvaas/BUILD.bazel
@@ -59,7 +59,6 @@ cc_library(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",
-        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -191,7 +190,7 @@ proto_library(
     name = "packet_trace_proto",
     testonly = False,
     srcs = ["packet_trace.proto"],
-
+    deps = ["//p4_pdpi:ir_proto"],
 )
 
 cc_proto_library(

--- a/dvaas/dataplane_validation.h
+++ b/dvaas/dataplane_validation.h
@@ -27,7 +27,6 @@ limitations under the License.
 #include <vector>
 
 #include "absl/container/btree_map.h"
-#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
@@ -40,7 +39,6 @@ limitations under the License.
 #include "dvaas/test_vector.h"
 #include "dvaas/test_vector.pb.h"
 #include "dvaas/validation_result.h"
-#include "google/protobuf/descriptor.h"
 #include "gutil/test_artifact_writer.h"
 #include "lib/p4rt/p4rt_port.h"
 #include "p4_pdpi/ir.pb.h"
@@ -280,14 +278,16 @@ public:
   virtual absl::StatusOr<P4Specification>
   InferP4Specification(SwitchApi &sut) const = 0;
 
-  // Gets the P4 simulation packet trace for the given config, entries, and
-  // input packet.
+  // Gets the P4 simulation packet trace(s) for the given config, entries, and
+  // input packet. Returns a map from input packet's hex string to list of
+  // packet traces each corresponding to one trace for that packet (there may be
+  // multiple traces, e.g. due to exploring WCMP non-determinism).
   virtual absl::StatusOr<
       absl::btree_map<std::string, std::vector<dvaas::PacketTrace>>>
   GetPacketTraces(
-      const p4::v1::ForwardingPipelineConfig& bmv2_compatible_config,
-      const pdpi::IrP4Info& ir_p4info, const pdpi::IrEntities& ir_entities,
-      const SwitchInput& switch_input) const = 0;
+      const p4::v1::ForwardingPipelineConfig &bmv2_compatible_config,
+      const pdpi::IrP4Info &ir_p4info, const pdpi::IrEntities &ir_entities,
+      const std::vector<SwitchInput> &switch_inputs) const = 0;
 
   // Creates entries for v1Model auxiliary tables that model the effects of the
   // given gNMI configuration in on packet forwarding (e.g. port loopback mode).

--- a/dvaas/packet_trace.proto
+++ b/dvaas/packet_trace.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dvaas;
 
+import "p4_pdpi/ir.proto";
+
 // A proto representation of the trace of a packet through a P4 packet
 // processor.
 message PacketTrace {
@@ -11,6 +13,13 @@ message PacketTrace {
 
 message TableApply {
   string table_name = 1;
-  bool table_was_hit = 2;
-  string hit_or_miss_textual_log = 3;
+  string hit_or_miss_textual_log = 2;
+
+  message Hit { pdpi.IrTableEntry table_entry = 3; }
+  message Miss {}
+
+  oneof result {
+    Hit hit = 4;
+    Miss miss = 5;
+  }
 }


### PR DESCRIPTION
### Keyword Check
/dvass/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_check.sh .
Keyword check Passed.
### Bazel build logs
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 729 targets (260 packages loaded, 22927 targets configured).
INFO: Found 729 targets...
INFO: From Generating C++ proto_library //dvaas:test_vector_proto:
dvaas/test_vector.proto:19:1: warning: Import dvaas/packet_trace.proto is unused.
INFO: From Generating Descriptor Set proto_library //dvaas:test_vector_proto:
dvaas/test_vector.proto:19:1: warning: Import dvaas/packet_trace.proto is unused.
INFO: From Compiling dvaas/test_vector.cc:
tests/forwarding/hash_testfixture.cc: At global scope:
tests/forwarding/hash_testfixture.cc:195:6: warning: 'void pins_test::{anonymous}::InitializeTestbed(thinkit::MirrorTestbed&, const p4::config::v1::P4Info&)' defined but not used [-Wunused-function]
  195 | void InitializeTestbed(thinkit::MirrorTestbed &testbed,
      |      ^~~~~~~~~~~~~~~~~
INFO: Elapsed time: 19.368s, Critical Path: 13.22s
INFO: 41 processes: 2 internal, 39 linux-sandbox.
INFO: Build completed successfully, 41 total actions
### Bazel test logs
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 729 targets (0 packages loaded, 382 targets configured).
INFO: Found 503 targets and 226 test targets...
INFO: Elapsed time: 173.149s, Critical Path: 126.36s
INFO: 283 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 283 total actions
//dvaas:port_id_map_test                                                 PASSED in 1.6s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.2s
//dvaas:test_run_validation_test                                         PASSED in 1.1s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.2s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.2s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 0.9s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.3s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//gutil:collections_test                                                 PASSED in 1.1s
//gutil:io_test                                                          PASSED in 1.0s
//gutil:proto_matchers_test                                              PASSED in 1.2s
//gutil:proto_ordering_test                                              PASSED in 1.2s
//gutil:proto_test                                                       PASSED in 0.9s
//gutil:status_matchers_test                                             PASSED in 0.8s
//gutil:test_artifact_writer_test                                        PASSED in 1.0s
//gutil:testing_test                                                     PASSED in 1.0s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 4.3s
//lib:basic_switch_test                                                  PASSED in 1.4s
//lib:ixia_helper_test                                                   PASSED in 2.3s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 1.8s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 16.2s
//lib/gnmi:gnmi_helper_test                                              PASSED in 3.5s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.1s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.9s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 1.1s
//lib/utils:generic_testbed_utils_test                                   PASSED in 2.1s
//lib/utils:json_utils_test                                              PASSED in 1.2s
//lib/validator:validator_backend_test                                   PASSED in 0.9s
//lib/validator:validator_lib_test                                       PASSED in 26.4s
//p4_fuzzer:constraints_test                                             PASSED in 3.8s
//p4_fuzzer:fuzz_util_test                                               PASSED in 126.3s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 1.2s
//p4_fuzzer:oracle_util_test                                             PASSED in 4.2s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 3.0s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 3.8s
//p4_fuzzer:switch_state_test                                            PASSED in 1.6s
//p4_pdpi:built_ins_test                                                 PASSED in 1.0s
//p4_pdpi:entity_keys_test                                               PASSED in 1.1s
//p4_pdpi:ir_properties_test                                             PASSED in 1.1s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.4s
//p4_pdpi:ir_tools_test                                                  PASSED in 1.5s
//p4_pdpi:names_test                                                     PASSED in 1.4s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.2s
//p4_pdpi:reference_annotations_test                                     PASSED in 1.3s
//p4_pdpi:references_test                                                PASSED in 1.3s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.0s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.9s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.0s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.1s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 20.1s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.3s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 8.3s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.3s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.0s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.2s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.4s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.1s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.3s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.2s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.2s
//p4_pdpi/testing:references_test                                        PASSED in 0.2s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 1.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.1s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.1s
//p4_symbolic:z3_util_test                                               PASSED in 1.2s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 1.8s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 1.9s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.2s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 1.9s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 1.7s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 1.9s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 1.7s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 1.9s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.1s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.1s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.1s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.1s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.1s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.0s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.2s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.1s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 10.1s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 5.0s
//p4_symbolic/sai:sai_test                                               PASSED in 4.7s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 2.8s
//p4_symbolic/symbolic:parser_test                                       PASSED in 1.7s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:reflector_test_packets                            PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 1.7s
//p4_symbolic/symbolic:util_test                                         PASSED in 1.3s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.2s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 5.8s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 7.4s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 2.1s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.5s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 1.8s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 2.1s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 2.1s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 0.9s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 1.6s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 1.3s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 1.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.1s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 2.0s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 1.7s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 1.7s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 1.9s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 1.5s
//p4rt_app/sonic:hashing_test                                            PASSED in 1.5s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 1.4s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.4s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.1s
//p4rt_app/sonic:response_handler_test                                   PASSED in 1.3s
//p4rt_app/sonic:state_verification_test                                 PASSED in 1.3s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.2s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 1.3s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.6s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.7s
//p4rt_app/tests:action_set_test                                         PASSED in 1.3s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.2s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.1s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.2s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 5.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.9s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.0s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.3s
//p4rt_app/tests:packetio_test                                           PASSED in 4.2s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.4s
//p4rt_app/tests:resource_limits_test                                    PASSED in 2.9s
//p4rt_app/tests:response_path_test                                      PASSED in 4.3s
//p4rt_app/tests:role_test                                               PASSED in 1.3s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.4s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.0s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 1.1s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.9s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.2s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.4s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.0s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 6.0s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.8s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 5.5s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.1s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.3s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 1.8s
//tests/forwarding:hash_statistics_util_test                             PASSED in 1.4s
//tests/lib:p4info_helper_test                                           PASSED in 1.6s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.5s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.2s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.9s
//thinkit:bazel_test_environment_test                                    PASSED in 1.3s
//thinkit:generic_testbed_test                                           PASSED in 1.7s
//thinkit:mock_control_device_test                                       PASSED in 1.1s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.2s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.3s
//thinkit:mock_ssh_client_test                                           PASSED in 0.2s
//thinkit:mock_switch_test                                               PASSED in 1.3s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 1.3s
//tests/lib:packet_generator_test                                        PASSED in 65.3s
  Stats over 4 runs: max = 65.3s, min = 63.1s, avg = 64.5s, dev = 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.0s
  Stats over 5 runs: max = 2.0s, min = 1.2s, avg = 1.6s, dev = 0.3s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 46.6s
  Stats over 50 runs: max = 46.6s, min = 1.4s, avg = 3.9s, dev = 8.8s

Executed 226 out of 226 tests: 226 tests pass.
INFO: Build completed successfully, 283 total actions
