### PR TITLE
[Dvaas]Print `reproducibility_rate` as part of LogStatistics in ValidationResult.

### DIFF
--- a/dvaas/BUILD.bazel
+++ b/dvaas/BUILD.bazel
@@ -86,6 +86,7 @@ cc_library(
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:str_format",
     ],
 )
 
@@ -252,7 +253,6 @@ cc_library(
     deps = [
         ":test_vector_cc_proto",
         "@com_google_absl//absl/algorithm:container",
-        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
     ],
 )

--- a/dvaas/BUILD.bazel
+++ b/dvaas/BUILD.bazel
@@ -25,10 +25,11 @@ package(
 DVAAS_USER_ALLOW_LIST = [
     "//platforms/networking/gpins/testing/blackbox/p4:__subpackages__",
     "//platforms/networking/gpins/testing/blackbox/replay:__subpackages__",
+    "//platforms/networking/gpins/testing/blackbox/experimental:__subpackages__",
     "//platforms/networking/gpins/testing/ondatra/thinkit/tests:__pkg__",
     "//tests/forwarding:__pkg__",
     "//tests/ondatra/thinkit:__pkg__",
-    "//p4testgen:__pkg__",
+    "//p4testgen:__subpackages__",
     "//platforms/networking/gpins/testing/lib/nsf/traffic_helpers:__subpackages__",
 ]
 
@@ -70,7 +71,6 @@ cc_library(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",
-        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -202,7 +202,7 @@ proto_library(
     name = "packet_trace_proto",
     testonly = False,
     srcs = ["packet_trace.proto"],
-
+    deps = ["//p4_pdpi:ir_proto"],
 )
 
 cc_proto_library(

--- a/dvaas/BUILD.bazel
+++ b/dvaas/BUILD.bazel
@@ -174,10 +174,35 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "mirror_testbed_config",
+    srcs = ["mirror_testbed_config.cc"],
+    hdrs = ["mirror_testbed_config.h"],
+    deps = [
+        ":switch_api",
+        "//lib/gnmi:gnmi_helper",
+        "//lib/gnmi:openconfig_cc_proto",
+        "//lib/p4rt:p4rt_port",
+        "//p4_pdpi:ir",
+        "//p4_pdpi:ir_cc_proto",
+        "//p4_pdpi:p4_runtime_session",
+        "//tests/lib:switch_test_setup_helpers",
+        "//thinkit:mirror_testbed",
+        "//thinkit:mirror_testbed_fixture",
+        "@com_github_gnmi//proto/gnmi:gnmi_cc_grpc_proto",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/container:btree",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
 proto_library(
     name = "packet_trace_proto",
     testonly = False,
     srcs = ["packet_trace.proto"],
+
 )
 
 cc_proto_library(
@@ -233,22 +258,6 @@ cc_library(
     ],
 )
 
-cc_library(
-    name = "mirror_testbed_config",
-    testonly = True,
-    srcs = ["mirror_testbed_config.cc"],
-    hdrs = ["mirror_testbed_config.h"],
-    deps = [
-        ":switch_api",
-        "//gutil:status",
-        "//lib/gnmi:gnmi_helper",
-        "//lib/gnmi:openconfig_cc_proto",
-        "//p4_pdpi:p4_runtime_session",
-        "//tests/lib:switch_test_setup_helpers",
-        "//thinkit:mirror_testbed_fixture",
-        "@com_google_absl//absl/status",
-    ],
-)
 cc_library(
     name = "switch_api",
     hdrs = ["switch_api.h"],
@@ -323,6 +332,40 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_library(
+    name = "traffic_generator",
+    srcs = ["traffic_generator.cc"],
+    hdrs = ["traffic_generator.h"],
+    deps = [
+        ":dataplane_validation",
+        ":mirror_testbed_config",
+        ":packet_injection",
+        ":port_id_map",
+        ":switch_api",
+        ":test_vector",
+        ":test_vector_cc_proto",
+        ":validation_result",
+        "//gutil:test_artifact_writer",
+        "//lib/p4rt:p4rt_port",
+        "//p4_pdpi:ir",
+        "//p4_pdpi:ir_cc_proto",
+        "//p4_pdpi:p4_runtime_session",
+        "//p4_pdpi:p4_runtime_session_extras",
+        "//p4_symbolic/packet_synthesizer:packet_synthesizer_cc_proto",
+        "//tests/forwarding:util",
+        "//thinkit:mirror_testbed",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:btree",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
     ],
 )
 

--- a/dvaas/BUILD.bazel
+++ b/dvaas/BUILD.bazel
@@ -25,7 +25,6 @@ package(
 DVAAS_USER_ALLOW_LIST = [
     "//platforms/networking/gpins/testing/blackbox/p4:__subpackages__",
     "//platforms/networking/gpins/testing/blackbox/replay:__subpackages__",
-    "//platforms/networking/gpins/testing/blackbox/experimental:__subpackages__",
     "//platforms/networking/gpins/testing/ondatra/thinkit/tests:__pkg__",
     "//tests/forwarding:__pkg__",
     "//tests/ondatra/thinkit:__pkg__",
@@ -115,6 +114,7 @@ cc_library(
         "//p4_pdpi/packetlib",
         "//p4_pdpi/packetlib:packetlib_cc_proto",
         "//tests/forwarding:util",
+        "@com_github_google_glog//:glog",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/status",
@@ -141,7 +141,6 @@ cc_library(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:optional",
-        "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest",
         "@com_google_protobuf//:protobuf",
     ],

--- a/dvaas/BUILD.bazel
+++ b/dvaas/BUILD.bazel
@@ -39,6 +39,7 @@ cc_library(
     deps = [
         ":output_writer",
         ":packet_injection",
+        ":packet_trace_cc_proto",
         ":port_id_map",
         ":switch_api",
         ":test_run_validation",
@@ -63,8 +64,7 @@ cc_library(
         "@com_github_gnmi//proto/gnmi:gnmi_cc_proto",
         "@com_github_google_glog//:glog",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
@@ -176,7 +176,14 @@ cc_library(
 
 proto_library(
     name = "packet_trace_proto",
+    testonly = False,
     srcs = ["packet_trace.proto"],
+)
+
+cc_proto_library(
+    name = "packet_trace_cc_proto",
+    testonly = False,
+    deps = [":packet_trace_proto"],
 )
 
 proto_library(

--- a/dvaas/dataplane_validation.cc
+++ b/dvaas/dataplane_validation.cc
@@ -95,6 +95,43 @@ absl::Status DetermineReproducibilityRate(
   return absl::OkStatus();
 }
 
+// Attaches the packet trace from `packet_traces` with a matching packet tag as
+// the packet in `test_outcome` to the input parameter `test_outcome`. Also
+// appends the packet trace to the test artifact writer.
+absl::Status AttachPacketTrace(
+    dvaas::PacketTestOutcome& test_outcome,
+    absl::btree_map<std::string, std::vector<dvaas::PacketTrace>>&
+        packet_traces,
+    gutil::TestArtifactWriter& dvaas_test_artifact_writer) {
+  ASSIGN_OR_RETURN(
+      int test_id,
+      dvaas::ExtractTestPacketTag(
+          test_outcome.test_run().test_vector().input().packet().parsed()));
+  const std::string& packet_hex =
+      test_outcome.test_run().test_vector().input().packet().hex();
+  RETURN_IF_ERROR(dvaas_test_artifact_writer.AppendToTestArtifact(
+      "packet_" + std::to_string(test_id) + ".trace.txt",
+      packet_traces[packet_hex][0].bmv2_textual_log()));
+
+  auto it = packet_traces.find(packet_hex);
+  if (it == packet_traces.end() || it->second.empty()) {
+    return absl::InternalError(
+        absl::StrCat("Packet trace not found for packet ", packet_hex));
+  }
+
+  std::string summarized_packet_trace;
+  for (const auto& table_apply : it->second[0].table_apply()) {
+    absl::StrAppend(&summarized_packet_trace,
+                    table_apply.hit_or_miss_textual_log(), "\n\n");
+  }
+  test_outcome.mutable_test_result()->mutable_failure()->set_description(
+      absl::StrCat(test_outcome.test_result().failure().description(),
+                   "\n== EXPECTED INPUT-OUTPUT TRACE (P4 SIMULATION) SUMMARY"
+                   "=========================\n",
+                   summarized_packet_trace));
+  return absl::OkStatus();
+}
+
 std::string ToString(
     const std::vector<SynthesizedPacket>& synthesized_packets) {
   return absl::StrJoin(synthesized_packets, "\n\n\n",
@@ -266,15 +303,25 @@ absl::StatusOr<GenerateTestVectorsResult> GenerateTestVectors(
   return generate_test_vectors_result;
 }
 
-absl::Status HandleFailure(const DataplaneValidationParams& params,
-                           const PacketInjectionParams& parameters,
-                           int failure_count, pdpi::P4RuntimeSession& sut,
-                           pdpi::P4RuntimeSession& control_switch,
-                           dvaas::PacketTestOutcome& test_outcome) {
+absl::Status HandleFailure(
+    const DataplaneValidationParams& params,
+    const PacketInjectionParams& parameters, int failure_count,
+    pdpi::P4RuntimeSession& sut, pdpi::P4RuntimeSession& control_switch,
+    dvaas::PacketTestOutcome& test_outcome,
+    absl::btree_map<std::string, std::vector<dvaas::PacketTrace>>&
+        packet_traces,
+    gutil::TestArtifactWriter& dvaas_test_artifact_writer) {
+  // Duplicate packet that caused test failure.
   if (failure_count <
       params.failure_enhancement_options.max_failures_to_attempt_to_replicate) {
     RETURN_IF_ERROR(DetermineReproducibilityRate(params, parameters, sut,
                                                  control_switch, test_outcome));
+  }
+
+  // Print packet traces.
+  if (params.failure_enhancement_options.print_packet_trace) {
+    RETURN_IF_ERROR(AttachPacketTrace(test_outcome, packet_traces,
+                                      dvaas_test_artifact_writer));
   }
   return absl::OkStatus();
 }
@@ -283,8 +330,7 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
     SwitchApi& sut, SwitchApi& control_switch,
     const DataplaneValidationParams& params) {
   // Set up custom writer that prefixes artifact names and adds headers.
-  std::unique_ptr<gutil::TestArtifactWriter> writer =
-      std::make_unique<DvaasTestArtifactWriter>(artifact_writer_, params);
+  DvaasTestArtifactWriter dvaas_test_artifact_writer(artifact_writer_, params);
 
   // Configure control switch.
   {
@@ -303,7 +349,7 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
   // Read and store table entries on SUT as an artifact.
   ASSIGN_OR_RETURN(pdpi::IrEntities entities,
                    pdpi::ReadIrEntitiesSorted(*sut.p4rt));
-  RETURN_IF_ERROR(writer->AppendToTestArtifact(
+  RETURN_IF_ERROR(dvaas_test_artifact_writer.AppendToTestArtifact(
       "sut_ir_entities.txtpb", gutil::PrintTextProto(entities)));
 
   // Store port mapping as an artifact (identity if not given a value).
@@ -312,7 +358,8 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
           ? *params.mirror_testbed_port_map_override
           : MirrorTestbedP4rtPortIdMap::CreateIdentityMap();
   RETURN_IF_ERROR(CheckAndStoreMappedAndUnmappedPortIds(
-      mirror_testbed_port_map, *sut.gnmi, *control_switch.gnmi, *writer));
+      mirror_testbed_port_map, *sut.gnmi, *control_switch.gnmi,
+      dvaas_test_artifact_writer));
 
   // Generate test vectors.
   GenerateTestVectorsResult generate_test_vectors_result;
@@ -321,7 +368,8 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
   if (params.packet_test_vector_override.empty()) {
     LOG(INFO) << "Auto-generating test vectors";
     ASSIGN_OR_RETURN(generate_test_vectors_result,
-                     GenerateTestVectors(params, sut, *backend_, *writer));
+                     GenerateTestVectors(params, sut, *backend_,
+                                         dvaas_test_artifact_writer));
   } else {
     LOG(INFO) << "Checking user-provided test vectors for well-formedness";
     ASSIGN_OR_RETURN(pdpi::IrP4Info ir_info, pdpi::GetIrP4Info(*sut.p4rt));
@@ -329,8 +377,8 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
                      LegitimizeUserProvidedTestVectors(
                          params.packet_test_vector_override, ir_info));
   }
-  RETURN_IF_ERROR(
-      writer->AppendToTestArtifact("test_vectors.txt", ToString(test_vectors)));
+  RETURN_IF_ERROR(dvaas_test_artifact_writer.AppendToTestArtifact(
+      "test_vectors.txt", ToString(test_vectors)));
 
   PacketInjectionParams packet_injection_params = {
       .max_packets_to_send_per_second = params.max_packets_to_send_per_second,
@@ -345,7 +393,7 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
       SendTestPacketsAndCollectOutputs(
           *sut.p4rt.get(), *control_switch.p4rt.get(), test_vectors,
           packet_injection_params, packet_statistics_));
-  RETURN_IF_ERROR(writer->AppendToTestArtifact(
+  RETURN_IF_ERROR(dvaas_test_artifact_writer.AppendToTestArtifact(
       "test_runs.textproto", gutil::PrintTextProto(test_runs)));
 
   // Validate test runs to create test outcomes.
@@ -399,8 +447,9 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
       if (test_outcome.test_result().has_failure()) {
         // Handle failures.
         RETURN_IF_ERROR(HandleFailure(
-            params, packet_injection_params, ++current_failures_count,
-            *sut.p4rt.get(), *control_switch.p4rt.get(), test_outcome));
+            params, packet_injection_params, current_failures_count++,
+            *sut.p4rt.get(), *control_switch.p4rt.get(), test_outcome,
+            packet_traces, dvaas_test_artifact_writer));
         double reproducibility_rate =
             test_outcome.test_result().failure().reproducibility_rate();
         LOG(INFO) << (reproducibility_rate == 1.0
@@ -408,36 +457,6 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
                           : absl::StrCat(
                                 "Non-deterministic failure. Success rate is ",
                                 reproducibility_rate));
-
-        ASSIGN_OR_RETURN(int test_id,
-                         dvaas::ExtractTestPacketTag(test_outcome.test_run()
-                                                         .test_vector()
-                                                         .input()
-                                                         .packet()
-                                                         .parsed()));
-        const std::string packet_hex =
-            test_outcome.test_run().test_vector().input().packet().hex();
-
-        if (!packet_traces.contains(packet_hex) ||
-            packet_traces[packet_hex].empty()) {
-          return absl::InternalError(
-              absl::StrCat("Packet trace not found for packet ", packet_hex));
-        }
-        std::string summarized_packet_trace;
-        for (auto& table_apply : packet_traces[packet_hex][0].table_apply()) {
-          absl::StrAppend(&summarized_packet_trace,
-                          table_apply.hit_or_miss_textual_log(), "\n\n");
-        }
-        test_outcome.mutable_test_result()->mutable_failure()->set_description(
-            absl::StrCat(
-                test_outcome.test_result().failure().description(),
-                "\n== EXPECTED INPUT-OUTPUT TRACE (P4 SIMULATION) SUMMARY "
-                "=========================\n",
-                summarized_packet_trace));
-
-        RETURN_IF_ERROR(writer->AppendToTestArtifact(
-            "packet_" + std::to_string(test_id) + ".trace.txt",
-            packet_traces[packet_hex][0].bmv2_textual_log()));
       }
     }
   }
@@ -445,7 +464,7 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
   ValidationResult validation_result(
       std::move(test_outcomes),
       generate_test_vectors_result.packet_synthesis_result);
-  RETURN_IF_ERROR(writer->AppendToTestArtifact(
+  RETURN_IF_ERROR(dvaas_test_artifact_writer.AppendToTestArtifact(
       "test_vector_failures.txt",
       absl::StrJoin(validation_result.GetAllFailures(), "\n\n")));
 

--- a/dvaas/dataplane_validation.cc
+++ b/dvaas/dataplane_validation.cc
@@ -311,56 +311,74 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
         ValidateTestRun(test_run, params.switch_output_diff_params);
   }
 
-  // Store the packet trace for the first failed test packet (if any).
+  // Store the packet trace for all failed test outcomes.
   ASSIGN_OR_RETURN(P4Specification p4_spec,
                    InferP4Specification(params, *backend_, sut));
   ASSIGN_OR_RETURN(pdpi::IrP4Info ir_p4info, pdpi::GetIrP4Info(*sut.p4rt));
+  std::vector<SwitchInput> failed_switch_inputs;
   for (dvaas::PacketTestOutcome& test_outcome :
        *test_outcomes.mutable_outcomes()) {
     if (test_outcome.test_result().has_failure()) {
-      LOG(INFO) << "Storing packet trace for the first failed test packet";
-      const SwitchInput& switch_input =
-          test_outcome.test_run().test_vector().input();
-      // Read P4Info and control plane entities from SUT, sorted for
-      // determinism.
-      ASSIGN_OR_RETURN(pdpi::IrEntities v1model_augmented_entities,
-                       pdpi::ReadIrEntitiesSorted(*sut.p4rt));
-      // Retrieve loopback info from gNMI configuration and create table
-      // entries.
-      ASSIGN_OR_RETURN(
-          pdpi::IrEntities loopback_table_entries,
-          backend_->CreateV1ModelAuxiliaryTableEntries(*sut.gnmi, ir_p4info));
+      failed_switch_inputs.push_back(
+          test_outcome.test_run().test_vector().input());
+    }
+  }
 
-      v1model_augmented_entities.MergeFrom(loopback_table_entries);
-      ASSIGN_OR_RETURN(
-          auto packet_traces,
-          backend_->GetPacketTraces(p4_spec.bmv2_config, ir_p4info,
-                                    v1model_augmented_entities, switch_input));
-      const std::string packet_hex =
-          test_outcome.test_run().test_vector().input().packet().hex();
+  if (!failed_switch_inputs.empty()) {
+    LOG(INFO) << "Storing packet traces for failed test packets";
 
-      if (!packet_traces.contains(packet_hex) ||
-          packet_traces[packet_hex].empty()) {
-        return absl::InternalError(
-            absl::StrCat("Packet trace not found for packet ", packet_hex));
+    // Read P4Info and control plane entities from SUT, sorted for
+    // determinism.
+    ASSIGN_OR_RETURN(pdpi::IrEntities v1model_augmented_entities,
+                     pdpi::ReadIrEntitiesSorted(*sut.p4rt));
+    // Retrieve loopback info from gNMI configuration and create table
+    // entries.
+    ASSIGN_OR_RETURN(
+        pdpi::IrEntities loopback_table_entries,
+        backend_->CreateV1ModelAuxiliaryTableEntries(*sut.gnmi, ir_p4info));
+
+    v1model_augmented_entities.MergeFrom(loopback_table_entries);
+
+    ASSIGN_OR_RETURN(auto packet_traces,
+                     backend_->GetPacketTraces(p4_spec.bmv2_config, ir_p4info,
+                                               v1model_augmented_entities,
+                                               failed_switch_inputs));
+
+    for (dvaas::PacketTestOutcome& test_outcome :
+         *test_outcomes.mutable_outcomes()) {
+      if (test_outcome.test_result().has_failure()) {
+        ASSIGN_OR_RETURN(int test_id,
+                         dvaas::ExtractTestPacketTag(test_outcome.test_run()
+                                                         .test_vector()
+                                                         .input()
+                                                         .packet()
+                                                         .parsed()));
+
+        const std::string packet_hex =
+            test_outcome.test_run().test_vector().input().packet().hex();
+
+        if (!packet_traces.contains(packet_hex) ||
+            packet_traces[packet_hex].empty()) {
+          return absl::InternalError(
+              absl::StrCat("Packet trace not found for packet ", packet_hex));
+        }
+
+        std::string summarized_packet_trace;
+        for (auto& table_apply : packet_traces[packet_hex][0].table_apply()) {
+          absl::StrAppend(&summarized_packet_trace,
+                          table_apply.hit_or_miss_textual_log(), "\n\n");
+        }
+        test_outcome.mutable_test_result()->mutable_failure()->set_description(
+            absl::StrCat(
+                test_outcome.test_result().failure().description(),
+                "\n== EXPECTED INPUT-OUTPUT TRACE (P4 SIMULATION) SUMMARY "
+                "=========================\n",
+                summarized_packet_trace));
+
+        RETURN_IF_ERROR(writer->AppendToTestArtifact(
+            "packet_" + std::to_string(test_id) + ".trace.txt",
+            packet_traces[packet_hex][0].bmv2_textual_log()));
       }
-
-      std::string summarized_packet_trace;
-      for (auto& table_apply : packet_traces[packet_hex][0].table_apply()) {
-        absl::StrAppend(&summarized_packet_trace,
-                        table_apply.hit_or_miss_textual_log(), "\n\n");
-      }
-      test_outcome.mutable_test_result()->mutable_failure()->set_description(
-          absl::StrCat(
-              test_outcome.test_result().failure().description(),
-              "\n== EXPECTED INPUT-OUTPUT TRACE (P4 SIMULATION) SUMMARY "
-              "=========================\n",
-              summarized_packet_trace));
-
-      RETURN_IF_ERROR(writer->AppendToTestArtifact(
-          "packet_" + packet_hex.substr(packet_hex.length() - 8) + ".trace.txt",
-          packet_traces[packet_hex][0].bmv2_textual_log()));
-      break;
     }
   }
 
@@ -413,8 +431,8 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
           .SetPrepend()
       << "expected enabled interfaces on SUT to be up: ";
 
-  // Do not return on error in order to restore the original control switch gNMI
-  // interface config's P4RT IDs.
+  // Do not return on error in order to restore the original control switch
+  // gNMI interface config's P4RT IDs.
   absl::StatusOr<ValidationResult> result =
       ValidateDataplane(sut, control_switch, params);
 

--- a/dvaas/dataplane_validation.cc
+++ b/dvaas/dataplane_validation.cc
@@ -17,6 +17,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"
@@ -26,6 +27,7 @@
 #include "absl/strings/string_view.h"
 #include "dvaas/output_writer.h"
 #include "dvaas/packet_injection.h"
+#include "dvaas/packet_trace.pb.h"
 #include "dvaas/port_id_map.h"
 #include "dvaas/switch_api.h"
 #include "dvaas/test_run_validation.h"
@@ -303,27 +305,50 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
         ValidateTestRun(test_run, params.switch_output_diff_params);
   }
 
-  ValidationResult validation_result(
-      test_outcomes, generate_test_vectors_result.packet_synthesis_result);
-  RETURN_IF_ERROR(writer->AppendToTestArtifact(
-      "test_vector_failures.txt",
-      absl::StrJoin(validation_result.GetAllFailures(), "\n\n")));
-
   // Store the packet trace for the first failed test packet (if any).
   ASSIGN_OR_RETURN(P4Specification p4_spec,
                    InferP4Specification(params, *backend_, sut));
   ASSIGN_OR_RETURN(pdpi::IrP4Info ir_p4info, pdpi::GetIrP4Info(*sut.p4rt));
-  for (const dvaas::PacketTestOutcome& test_outcome :
-       test_outcomes.outcomes()) {
+  for (dvaas::PacketTestOutcome& test_outcome :
+       *test_outcomes.mutable_outcomes()) {
     if (test_outcome.test_result().has_failure()) {
       LOG(INFO) << "Storing packet trace for the first failed test packet";
       const SwitchInput& switch_input =
           test_outcome.test_run().test_vector().input();
-      RETURN_IF_ERROR(backend_->StorePacketTrace(p4_spec.bmv2_config, ir_p4info,
+      ASSIGN_OR_RETURN(auto packet_traces,
+                       backend_->GetPacketTraces(p4_spec.bmv2_config, ir_p4info,
                                                  entities, switch_input));
+      const std::string packet_hex =
+          test_outcome.test_run().test_vector().input().packet().hex();
+
+      if (!packet_traces.contains(packet_hex) ||
+          packet_traces[packet_hex].empty()) {
+        return absl::InternalError(
+            absl::StrCat("Packet trace not found for packet ", packet_hex));
+      }
+
+      std::string bmv2_textual_log =
+          packet_traces[packet_hex][0].bmv2_textual_log();
+
+      test_outcome.mutable_test_result()->mutable_failure()->set_description(
+          absl::StrCat(test_outcome.test_result().failure().description(),
+                       "\n== P4 SIMULATION PACKET TRACE "
+                       "==================================================\n",
+                       bmv2_textual_log));
+
+      RETURN_IF_ERROR(writer->AppendToTestArtifact(
+          "packet_" + packet_hex.substr(packet_hex.length() - 8) + ".trace.txt",
+          bmv2_textual_log));
       break;
     }
   }
+
+  ValidationResult validation_result(
+      std::move(test_outcomes),
+      generate_test_vectors_result.packet_synthesis_result);
+  RETURN_IF_ERROR(writer->AppendToTestArtifact(
+      "test_vector_failures.txt",
+      absl::StrJoin(validation_result.GetAllFailures(), "\n\n")));
 
   return validation_result;
 }

--- a/dvaas/dataplane_validation.cc
+++ b/dvaas/dataplane_validation.cc
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/btree_map.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
@@ -58,6 +59,41 @@ namespace {
 
 using ::p4_symbolic::packet_synthesizer::SynthesizedPacket;
 using ::pins_test::P4rtPortId;
+
+// Determines the reproducibility rate of a test failure and sets it in
+// `test_outcome`.
+absl::Status DetermineReproducibilityRate(
+    const DataplaneValidationParams& params,
+    const PacketInjectionParams& parameters, pdpi::P4RuntimeSession& sut,
+    pdpi::P4RuntimeSession& control_switch,
+    dvaas::PacketTestOutcome& test_outcome) {
+  // Duplicate the packet that caused a test failure.
+  PacketTestVectorById test_vectors;
+  PacketStatistics statistics;
+  for (int tag_id = 0; tag_id < params.failure_enhancement_options
+                                    .num_of_replication_attempts_per_failure;
+       ++tag_id) {
+    PacketTestVector packet_test_vector = test_outcome.test_run().test_vector();
+    RETURN_IF_ERROR(UpdateTestTag(packet_test_vector, tag_id));
+    test_vectors[tag_id] = std::move(packet_test_vector);
+  }
+
+  // Call SendTestPacketsAndCollectOutputs.
+  ASSIGN_OR_RETURN(PacketTestRuns test_runs,
+                   SendTestPacketsAndCollectOutputs(
+                       sut, control_switch, test_vectors, parameters,
+                       statistics, /*log_injection_progress=*/false));
+
+  ValidationResult validation_result =
+      ValidationResult(test_runs, params.switch_output_diff_params,
+                       /*packet_synthesis_result=*/{});
+
+  test_outcome.mutable_test_result()
+      ->mutable_failure()
+      ->set_reproducibility_rate(1 - validation_result.GetSuccessRate());
+
+  return absl::OkStatus();
+}
 
 std::string ToString(
     const std::vector<SynthesizedPacket>& synthesized_packets) {
@@ -230,6 +266,19 @@ absl::StatusOr<GenerateTestVectorsResult> GenerateTestVectors(
   return generate_test_vectors_result;
 }
 
+absl::Status HandleFailure(const DataplaneValidationParams& params,
+                           const PacketInjectionParams& parameters,
+                           int failure_count, pdpi::P4RuntimeSession& sut,
+                           pdpi::P4RuntimeSession& control_switch,
+                           dvaas::PacketTestOutcome& test_outcome) {
+  if (failure_count <
+      params.failure_enhancement_options.max_failures_to_attempt_to_replicate) {
+    RETURN_IF_ERROR(DetermineReproducibilityRate(params, parameters, sut,
+                                                 control_switch, test_outcome));
+  }
+  return absl::OkStatus();
+}
+
 absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
     SwitchApi& sut, SwitchApi& control_switch,
     const DataplaneValidationParams& params) {
@@ -283,23 +332,21 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
   RETURN_IF_ERROR(
       writer->AppendToTestArtifact("test_vectors.txt", ToString(test_vectors)));
 
+  PacketInjectionParams packet_injection_params = {
+      .max_packets_to_send_per_second = params.max_packets_to_send_per_second,
+      .is_expected_unsolicited_packet = [&](const packetlib::Packet packet)
+          -> bool { return backend_->IsExpectedUnsolicitedPacket(packet); },
+      .mirror_testbed_port_map = mirror_testbed_port_map,
+  };
+
   // Send tests to switch and collect results.
   ASSIGN_OR_RETURN(
       PacketTestRuns test_runs,
       SendTestPacketsAndCollectOutputs(
           *sut.p4rt.get(), *control_switch.p4rt.get(), test_vectors,
-          {
-              .max_packets_to_send_per_second =
-                  params.max_packets_to_send_per_second,
-              .is_expected_unsolicited_packet =
-                  [&](const packetlib::Packet packet) -> bool {
-                return backend_->IsExpectedUnsolicitedPacket(packet);
-              },
-              .mirror_testbed_port_map = mirror_testbed_port_map,
-          },
-          packet_statistics_));
-  RETURN_IF_ERROR(writer->AppendToTestArtifact("test_runs.textproto",
-                                               test_runs.DebugString()));
+          packet_injection_params, packet_statistics_));
+  RETURN_IF_ERROR(writer->AppendToTestArtifact(
+      "test_runs.textproto", gutil::PrintTextProto(test_runs)));
 
   // Validate test runs to create test outcomes.
   dvaas::PacketTestOutcomes test_outcomes;
@@ -344,16 +391,30 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
                                                v1model_augmented_entities,
                                                failed_switch_inputs));
 
+    int current_failures_count = 0;
+    // Rerun at most `num_failures_to_rerun` to avoid timeouts if there are too
+    // many failures.
     for (dvaas::PacketTestOutcome& test_outcome :
          *test_outcomes.mutable_outcomes()) {
       if (test_outcome.test_result().has_failure()) {
+        // Handle failures.
+        RETURN_IF_ERROR(HandleFailure(
+            params, packet_injection_params, ++current_failures_count,
+            *sut.p4rt.get(), *control_switch.p4rt.get(), test_outcome));
+        double reproducibility_rate =
+            test_outcome.test_result().failure().reproducibility_rate();
+        LOG(INFO) << (reproducibility_rate == 1.0
+                          ? "Deterministic failure"
+                          : absl::StrCat(
+                                "Non-deterministic failure. Success rate is ",
+                                reproducibility_rate));
+
         ASSIGN_OR_RETURN(int test_id,
                          dvaas::ExtractTestPacketTag(test_outcome.test_run()
                                                          .test_vector()
                                                          .input()
                                                          .packet()
                                                          .parsed()));
-
         const std::string packet_hex =
             test_outcome.test_run().test_vector().input().packet().hex();
 
@@ -362,7 +423,6 @@ absl::StatusOr<ValidationResult> DataplaneValidator::ValidateDataplane(
           return absl::InternalError(
               absl::StrCat("Packet trace not found for packet ", packet_hex));
         }
-
         std::string summarized_packet_trace;
         for (auto& table_apply : packet_traces[packet_hex][0].table_apply()) {
           absl::StrAppend(&summarized_packet_trace,

--- a/dvaas/dataplane_validation.h
+++ b/dvaas/dataplane_validation.h
@@ -280,13 +280,6 @@ public:
   virtual absl::StatusOr<P4Specification>
   InferP4Specification(SwitchApi &sut) const = 0;
 
-  // Stores the P4 simulation packet trace for the given config, entries, and
-  // input packet.
-  virtual absl::Status StorePacketTrace(
-      const p4::v1::ForwardingPipelineConfig& bmv2_compatible_config,
-      const pdpi::IrP4Info& ir_p4info, const pdpi::IrEntities& ir_entities,
-      const SwitchInput& switch_input) const = 0;
-
   // Gets the P4 simulation packet trace for the given config, entries, and
   // input packet.
   virtual absl::StatusOr<
@@ -295,6 +288,11 @@ public:
       const p4::v1::ForwardingPipelineConfig& bmv2_compatible_config,
       const pdpi::IrP4Info& ir_p4info, const pdpi::IrEntities& ir_entities,
       const SwitchInput& switch_input) const = 0;
+
+  // Creates entries for v1Model auxiliary tables that model the effects of the
+  // given gNMI configuration in on packet forwarding (e.g. port loopback mode).
+  virtual absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryTableEntries(
+      gnmi::gNMI::StubInterface& gnmi_stub, pdpi::IrP4Info ir_p4info) const = 0;
 
   virtual ~DataplaneValidationBackend() = default;
 };

--- a/dvaas/dataplane_validation.h
+++ b/dvaas/dataplane_validation.h
@@ -74,6 +74,8 @@ struct P4Specification {
 struct FailureEnhancementOptions {
   int num_of_replication_attempts_per_failure = 1000;
   int max_failures_to_attempt_to_replicate = 10;
+  // If true, print the packet's trace.
+  bool print_packet_trace = true;
 };
 
 // Specifies user-facing parameters of DVaaS. These are also the parameters that

--- a/dvaas/dataplane_validation.h
+++ b/dvaas/dataplane_validation.h
@@ -67,6 +67,15 @@ struct P4Specification {
   p4::v1::ForwardingPipelineConfig bmv2_config;
 };
 
+// Stores configurable parameters for `HandleFailure` for packet failure
+// determinism. Attempt at most `num_of_replication_attempts_per_failure`
+// number of reruns for the first `max_failures_to_attempt_to_replicate`
+// failures.
+struct FailureEnhancementOptions {
+  int num_of_replication_attempts_per_failure = 1000;
+  int max_failures_to_attempt_to_replicate = 10;
+};
+
 // Specifies user-facing parameters of DVaaS. These are also the parameters that
 // are likely to vary across tests.
 struct DataplaneValidationParams {
@@ -115,6 +124,10 @@ struct DataplaneValidationParams {
   // enough in most cases.
   std::optional<p4_symbolic::packet_synthesizer::CoverageGoals>
       coverage_goals_override;
+
+  // A struct to store configurable parameters for packet failure determinism.
+  // Parameters in `failure_enhancement_options` are assigned default values.
+  FailureEnhancementOptions failure_enhancement_options;
 };
 
 // Forward declaration. See below for description.

--- a/dvaas/dataplane_validation.h
+++ b/dvaas/dataplane_validation.h
@@ -26,14 +26,14 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
+#include "absl/container/btree_map.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "dvaas/output_writer.h"
 #include "dvaas/packet_injection.h"
+#include "dvaas/packet_trace.pb.h"
 #include "dvaas/port_id_map.h"
 #include "dvaas/switch_api.h"
 #include "dvaas/test_run_validation.h"
@@ -283,6 +283,15 @@ public:
   // Stores the P4 simulation packet trace for the given config, entries, and
   // input packet.
   virtual absl::Status StorePacketTrace(
+      const p4::v1::ForwardingPipelineConfig& bmv2_compatible_config,
+      const pdpi::IrP4Info& ir_p4info, const pdpi::IrEntities& ir_entities,
+      const SwitchInput& switch_input) const = 0;
+
+  // Gets the P4 simulation packet trace for the given config, entries, and
+  // input packet.
+  virtual absl::StatusOr<
+      absl::btree_map<std::string, std::vector<dvaas::PacketTrace>>>
+  GetPacketTraces(
       const p4::v1::ForwardingPipelineConfig& bmv2_compatible_config,
       const pdpi::IrP4Info& ir_p4info, const pdpi::IrEntities& ir_entities,
       const SwitchInput& switch_input) const = 0;

--- a/dvaas/dataplane_validation.h
+++ b/dvaas/dataplane_validation.h
@@ -72,8 +72,8 @@ struct P4Specification {
 // number of reruns for the first `max_failures_to_attempt_to_replicate`
 // failures.
 struct FailureEnhancementOptions {
-  int num_of_replication_attempts_per_failure = 1000;
-  int max_failures_to_attempt_to_replicate = 10;
+  int num_of_replication_attempts_per_failure = 0;
+  int max_failures_to_attempt_to_replicate = 0;
   // If true, print the packet's trace.
   bool print_packet_trace = true;
 };

--- a/dvaas/dataplane_validation.h
+++ b/dvaas/dataplane_validation.h
@@ -27,7 +27,6 @@ limitations under the License.
 #include <vector>
 
 #include "absl/container/btree_map.h"
-#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
@@ -40,7 +39,6 @@ limitations under the License.
 #include "dvaas/test_vector.h"
 #include "dvaas/test_vector.pb.h"
 #include "dvaas/validation_result.h"
-#include "google/protobuf/descriptor.h"
 #include "gutil/test_artifact_writer.h"
 #include "lib/p4rt/p4rt_port.h"
 #include "p4_pdpi/ir.pb.h"
@@ -280,14 +278,16 @@ public:
   virtual absl::StatusOr<P4Specification>
   InferP4Specification(SwitchApi &sut) const = 0;
 
-  // Gets the P4 simulation packet trace for the given config, entries, and
-  // input packet.
+  // Gets the P4 simulation packet trace(s) for the given config, entries, and
+  // input packet. Returns a map from input packet's hex string to list of
+  // packet traces each corresponding to one trace for that packet (there may be
+  // multiple traces, e.g. due to exploring WCMP non-determinism).
   virtual absl::StatusOr<
       absl::btree_map<std::string, std::vector<dvaas::PacketTrace>>>
   GetPacketTraces(
       const p4::v1::ForwardingPipelineConfig& bmv2_compatible_config,
       const pdpi::IrP4Info& ir_p4info, const pdpi::IrEntities& ir_entities,
-      const SwitchInput& switch_input) const = 0;
+      const std::vector<SwitchInput>& switch_inputs) const = 0;
 
   // Creates entries for v1Model auxiliary tables that model the effects of the
   // given gNMI configuration in on packet forwarding (e.g. port loopback mode).

--- a/dvaas/packet_injection.cc
+++ b/dvaas/packet_injection.cc
@@ -49,12 +49,7 @@ absl::StatusOr<pdpi::IrP4Info> GetIrP4Info(
   return pdpi::CreateIrP4Info(response.config().p4info());
 }
 
-// Processed information about a PacketIn message with a tagged payload.
-struct TaggedPacketIn {
-  int tag;
-  p4::v1::PacketIn packet_in;
-  packetlib::Packet parsed_inner_packet;
-};
+}  // namespace
 
 absl::StatusOr<std::vector<TaggedPacketIn>>
 CollectStreamMessageResponsesAndReturnTaggedPacketIns(
@@ -116,8 +111,6 @@ absl::StatusOr<P4rtPortId> GetSutEgressPortFromControlSwitchPacketIn(
   return mirror_testbed_port_map.GetSutPortConnectedToControlSwitchPort(
       control_switch_ingress_port);
 }
-
-}  // namespace
 
 absl::StatusOr<std::string> GetIngressPortFromIrPacketIn(
     const pdpi::IrPacketIn& packet_in) {

--- a/dvaas/packet_injection.cc
+++ b/dvaas/packet_injection.cc
@@ -22,10 +22,12 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/escaping.h"
+#include "absl/strings/str_cat.h"
 #include "absl/time/time.h"
 #include "dvaas/port_id_map.h"
 #include "dvaas/test_vector.h"
 #include "dvaas/test_vector.pb.h"
+#include "glog/logging.h"
 #include "gutil/status.h"
 #include "lib/p4rt/p4rt_port.h"
 #include "p4/v1/p4runtime.pb.h"
@@ -124,7 +126,8 @@ absl::StatusOr<std::string> GetIngressPortFromIrPacketIn(
 absl::StatusOr<PacketTestRuns> SendTestPacketsAndCollectOutputs(
     pdpi::P4RuntimeSession& sut, pdpi::P4RuntimeSession& control_switch,
     const PacketTestVectorById& packet_test_vector_by_id,
-    const PacketInjectionParams& parameters, PacketStatistics& statistics) {
+    const PacketInjectionParams& parameters, PacketStatistics& statistics,
+    bool log_injection_progress) {
   LOG(INFO) << "Injecting test packets into the dataplane "
             << packet_test_vector_by_id.size();
   statistics.total_packets_injected += packet_test_vector_by_id.size();
@@ -205,7 +208,7 @@ absl::StatusOr<PacketTestRuns> SendTestPacketsAndCollectOutputs(
             sut, kCollectionDuration,
             parameters.is_expected_unsolicited_packet);
     RETURN_IF_ERROR(sut_packet_ins.status())
-        << "while  collecting the output of SUT";
+        << "while collecting the output of SUT";
     LOG(INFO) << "Collected " << sut_packet_ins->size()
               << " punted packets (from SUT)";
     statistics.total_packets_punted += sut_packet_ins->size();

--- a/dvaas/packet_injection.h
+++ b/dvaas/packet_injection.h
@@ -36,6 +36,13 @@ struct PacketStatistics {
   int total_packets_punted = 0;
 };
 
+// Processed information about a PacketIn message with a tagged payload.
+struct TaggedPacketIn {
+  int tag;
+  p4::v1::PacketIn packet_in;
+  packetlib::Packet parsed_inner_packet;
+};
+
 // Type of a function that given an unsolicited (i.e. a packet that is NOT
 // a result of a input test packet) received either from the SUT or
 // the control switch, determines if the packet is among expected such packets
@@ -90,6 +97,20 @@ struct PacketInjectionParams {
   // rather than ignoring all packet-ins.
   bool enable_sut_packet_in_collection = true;
 };
+
+// Injects a packet to the control switch egress with a packet injection delay
+// based on the PacketInjectionParam's maximum packets to send per second.
+// Injects a packet to the control switch egress with a packet injection delay
+// based on the PacketInjectionParam's maximum packets to send per second.
+absl::StatusOr<pins_test::P4rtPortId> GetSutEgressPortFromControlSwitchPacketIn(
+    const pdpi::IrPacketIn& packet_in,
+    const MirrorTestbedP4rtPortIdMap& mirror_testbed_port_map);
+
+absl::StatusOr<std::vector<TaggedPacketIn>>
+CollectStreamMessageResponsesAndReturnTaggedPacketIns(
+    pdpi::P4RuntimeSession& p4rt_session, absl::Duration duration,
+    const IsExpectedUnsolicitedPacketFunctionType&
+        is_expected_unsolicited_packet);
 
 // Determines the switch's behavior when receiving test packets by:
 // - Injecting those packets to the control switch egress to send to the SUT.

--- a/dvaas/packet_injection.h
+++ b/dvaas/packet_injection.h
@@ -117,9 +117,10 @@ CollectStreamMessageResponsesAndReturnTaggedPacketIns(
 // - Determining the set of packets that were forwarded (punted from control
 //   switch) and punted (punted from SUT) for each input packet.
 absl::StatusOr<PacketTestRuns> SendTestPacketsAndCollectOutputs(
-    pdpi::P4RuntimeSession &sut, pdpi::P4RuntimeSession &control_switch,
-    const PacketTestVectorById &packet_test_vector_by_id,
-    const PacketInjectionParams &parameters, PacketStatistics &statistics);
+    pdpi::P4RuntimeSession& sut, pdpi::P4RuntimeSession& control_switch,
+    const PacketTestVectorById& packet_test_vector_by_id,
+    const PacketInjectionParams& parameters, PacketStatistics& statistics,
+    bool log_injection_progress = true);
 
 } // namespace dvaas
 

--- a/dvaas/packet_trace.proto
+++ b/dvaas/packet_trace.proto
@@ -6,4 +6,11 @@ package dvaas;
 // processor.
 message PacketTrace {
   string bmv2_textual_log = 1;
+  repeated TableApply table_apply = 2;
+}
+
+message TableApply {
+  string table_name = 1;
+  bool table_was_hit = 2;
+  string hit_or_miss_textual_log = 3;
 }

--- a/dvaas/packet_trace.proto
+++ b/dvaas/packet_trace.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dvaas;
 
+import "p4_pdpi/ir.proto";
+
 // A proto representation of the trace of a packet through a P4 packet
 // processor.
 message PacketTrace {
@@ -11,6 +13,15 @@ message PacketTrace {
 
 message TableApply {
   string table_name = 1;
-  bool table_was_hit = 2;
-  string hit_or_miss_textual_log = 3;
+  string hit_or_miss_textual_log = 2;
+
+  message Hit {
+    pdpi.IrTableEntry table_entry = 3;
+  }
+  message Miss {}
+
+  oneof result {
+    Hit hit = 4;
+    Miss miss = 5;
+  }
 }

--- a/dvaas/port_id_map.cc
+++ b/dvaas/port_id_map.cc
@@ -84,10 +84,10 @@ MirrorTestbedP4rtPortIdMap::GetSutPortConnectedToControlSwitchPort(
   // Handle explicit map.
   const auto it = control_to_sut_port_map_->find(control_port);
   if (it == control_to_sut_port_map_->end()) {
-    return absl::NotFoundError(
-        absl::Substitute("Control port '$0' was not found in control switch "
-                         "to SUT P4RT port ID map.",
-                         control_port));
+    return absl::NotFoundError(absl::Substitute(
+        "Control port '$0' was not found among keys of control switch "
+        "to SUT P4RT port ID one-to-one map.",
+        control_port));
   }
   return it->second;
 }
@@ -104,10 +104,10 @@ MirrorTestbedP4rtPortIdMap::GetControlSwitchPortConnectedToSutPort(
                                     return control_sut_port.second == sut_port;
                                   });
   if (it == control_to_sut_port_map_->end()) {
-    return absl::NotFoundError(
-        absl::Substitute("SUT port '$0' was not found in control switch "
-                         "to control switch P4RT port ID map.",
-                         sut_port));
+    return absl::NotFoundError(absl::Substitute(
+        "SUT port '$0' was not found among values of control switch "
+        "to SUT P4RT port ID one-to-one map.",
+        sut_port));
   }
   return it->first;
 }

--- a/dvaas/test_run_validation.cc
+++ b/dvaas/test_run_validation.cc
@@ -312,7 +312,6 @@ static constexpr absl::string_view kActualBanner =
 static constexpr absl::string_view kExpectationBanner =
     "== EXPECTED OUTPUT "
     "=============================================================";
-
 }  // namespace
 
 PacketTestValidationResult ValidateTestRun(

--- a/dvaas/test_run_validation.cc
+++ b/dvaas/test_run_validation.cc
@@ -19,7 +19,6 @@
 #include <utility>
 #include <vector>
 
-#include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"

--- a/dvaas/test_run_validation.h
+++ b/dvaas/test_run_validation.h
@@ -20,7 +20,6 @@
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
-#include "absl/types/span.h"
 #include "dvaas/output_writer.h"
 #include "dvaas/test_vector.pb.h"
 #include "google/protobuf/descriptor.h"

--- a/dvaas/test_vector.h
+++ b/dvaas/test_vector.h
@@ -26,6 +26,9 @@
 
 namespace dvaas {
 
+// A map of packet tags to corresponding test vectors.
+using PacketTestVectorById = absl::btree_map<int, PacketTestVector>;
+
 // Returns a string that must be included in the payload of test packets.
 // This "tag" encodes the given test packet ID, which must be:
 // * Uniform across all packets within a packet test vector, incl. input &
@@ -48,8 +51,6 @@ std::ostream &operator<<(std::ostream &os, const SwitchOutput &output);
 // error if the packets are not already tagged.
 absl::Status UpdateTestTag(PacketTestVector &packet_test_vector, int new_tag);
 
-using PacketTestVectorById = absl::btree_map<int, PacketTestVector>;
-
-} // namespace dvaas
+}  // namespace dvaas
 
 #endif // PINS_TESTS_FORWARDING_TEST_VECTOR_H_

--- a/dvaas/test_vector.proto
+++ b/dvaas/test_vector.proto
@@ -105,6 +105,8 @@ message PacketTestValidationResult {
   message Failure {
     // A detailed explanation of how the switch did not behave as expected.
     string description = 1;
+    // The ratio of times sending the same packet reproduces the failure.
+    double reproducibility_rate = 2;
   }
   // If present, indicates that the switch did not behave as expected.
   Failure failure = 1;

--- a/dvaas/test_vector.proto
+++ b/dvaas/test_vector.proto
@@ -114,7 +114,6 @@ message PacketTestValidationResult {
 message PacketTestOutcome {
   PacketTestRun test_run = 1;
   PacketTestValidationResult test_result = 2;
-  PacketTrace p4_packet_trace = 3;
 }
 
 // A list of test outcomes.

--- a/dvaas/test_vector_stats.cc
+++ b/dvaas/test_vector_stats.cc
@@ -28,7 +28,11 @@ void AddTestVectorStats(const PacketTestOutcome& outcome,
                         TestVectorStats& stats) {
   stats.num_vectors += 1;
 
-  if (!outcome.test_result().has_failure()) {
+  if (outcome.test_result().has_failure()) {
+    if (outcome.test_result().failure().reproducibility_rate() == 1.0) {
+      stats.num_deterministic_failures += 1;
+    }
+  } else {
     stats.num_vectors_passed += 1;
   }
 
@@ -102,6 +106,11 @@ std::string ExplainTestVectorStats(const TestVectorStats& stats) {
       stats.num_vectors_punting, stats.num_packets_punted);
   absl::StrAppendFormat(&result, "%d test vectors produced no output packets\n",
                         stats.num_vectors_dropping);
+  absl::StrAppendFormat(&result,
+                        "%d of %d test vectors with failures were "
+                        "deterministically reproducible\n",
+                        stats.num_deterministic_failures,
+                        stats.num_vectors - stats.num_vectors_passed);
   return result;
 }
 

--- a/dvaas/test_vector_stats.h
+++ b/dvaas/test_vector_stats.h
@@ -33,6 +33,7 @@ struct TestVectorStats {
 
   int num_packets_forwarded = 0;
   int num_packets_punted = 0;
+  int num_deterministic_failures = 0;
 };
 
 TestVectorStats ComputeTestVectorStats(const PacketTestOutcomes &test_outcomes);

--- a/dvaas/test_vector_stats_test.expected
+++ b/dvaas/test_vector_stats_test.expected
@@ -1,5 +1,6 @@
-66.67% of 6 test vectors passed
-100.00% of 6 test vectors produced the correct number and type of output packets
+57.14% of 7 test vectors passed
+100.00% of 7 test vectors produced the correct number and type of output packets
 4 test vectors forwarded, producing 6 forwarded output packets
-2 test vectors punted, producing 2 punted output packets
+3 test vectors punted, producing 3 punted output packets
 1 test vectors produced no output packets
+1 of 3 test vectors with failures were deterministically reproducible

--- a/dvaas/traffic_generator.cc
+++ b/dvaas/traffic_generator.cc
@@ -20,8 +20,10 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/btree_map.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/escaping.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/clock.h"
@@ -31,21 +33,27 @@
 #include "dvaas/packet_injection.h"
 #include "dvaas/port_id_map.h"
 #include "dvaas/switch_api.h"
+#include "dvaas/test_vector.h"
 #include "dvaas/test_vector.pb.h"
 #include "dvaas/validation_result.h"
 #include "glog/logging.h"
 #include "gutil/status.h"
 #include "gutil/test_artifact_writer.h"
+#include "lib/p4rt/p4rt_port.h"
+#include "p4_pdpi/ir.h"
 #include "p4_pdpi/ir.pb.h"
 #include "p4_pdpi/p4_runtime_session.h"
 #include "p4_pdpi/p4_runtime_session_extras.h"
 #include "p4_symbolic/packet_synthesizer/packet_synthesizer.pb.h"
-#include "thinkit/mirror_testbed_fixture.h"
+#include "tests/forwarding/util.h"
+#include "thinkit/mirror_testbed.h"
 
 // Crash if `status` is not okay. Only use in tests.
 #define CHECK_OK(val) CHECK_EQ(::absl::OkStatus(), (val))  // Crash OK.
 
 namespace dvaas {
+
+// ============================= SimpleTrafficGen ==============================
 
 SimpleTrafficGenerator::State SimpleTrafficGenerator::GetState() {
   absl::MutexLock lock(&state_mutex_);
@@ -58,8 +66,7 @@ void SimpleTrafficGenerator::SetState(State state) {
 }
 
 absl::StatusOr<PacketSynthesisStats> SimpleTrafficGenerator::Init(
-    std::shared_ptr<thinkit::MirrorTestbedInterface> testbed,
-    const TrafficGenerator::Params& params) {
+    thinkit::MirrorTestbed* testbed, const TrafficGenerator::Params& params) {
   if (GetState() == kTrafficFlowing) {
     return absl::FailedPreconditionError(
         "Cannot initialize while traffic is flowing");
@@ -157,6 +164,10 @@ void SimpleTrafficGenerator::InjectTraffic() {
         {
             .max_packets_to_send_per_second =
                 params_.validation_params.max_packets_to_send_per_second,
+            .is_expected_unsolicited_packet =
+                [&](const packetlib::Packet packet) -> bool {
+              return backend_->IsExpectedUnsolicitedPacket(packet);
+            },
             .mirror_testbed_port_map =
                 params_.validation_params.mirror_testbed_port_map_override
                     .value_or(MirrorTestbedP4rtPortIdMap::CreateIdentityMap()),
@@ -209,4 +220,382 @@ SimpleTrafficGenerator::~SimpleTrafficGenerator() {
   }
 }
 
+// ======================= TrafficGenWithGuaranteedRate ========================
+
+TrafficGeneratorWithGuaranteedRate::~TrafficGeneratorWithGuaranteedRate() {
+  if (GetState() == kTrafficInjectionAndCollection) {
+    LOG(ERROR) << "TrafficGeneratorWithGuaranteedRate destructed while traffic "
+                  "is flowing with the state: "
+               << GetState() << ". Stopping traffic.";
+    absl::Status status = StopTraffic();
+    if (!status.ok()) {
+      LOG(FATAL) << "Failed to stop traffic: " << status;  // Crash OK
+    }
+  }
+  if (GetState() == kTrafficCollection) {
+    LOG(FATAL) << "Unexpected kTrafficCollection state in call to "  // Crash OK
+                  "destructor of TrafficGeneratorWithGuaranteedRate.";
+  }
+}
+
+TrafficGeneratorWithGuaranteedRate::State
+TrafficGeneratorWithGuaranteedRate::GetState() {
+  absl::MutexLock lock(&state_mutex_);
+  return state_;
+}
+
+void TrafficGeneratorWithGuaranteedRate::SetState(State state) {
+  absl::MutexLock lock(&state_mutex_);
+  state_ = state;
+}
+
+absl::StatusOr<PacketSynthesisStats> TrafficGeneratorWithGuaranteedRate::Init(
+    thinkit::MirrorTestbed* testbed, const TrafficGenerator::Params& params) {
+  if (GetState() == kTrafficInjectionAndCollection) {
+    return absl::FailedPreconditionError(
+        "Cannot initialize while traffic is being injected and collected.");
+  }
+  if (GetState() == kTrafficCollection) {
+    return absl::InternalError(
+        "Unexpected kTrafficCollection state in call to Init.");
+  }
+
+  params_ = params;
+
+  // Configure testbed.
+  ASSIGN_OR_RETURN(auto mirror_testbed_configurator,
+                   MirrorTestbedConfigurator::Create(testbed));
+  testbed_configurator_ = std::make_unique<MirrorTestbedConfigurator>(
+      std::move(mirror_testbed_configurator));
+  RETURN_IF_ERROR(testbed_configurator_->ConfigureForForwardingTest({
+      .mirror_sut_ports_ids_to_control_switch =
+          !params_.validation_params.mirror_testbed_port_map_override
+               .has_value(),
+  }));
+  // Install punt entries on control switch.
+  // TODO: Use testbed configurator to do this, instead.
+  pdpi::P4RuntimeSession& control_p4rt =
+      *testbed_configurator_->ControlSwitchApi().p4rt;
+  RETURN_IF_ERROR(pdpi::ClearEntities(control_p4rt));
+  ASSIGN_OR_RETURN(const pdpi::IrP4Info ir_p4info,
+                   pdpi::GetIrP4Info(control_p4rt));
+  ASSIGN_OR_RETURN(const pdpi::IrEntities punt_entries,
+                   backend_->GetEntitiesToPuntAllPackets(ir_p4info));
+  RETURN_IF_ERROR(pdpi::InstallIrEntities(control_p4rt, punt_entries));
+
+  // Generate test vectors.
+  gutil::BazelTestArtifactWriter writer;
+  ASSIGN_OR_RETURN(
+      generate_test_vectors_result_,
+      GenerateTestVectors(params.validation_params,
+                          testbed_configurator_->SutApi(), *backend_, writer));
+
+  SetState(kInitialized);
+
+  return PacketSynthesisStats{};
+}
+
+absl::Status TrafficGeneratorWithGuaranteedRate::StartTraffic() {
+  State state = GetState();
+  if (state == kUninitialized) {
+    return absl::FailedPreconditionError(
+        "Cannot start traffic before initialization.");
+  }
+  if (state == kTrafficInjectionAndCollection) {
+    return absl::FailedPreconditionError(
+        "Traffic injection has already started");
+  }
+  if (state == kTrafficCollection) {
+    return absl::InternalError(
+        "Unexpected kTrafficCollection state in call to StartTraffic");
+  }
+
+  // Spawn traffic injection thread.
+  traffic_injection_thread_ = std::thread([&]() {
+    CHECK_OK(  // Crash OK
+        TrafficGeneratorWithGuaranteedRate::InjectInputTraffic());
+  });
+
+  // Spawn traffic collection thread.
+  traffic_collection_thread_ = std::thread([&]() {
+    CHECK_OK(  // Crash OK
+        TrafficGeneratorWithGuaranteedRate::CollectOutputTraffic());
+  });
+
+  // Wait for state to change before returning.
+  while (GetState() != kTrafficInjectionAndCollection) {
+    absl::SleepFor(absl::Seconds(1));
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status TrafficGeneratorWithGuaranteedRate::StopTraffic() {
+  if (GetState() != kTrafficInjectionAndCollection) {
+    return absl::FailedPreconditionError(
+        "Cannot stop traffic if not already flowing.");
+  }
+
+  // Change state.
+  SetState(kTrafficCollection);
+
+  // Wait for traffic injection thread to stop.
+  traffic_injection_thread_.join();
+
+  // Must wait for kMaxPacketInFlightDuration to ensure there are no more
+  // in-flight packets after finishing packet injection so they can all be
+  // collected and processed.
+  absl::SleepFor(kMaxPacketInFlightDuration);
+
+  // Change state.
+  SetState(kInitialized);
+
+  // Wait for traffic collection thread to stop.
+  traffic_collection_thread_.join();
+  return absl::OkStatus();
+}
+
+absl::Status TrafficGeneratorWithGuaranteedRate::InjectInputTraffic() {
+  // Change state.
+  SetState(kTrafficInjectionAndCollection);
+
+  pdpi::P4RuntimeSession& control_switch =
+      *testbed_configurator_->ControlSwitchApi().p4rt;
+  const PacketTestVectorById& packet_test_vector_by_id =
+      generate_test_vectors_result_.packet_test_vector_by_id;
+  const MirrorTestbedP4rtPortIdMap mirror_testbed_port_map =
+      params_.validation_params.mirror_testbed_port_map_override.value_or(
+          MirrorTestbedP4rtPortIdMap::CreateIdentityMap());
+
+  ASSIGN_OR_RETURN(pdpi::IrP4Info control_ir_p4info,
+                   GetIrP4Info(control_switch));
+
+  // Compute per packet injection delay.
+  std::optional<absl::Duration> injection_delay;
+  if (params_.validation_params.max_packets_to_send_per_second.has_value()) {
+    injection_delay = absl::Milliseconds(
+        1e3 / *params_.validation_params.max_packets_to_send_per_second);
+  }
+
+  LOG(INFO) << "Starting to inject traffic";
+  int iterations = 0;
+  int total_packets_injected = 0;
+  while (GetState() == kTrafficInjectionAndCollection) {
+    ++iterations;
+    LOG_EVERY_T(INFO, 10) << "Traffic injection iteration #" << iterations;
+
+    // Send the packets.
+    for (auto [_, packet_test_vector] : packet_test_vector_by_id) {
+      int new_tag = packet_tag_id_;
+      packet_tag_id_++;
+      LOG_EVERY_T(INFO, 10) << "Injecting test packet #" << new_tag;
+
+      if (packet_test_vector.input().type() == SwitchInput::DATAPLANE) {
+        // Update tag.
+        RETURN_IF_ERROR(UpdateTestTag(packet_test_vector, new_tag));
+
+        // Get corresponding control switch port for the packet's ingress port.
+        ASSIGN_OR_RETURN(pins_test::P4rtPortId sut_ingress_port,
+                         pins_test::P4rtPortId::MakeFromP4rtEncoding(
+                             packet_test_vector.input().packet().port()));
+        ASSIGN_OR_RETURN(
+            pins_test::P4rtPortId control_switch_port,
+            mirror_testbed_port_map.GetControlSwitchPortConnectedToSutPort(
+                sut_ingress_port));
+
+        // Inject to egress of control switch.
+        RETURN_IF_ERROR(pins::InjectEgressPacket(
+            control_switch_port.GetP4rtEncoding(),
+            absl::HexStringToBytes(packet_test_vector.input().packet().hex()),
+            control_ir_p4info, &control_switch, injection_delay));
+
+        absl::MutexLock lock(&injected_traffic_mutex_);
+        injected_traffic_.push_back({
+            .tag = new_tag,
+            .packet_test_vector = std::move(packet_test_vector),
+        });
+      } else {
+        LOG(ERROR) << "Test vector input type not supported\n"
+                   << packet_test_vector.input().DebugString();
+      }
+    }
+    total_packets_injected += packet_test_vector_by_id.size();
+  }
+  LOG(INFO) << "Stopped traffic injection";
+  statistics_.total_packets_injected += total_packets_injected;
+  return absl::OkStatus();
+}
+
+absl::Status TrafficGeneratorWithGuaranteedRate::CollectOutputTraffic() {
+  absl::SleepFor(kMaxPacketInFlightDuration);
+  pdpi::P4RuntimeSession& sut = *testbed_configurator_->SutApi().p4rt;
+  pdpi::P4RuntimeSession& control_switch =
+      *testbed_configurator_->ControlSwitchApi().p4rt;
+  bool enable_sut_packet_in_collection =
+      !params_.validation_params.switch_output_diff_params
+           .treat_expected_and_actual_outputs_as_having_no_packet_ins;
+  auto is_expected_unsolicited_packet =
+      [&](const packetlib::Packet packet) -> bool {
+    return backend_->IsExpectedUnsolicitedPacket(packet);
+  };
+
+  MirrorTestbedP4rtPortIdMap mirror_testbed_port_map =
+      params_.validation_params.mirror_testbed_port_map_override.value_or(
+          MirrorTestbedP4rtPortIdMap::CreateIdentityMap());
+
+  ASSIGN_OR_RETURN(pdpi::IrP4Info control_ir_p4info,
+                   GetIrP4Info(control_switch));
+  ASSIGN_OR_RETURN(pdpi::IrP4Info sut_ir_p4info, GetIrP4Info(sut));
+
+  int iterations = 0;
+  int total_packets_forwarded = 0;
+  int total_packets_punted = 0;
+  LOG(INFO) << "Starting to collect traffic results";
+  while (GetState() == kTrafficInjectionAndCollection ||
+         GetState() == kTrafficCollection) {
+    ++iterations;
+    LOG_EVERY_T(INFO, 10) << "Traffic collection iteration #" << iterations;
+
+    ASSIGN_OR_RETURN(std::vector<TaggedPacketIn> control_packet_ins,
+                     CollectStreamMessageResponsesAndReturnTaggedPacketIns(
+                         control_switch, kCollectOutputTrafficDuration,
+                         is_expected_unsolicited_packet));
+
+    absl::StatusOr<std::vector<TaggedPacketIn>> sut_packet_ins =
+        std::vector<TaggedPacketIn>();
+    if (enable_sut_packet_in_collection) {
+      ASSIGN_OR_RETURN(sut_packet_ins,
+                       CollectStreamMessageResponsesAndReturnTaggedPacketIns(
+                           sut, kCollectOutputTrafficDuration,
+                           is_expected_unsolicited_packet));
+    }
+
+    // Processing the output of the control switch.
+    for (TaggedPacketIn& packet_in : control_packet_ins) {
+      // Add to (forwarded) switch output for ID.
+      absl::MutexLock lock(&collected_traffic_mutex_);
+      Packet& forwarded_output =
+          *collected_traffic_by_id_[packet_in.tag].add_packets();
+
+      // Set hex and parsed packet.
+      forwarded_output.set_hex(
+          absl::BytesToHexString(packet_in.packet_in.payload()));
+      *forwarded_output.mutable_parsed() = packet_in.parsed_inner_packet;
+
+      // Set port.
+      ASSIGN_OR_RETURN(
+          pdpi::IrPacketIn ir_packet_in,
+          pdpi::PiPacketInToIr(control_ir_p4info, packet_in.packet_in));
+      ASSIGN_OR_RETURN(pins_test::P4rtPortId sut_egress_port,
+                       GetSutEgressPortFromControlSwitchPacketIn(
+                           ir_packet_in, mirror_testbed_port_map));
+      *forwarded_output.mutable_port() = sut_egress_port.GetP4rtEncoding();
+    }
+
+    // Processing the output of SUT.
+    for (const TaggedPacketIn& packet_in : *sut_packet_ins) {
+      absl::MutexLock lock(&collected_traffic_mutex_);
+
+      // Add to (punted) switch output for ID.
+      PacketIn& punted_output =
+          *collected_traffic_by_id_[packet_in.tag].add_packet_ins();
+
+      // Set hex and parsed packet.
+      punted_output.set_hex(
+          absl::BytesToHexString(packet_in.packet_in.payload()));
+      *punted_output.mutable_parsed() = packet_in.parsed_inner_packet;
+
+      // Set metadata.
+      ASSIGN_OR_RETURN(
+          pdpi::IrPacketIn ir_packet_in,
+          pdpi::PiPacketInToIr(sut_ir_p4info, packet_in.packet_in));
+      *punted_output.mutable_metadata() = ir_packet_in.metadata();
+    }
+
+    total_packets_forwarded += control_packet_ins.size();
+    total_packets_punted += sut_packet_ins->size();
+    LOG_EVERY_T(INFO, 10) << "Total control switch packets: "
+                          << total_packets_forwarded
+                          << ", Total SUT packets: " << total_packets_punted;
+  }
+  LOG(INFO) << "Stopped traffic collection";
+
+  statistics_.total_packets_forwarded += total_packets_forwarded;
+  statistics_.total_packets_punted += total_packets_punted;
+  return absl::OkStatus();
+}
+
+absl::StatusOr<ValidationResult>
+TrafficGeneratorWithGuaranteedRate::GetValidationResult() {
+  LOG(INFO) << "Getting validation result";
+  // Swap `injected_traffic_vector` and `injected_traffic_` and add the
+  // `residual_injected_traffic_` to `injected_traffic_`.
+  std::vector<InjectedTraffic> injected_traffic_vector;
+  injected_traffic_mutex_.Lock();
+  injected_traffic_.swap(injected_traffic_vector);
+  injected_traffic_mutex_.Unlock();
+  for (const InjectedTraffic& injected_traffic : residual_injected_traffic_) {
+    injected_traffic_vector.push_back(injected_traffic);
+  }
+  residual_injected_traffic_.clear();
+
+  const absl::Time kPacketInjectionCutoffTimeForValidation = absl::Now();
+  // Wait to ensure all in-flight packets have arrived so the results can be
+  // aggregated with the injected_traffic_.
+  absl::SleepFor(kMaxPacketInFlightDuration);
+
+  // Swap `collected_traffic_by_id` and `collected_traffic_by_id_` and add
+  // the `residual_collected_traffic_by_id_` to `collected_traffic_by_id_`.
+  absl::btree_map<int, SwitchOutput> collected_traffic_by_id;
+  collected_traffic_mutex_.Lock();
+  collected_traffic_by_id_.swap(collected_traffic_by_id);
+  collected_traffic_mutex_.Unlock();
+  for (const auto& [id, switch_output] : residual_collected_traffic_by_id_) {
+    collected_traffic_by_id[id].mutable_packets()->Add(
+        switch_output.packets().begin(), switch_output.packets().end());
+    collected_traffic_by_id[id].mutable_packet_ins()->Add(
+        switch_output.packet_ins().begin(), switch_output.packet_ins().end());
+  }
+  residual_collected_traffic_by_id_.clear();
+
+  test_runs_.mutable_test_runs()->Reserve(test_runs_.test_runs_size() +
+                                          injected_traffic_vector.size());
+
+  // Only consider traffic injected before the cut off time for validation. This
+  // is done to ensure in-flight packets are accounted for. The remaining
+  // injected/collected traffic are kept in `residual_*` for subsequent calls to
+  // this function.
+  for (const InjectedTraffic& injected_traffic : injected_traffic_vector) {
+    if (injected_traffic.injection_time <
+        kPacketInjectionCutoffTimeForValidation) {
+      // Add results to test_runs_.
+      PacketTestRun* packet_test_run = test_runs_.mutable_test_runs()->Add();
+      *packet_test_run->mutable_test_vector() =
+          injected_traffic.packet_test_vector;
+      if (collected_traffic_by_id.contains(injected_traffic.tag)) {
+        *packet_test_run->mutable_actual_output() =
+            collected_traffic_by_id[injected_traffic.tag];
+        collected_traffic_by_id.erase(injected_traffic.tag);
+      }
+    } else {
+      residual_injected_traffic_.push_back(injected_traffic);
+    }
+  }
+
+  // Empty remaining collected_traffic_map items into
+  // residual_collected_traffic_by_id_.
+  for (const auto& [id, switch_output] : collected_traffic_by_id) {
+    residual_collected_traffic_by_id_[id] = switch_output;
+  }
+
+  return ValidationResult(
+      test_runs_, params_.validation_params.switch_output_diff_params,
+      generate_test_vectors_result_.packet_synthesis_result);
+}
+
+absl::StatusOr<ValidationResult>
+TrafficGeneratorWithGuaranteedRate::GetAndClearValidationResult() {
+  test_runs_.clear_test_runs();
+  return GetValidationResult();
+}
 }  // namespace dvaas

--- a/dvaas/traffic_generator.h
+++ b/dvaas/traffic_generator.h
@@ -21,16 +21,19 @@
 #include <vector>
 
 #include "absl/base/thread_annotations.h"
+#include "absl/container/btree_map.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include "dvaas/dataplane_validation.h"
 #include "dvaas/mirror_testbed_config.h"
+#include "dvaas/packet_injection.h"
 #include "dvaas/test_vector.h"
 #include "dvaas/test_vector.pb.h"
 #include "dvaas/validation_result.h"
 #include "thinkit/mirror_testbed.h"
-#include "thinkit/mirror_testbed_fixture.h"
 
 namespace dvaas {
 
@@ -49,15 +52,16 @@ public:
     // See dataplane_validation.h for details.
     DataplaneValidationParams validation_params;
 
-    // TODO: Implement ignore_punted_packets_for_validation.
-    // If true, ignores punting behavior during validation.
-    // bool ignore_punting_for_validation;
     // TODO: Provide a knob to say I only want L3 forwarded packets.
   };
 
   // Initialises the traffic generator (and the testbed) with the given params,
   // including synthesising test packets. Does NOT start traffic.
   // On success, returns statistic about packet synthesis.
+  //
+  // Note: TrafficGenerator does not take ownership of the given testbed, and
+  // the caller is responsible for ensuring it outlives the created
+  // configurator.
   //
   // NOTE: The table entries, P4Info, and gNMI configuration used in packets
   // synthesis will be read from the SUT itself.
@@ -92,9 +96,8 @@ public:
   // - Any preexisting P4RT connections to SUT and control switch will be
   //   non-primary.
   // - The gNMI configs will be unchanged.
-  virtual absl::StatusOr<PacketSynthesisStats>
-  Init(std::shared_ptr<thinkit::MirrorTestbedInterface> testbed,
-       const Params &params) = 0;
+  virtual absl::StatusOr<PacketSynthesisStats> Init(
+      thinkit::MirrorTestbed* testbed, const Params& params) = 0;
 
   // Asynchronously starts injecting traffic (and validating the result) using
   // test packets that were synthesized during `Init`.
@@ -144,9 +147,8 @@ public:
       std::unique_ptr<DataplaneValidationBackend> backend)
       : backend_(std::move(backend)) {}
 
-  absl::StatusOr<PacketSynthesisStats>
-  Init(std::shared_ptr<thinkit::MirrorTestbedInterface> testbed,
-       const Params &params) override;
+  absl::StatusOr<PacketSynthesisStats> Init(thinkit::MirrorTestbed* testbed,
+                                            const Params& params) override;
   absl::Status StartTraffic() override;
   absl::Status StopTraffic() override;
   absl::StatusOr<ValidationResult> GetValidationResult() override;
@@ -204,6 +206,130 @@ public:
   TrafficGenerator::Params params_;
 };
 
-} // namespace dvaas
+// The duration needed to wait to ensure packets are no longer in-flight during
+// packet injection.
+const absl::Duration kMaxPacketInFlightDuration = absl::Seconds(3);
+// The duration of how long to wait before collecting all unread stream messages
+// responses from the P4RT session.
+const absl::Duration kCollectOutputTrafficDuration = absl::Seconds(1);
+
+// An implementation of `TrafficGenerator` interface that provides a consistent
+// traffic injection rate guarantee (see `InjectInputTraffic` function comments
+// for more details).
+class TrafficGeneratorWithGuaranteedRate : public TrafficGenerator {
+ public:
+  TrafficGeneratorWithGuaranteedRate() = delete;
+  explicit TrafficGeneratorWithGuaranteedRate(
+      std::unique_ptr<DataplaneValidationBackend> backend)
+      : backend_(std::move(backend)) {}
+
+  absl::StatusOr<PacketSynthesisStats> Init(thinkit::MirrorTestbed* testbed,
+                                            const Params& params) override;
+  absl::Status StartTraffic() override;
+  absl::Status StopTraffic() override;
+  absl::StatusOr<ValidationResult> GetValidationResult() override;
+  absl::StatusOr<ValidationResult> GetAndClearValidationResult() override;
+  ~TrafficGeneratorWithGuaranteedRate();
+
+ private:
+  std::unique_ptr<DataplaneValidationBackend> backend_;
+  std::unique_ptr<MirrorTestbedConfigurator> testbed_configurator_;
+  // Test vectors created as a result of (latest) call to `Init`. Calls to
+  // `StartTraffic` use these test vectors.
+  GenerateTestVectorsResult generate_test_vectors_result_;
+
+  struct InjectedTraffic {
+    int tag;
+    PacketTestVector packet_test_vector;
+    absl::Time injection_time = absl::Now();
+  };
+
+  enum State {
+    // The object has been created but `Init` has not been called.
+    kUninitialized,
+    // `Init` has been called, but no input packets are injected and no output
+    // is being collected (either `StartTraffic` has not been called or
+    // `StopTraffic` has been called and finished after that).
+    kInitialized,
+    // Input packets are being injected and the output is being collected
+    // (`StartTraffic` is called and `StopTraffic` has NOT been called after
+    // that).
+    kTrafficInjectionAndCollection,
+    // No new input packets is being injected but the output is still being
+    // collected to account for in-flight packets (transient state during call
+    // to `StopTraffic` for kMaxPacketInFlightDuration).
+    kTrafficCollection,
+  };
+  // The state of the TrafficGeneratorWithGuaranteedRate object.
+  State state_ ABSL_GUARDED_BY(state_mutex_) = kUninitialized;
+  // Mutex to synchronize access to state_;
+  absl::Mutex state_mutex_;
+
+  // Thread safe getter for state_.
+  State GetState() ABSL_LOCKS_EXCLUDED(state_mutex_);
+  // Thread safe setter for state_.
+  void SetState(State state) ABSL_LOCKS_EXCLUDED(state_mutex_);
+
+  // The same test vectors are reused multiple times so we use a counter to
+  // produce unique tag ids and retag test vectors per each use.
+  int packet_tag_id_ = 1;
+
+  PacketStatistics statistics_;
+
+  // Traffic injected after latest call to `Get*ValidationResult`.
+  std::vector<InjectedTraffic> injected_traffic_
+      ABSL_GUARDED_BY(injected_traffic_mutex_);
+  absl::Mutex injected_traffic_mutex_;
+  // Injected traffic not validated during previous calls to
+  // `Get*ValidationResult` based on injection timestamp (to account for
+  // in-flight packets).
+  std::vector<InjectedTraffic> residual_injected_traffic_;
+
+  // Traffic collected (from control switch and SUT)  after latest call to
+  // `Get*ValidationResult`.
+  absl::btree_map<int, SwitchOutput> collected_traffic_by_id_
+      ABSL_GUARDED_BY(collected_traffic_mutex_);
+  absl::Mutex collected_traffic_mutex_;
+  // Residual collected traffic from `collected_traffic_by_id_` not validated
+  // during previous calls to `Get*ValidationResult` when there is not a
+  // InjectedTraffic with a matching tag.
+  absl::btree_map<int, SwitchOutput> residual_collected_traffic_by_id_;
+
+  // The thread that is spawned during the call to `StartTraffic` and runs
+  // `InjectInputTraffic` function. The thread continues until `StopTraffic` is
+  // called.
+  std::thread traffic_injection_thread_;
+  // Runs in a separate thread and loops so long as state is
+  // kTrafficInjectionAndCollection. It injects packets until traffic is
+  // stopped. In each iteration of the loop, it retags and injects packets from
+  // `generate_test_vectors_result_.packet_test_vector_by_id` at the rate
+  // specified by `params_`. Timestamps and records injected packets in
+  // `injected_traffic_` for processing during calls to `Get*ValidationResult`.
+  absl::Status InjectInputTraffic()
+      ABSL_LOCKS_EXCLUDED(injected_traffic_mutex_);
+
+  // The thread that is spawned during the call to `StartTraffic` and runs
+  // `CollectOutputTraffic` function. The thread continues until `StopTraffic`
+  // is called.
+  std::thread traffic_collection_thread_;
+  // Runs in a separate thread and loops so long as state is
+  // kTrafficInjectionAndCollection or kTrafficCollection. It retrieves and
+  // processes packets from the control switch and SUT until traffic is stopped.
+  // In each iteration of the loop, collects packets for
+  // kCollectOutputTrafficDuration. The result is stored in
+  // `collected_traffic_by_id_` for processing during calls to
+  // `Get*ValidationResult`.
+  absl::Status CollectOutputTraffic()
+      ABSL_LOCKS_EXCLUDED(collected_traffic_mutex_);
+
+  // Result of packet injection and collection (i.e. test vector + switch
+  // output), produced and used by `GetValidationStats` by processing
+  // `injected_traffic_` and `collected_traffic_by_id_` (and residues).
+  PacketTestRuns test_runs_;
+
+  // Parameters received in the (latest) call to `Init`.
+  TrafficGenerator::Params params_;
+};
+}  // namespace dvaas
 
 #endif // PINS_DVAAS_TRAFFIC_GENERATOR_H_

--- a/dvaas/validation_result.cc
+++ b/dvaas/validation_result.cc
@@ -50,12 +50,7 @@ ValidationResult::ValidationResult(
 
 absl::Status ValidationResult::HasSuccessRateOfAtLeast(
     double expected_success_rate) const {
-  // Avoid division by 0.
-  if (test_vector_stats_.num_vectors == 0) return absl::OkStatus();
-
-  double success_rate =
-      static_cast<double>(test_vector_stats_.num_vectors_passed) /
-      static_cast<double>(test_vector_stats_.num_vectors);
+  double success_rate = GetSuccessRate();
   if (success_rate < expected_success_rate) {
     auto it =
         absl::c_find_if(test_outcomes_.outcomes(), [](const auto& outcome) {
@@ -69,6 +64,13 @@ absl::Status ValidationResult::HasSuccessRateOfAtLeast(
            << it->test_result().failure().description();
   }
   return absl::OkStatus();
+}
+
+double ValidationResult::GetSuccessRate() const {
+  // Avoid division by 0.
+  if (test_vector_stats_.num_vectors == 0) return 1.0;
+  return static_cast<double>(test_vector_stats_.num_vectors_passed) /
+         static_cast<double>(test_vector_stats_.num_vectors);
 }
 
 const ValidationResult& ValidationResult::LogStatistics() const {

--- a/dvaas/validation_result.h
+++ b/dvaas/validation_result.h
@@ -57,6 +57,9 @@ public:
   // ```
   absl::Status HasSuccessRateOfAtLeast(double expected_success_rate) const;
 
+  // Returns the fraction of test vectors that passed.
+  double GetSuccessRate() const;
+
   // Logs various statistics about the number of test vectors and how many of
   // them passed.
   const ValidationResult &LogStatistics() const;

--- a/tests/forwarding/arriba_test.cc
+++ b/tests/forwarding/arriba_test.cc
@@ -26,11 +26,16 @@ namespace pins_test {
 namespace {
 
 TEST_P(ArribaTest, SwitchUnderTestPassesArribaTestVector) {
-  ASSERT_OK_AND_ASSIGN(
-      dvaas::MirrorTestbedConfigurator configured_testbed,
-      dvaas::MirrorTestbedConfigurator::Create(GetParam().mirror_testbed));
+  ASSERT_OK_AND_ASSIGN(dvaas::MirrorTestbedConfigurator configured_testbed,
+                       dvaas::MirrorTestbedConfigurator::Create(
+                           &GetParam().mirror_testbed->GetMirrorTestbed()));
 
-  ASSERT_OK(configured_testbed.ConfigureForForwardingTest());
+  ASSERT_OK(configured_testbed.ConfigureForForwardingTest({
+      .configure_sut_port_ids_for_expected_entries = true,
+      .sut_entries_to_expect_after_configuration =
+          GetParam().arriba_test_vector.ir_table_entries(),
+      .mirror_sut_ports_ids_to_control_switch = true,
+  }));
 
   EXPECT_OK(dvaas::ValidateAgaistArribaTestVector(
       *configured_testbed.SutApi().p4rt,


### PR DESCRIPTION
### Keyword check
dvass/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_check.sh .
Keyword check Passed.
### Bazel build logs
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 729 targets (260 packages loaded, 22927 targets configured).
INFO: Found 729 targets...
INFO: From Compiling dvaas/dataplane_validation.cc:
In file included from ./gutil/proto.h:26,
                 from dvaas/dataplane_validation.cc:40:
In file included from tests/forwarding/ouroboros_test.cc:55:
./tests/lib/switch_test_setup_helpers.h:132:1: note: declared here
  132 | ConfigureSwitchPairAndReturnP4RuntimeSessionPair(
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO: Elapsed time: 17.630s, Critical Path: 11.61s
INFO: 17 processes: 1 internal, 16 linux-sandbox.
INFO: Build completed successfully, 17 total actions
### Bazel tests logs
sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 729 targets (0 packages loaded, 382 targets configured).
INFO: Found 503 targets and 226 test targets...
INFO: Elapsed time: 171.877s, Critical Path: 119.59s
INFO: 283 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 283 total actions
//dvaas:port_id_map_test                                                 PASSED in 1.4s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.2s
//dvaas:test_run_validation_test                                         PASSED in 1.0s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.2s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//gutil:collections_test                                                 PASSED in 0.8s
//gutil:io_test                                                          PASSED in 0.9s
//gutil:proto_matchers_test                                              PASSED in 1.3s
//gutil:proto_ordering_test                                              PASSED in 0.9s
//gutil:proto_test                                                       PASSED in 0.8s
//gutil:status_matchers_test                                             PASSED in 0.8s
//gutil:test_artifact_writer_test                                        PASSED in 1.0s
//gutil:testing_test                                                     PASSED in 1.0s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 3.9s
//lib:basic_switch_test                                                  PASSED in 1.7s
//lib:ixia_helper_test                                                   PASSED in 1.9s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 1.0s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 15.9s
//lib/gnmi:gnmi_helper_test                                              PASSED in 3.3s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.9s
//lib/p4rt:p4rt_port_test                                                PASSED in 0.8s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 1.7s
//lib/utils:generic_testbed_utils_test                                   PASSED in 2.2s
//lib/utils:json_utils_test                                              PASSED in 1.0s
//lib/validator:validator_backend_test                                   PASSED in 1.1s
//lib/validator:validator_lib_test                                       PASSED in 26.6s
//p4_fuzzer:constraints_test                                             PASSED in 4.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 119.5s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 1.5s
//p4_fuzzer:oracle_util_test                                             PASSED in 4.3s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 3.7s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 3.5s
//p4_fuzzer:switch_state_test                                            PASSED in 1.9s
//p4_pdpi:built_ins_test                                                 PASSED in 0.9s
//p4_pdpi:entity_keys_test                                               PASSED in 0.8s
//p4_pdpi:ir_properties_test                                             PASSED in 1.0s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.1s
//p4_pdpi:ir_tools_test                                                  PASSED in 1.3s
//p4_pdpi:names_test                                                     PASSED in 1.2s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.0s
//p4_pdpi:reference_annotations_test                                     PASSED in 1.4s
//p4_pdpi:references_test                                                PASSED in 1.1s
//p4_pdpi:sequencing_util_test                                           PASSED in 0.9s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.9s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.9s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 0.8s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 20.5s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.2s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 6.8s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.0s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.1s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.8s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.0s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.4s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.2s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.2s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:references_test                                        PASSED in 0.2s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 1.4s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.0s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.2s
//p4_symbolic:z3_util_test                                               PASSED in 1.1s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 1.6s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 1.9s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 1.9s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 1.5s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 1.9s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 1.9s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 1.8s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.2s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.1s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.1s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.1s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.1s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.1s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.2s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 11.1s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 5.0s
//p4_symbolic/sai:sai_test                                               PASSED in 3.1s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 2.3s
//p4_symbolic/symbolic:parser_test                                       PASSED in 1.8s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:reflector_test_packets                            PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 1.4s
//p4_symbolic/symbolic:util_test                                         PASSED in 0.9s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.0s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 3.9s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 9.4s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.8s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.7s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 1.5s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 2.0s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.7s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 1.8s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 1.0s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 1.5s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 1.3s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 1.5s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 1.8s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 1.7s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 1.6s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 1.5s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 1.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 1.5s
//p4rt_app/sonic:hashing_test                                            PASSED in 1.6s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 1.3s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 0.9s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.1s
//p4rt_app/sonic:response_handler_test                                   PASSED in 1.5s
//p4rt_app/sonic:state_verification_test                                 PASSED in 1.2s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.2s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 1.3s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.3s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.6s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.7s
//p4rt_app/tests:action_set_test                                         PASSED in 1.3s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.1s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.1s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.2s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 5.7s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.9s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.0s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.2s
//p4rt_app/tests:packetio_test                                           PASSED in 4.1s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.5s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.4s
//p4rt_app/tests:response_path_test                                      PASSED in 4.3s
//p4rt_app/tests:role_test                                               PASSED in 1.3s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.4s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.0s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 1.1s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 0.9s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.1s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.0s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 3.9s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 1.6s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 5.6s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.0s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.5s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.6s
//tests/forwarding:hash_statistics_util_test                             PASSED in 1.9s
//tests/lib:p4info_helper_test                                           PASSED in 1.2s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.5s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.2s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.2s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.0s
//thinkit:bazel_test_environment_test                                    PASSED in 1.1s
//thinkit:generic_testbed_test                                           PASSED in 1.5s
//thinkit:mock_control_device_test                                       PASSED in 1.0s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.2s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.9s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.1s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.1s
//tests/lib:packet_generator_test                                        PASSED in 64.1s
  Stats over 4 runs: max = 64.1s, min = 63.3s, avg = 63.7s, dev = 0.3s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.5s
  Stats over 5 runs: max = 1.5s, min = 1.1s, avg = 1.3s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 48.0s
  Stats over 50 runs: max = 48.0s, min = 1.3s, avg = 6.2s, dev = 12.4s

Executed 226 out of 226 tests: 226 tests pass.
INFO: Build completed successfully, 283 total actions
