### PR TITLE
[Thinkit/Tests] Add NSF backoff test & to add checks for NSF reboot related tests.

### DIFF
--- a/tests/sflow/BUILD.bazel
+++ b/tests/sflow/BUILD.bazel
@@ -46,6 +46,7 @@ cc_library(
         "//tests/forwarding:group_programming_util",
         "//tests/forwarding:util",
         "//tests/integration/system/nsf:util",
+        "//tests/integration/system/nsf/interfaces:test_params",
         "//tests/integration/system/nsf/interfaces:testbed",
         "//tests/lib:p4rt_fixed_table_programming_helper",
         "//tests/lib:switch_test_setup_helpers",

--- a/tests/sflow/sflow_test.cc
+++ b/tests/sflow/sflow_test.cc
@@ -70,6 +70,7 @@
 #include "sai_p4/instantiations/google/sai_pd.pb.h"
 #include "tests/forwarding/group_programming_util.h"
 #include "tests/forwarding/util.h"
+#include "tests/integration/system/nsf/interfaces/test_params.h"
 #include "tests/integration/system/nsf/interfaces/testbed.h"
 #include "tests/integration/system/nsf/util.h"
 #include "tests/lib/p4rt_fixed_table_programming_helper.h"
@@ -1117,6 +1118,214 @@ absl::StatusOr<int> GetPortIdFromInterfaceName(
   return port_id;
 }
 
+void PerformBackoffTest(
+    thinkit::GenericTestbed *testbed, gnmi::gNMI::StubInterface *gnmi_stub,
+    thinkit::SSHClient *ssh_client, const IxiaLink &ingress_link,
+    const std::string &sut_gnmi_config,
+    const absl::flat_hash_set<std::string> &sflow_enabled_interfaces) {
+  // Read initial sample rate from testbed.
+  absl::flat_hash_map<std::string, int> initial_interfaces_to_sample_rate;
+  ASSERT_OK_AND_ASSIGN(initial_interfaces_to_sample_rate,
+                       GetSflowActualSamplingRateForInterfaces(
+                           gnmi_stub, sflow_enabled_interfaces));
+  ASSERT_FALSE(initial_interfaces_to_sample_rate.empty());
+
+  const int interface_sample_rate =
+      initial_interfaces_to_sample_rate.begin()->second;
+
+  // Set up Ixia traffic.
+  // ixia_ref_pair would include the traffic reference and topology reference
+  // which could be used to send traffic later.
+  std::pair<std::vector<std::string>, std::string> ixia_ref_pair;
+  ASSERT_OK_AND_ASSIGN(ixia_ref_pair,
+                       SetUpIxiaTraffic({ingress_link}, *testbed, 0, 0));
+  const std::string traffic_ref = ixia_ref_pair.first[0],
+                    topology_ref = ixia_ref_pair.second;
+
+  // Setup Ixia for normal traffic speed - it would generate 10
+  // samples/sec.
+  int64_t traffic_rate = 10 * interface_sample_rate;
+  ASSERT_OK(SetIxiaTrafficParams(traffic_ref,
+                                 traffic_rate * kBackoffTrafficDurationSecs,
+                                 traffic_rate, *testbed));
+
+  // Start sflowtool on SUT.
+  std::string sflow_result;
+  {
+    ASSERT_OK_AND_ASSIGN(
+        std::thread sflow_tool_thread,
+        RunSflowCollectorForNSecs(
+            *ssh_client, testbed->Sut().ChassisName(),
+            kSflowtoolLineFormatTemplate,
+            /*sflowtool_runtime=*/kBackoffTrafficDurationSecs + 30,
+            sflow_result));
+
+    // Wait for sflowtool to finish.
+    absl::Cleanup clean_up([&sflow_tool_thread] {
+      if (sflow_tool_thread.joinable()) {
+        sflow_tool_thread.join();
+      }
+    });
+
+    // Send packets from Ixia to SUT.
+    ASSERT_OK(SendSflowTraffic(
+        std::vector<std::string>{std::string(traffic_ref)}, topology_ref,
+        {ingress_link}, *testbed, gnmi_stub,
+        /*pkt_count=*/traffic_rate * kBackoffTrafficDurationSecs,
+        traffic_rate));
+  }
+
+  ASSERT_OK(testbed->Environment().StoreTestArtifact(
+      absl::StrCat("sFlow_samples_traffic_rate_", traffic_rate,
+                   "_before_backoff.txt"),
+      sflow_result));
+
+  // Verify that sample rate on all interfaces is still the initial value.
+  ASSERT_OK(IsExpectedSamplingRateFromGnmi(gnmi_stub, sflow_enabled_interfaces,
+                                           initial_interfaces_to_sample_rate,
+                                           /*multiple=*/1));
+  // Verify that sample rate from sflowtool result is the same as initial.
+  ASSERT_OK(
+      IsExpectedSampleRateFromSamples(sflow_result, interface_sample_rate));
+
+  // Setup Ixia for higher traffic speed to trigger sFlow backoff - it would
+  // generate kBackOffThresholdSamples per sec.
+  traffic_rate = kBackOffThresholdSamples * interface_sample_rate;
+  ASSERT_OK(SetIxiaTrafficParams(traffic_ref,
+                                 traffic_rate * kBackoffTrafficDurationSecs,
+                                 traffic_rate, *testbed));
+
+  // Start sflowtool on SUT.
+  {
+    ASSERT_OK_AND_ASSIGN(
+        std::thread sflow_tool_thread,
+        RunSflowCollectorForNSecs(
+            *ssh_client, testbed->Sut().ChassisName(),
+            kSflowtoolLineFormatTemplate,
+            /*sflowtool_runtime=*/kBackoffTrafficDurationSecs + 30,
+            sflow_result));
+
+    // Wait for sflowtool to finish.
+    absl::Cleanup clean_up([&sflow_tool_thread] {
+      if (sflow_tool_thread.joinable()) {
+        sflow_tool_thread.join();
+      }
+    });
+
+    // Send packets from Ixia to SUT. We set the `expected_drop_ratio` to 0.05
+    // since Ixia traffic unavoidably causes some drops on BE1 queue.
+    ASSERT_OK(SendSflowTraffic(
+        std::vector<std::string>{std::string(traffic_ref)}, topology_ref,
+        {ingress_link}, *testbed, gnmi_stub,
+        /*pkt_count=*/traffic_rate * kBackoffTrafficDurationSecs,
+        traffic_rate));
+  }
+
+  ASSERT_OK(testbed->Environment().StoreTestArtifact(
+      absl::StrCat("sFlow_samples_traffic_rate_", traffic_rate,
+                   "_triggering_backoff.txt"),
+      sflow_result));
+
+  // Verify that sample rate on all interfaces is doubled.
+  ASSERT_OK(IsExpectedSamplingRateFromGnmi(gnmi_stub, sflow_enabled_interfaces,
+                                           initial_interfaces_to_sample_rate,
+                                           /*multiple=*/2));
+
+  // Use a normal traffic speed, sample rate should remain as doubled.
+  traffic_rate = 10 * interface_sample_rate;
+  ASSERT_OK(SetIxiaTrafficParams(traffic_ref,
+                                 traffic_rate * kBackoffTrafficDurationSecs,
+                                 traffic_rate, *testbed));
+
+  {
+    // Start sflowtool on SUT.
+    ASSERT_OK_AND_ASSIGN(
+        std::thread sflow_tool_thread,
+        RunSflowCollectorForNSecs(
+            *ssh_client, testbed->Sut().ChassisName(),
+            kSflowtoolLineFormatTemplate,
+            /*sflowtool_runtime=*/kBackoffTrafficDurationSecs + 30,
+            sflow_result));
+
+    // Wait for sflowtool to finish.
+    absl::Cleanup clean_up([&sflow_tool_thread] {
+      if (sflow_tool_thread.joinable()) {
+        sflow_tool_thread.join();
+      }
+    });
+
+    // Send packets from Ixia to SUT.
+    ASSERT_OK(SendSflowTraffic(
+        std::vector<std::string>{std::string(traffic_ref)}, topology_ref,
+        {ingress_link}, *testbed, gnmi_stub,
+        /*pkt_count=*/traffic_rate * kBackoffTrafficDurationSecs,
+        traffic_rate));
+  }
+
+  ASSERT_OK(testbed->Environment().StoreTestArtifact(
+      absl::StrCat("sFlow_samples_traffic_rate_", traffic_rate,
+                   "_after_backoff.txt"),
+      sflow_result));
+
+  // Verify that sample rate on all interfaces is still doubled.
+  ASSERT_OK(IsExpectedSamplingRateFromGnmi(gnmi_stub, sflow_enabled_interfaces,
+                                           initial_interfaces_to_sample_rate,
+                                           /*multiple=*/2));
+  // Verify that sample rate from sflowtool result is still doubled.
+  EXPECT_OK(
+      IsExpectedSampleRateFromSamples(sflow_result, 2 * interface_sample_rate));
+
+  // Push initial config again, expect the sample rate is still doubled than
+  // initial value.
+  ASSERT_OK(pins_test::PushGnmiConfig(testbed->Sut(), sut_gnmi_config));
+  ASSERT_OK(IsExpectedSamplingRateFromGnmi(gnmi_stub, sflow_enabled_interfaces,
+                                           initial_interfaces_to_sample_rate,
+                                           /*multiple=*/2));
+
+  // Use a normal traffic speed, sample rate should remain as doubled.
+  traffic_rate = 10 * interface_sample_rate;
+  ASSERT_OK(SetIxiaTrafficParams(traffic_ref,
+                                 traffic_rate * kBackoffTrafficDurationSecs,
+                                 traffic_rate, *testbed));
+
+  {
+    // Start sflowtool on SUT.
+    ASSERT_OK_AND_ASSIGN(
+        std::thread sflow_tool_thread,
+        RunSflowCollectorForNSecs(
+            *ssh_client, testbed->Sut().ChassisName(),
+            kSflowtoolLineFormatTemplate,
+            /*sflowtool_runtime=*/kBackoffTrafficDurationSecs + 30,
+            sflow_result));
+
+    // Wait for sflowtool to finish.
+    absl::Cleanup clean_up([&sflow_tool_thread] {
+      if (sflow_tool_thread.joinable()) {
+        sflow_tool_thread.join();
+      }
+    });
+
+    // Send packets from Ixia to SUT.
+    ASSERT_OK(SendSflowTraffic(
+        std::vector<std::string>{std::string(traffic_ref)}, topology_ref,
+        {ingress_link}, *testbed, gnmi_stub,
+        /*pkt_count=*/traffic_rate * kBackoffTrafficDurationSecs,
+        traffic_rate));
+  }
+
+  ASSERT_OK(testbed->Environment().StoreTestArtifact(
+      absl::StrCat("sFlow_samples_traffic_rate_", traffic_rate,
+                   "_config_push_after_backoff.txt"),
+      sflow_result));
+
+  // Verify that sample rate is still doubled.
+  ASSERT_OK(IsExpectedSamplingRateFromGnmi(gnmi_stub, sflow_enabled_interfaces,
+                                           initial_interfaces_to_sample_rate,
+                                           /*multiple=*/2));
+  EXPECT_OK(
+      IsExpectedSampleRateFromSamples(sflow_result, 2 * interface_sample_rate));
+}
+
 }  // namespace
 
 void SflowTestFixture::SetUp() {
@@ -1728,8 +1937,9 @@ TEST_P(SampleRateTest, VerifySamplingRateWorks) {
 // 3. Send traffic at a normal rate which would not trigger sFlow backoff.
 // Verify that sample rate is still doubled on all interfaces and samples.
 TEST_P(BackoffTest, VerifyBackoffWorks) {
-
-  const IxiaLink& ingress_link = ready_links_[0];
+  if (GetParam().nsf_enabled) {
+    GTEST_SKIP() << "NSF is enabled, skip VerifyBackoffWorks test.";
+  }
 
   absl::flat_hash_map<std::string, bool> sflow_interfaces;
   ASSERT_OK_AND_ASSIGN(sflow_interfaces, GetSflowInterfacesFromSut(*testbed_));
@@ -1739,205 +1949,85 @@ TEST_P(BackoffTest, VerifyBackoffWorks) {
       sflow_enabled_interfaces.insert(name);
     }
   }
+  PerformBackoffTest(testbed_.get(), gnmi_stub_.get(), ssh_client_,
+                     ready_links_[0], gnmi_config_with_sflow_,
+                     sflow_enabled_interfaces);
+}
 
-  // Read initial sample rate from testbed.
-  absl::flat_hash_map<std::string, int> initial_interfaces_to_sample_rate;
-  ASSERT_OK_AND_ASSIGN(initial_interfaces_to_sample_rate,
-                       GetSflowSamplingRateForInterfaces(
+// 1. Perform backoff on a switch.
+// 2. Verify sFlow state.
+// 3. Perform NSF reboot on a switch and wait for NSF reconciliation.
+// 4. Verify sFlow state.
+// 5. Send traffic to switch to trigger backoff.
+// 6. Verify sFlow states.
+TEST_P(BackoffTest, VerifyBackOffWorksAfterNsf) {
+  if (!GetParam().nsf_enabled) {
+    GTEST_SKIP() << "NSF is disabled, skip VerifyBackOffWorksAfterNsf test.";
+  }
+  ASSERT_GE(ready_links_.size(), 2) << "Needs two ready ixia links for testing";
+  absl::flat_hash_map<std::string, bool> sflow_interfaces;
+  ASSERT_OK_AND_ASSIGN(sflow_interfaces, GetSflowInterfacesFromSut(*testbed_));
+  absl::flat_hash_set<std::string> sflow_enabled_interfaces;
+  for (const auto& [name, enabled] : sflow_interfaces) {
+    if (enabled) {
+      sflow_enabled_interfaces.insert(name);
+    }
+  }
+
+  {
+    SCOPED_TRACE("Backoff test before NSF");
+    ASSERT_NO_FATAL_FAILURE(PerformBackoffTest(
+        testbed_.get(), gnmi_stub_.get(), ssh_client_, ready_links_[1],
+        gnmi_config_with_sflow_, sflow_enabled_interfaces));
+  }
+  absl::flat_hash_map<std::string, int> interfaces_to_sample_rate;
+  ASSERT_OK_AND_ASSIGN(interfaces_to_sample_rate,
+                       GetSflowActualSamplingRateForInterfaces(
                            gnmi_stub_.get(), sflow_enabled_interfaces));
 
-  // Set up Ixia traffic.
-  // ixia_ref_pair would include the traffic reference and topology reference
-  // which could be used to send traffic later.
-  std::pair<std::vector<std::string>, std::string> ixia_ref_pair;
-  ASSERT_OK_AND_ASSIGN(ixia_ref_pair,
-                       SetUpIxiaTraffic({ingress_link}, *testbed_, 0, 0));
-  const std::string traffic_ref = ixia_ref_pair.first[0],
-                    topology_ref = ixia_ref_pair.second;
-
-  const int interface_sample_rate = kSamplingRateInterval;
-  // Setup Ixia for normal traffic speed - it would generate 10
-  // samples/sec.
-  int64_t traffic_rate = 10 * interface_sample_rate;
-  ASSERT_OK(SetIxiaTrafficParams(traffic_ref,
-                                 traffic_rate * kBackoffTrafficDurationSecs,
-                                 traffic_rate, *testbed_));
-
-  // Start sflowtool on SUT.
-  std::string sflow_result;
+  // Perform NSF reboot.
   {
-    ASSERT_OK_AND_ASSIGN(
-        std::thread sflow_tool_thread,
-        RunSflowCollectorForNSecs(
-            *ssh_client_, testbed_->Sut().ChassisName(),
-            kSflowtoolLineFormatTemplate,
-            /*sflowtool_runtime=*/kBackoffTrafficDurationSecs + 30,
-            sflow_result));
-
-    // Wait for sflowtool to finish.
-    absl::Cleanup clean_up([&sflow_tool_thread] {
-      if (sflow_tool_thread.joinable()) {
-        sflow_tool_thread.join();
-      }
+    LOG(INFO) << "Perform NSF reboot.";
+    pins_test::Testbed testbed_variant;
+    testbed_variant.emplace<std::unique_ptr<thinkit::GenericTestbed>>(
+        std::move(testbed_));
+    absl::Cleanup restore_testbed([this, &testbed_variant] {
+      // TODO: NSF `Testbed` should use raw pointer of
+      // GenericTestbed
+      testbed_ = std::move(std::get<0>(testbed_variant));
     });
-
-    // Send packets from Ixia to SUT.
-    ASSERT_OK(SendSflowTraffic(
-        std::vector<std::string>{std::string(traffic_ref)}, topology_ref,
-        {ingress_link}, *testbed_, gnmi_stub_.get(),
-        /*pkt_count=*/traffic_rate * kBackoffTrafficDurationSecs,
-        traffic_rate));
+    ASSERT_OK(pins_test::NsfReboot(testbed_variant));
+    // TODO: RebootStatus() RPC is not returning status after NSF
+    // is complete.
+    // ASSERT_OK(
+    //     pins_test::WaitForNsfReboot(testbed_variant,
+    //     *GetParam().ssh_client));
+    ASSERT_OK(pins_test::WaitForReboot(testbed_variant, *ssh_client_));
+    pins_test::ImageConfigParams image_config_params{
+        .gnmi_config = gnmi_config_with_sflow_,
+    };
+    ASSERT_OK(pins_test::ValidateTestbedState(
+        testbed_variant, *GetParam().ssh_client, &image_config_params));
+    LOG(INFO) << "NSF reboot finished.";
   }
 
-  ASSERT_OK(testbed_->Environment().StoreTestArtifact(
-      absl::StrCat("sFlow_samples_traffic_rate_", traffic_rate,
-                   "_before_backoff.txt"),
-      sflow_result));
+  ASSERT_OK(pins_test::WaitForCondition(
+      CheckStateDbPortIndexTableExists, absl::Minutes(2), *ssh_client_,
+      testbed_->Sut().ChassisName(),
+      std::vector<std::string>{sflow_enabled_interfaces.begin(),
+                               sflow_enabled_interfaces.end()}));
 
-  // Verify that sample rate on all interfaces is still the initial value.
+  // Verify that sample rate on all interfaces remains the same after NSF.
   ASSERT_OK(IsExpectedSamplingRateFromGnmi(
-      gnmi_stub_.get(), sflow_enabled_interfaces,
-      initial_interfaces_to_sample_rate, /*multiple=*/1));
-  // Verify that sample rate from sflowtool result is the same as initial.
-  ASSERT_OK(
-      IsExpectedSampleRateFromSamples(sflow_result, interface_sample_rate));
-
-  // Setup Ixia for higher traffic speed to trigger sFlow backoff - it would
-  // generate kBackOffThresholdSamples per sec.
-  traffic_rate = kBackOffThresholdSamples * interface_sample_rate;
-  ASSERT_OK(SetIxiaTrafficParams(traffic_ref,
-                                 traffic_rate * kBackoffTrafficDurationSecs,
-                                 traffic_rate, *testbed_));
-
-  // Start sflowtool on SUT.
-  {
-    ASSERT_OK_AND_ASSIGN(
-        std::thread sflow_tool_thread,
-        RunSflowCollectorForNSecs(
-            *ssh_client_, testbed_->Sut().ChassisName(),
-            kSflowtoolLineFormatTemplate,
-            /*sflowtool_runtime=*/kBackoffTrafficDurationSecs + 30,
-            sflow_result));
-
-    // Wait for sflowtool to finish.
-    absl::Cleanup clean_up([&sflow_tool_thread] {
-      if (sflow_tool_thread.joinable()) {
-        sflow_tool_thread.join();
-      }
-    });
-
-    // Send packets from Ixia to SUT. We set the `expected_drop_ratio` to 0.05
-    // since Ixia traffic unavoidably causes some drops on BE1 queue.
-    ASSERT_OK(SendSflowTraffic(
-        std::vector<std::string>{std::string(traffic_ref)}, topology_ref,
-        {ingress_link}, *testbed_, gnmi_stub_.get(),
-        /*pkt_count=*/traffic_rate * kBackoffTrafficDurationSecs,
-        traffic_rate));
-  }
-
-  ASSERT_OK(testbed_->Environment().StoreTestArtifact(
-      absl::StrCat("sFlow_samples_traffic_rate_", traffic_rate,
-                   "_triggering_backoff.txt"),
-      sflow_result));
-
-  // Verify that sample rate on all interfaces is doubled.
-  ASSERT_OK(IsExpectedSamplingRateFromGnmi(
-      gnmi_stub_.get(), sflow_enabled_interfaces,
-      initial_interfaces_to_sample_rate, /*multiple=*/2));
-
-  // Use a normal traffic speed, sample rate should remain as doubled.
-  traffic_rate = 10 * interface_sample_rate;
-  ASSERT_OK(SetIxiaTrafficParams(traffic_ref,
-                                 traffic_rate * kBackoffTrafficDurationSecs,
-                                 traffic_rate, *testbed_));
+      gnmi_stub_.get(), sflow_enabled_interfaces, interfaces_to_sample_rate,
+      /*multiple=*/1));
 
   {
-    // Start sflowtool on SUT.
-    ASSERT_OK_AND_ASSIGN(
-        std::thread sflow_tool_thread,
-        RunSflowCollectorForNSecs(
-            *ssh_client_, testbed_->Sut().ChassisName(),
-            kSflowtoolLineFormatTemplate,
-            /*sflowtool_runtime=*/kBackoffTrafficDurationSecs + 30,
-            sflow_result));
-
-    // Wait for sflowtool to finish.
-    absl::Cleanup clean_up([&sflow_tool_thread] {
-      if (sflow_tool_thread.joinable()) {
-        sflow_tool_thread.join();
-      }
-    });
-
-    // Send packets from Ixia to SUT.
-    ASSERT_OK(SendSflowTraffic(
-        std::vector<std::string>{std::string(traffic_ref)}, topology_ref,
-        {ingress_link}, *testbed_, gnmi_stub_.get(),
-        /*pkt_count=*/traffic_rate * kBackoffTrafficDurationSecs,
-        traffic_rate));
+    SCOPED_TRACE("Backoff test after NSF");
+    ASSERT_NO_FATAL_FAILURE(PerformBackoffTest(
+        testbed_.get(), gnmi_stub_.get(), ssh_client_, ready_links_[0],
+        gnmi_config_with_sflow_, sflow_enabled_interfaces));
   }
-
-  ASSERT_OK(testbed_->Environment().StoreTestArtifact(
-      absl::StrCat("sFlow_samples_traffic_rate_", traffic_rate,
-                   "_after_backoff.txt"),
-      sflow_result));
-
-  // Verify that sample rate on all interfaces is still doubled.
-  ASSERT_OK(IsExpectedSamplingRateFromGnmi(
-      gnmi_stub_.get(), sflow_enabled_interfaces,
-      initial_interfaces_to_sample_rate, /*multiple=*/2));
-  // Verify that sample rate from sflowtool result is still doubled.
-  EXPECT_OK(
-      IsExpectedSampleRateFromSamples(sflow_result, 2 * interface_sample_rate));
-
-  // Push initial config again, expect the sample rate is still doubled than
-  // initial value.
-  ASSERT_OK(
-      pins_test::PushGnmiConfig(testbed_->Sut(), gnmi_config_with_sflow_));
-  ASSERT_OK(IsExpectedSamplingRateFromGnmi(
-      gnmi_stub_.get(), sflow_enabled_interfaces,
-      initial_interfaces_to_sample_rate, /*multiple=*/2));
-
-  // Use a normal traffic speed, sample rate should remain as doubled.
-  traffic_rate = 10 * interface_sample_rate;
-  ASSERT_OK(SetIxiaTrafficParams(traffic_ref,
-                                 traffic_rate * kBackoffTrafficDurationSecs,
-                                 traffic_rate, *testbed_));
-  {
-    // Start sflowtool on SUT.
-    ASSERT_OK_AND_ASSIGN(
-        std::thread sflow_tool_thread,
-        RunSflowCollectorForNSecs(
-            *ssh_client_, testbed_->Sut().ChassisName(),
-            kSflowtoolLineFormatTemplate,
-            /*sflowtool_runtime=*/kBackoffTrafficDurationSecs + 30,
-            sflow_result));
-
-    // Wait for sflowtool to finish.
-    absl::Cleanup clean_up([&sflow_tool_thread] {
-      if (sflow_tool_thread.joinable()) {
-        sflow_tool_thread.join();
-      }
-    });
-
-    // Send packets from Ixia to SUT.
-    ASSERT_OK(SendSflowTraffic(
-        std::vector<std::string>{std::string(traffic_ref)}, topology_ref,
-        {ingress_link}, *testbed_, gnmi_stub_.get(),
-        /*pkt_count=*/traffic_rate * kBackoffTrafficDurationSecs,
-        traffic_rate));
-  }
-
-  ASSERT_OK(testbed_->Environment().StoreTestArtifact(
-      absl::StrCat("sFlow_samples_traffic_rate_", traffic_rate,
-                   "_config_push_after_backoff.txt"),
-      sflow_result));
-
-  // Verify that sample rate is still doubled.
-  ASSERT_OK(IsExpectedSamplingRateFromGnmi(
-      gnmi_stub_.get(), sflow_enabled_interfaces,
-      initial_interfaces_to_sample_rate, /*multiple=*/2));
-  EXPECT_OK(
-      IsExpectedSampleRateFromSamples(sflow_result, 2 * interface_sample_rate));
 }
 
 namespace {
@@ -2394,6 +2484,28 @@ void SflowMirrorTestFixture::TearDown() {
   GetParam().testbed_interface->TearDown();
 }
 
+absl::Status SflowMirrorTestFixture::NsfRebootAndWaitForGnmiConvergence(
+    thinkit::MirrorTestbed& testbed, absl::string_view gnmi_config) {
+  LOG(INFO) << "Start NSF reboot on switch";
+  pins_test::Testbed testbed_variant;
+  testbed_variant.emplace<thinkit::MirrorTestbed*>(&testbed);
+  RETURN_IF_ERROR(pins_test::NsfReboot(testbed_variant));
+  // TODO: RebootStatus() RPC is not returning status after NSF
+  // is complete.
+  // ASSERT_OK(
+  //     pins_test::WaitForNsfReboot(testbed_variant,
+  //     *GetParam().ssh_client));
+  RETURN_IF_ERROR(
+      pins_test::WaitForReboot(testbed_variant, *GetParam().ssh_client));
+  pins_test::ImageConfigParams image_config_params{
+      .gnmi_config = std::string(gnmi_config),
+  };
+  RETURN_IF_ERROR(pins_test::ValidateTestbedState(
+      testbed_variant, *GetParam().ssh_client, &image_config_params));
+  LOG(INFO) << "NSF reboot finished and gNMI config is converged.";
+  return absl::OkStatus();
+}
+
 // Push config with collector controller_IP:portA to switch.
 // Perform NSF reboot on switch.
 // Push config with collector localhost:portB to switch.
@@ -2459,13 +2571,8 @@ TEST_P(SflowRebootTestFixture, ChangeCollectorConfigOnNsfReboot) {
   ASSERT_OK(ProgramRoutesForIpv6(*sut_p4_session_, GetSutIrP4Info(), vrf_id,
                                  collector_ipv6, next_hop_id));
 
-  pins_test::Testbed testbed_variant;
-  testbed_variant.emplace<thinkit::MirrorTestbed*>(&testbed);
-  ASSERT_OK(pins_test::NsfReboot(testbed_variant));
   ASSERT_OK(
-      pins_test::WaitForNsfReboot(testbed_variant, *GetParam().ssh_client));
-  ASSERT_OK(
-      pins_test::ValidateTestbedState(testbed_variant, *GetParam().ssh_client));
+      NsfRebootAndWaitForGnmiConvergence(testbed, sut_gnmi_config_with_sflow));
   // Wait until all sFlow gNMI states are converged.
   ASSERT_OK(pins_test::WaitForCondition(
       VerifySflowStatesConverged, absl::Seconds(60), sut_gnmi_stub_.get(),
@@ -3164,9 +3271,8 @@ TEST_P(SflowRebootTestFixture, TestSamplingWorksAfterReboot) {
     sut_p4_session_ = nullptr;
   }
   if (GetParam().nsf_enabled) {
-    pins_test::Testbed testbed_variant;
-    testbed_variant.emplace<thinkit::MirrorTestbed*>(&testbed);
-    ASSERT_OK(pins_test::NsfReboot(testbed_variant));
+    ASSERT_OK(NsfRebootAndWaitForGnmiConvergence(testbed,
+                                                 sut_gnmi_config_with_sflow));
   } else {
     pins_test::TestGnoiSystemColdReboot(testbed.Sut());
   }
@@ -3194,6 +3300,7 @@ TEST_P(SflowRebootTestFixture, TestSamplingWorksAfterReboot) {
                              sut_gnmi_stub_.get(), interface_name));
   }
 
+  const int num_packets_after_reboot = 20000;
   {
     // Start sflowtool on SUT.
     ASSERT_OK_AND_ASSIGN(
@@ -3202,7 +3309,7 @@ TEST_P(SflowRebootTestFixture, TestSamplingWorksAfterReboot) {
             *GetParam().ssh_client, testbed.Sut().ChassisName(),
             kSflowtoolLineFormatTemplate,
             /*sflowtool_runtime=*/
-            (num_packets / kInbandTrafficPps + 3) *
+            (num_packets_after_reboot / kInbandTrafficPps + 3) *
                     traffic_interfaces_and_port_ids.size() +
                 20,
             sflow_result));
@@ -3221,7 +3328,7 @@ TEST_P(SflowRebootTestFixture, TestSamplingWorksAfterReboot) {
           GetPortIdFromInterfaceName(control_switch_port_id_per_port_name,
                                      interface_name));
       ASSERT_OK(SendNPacketsFromSwitch(
-          num_packets, kInbandTrafficPps, control_switch_port_id,
+          num_packets_after_reboot, kInbandTrafficPps, control_switch_port_id,
           interface_name, sut_gnmi_stub_.get(), GetControlIrP4Info(),
           *control_p4_session_, testbed.Environment()));
     }
@@ -3241,9 +3348,9 @@ TEST_P(SflowRebootTestFixture, TestSamplingWorksAfterReboot) {
         GetSflowSamplesOnSut(sflow_result, control_switch_port_id);
     SflowResult result = SflowResult{
         .sut_interface = interface_name,
-        .packets = num_packets,
+        .packets = num_packets_after_reboot,
         .sampling_rate = kInbandSamplingRate,
-        .expected_samples = num_packets / kInbandSamplingRate,
+        .expected_samples = num_packets_after_reboot / kInbandSamplingRate,
         .actual_samples = sample_count,
     };
     LOG(INFO) << "------ Test result ------\n" << result.DebugString();

--- a/tests/sflow/sflow_test.h
+++ b/tests/sflow/sflow_test.h
@@ -19,11 +19,14 @@
 #include <string>
 #include <vector>
 
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
 #include "gtest/gtest.h"
 #include "p4_pdpi/p4_runtime_session.h"
 #include "proto/gnmi/gnmi.grpc.pb.h"
 #include "thinkit/generic_testbed.h"
 #include "thinkit/generic_testbed_fixture.h"
+#include "thinkit/mirror_testbed.h"
 #include "thinkit/mirror_testbed_fixture.h"
 #include "thinkit/ssh_client.h"
 
@@ -39,6 +42,8 @@ struct SflowTestParams {
   int sample_size;
   // For sampling rate tests.
   int sample_rate;
+  // For NSF tests.
+  bool nsf_enabled;
 };
 
 // Structure represents a link between SUT and Ixia.
@@ -101,6 +106,9 @@ class SflowMirrorTestFixture
   void SetUp() override;
 
   void TearDown() override;
+
+  absl::Status NsfRebootAndWaitForGnmiConvergence(
+      thinkit::MirrorTestbed& testbed, absl::string_view gnmi_config);
 
   p4::config::v1::P4Info GetSutP4Info() { return sut_p4_info_; }
   p4::config::v1::P4Info GetControlP4Info() { return control_p4_info_; }


### PR DESCRIPTION
### Keyword Check:
divyagayathris@divyagayathris-16:~/Apr11/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_check.sh tests/.
Keyword check Passed.

### Build Results:
divyagayathris@2ef3a271cd98:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 734 targets (0 packages loaded, 0 targets configured).
INFO: Found 734 targets...
...
INFO: Elapsed time: 23.604s, Critical Path: 23.03s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions

### Test Results:
divyagayathris@2ef3a271cd98:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 734 targets (0 packages loaded, 3 targets configured).
INFO: Found 507 targets and 227 test targets...
INFO: Elapsed time: 178.044s, Critical Path: 131.77s
INFO: 284 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 284 total actions
//dvaas:port_id_map_test                                                 PASSED in 1.4s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.3s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.2s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.3s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.4s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.4s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 1.1s
//gutil:io_test                                                          PASSED in 1.1s
//gutil:proto_matchers_test                                              PASSED in 1.4s
//gutil:proto_ordering_test                                              PASSED in 1.1s
//gutil:proto_test                                                       PASSED in 1.0s
//gutil:status_matchers_test                                             PASSED in 1.0s
//gutil:test_artifact_writer_test                                        PASSED in 1.2s
//gutil:testing_test                                                     PASSED in 1.1s
//gutil:timer_test                                                       PASSED in 5.2s
//gutil:version_test                                                     PASSED in 3.7s
//lib:basic_switch_test                                                  PASSED in 1.7s
//lib:ixia_helper_test                                                   PASSED in 2.5s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 1.8s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 16.0s
//lib/gnmi:gnmi_helper_test                                              PASSED in 3.6s
//lib/gnoi:gnoi_helper_test                                              PASSED in 0.9s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.0s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 1.5s
//lib/utils:generic_testbed_utils_test                                   PASSED in 1.9s
//lib/utils:json_utils_test                                              PASSED in 1.0s
//lib/validator:validator_backend_test                                   PASSED in 0.9s
//lib/validator:validator_lib_test                                       PASSED in 26.6s
//p4_fuzzer:constraints_test                                             PASSED in 6.0s
//p4_fuzzer:fuzz_util_test                                               PASSED in 131.6s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 1.5s
//p4_fuzzer:oracle_util_test                                             PASSED in 4.2s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 3.5s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 3.4s
//p4_fuzzer:switch_state_test                                            PASSED in 1.9s
//p4_pdpi:built_ins_test                                                 PASSED in 1.1s
//p4_pdpi:entity_keys_test                                               PASSED in 1.0s
//p4_pdpi:ir_properties_test                                             PASSED in 0.9s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.0s
//p4_pdpi:ir_tools_test                                                  PASSED in 1.5s
//p4_pdpi:names_test                                                     PASSED in 1.5s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.1s
//p4_pdpi:p4info_union_test                                              PASSED in 0.8s
//p4_pdpi:reference_annotations_test                                     PASSED in 1.4s
//p4_pdpi:references_test                                                PASSED in 1.2s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.2s
//p4_pdpi:ternary_test                                                   PASSED in 1.0s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 0.9s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 0.8s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.0s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 19.5s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 0.9s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 5.2s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.1s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.0s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 0.9s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.3s
//p4_pdpi/testing:info_test                                              PASSED in 0.2s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.1s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.2s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.2s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:references_test                                        PASSED in 0.2s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.3s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 1.6s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.0s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.2s
//p4_symbolic:z3_util_test                                               PASSED in 1.2s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 3.1s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 3.2s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 2.9s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 3.3s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 2.9s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 3.2s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 2.9s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.4s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.1s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.1s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.1s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.0s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.0s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.1s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 14.4s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 20.0s
//p4_symbolic/sai:sai_test                                               PASSED in 4.8s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 3.6s
//p4_symbolic/symbolic:parser_test                                       PASSED in 2.1s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.0s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 1.7s
//p4_symbolic/symbolic:util_test                                         PASSED in 1.5s
//p4_symbolic/symbolic:values_test                                       PASSED in 0.9s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 9.9s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 7.3s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 1.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 1.7s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 1.7s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 1.6s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 1.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 2.4s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 1.8s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 1.0s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 1.6s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 1.2s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 1.6s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.2s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 1.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 1.4s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 1.4s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 1.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 1.5s
//p4rt_app/sonic:hashing_test                                            PASSED in 1.8s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 1.4s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.3s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.1s
//p4rt_app/sonic:response_handler_test                                   PASSED in 1.3s
//p4rt_app/sonic:state_verification_test                                 PASSED in 1.4s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.2s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 1.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.7s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 1.7s
//p4rt_app/tests:action_set_test                                         PASSED in 1.3s
//p4rt_app/tests:api_access_test                                         PASSED in 1.0s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.2s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.1s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.2s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 3.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 5.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.4s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.8s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.4s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.0s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.2s
//p4rt_app/tests:packetio_test                                           PASSED in 4.1s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 3.5s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.2s
//p4rt_app/tests:response_path_test                                      PASSED in 4.3s
//p4rt_app/tests:role_test                                               PASSED in 1.3s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.4s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.0s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 1.2s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.2s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.1s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.2s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.1s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.4s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 4.7s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 2.4s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 6.6s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.0s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.4s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.8s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.0s
//tests/lib:p4info_helper_test                                           PASSED in 1.8s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.7s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.2s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.7s
//thinkit:bazel_test_environment_test                                    PASSED in 1.4s
//thinkit:generic_testbed_test                                           PASSED in 1.4s
//thinkit:mock_control_device_test                                       PASSED in 0.9s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.0s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.3s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.1s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 1.4s
//tests/lib:packet_generator_test                                        PASSED in 65.1s
  Stats over 4 runs: max = 65.1s, min = 63.0s, avg = 64.2s, dev = 0.9s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.7s
  Stats over 5 runs: max = 1.7s, min = 1.4s, avg = 1.5s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 43.1s
  Stats over 50 runs: max = 43.1s, min = 1.1s, avg = 5.1s, dev = 11.2s

Executed 227 out of 227 tests: 227 tests pass.
INFO: Build completed successfully, 284 total actions
divyagayathris@2ef3a271cd98:/sonic/src/sonic-p4rt/sonic-pins$ 