### PR TITLE
 [lib_gnmi] Add a test for `IsJsonSubset` for leaf list and Adding gNMI helper functions.

### DIFF
--- a/lib/gnmi/gnmi_helper.cc
+++ b/lib/gnmi/gnmi_helper.cc
@@ -694,6 +694,12 @@ absl::Status PushGnmiConfig(gnmi::gNMI::StubInterface& stub,
   gnmi::SetResponse resp;
   grpc::ClientContext context;
   grpc::Status status = stub.Set(&context, req, &resp);
+  if (status.error_code() == grpc::StatusCode::UNAVAILABLE) {
+    // Retry the config push if the return code was UNAVAILABLE.
+    LOG(INFO) << "SET returned UNAVAILABLE: " << resp.ShortDebugString();
+    absl::SleepFor(absl::Seconds(5));
+    status = stub.Set(&context, req, &resp);
+  }
   if (!status.ok()) return gutil::GrpcStatusToAbslStatus(status);
   LOG(INFO) << "Config push response: " << resp.ShortDebugString();
   return absl::OkStatus();
@@ -1487,6 +1493,43 @@ absl::string_view StripQuotes(absl::string_view string) {
 
 absl::string_view StripBrackets(absl::string_view string) {
   return absl::StripPrefix(absl::StripSuffix(string, "]"), "[");
+}
+
+absl::StatusOr<absl::btree_set<std::string>>
+GetP4rtIdOfInterfacesInAsicMacLocalLoopbackMode(
+    gnmi::gNMI::StubInterface &gnmi_stub) {
+  ASSIGN_OR_RETURN(
+      std::string response,
+      pins_test::GetGnmiStatePathInfo(&gnmi_stub, "interfaces",
+                                      "openconfig-interfaces:interfaces"));
+
+  json response_json = json::parse(response);
+  ASSIGN_OR_RETURN(json interfaces, GetField(response_json, "interface"));
+
+  absl::btree_set<std::string> loopback_mode_set;
+  for (const auto &interface : interfaces.items()) {
+    if (interface.value().find("config") == interface.value().end()) {
+      continue;
+    }
+    ASSIGN_OR_RETURN(json config, GetField(interface.value(), "config"));
+    // Skip if the config doesn't have loopback-mode.
+    if (config.find("loopback-mode") == config.end()) {
+      continue;
+    }
+    ASSIGN_OR_RETURN(json loopback_mode, GetField(config, "loopback-mode"));
+    if (loopback_mode.get<std::string>() == "ASIC_MAC_LOCAL") {
+      if (config.find("openconfig-p4rt:id") == config.end()) {
+        return gutil::InternalErrorBuilder().LogError()
+               << "openconfig-p4rt:id is missing in gNMI configuration and is "
+                  "required for ASIC_MAC_LOCAL loopback mode.";
+      }
+      ASSIGN_OR_RETURN(json port, GetField(config, "openconfig-p4rt:id"));
+      P4rtPortId p4rt_port_id =
+          P4rtPortId::MakeFromOpenConfigEncoding(port.get<int>());
+      loopback_mode_set.insert(p4rt_port_id.GetP4rtEncoding());
+    }
+  }
+  return loopback_mode_set;
 }
 
 absl::StatusOr<absl::flat_hash_map<std::string, std::string>>

--- a/lib/gnmi/gnmi_helper.h
+++ b/lib/gnmi/gnmi_helper.h
@@ -454,6 +454,11 @@ absl::string_view StripQuotes(absl::string_view string);
 // Strips the beginning and ending brackets ('[', ']') from the `string`.
 absl::string_view StripBrackets(absl::string_view string);
 
+// Returns a set of `ASIC_MAC_LOCAL` loopback mode ports.
+absl::StatusOr<absl::btree_set<std::string>>
+GetP4rtIdOfInterfacesInAsicMacLocalLoopbackMode(
+    gnmi::gNMI::StubInterface &gnmi_stub);
+
 // Returns a map from interface names to their physical transceiver name.
 absl::StatusOr<absl::flat_hash_map<std::string, std::string>>
 GetInterfaceToTransceiverMap(gnmi::gNMI::StubInterface &gnmi_stub);

--- a/lib/gnmi/gnmi_helper_test.cc
+++ b/lib/gnmi/gnmi_helper_test.cc
@@ -2314,6 +2314,59 @@ TEST(InterfaceToTransceiver, WorksProperly) {
               IsOkAndHolds(UnorderedPointwise(Eq(), expected_map)));
 }
 
+TEST(LoopbackMode, WorksProperly) {
+  gnmi::GetResponse response;
+  *response.add_notification()
+       ->add_update()
+       ->mutable_val()
+       ->mutable_json_ietf_val() = R"(
+    {
+      "openconfig-interfaces:interfaces": {
+        "interface": [
+          {
+            "name":"EthernetEnabled0",
+            "config":{
+              "loopback-mode":"ASIC_MAC_LOCAL",
+              "openconfig-p4rt:id": 2
+            }
+          },
+          {
+            "name":"EthernetEnabled1",
+            "config":{
+              "loopback-mode":"NOT_ASIC_MAC_LOCAL",
+              "openconfig-p4rt:id": 4
+            }
+          },
+          {
+            "name":"EthernetEnabled2",
+            "config":{
+              "loopback-mode":"ASIC_MAC_LOCAL",
+              "openconfig-p4rt:id": 5
+            }
+          },
+          {
+            "name":"EthernetEnabled3",
+            "config":{
+              "openconfig-p4rt:id": 7
+            }
+          },
+          {
+            "name":"EthernetEnabled4"
+          }
+        ]
+      }
+    })";
+
+  gnmi::MockgNMIStub mock_stub;
+  EXPECT_CALL(mock_stub, Get)
+      .WillRepeatedly(
+          DoAll(SetArgPointee<2>(response), Return(grpc::Status::OK)));
+  absl::btree_set<std::string> expected_set{"2", "5"};
+  LOG(INFO) << "loopback_mode: ";
+  EXPECT_THAT(GetP4rtIdOfInterfacesInAsicMacLocalLoopbackMode(mock_stub),
+              IsOkAndHolds(UnorderedPointwise(Eq(), expected_set)));
+}
+
 TEST(TransceiverPartInformation, WorksProperly) {
   gnmi::GetResponse response;
   *response.add_notification()


### PR DESCRIPTION
Keyword Check Result:
/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_check.sh ./lib/.
Keyword check Passed.

Bazel Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 727 targets (0 packages loaded, 0 targets configured).
INFO: Found 727 targets...
INFO: From Compiling tests/qos/qos_test_util.cc:
In file included from tests/qos/qos_test_util.cc:15:
./tests/qos/qos_test_util.h: In function 'std::string pins_test::SwtichRoleToDisableQoSToString(SwitchRoleToDisablePuntFlowQoS)':
tests/gnmi/ethcounter_ixia_test.cc:1465:5: note: in expansion of macro 'ASSIGN_OR_RETURN'
 1465 |     ASSIGN_OR_RETURN(p4::v1::TableEntry pi_entry,
      |     ^~~~~~~~~~~~~~~~
./p4_pdpi/pd.h:142:36: note: declared here
  142 | absl::StatusOr<p4::v1::TableEntry> PartialPdTableEntryToPiTableEntry(
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO: Elapsed time: 157.052s, Critical Path: 60.85s
INFO: 56 processes: 2 internal, 54 linux-sandbox.
INFO: Build completed successfully, 56 total actions

Bazel Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 727 targets (0 packages loaded, 0 targets configured).
INFO: Found 501 targets and 226 test targets...
INFO: Elapsed time: 280.841s, Critical Path: 118.76s
INFO: 283 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 283 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 2.9s
  Stats over 5 runs: max = 0.9s, min = 0.7s, avg = 0.7s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 45.4s
  Stats over 50 runs: max = 45.4s, min = 0.8s, avg = 3.9s, dev = 10.4s

Executed 226 out of 226 tests: 226 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeoutINFO: Build completed successfully, 283 total actions
