### PR TITLE
[Thinkit] Fix bug where start traffic didn't wait for apply to finish.And Support interfaces and interface level response while getting interface paths

### DIFF
--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -118,6 +118,7 @@ cc_library(
         "//p4_pdpi/netaddr:ipv6_address",
         "//p4_pdpi/netaddr:mac_address",
         "//thinkit:generic_testbed",
+        "@com_github_gnmi//proto/gnmi:gnmi_cc_grpc_proto",
         "@com_github_google_glog//:glog",
         "@com_github_nlohmann_json//:nlohmann_json",
         "@com_google_absl//absl/container:flat_hash_map",
@@ -137,9 +138,13 @@ cc_test(
     srcs = ["ixia_helper_test.cc"],
     deps = [
         ":ixia_helper",
+        ":ixia_helper_cc_proto",
+        "//gutil:proto",
         "//gutil:proto_matchers",
         "//gutil:status_matchers",
         "//thinkit:generic_testbed",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -143,6 +143,7 @@ cc_test(
         "//gutil:proto_matchers",
         "//gutil:status_matchers",
         "//thinkit:generic_testbed",
+        "//thinkit:mock_generic_testbed",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest_main",

--- a/lib/gnmi/BUILD.bazel
+++ b/lib/gnmi/BUILD.bazel
@@ -77,6 +77,7 @@ cc_test(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",

--- a/lib/gnmi/gnmi_helper.cc
+++ b/lib/gnmi/gnmi_helper.cc
@@ -94,17 +94,22 @@ GetPortNameToIdMapFromJsonString(absl::string_view json_string,
   VLOG(2) << "Getting Port Name -> ID Map from JSON string: " << json_string;
   const nlohmann::basic_json<> response_json = json::parse(json_string);
 
-  const auto oc_intf_json =
-      response_json.find("openconfig-interfaces:interfaces");
-  if (oc_intf_json == response_json.end()) {
-    return absl::NotFoundError(
-        absl::StrCat("'openconfig-interfaces:interfaces' not found: ",
-                     response_json.dump()));
-  }
-  const auto oc_intf_list_json = oc_intf_json->find("interface");
-  if (oc_intf_list_json == oc_intf_json->end()) {
-    return absl::NotFoundError(
-        absl::StrCat("'interface' not found: ", oc_intf_json->dump()));
+  // TODO: Only check for "openconfig-interfaces:interfaces" once
+  // LegoHerc responses are scoped at the correct level.
+  auto oc_intf_list_json = response_json.find("interface");
+  if (oc_intf_list_json == response_json.end()) {
+    const auto oc_intf_json =
+        response_json.find("openconfig-interfaces:interfaces");
+    if (oc_intf_json == response_json.end()) {
+      return absl::NotFoundError(
+          absl::StrCat("'openconfig-interfaces:interfaces' not found: ",
+                       response_json.dump()));
+    }
+    oc_intf_list_json = oc_intf_json->find("interface");
+    if (oc_intf_list_json == oc_intf_json->end()) {
+      return absl::NotFoundError(
+          absl::StrCat("'interface' not found: ", oc_intf_json->dump()));
+    }
   }
 
   absl::flat_hash_map<std::string, std::string> interface_name_to_port_id;
@@ -794,15 +799,21 @@ GetInterfaceToOperStatusMapOverGnmi(gnmi::gNMI::StubInterface& stub,
 
   const auto resp_json = nlohmann::json::parse(
       resp.notification(0).update(0).val().json_ietf_val());
-  const auto oc_intf_json = resp_json.find("openconfig-interfaces:interfaces");
-  if (oc_intf_json == resp_json.end()) {
-    return absl::NotFoundError(absl::StrCat(
-        "'openconfig-interfaces:interfaces' not found: ", resp_json.dump()));
-  }
-  const auto oc_intf_list_json = oc_intf_json->find("interface");
-  if (oc_intf_list_json == oc_intf_json->end()) {
-    return absl::NotFoundError(
-        absl::StrCat("'interface' not found: ", oc_intf_json->dump()));
+  // TODO: Only check for "openconfig-interfaces:interfaces" once
+  // LegoHerc responses are scoped at the correct level.
+  auto oc_intf_list_json = resp_json.find("interface");
+  if (oc_intf_list_json == resp_json.end()) {
+    const auto oc_intf_json =
+        resp_json.find("openconfig-interfaces:interfaces");
+    if (oc_intf_json == resp_json.end()) {
+      return absl::NotFoundError(absl::StrCat(
+          "'openconfig-interfaces:interfaces' not found: ", resp_json.dump()));
+    }
+    oc_intf_list_json = oc_intf_json->find("interface");
+    if (oc_intf_list_json == oc_intf_json->end()) {
+      return absl::NotFoundError(
+          absl::StrCat("'interface' not found: ", oc_intf_json->dump()));
+    }
   }
 
   absl::flat_hash_map<std::string, std::string> interface_to_oper_status_map;

--- a/lib/gnmi/gnmi_helper.cc
+++ b/lib/gnmi/gnmi_helper.cc
@@ -2035,4 +2035,16 @@ absl::StatusOr<std::string> ParseJsonValue(absl::string_view json) {
   return parsed_json.begin().value();
 }
 
+absl::StatusOr<uint64_t> GetGnmiSystemUpTime(gnmi::gNMI::StubInterface &stub) {
+  ASSIGN_OR_RETURN(auto uptime_str, pins_test::GetGnmiStatePathInfo(
+                                        &stub, "/system/state/up-time",
+                                        "openconfig-system:up-time"));
+  uint64_t uptime;
+  if (!absl::SimpleAtoi(std::string(pins_test::StripQuotes(uptime_str)),
+                        &uptime)) {
+    return absl::InternalError(absl::StrCat("Unable to parse up-time: ", uptime,
+                                            ". Not a valid integer."));
+  }
+  return uptime;
+}
 }  // namespace pins_test

--- a/lib/gnmi/gnmi_helper.cc
+++ b/lib/gnmi/gnmi_helper.cc
@@ -815,7 +815,7 @@ GetInterfaceToOperStatusMapOverGnmi(gnmi::gNMI::StubInterface& stub,
     std::string name = std::string(StripQuotes(element_name_json->dump()));
 
     // TODO: Remove once CPU contains the oper-state subtree.
-    if (absl::StartsWith(name, "CPU")) {
+    if (absl::StartsWith(name, "CPU") || absl::StartsWith(name, "br")) {
       LOG(INFO) << "Skipping " << name << ".";
       continue;
     }

--- a/lib/gnmi/gnmi_helper.cc
+++ b/lib/gnmi/gnmi_helper.cc
@@ -368,11 +368,10 @@ absl::StatusOr<Counters> GetCountersForInterface(const json& interface_json) {
   ASSIGN_OR_RETURN(counters.out_discards,
                    ParseJsonValueAsUint(interface_json,
                                         {"state", "counters", "out-discards"}));
-  ASSIGN_OR_RETURN(
-      counters.in_buffer_discards,
-      ParseJsonValueAsUint(
-          interface_json,
-          {"state", "counters", "google-pins-interfaces:in-buffer-discards"}));
+  ASSIGN_OR_RETURN(counters.in_buffer_discards,
+                   ParseJsonValueAsUint(
+                       interface_json, {"state", "counters",
+                                        "pins-interfaces:in-buffer-discards"}));
   ASSIGN_OR_RETURN(
       counters.in_maxsize_exceeded,
       ParseJsonValueAsUint(interface_json,
@@ -695,12 +694,6 @@ absl::Status PushGnmiConfig(gnmi::gNMI::StubInterface& stub,
   gnmi::SetResponse resp;
   grpc::ClientContext context;
   grpc::Status status = stub.Set(&context, req, &resp);
-  if (status.error_code() == grpc::StatusCode::UNAVAILABLE) {
-    // Retry the config push if the return code was UNAVAILABLE.
-    LOG(INFO) << "SET returned UNAVAILABLE: " << resp.ShortDebugString();
-    absl::SleepFor(absl::Seconds(5));
-    status = stub.Set(&context, req, &resp);
-  }
   if (!status.ok()) return gutil::GrpcStatusToAbslStatus(status);
   LOG(INFO) << "Config push response: " << resp.ShortDebugString();
   return absl::OkStatus();
@@ -1018,6 +1011,19 @@ absl::StatusOr<absl::flat_hash_set<std::string>> GetConfigDisabledInterfaces(
     }
   }
   return disabled_interfaces;
+}
+
+absl::StatusOr<absl::flat_hash_set<std::string>>
+GetConfigEnabledInterfaces(gnmi::gNMI::StubInterface &stub) {
+  absl::flat_hash_set<std::string> enabled_interfaces;
+  ASSIGN_OR_RETURN(auto all_interfaces, pins_test::GetInterfacesAsProto(
+                                            stub, gnmi::GetRequest::CONFIG));
+  for (const auto &interface : all_interfaces.interfaces()) {
+    if (interface.config().enabled() == true) {
+      enabled_interfaces.insert(interface.name());
+    }
+  }
+  return enabled_interfaces;
 }
 
 absl::StatusOr<OperStatus> GetInterfaceOperStatusOverGnmi(
@@ -2047,4 +2053,38 @@ absl::StatusOr<uint64_t> GetGnmiSystemUpTime(gnmi::gNMI::StubInterface &stub) {
   }
   return uptime;
 }
+
+absl::StatusOr<std::string>
+GetOcOsNetworkStackGnmiStatePathInfo(gnmi::gNMI::StubInterface &stub,
+                                     absl::string_view key,
+                                     absl::string_view field) {
+  return pins_test::GetGnmiStatePathInfo(
+      &stub,
+      absl::Substitute("/components/component[name=$0]/state/$1", key, field),
+      absl::Substitute("openconfig-platform:$0", field));
+}
+
+absl::StatusOr<uint64_t>
+GetInterfaceCounter(absl::string_view stat_name, absl::string_view interface,
+                    gnmi::gNMI::StubInterface *gnmi_stub) {
+  std::string ops_state_path;
+  std::string ops_parse_str;
+
+  ops_state_path = absl::StrCat("interfaces/interface[name=", interface,
+                                "]/state/counters/", stat_name);
+  ops_parse_str = absl::StrCat("openconfig-interfaces:", stat_name);
+
+  ASSIGN_OR_RETURN(
+      std::string ops_response,
+      GetGnmiStatePathInfo(gnmi_stub, ops_state_path, ops_parse_str));
+
+  uint64_t stat;
+  // Skip over the quotes.
+  if (!absl::SimpleAtoi(StripQuotes(ops_response), &stat)) {
+    return absl::InternalError(
+        absl::StrCat("Unable to parse counter from ", ops_response));
+  }
+  return stat;
+}
+
 }  // namespace pins_test

--- a/lib/gnmi/gnmi_helper.cc
+++ b/lib/gnmi/gnmi_helper.cc
@@ -695,6 +695,12 @@ absl::Status PushGnmiConfig(gnmi::gNMI::StubInterface& stub,
   gnmi::SetResponse resp;
   grpc::ClientContext context;
   grpc::Status status = stub.Set(&context, req, &resp);
+  if (status.error_code() == grpc::StatusCode::UNAVAILABLE) {
+    // Retry the config push if the return code was UNAVAILABLE.
+    LOG(INFO) << "SET returned UNAVAILABLE: " << resp.ShortDebugString();
+    absl::SleepFor(absl::Seconds(5));
+    status = stub.Set(&context, req, &resp);
+  }
   if (!status.ok()) return gutil::GrpcStatusToAbslStatus(status);
   LOG(INFO) << "Config push response: " << resp.ShortDebugString();
   return absl::OkStatus();
@@ -1488,6 +1494,43 @@ absl::string_view StripQuotes(absl::string_view string) {
 
 absl::string_view StripBrackets(absl::string_view string) {
   return absl::StripPrefix(absl::StripSuffix(string, "]"), "[");
+}
+
+absl::StatusOr<absl::btree_set<std::string>>
+GetP4rtIdOfInterfacesInAsicMacLocalLoopbackMode(
+    gnmi::gNMI::StubInterface &gnmi_stub) {
+  ASSIGN_OR_RETURN(
+      std::string response,
+      pins_test::GetGnmiStatePathInfo(&gnmi_stub, "interfaces",
+                                      "openconfig-interfaces:interfaces"));
+
+  json response_json = json::parse(response);
+  ASSIGN_OR_RETURN(json interfaces, GetField(response_json, "interface"));
+
+  absl::btree_set<std::string> loopback_mode_set;
+  for (const auto &interface : interfaces.items()) {
+    if (interface.value().find("config") == interface.value().end()) {
+      continue;
+    }
+    ASSIGN_OR_RETURN(json config, GetField(interface.value(), "config"));
+    // Skip if the config doesn't have loopback-mode.
+    if (config.find("loopback-mode") == config.end()) {
+      continue;
+    }
+    ASSIGN_OR_RETURN(json loopback_mode, GetField(config, "loopback-mode"));
+    if (loopback_mode.get<std::string>() == "ASIC_MAC_LOCAL") {
+      if (config.find("openconfig-p4rt:id") == config.end()) {
+        return gutil::InternalErrorBuilder().LogError()
+               << "openconfig-p4rt:id is missing in gNMI configuration and is "
+                  "required for ASIC_MAC_LOCAL loopback mode.";
+      }
+      ASSIGN_OR_RETURN(json port, GetField(config, "openconfig-p4rt:id"));
+      P4rtPortId p4rt_port_id =
+          P4rtPortId::MakeFromOpenConfigEncoding(port.get<int>());
+      loopback_mode_set.insert(p4rt_port_id.GetP4rtEncoding());
+    }
+  }
+  return loopback_mode_set;
 }
 
 absl::StatusOr<absl::flat_hash_map<std::string, std::string>>

--- a/lib/gnmi/gnmi_helper.h
+++ b/lib/gnmi/gnmi_helper.h
@@ -79,6 +79,8 @@ enum class GnmiFieldType {
   kState,
 };
 
+enum class DelayType : std::uint8_t { kIngressDelay, kEgressDelay };
+
 // Describes a single interface in a gNMI config.
 struct OpenConfigInterfaceDescription {
   std::string port_name;
@@ -312,6 +314,10 @@ GetUpInterfacesOverGnmi(gnmi::gNMI::StubInterface &stub,
 // Returns a set of interfaces which are in the disabled state.
 absl::StatusOr<absl::flat_hash_set<std::string>>
 GetConfigDisabledInterfaces(gnmi::gNMI::StubInterface &stub);
+
+// Returns a set of interfaces which are in the enabled state.
+absl::StatusOr<absl::flat_hash_set<std::string>>
+GetConfigEnabledInterfaces(gnmi::gNMI::StubInterface &stub);
 
 // Gets the operational status of an interface.
 absl::StatusOr<OperStatus>
@@ -563,5 +569,17 @@ absl::StatusOr<std::string> ParseJsonValue(absl::string_view json);
 // Gets switch up time over gNMI since the last reboot.
 absl::StatusOr<uint64_t> GetGnmiSystemUpTime(gnmi::gNMI::StubInterface &stub);
 
+// Gets the PINS Stack related details over gNMI. Supported keys are
+// "network_stack0", "network_stack1", "os0", "os1" and supported fields are
+// "name", "oper-status", "software-version" "parent" and "type".
+absl::StatusOr<std::string>
+GetOcOsNetworkStackGnmiStatePathInfo(gnmi::gNMI::StubInterface &stub,
+                                     absl::string_view key,
+                                     absl::string_view field);
+
+// Gets the interface stat value over gNMI.
+absl::StatusOr<uint64_t>
+GetInterfaceCounter(absl::string_view stat_name, absl::string_view interface,
+                    gnmi::gNMI::StubInterface *gnmi_stub);
 } // namespace pins_test
 #endif // PINS_LIB_GNMI_GNMI_HELPER_H_

--- a/lib/gnmi/gnmi_helper.h
+++ b/lib/gnmi/gnmi_helper.h
@@ -560,5 +560,8 @@ void StripSymbolFromString(std::string &str, char symbol);
 //   {"field":"value"}
 absl::StatusOr<std::string> ParseJsonValue(absl::string_view json);
 
+// Gets switch up time over gNMI since the last reboot.
+absl::StatusOr<uint64_t> GetGnmiSystemUpTime(gnmi::gNMI::StubInterface &stub);
+
 } // namespace pins_test
 #endif // PINS_LIB_GNMI_GNMI_HELPER_H_

--- a/lib/gnmi/gnmi_helper.h
+++ b/lib/gnmi/gnmi_helper.h
@@ -454,6 +454,11 @@ absl::string_view StripQuotes(absl::string_view string);
 // Strips the beginning and ending brackets ('[', ']') from the `string`.
 absl::string_view StripBrackets(absl::string_view string);
 
+// Returns a set of `ASIC_MAC_LOCAL` loopback mode ports.
+absl::StatusOr<absl::btree_set<std::string>>
+GetP4rtIdOfInterfacesInAsicMacLocalLoopbackMode(
+    gnmi::gNMI::StubInterface &gnmi_stub);
+
 // Returns a map from interface names to their physical transceiver name.
 absl::StatusOr<absl::flat_hash_map<std::string, std::string>>
 GetInterfaceToTransceiverMap(gnmi::gNMI::StubInterface &gnmi_stub);

--- a/lib/gnmi/gnmi_helper_test.cc
+++ b/lib/gnmi/gnmi_helper_test.cc
@@ -2318,6 +2318,59 @@ TEST(InterfaceToTransceiver, WorksProperly) {
               IsOkAndHolds(UnorderedPointwise(Eq(), expected_map)));
 }
 
+TEST(LoopbackMode, WorksProperly) {
+  gnmi::GetResponse response;
+  *response.add_notification()
+       ->add_update()
+       ->mutable_val()
+       ->mutable_json_ietf_val() = R"(
+    {
+      "openconfig-interfaces:interfaces": {
+        "interface": [
+          {
+            "name":"EthernetEnabled0",
+            "config":{
+              "loopback-mode":"ASIC_MAC_LOCAL",
+              "openconfig-p4rt:id": 2
+            }
+          },
+          {
+            "name":"EthernetEnabled1",
+            "config":{
+              "loopback-mode":"NOT_ASIC_MAC_LOCAL",
+              "openconfig-p4rt:id": 4
+            }
+          },
+          {
+            "name":"EthernetEnabled2",
+            "config":{
+              "loopback-mode":"ASIC_MAC_LOCAL",
+              "openconfig-p4rt:id": 5
+            }
+          },
+          {
+            "name":"EthernetEnabled3",
+            "config":{
+              "openconfig-p4rt:id": 7
+            }
+          },
+          {
+            "name":"EthernetEnabled4"
+          }
+        ]
+      }
+    })";
+
+  gnmi::MockgNMIStub mock_stub;
+  EXPECT_CALL(mock_stub, Get)
+      .WillRepeatedly(
+          DoAll(SetArgPointee<2>(response), Return(grpc::Status::OK)));
+  absl::btree_set<std::string> expected_set{"2", "5"};
+  LOG(INFO) << "loopback_mode: ";
+  EXPECT_THAT(GetP4rtIdOfInterfacesInAsicMacLocalLoopbackMode(mock_stub),
+              IsOkAndHolds(UnorderedPointwise(Eq(), expected_set)));
+}
+
 TEST(TransceiverPartInformation, WorksProperly) {
   gnmi::GetResponse response;
   *response.add_notification()

--- a/lib/ixia_helper.cc
+++ b/lib/ixia_helper.cc
@@ -14,11 +14,11 @@
 
 #include "lib/ixia_helper.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
-#include <type_traits>
 #include <variant>
 #include <vector>
 
@@ -46,6 +46,7 @@
 #include "lib/gnmi/gnmi_helper.h"
 #include "lib/ixia_helper.pb.h"
 #include "lib/utils/json_utils.h"
+#include "proto/gnmi/gnmi.grpc.pb.h"
 #include "thinkit/generic_testbed.h"
 
 namespace pins_test::ixia {
@@ -1213,20 +1214,14 @@ absl::StatusOr<TrafficStats> ParseTrafficItemStats(
     {
       ASSIGN_OR_RETURN(std::string raw, gutil::FindOrStatus(value_by_caption,
                                                             "First TimeStamp"));
-      if (raw.empty()) {
-        return gutil::UnavailableErrorBuilder()
-               << "'First TimeStamp' not available yet";
-      }
-      ASSIGN_OR_RETURN(auto value,
-                       ParseTimeStampAsSeconds(raw, "First TimeStamp"));
-      parsed_row.set_first_time_stamp(value);
+      parsed_row.set_first_time_stamp(
+          ParseTimeStampAsSeconds(raw, "First TimeStamp").value_or(0.0));
     }
     {
       ASSIGN_OR_RETURN(std::string raw,
                        gutil::FindOrStatus(value_by_caption, "Last TimeStamp"));
-      ASSIGN_OR_RETURN(auto value,
-                       ParseTimeStampAsSeconds(raw, "Last TimeStamp"));
-      parsed_row.set_last_time_stamp(value);
+      parsed_row.set_last_time_stamp(
+          ParseTimeStampAsSeconds(raw, "Last TimeStamp").value_or(0.0));
     }
   }
 

--- a/lib/ixia_helper.h
+++ b/lib/ixia_helper.h
@@ -30,6 +30,7 @@
 #include "p4_pdpi/netaddr/ipv4_address.h"
 #include "p4_pdpi/netaddr/ipv6_address.h"
 #include "p4_pdpi/netaddr/mac_address.h"
+#include "proto/gnmi/gnmi.grpc.pb.h"
 #include "thinkit/generic_testbed.h"
 
 namespace pins_test::ixia {
@@ -329,6 +330,10 @@ GetAllTrafficItemStats(absl::string_view href,
 
 // Computes average rate (bytes/s) at which traffic was received back by Ixia.
 inline double BytesPerSecondReceived(const TrafficItemStats &stats) {
+  // If the first timestamp is 0, this means no traffic has been received.
+  if (stats.first_time_stamp() == 0.0) {
+    return 0.0;
+  }
   return stats.rx_bytes() /
          (stats.last_time_stamp() - stats.first_time_stamp());
 }

--- a/lib/ixia_helper_test.cc
+++ b/lib/ixia_helper_test.cc
@@ -1,9 +1,15 @@
 #include "lib/ixia_helper.h"
 
+#include <string>
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "gutil/proto.h"
 #include "gutil/proto_matchers.h"
 #include "gutil/status_matchers.h"
+#include "lib/ixia_helper.pb.h"
 #include "thinkit/generic_testbed.h"
 
 namespace pins_test::ixia {
@@ -11,6 +17,8 @@ namespace pins_test::ixia {
 using ::gutil::EqualsProto;
 using ::gutil::IsOkAndHolds;
 using ::gutil::StatusIs;
+
+using ::testing::Eq;
 
 TEST(FindIdByField, FindsId) {
   static constexpr absl::string_view kArray =
@@ -270,6 +278,126 @@ TEST(ParseTrafficItemStats, ParsesExampleCorrectly) {
                   }
                 }
               )pb")));
+}
+
+TEST(IxiaHelper, ParseMissingTimestamps) {
+  static constexpr absl::string_view kExample = R"json({
+      "rowCount": 2,
+      "rowValues": {
+        "arg1": [
+          [
+            "Ethernet - 001",
+            "Ethernet - 003",
+            "Unicast Traffic",
+            "Unicast Traffic-Main Traffic - Flow Group 0001",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "1088",
+            "1081",
+            "6314",
+            "",
+            ""
+          ]
+        ]
+      },
+      "egressMode": "conditional",
+      "currentPage": 1,
+      "timestamp": 360000,
+      "isReady": true,
+      "allowPaging": true,
+      "totalPages": 1,
+      "totalRows": 1,
+      "pageSize": 50,
+      "columnCaptions": [
+        "Tx Port",
+        "Rx Port",
+        "Traffic Item",
+        "Flow Group",
+        "Tx Frames",
+        "Rx Frames",
+        "Frames Delta",
+        "Loss %",
+        "Tx Frame Rate",
+        "Rx Frame Rate",
+        "Tx L1 Rate (bps)",
+        "Rx L1 Rate (bps)",
+        "Rx Bytes",
+        "Tx Rate (Bps)",
+        "Rx Rate (Bps)",
+        "Tx Rate (bps)",
+        "Rx Rate (bps)",
+        "Tx Rate (Kbps)",
+        "Rx Rate (Kbps)",
+        "Tx Rate (Mbps)",
+        "Rx Rate (Mbps)",
+        "Store-Forward Avg Latency (ns)",
+        "Store-Forward Min Latency (ns)",
+        "Store-Forward Max Latency (ns)",
+        "First TimeStamp",
+        "Last TimeStamp"
+      ],
+      "columnCount": 26,
+      "isBlocked": false,
+      "egressPageSize": "This operation is not supported as this is not an ingress/egress view",
+      "links": [
+        {
+          "rel": "self",
+          "method": "GET",
+          "href": "/api/v1/sessions/1239/ixnetwork/statistics/view/9/data"
+        },
+        {
+          "rel": "meta",
+          "method": "OPTIONS",
+          "href": "/api/v1/sessions/1239/ixnetwork/statistics/view/9/data"
+        }
+      ]
+    })json";
+
+  EXPECT_THAT(ParseTrafficItemStats(kExample), IsOkAndHolds(EqualsProto(R"pb(
+                stats_by_traffic_item {
+                  key: "Unicast Traffic"
+                  value: {
+                    tx_port: "Ethernet - 001"
+                    rx_port: "Ethernet - 003"
+                    traffic_item_name: "Unicast Traffic"
+                    num_tx_frames: 0
+                    num_rx_frames: 0
+                    rx_bytes: 0
+                    first_time_stamp: 0.0
+                    last_time_stamp: 0.0
+                  }
+                }
+              )pb")));
+}
+
+TEST(IxiaHelper, NoTimestampIsZeroRate) {
+  EXPECT_THAT(
+      BytesPerSecondReceived(*gutil::ParseTextProto<TrafficItemStats>(R"pb(
+        tx_port: "Ethernet - 001"
+        rx_port: "Ethernet - 003"
+        traffic_item_name: "Unicast Traffic"
+        num_tx_frames: 0
+        num_rx_frames: 0
+        rx_bytes: 0
+        first_time_stamp: 0.0
+        last_time_stamp: 0.0
+      )pb")),
+      Eq(0.0));
 }
 
 }  // namespace pins_test::ixia

--- a/lib/p4rt/BUILD.bazel
+++ b/lib/p4rt/BUILD.bazel
@@ -76,7 +76,10 @@ cc_library(
     srcs = ["p4rt_port.cc"],
     hdrs = ["p4rt_port.h"],
     deps = [
+        "//gutil:status",
+        "//p4_pdpi/string_encodings:byte_string",
         "//p4_pdpi/string_encodings:decimal_string",
+        "@com_google_absl//absl/numeric:bits",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
@@ -91,6 +94,8 @@ cc_test(
     deps = [
         ":p4rt_port",
         "//gutil:status_matchers",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/lib/p4rt/p4rt_port.h
+++ b/lib/p4rt/p4rt_port.h
@@ -18,7 +18,9 @@
 #define PINS_LIB_P4RT_P4RT_PORT_H_
 
 #include <cstdint>
+#include <ostream>
 #include <string>
+#include <vector>
 
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
@@ -29,12 +31,13 @@ namespace pins_test {
 
 // Class representing a P4Runtime port ID.
 //
-// For historical reasons, there exists two encodings of P4Runtime port IDs:
+// For historical reasons, there exists three encodings of P4Runtime port IDs:
 // - As an integer (uint32_t) `42`, e.g. in OpenConfig.
 // - As a decimal string `"42"`, e.g. in P4Runtime messages such as table
 // entries.
-//
-// This class represents a P4Runtime port ID, abstracting away the encoding.
+// - As a binary string `"\x2A"`, e.g. in P4Runtime messages to BMv2, which
+// doesn't currently support decimal strings. This class represents a P4Runtime
+// port ID, abstracting away the encoding.
 // TODO: Agree on a single encoding so this class becomes obsolete.
 class P4rtPortId {
 public:
@@ -59,6 +62,10 @@ public:
 
   // Returns P4Runtime encoding of the port ID, e.g. the string `"42"`.
   std::string GetP4rtEncoding() const;
+
+  // Returns BMv2 P4Runtime encoding of the port ID, e.g. the byte string
+  // `"\x2A"`.
+  absl::StatusOr<std::string> GetBmv2P4rtEncoding() const;
 
   bool operator==(const P4rtPortId &other) const;
   bool operator<(const P4rtPortId &other) const;

--- a/lib/validator/validator_lib.h
+++ b/lib/validator/validator_lib.h
@@ -93,6 +93,14 @@ absl::Status PortsDown(thinkit::Switch &thinkit_switch,
                        bool with_healthz = true,
                        absl::Duration timeout = kDefaultTimeout);
 
+// Checks if "oper-status" of all interfaces are "NOT_PRESENT". If the
+// interfaces are provided, checks only those interfaces.
+// Will wait up to `timeout` for the RPC to return. Performs one request.
+absl::Status PortsNotPresent(thinkit::Switch &thinkit_switch,
+                             absl::Span<const std::string> interfaces = {},
+                             bool with_healthz = true,
+                             absl::Duration timeout = kDefaultTimeout);
+
 inline absl::Status AllPortsUp(thinkit::Switch &thinkit_switch,
                                bool with_healthz = true,
                                absl::Duration timeout = kDefaultTimeout) {


### PR DESCRIPTION
Keyword check Result:
/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_check.sh ./lib/ .
Keyword check Passed.

Bazel Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 732 targets (0 packages loaded, 0 targets configured).
INFO: Found 732 targets...
INFO: From Compiling lib/gnmi/gnmi_helper.cc:
lib/gnmi/gnmi_helper.cc: In function 'absl::lts_20230802::StatusOr<nlohmann::basic_json<> > pins_test::{anonymous}::GetElement(const nlohmann::json&, int)':
lib/gnmi/gnmi_helper.cc:183:26: warning: comparison of integer expressions of different signedness: 'int' and 'nlohmann::basic_json<>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  183 |   if (index < 0 || index >= array.size()) {
INFO: Elapsed time: 88.092s, Critical Path: 75.84s
INFO: 15 processes: 2 internal, 13 linux-sandbox.
INFO: Build completed successfully, 15 total actions


/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 732 targets (0 packages loaded, 0 targets configured).
INFO: Found 505 targets and 227 test targets...
INFO: Elapsed time: 386.876s, Critical Path: 241.63s
INFO: 284 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 284 total actions
//dvaas:port_id_map_test                                                 PASSED in 1.7s
//lib:basic_switch_test                                                  PASSED in 1.7s
//lib:ixia_helper_test                                                   PASSED in 7.4s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 1.4s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 16.9s
//lib/gnmi:gnmi_helper_test                                              PASSED in 3.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 91.6s
  Stats over 50 runs: max = 91.6s, min = 1.4s, avg = 6.3s, dev = 17.5s

Executed 227 out of 227 tests: 227 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeoutINFO: Build completed successfully, 284 total actions
