### PR TITLE
[Thinkit] Support new PFC + watchdog paths and Add an option to skip appending traffic type in SetTrafficParameters.

### DIFF
--- a/lib/gnmi/gnmi_helper.cc
+++ b/lib/gnmi/gnmi_helper.cc
@@ -2012,6 +2012,32 @@ absl::Status SetPortLoopbackMode(bool port_loopback,
                                       GnmiSetType::kUpdate, config_json);
 }
 
+absl::StatusOr<std::string> GetPortPfcRxEnable(
+    const absl::string_view interface_name,
+    gnmi::gNMI::StubInterface& gnmi_stub) {
+  std::string config_path =
+      absl::StrCat("interfaces/interface[name=", interface_name,
+                   "]/ethernet/state/google-pins-interfaces:enable-pfc-rx");
+  const std::string parse_str = "google-pins-interfaces:enable-pfc-rx";
+
+  ASSIGN_OR_RETURN(std::string enable_pfc_rx,
+                   GetGnmiStatePathInfo(&gnmi_stub, config_path, parse_str));
+  return enable_pfc_rx;
+}
+
+absl::Status SetPortPfcRxEnable(const absl::string_view interface_name,
+                                std::string port_pfc_rx_enable,
+                                gnmi::gNMI::StubInterface& gnmi_stub) {
+  std::string config_path =
+      absl::StrCat("interfaces/interface[name=", interface_name,
+                   "]/ethernet/config/enable-pfc-rx");
+  std::string config_json = absl::StrCat(
+      "{\"openconfig-interfaces:enable-pfc-rx\":", port_pfc_rx_enable, "}");
+
+  return pins_test::SetGnmiConfigPath(&gnmi_stub, config_path,
+                                      GnmiSetType::kUpdate, config_json);
+}
+
 absl::StatusOr<absl::flat_hash_map<std::string, Counters>>
 GetAllInterfaceCounters(gnmi::gNMI::StubInterface& gnmi_stub) {
   ASSIGN_OR_RETURN(

--- a/lib/gnmi/gnmi_helper.h
+++ b/lib/gnmi/gnmi_helper.h
@@ -555,6 +555,15 @@ absl::Status SetPortLoopbackMode(bool port_loopback,
                                  absl::string_view interface_name,
                                  gnmi::gNMI::StubInterface &gnmi_stub);
 
+// Set PFC Rx for a port.
+absl::Status SetPortPfcRxEnable(absl::string_view interface_name,
+                                std::string port_pfc_rx_enable,
+                                gnmi::gNMI::StubInterface& gnmi_stub);
+
+// Get PFC Rx enable for a port.
+absl::StatusOr<std::string> GetPortPfcRxEnable(
+    absl::string_view interface_name, gnmi::gNMI::StubInterface& gnmi_stub);
+
 // Gets counters for all interfaces.
 absl::StatusOr<absl::flat_hash_map<std::string, Counters>>
 GetAllInterfaceCounters(gnmi::gNMI::StubInterface &gnmi_stub);

--- a/lib/ixia_helper.cc
+++ b/lib/ixia_helper.cc
@@ -1369,8 +1369,11 @@ absl::StatusOr<TrafficItemStats> GetTrafficItemStats(
 
 absl::Status SetIpTrafficParameters(absl::string_view tref,
                                     const Ipv4TrafficParameters &params,
-                                    thinkit::GenericTestbed &testbed) {
-  RETURN_IF_ERROR(AppendIPv4(tref, testbed));
+                                    thinkit::GenericTestbed &testbed,
+                                    bool is_update) {
+  if (!is_update) {
+    RETURN_IF_ERROR(AppendIPv4(tref, testbed));
+  }
   RETURN_IF_ERROR(SetSrcIPv4(tref, params.src_ipv4.ToString(), testbed));
   RETURN_IF_ERROR(SetDestIPv4(tref, params.dst_ipv4.ToString(), testbed));
   if (params.priority.has_value()) {
@@ -1383,8 +1386,11 @@ absl::Status SetIpTrafficParameters(absl::string_view tref,
 
 absl::Status SetIpTrafficParameters(absl::string_view tref,
                                     const Ipv6TrafficParameters &params,
-                                    thinkit::GenericTestbed &testbed) {
-  RETURN_IF_ERROR(AppendIPv6(tref, testbed));
+                                    thinkit::GenericTestbed &testbed,
+                                    bool is_update) {
+  if (!is_update) {
+    RETURN_IF_ERROR(AppendIPv6(tref, testbed));
+  }
   RETURN_IF_ERROR(SetSrcIPv6(tref, params.src_ipv6.ToString(), testbed));
   RETURN_IF_ERROR(SetDestIPv6(tref, params.dst_ipv6.ToString(), testbed));
   if (params.priority.has_value()) {
@@ -1397,8 +1403,11 @@ absl::Status SetIpTrafficParameters(absl::string_view tref,
 
 absl::Status SetPfcTrafficParameters(absl::string_view tref,
                                      const PfcTrafficParameters &params,
-                                     thinkit::GenericTestbed &testbed) {
-  RETURN_IF_ERROR(AppendPfc(tref, testbed));
+                                     thinkit::GenericTestbed &testbed,
+                                     bool is_update) {
+  if (!is_update) {
+    RETURN_IF_ERROR(AppendPfc(tref, testbed));
+  }
   RETURN_IF_ERROR(
       SetPfcPriorityEnableVector(tref, params.priority_enable_vector, testbed));
   RETURN_IF_ERROR(
@@ -1409,7 +1418,8 @@ absl::Status SetPfcTrafficParameters(absl::string_view tref,
 
 absl::Status SetTrafficParameters(absl::string_view tref,
                                   const TrafficParameters &params,
-                                  thinkit::GenericTestbed &testbed) {
+                                  thinkit::GenericTestbed &testbed,
+                                  bool is_update) {
   if (params.frame_count.has_value()) {
     RETURN_IF_ERROR(SetFrameCount(tref, *params.frame_count, testbed));
   }
@@ -1427,8 +1437,8 @@ absl::Status SetTrafficParameters(absl::string_view tref,
       params.traffic_speed));
 
   if (params.pfc_parameters.has_value()) {
-    RETURN_IF_ERROR(
-        SetPfcTrafficParameters(tref, *params.pfc_parameters, testbed));
+    RETURN_IF_ERROR(SetPfcTrafficParameters(tref, *params.pfc_parameters,
+                                            testbed, is_update));
   } else {
     RETURN_IF_ERROR(SetSrcMac(tref, params.src_mac.ToString(), testbed));
     RETURN_IF_ERROR(SetDestMac(tref, params.dst_mac.ToString(), testbed));
@@ -1436,7 +1446,7 @@ absl::Status SetTrafficParameters(absl::string_view tref,
   if (params.ip_parameters.has_value()) {
     RETURN_IF_ERROR(std::visit(
         [&](const auto &ip_params) {
-          return SetIpTrafficParameters(tref, ip_params, testbed);
+          return SetIpTrafficParameters(tref, ip_params, testbed, is_update);
         },
         *params.ip_parameters));
   }

--- a/lib/ixia_helper.h
+++ b/lib/ixia_helper.h
@@ -312,7 +312,8 @@ struct TrafficParameters {
 // Takes in the tref returned by IxiaSession / SetUpTrafficItem.
 absl::Status SetTrafficParameters(absl::string_view tref,
                                   const TrafficParameters &params,
-                                  thinkit::GenericTestbed &testbed);
+                                  thinkit::GenericTestbed &testbed,
+                                  bool is_update = false);
 
 // Sets the priority enable vector field in the PFC header.
 absl::Status SetPfcPriorityEnableVector(

--- a/tests/qos/BUILD.bazel
+++ b/tests/qos/BUILD.bazel
@@ -127,6 +127,7 @@ cc_library(
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/time",

--- a/tests/qos/pfc_test.cc
+++ b/tests/qos/pfc_test.cc
@@ -15,8 +15,10 @@
 #include "tests/qos/pfc_test.h"
 
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <optional>
+#include <ostream>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -26,6 +28,7 @@
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
+#include "absl/strings/substitute.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "glog/logging.h"
@@ -50,6 +53,22 @@
 #include "thinkit/switch.h"
 
 namespace pins_test {
+
+// Structure represents the information needed to log the test results.
+struct PfcLogInfo {
+  int dscp;
+  std::string queue;
+  int priority;
+  int pause_quanta;
+};
+
+// Overloading the ostream operator for printing PfcLogInfo
+std::ostream &operator<<(std::ostream &os, const PfcLogInfo &info) {
+  os << "====== DSCP: " << info.dscp << ", Queue: " << info.queue
+     << ", PFC Priority: " << info.priority
+     << ", Pause Quantas: " << info.pause_quanta << " =====";
+  return os;
+}
 
 constexpr int kDefaultFrameSize = 1500;
 
@@ -142,7 +161,8 @@ void PfcTestWithIxia::SetUp() {
       "Test packet route: [Ixia: %s] => [SUT: %s] -> [SUT: %s] => [Ixia: %s]",
       ixia_interface, sut_interface, sut_egress_interface, ixia_rx_interface);
 
-  // TODO: Configure PFC enable on egress port
+  // Enable PFC Rx on egress port
+  // ASSERT_OK(SetPortPfcRxEnable(sut_egress_interface, true, *gnmi_stub_));
 
   // We will perform the following steps with Ixia:
   // Setup main Ixia forwarded traffic.
@@ -250,6 +270,135 @@ absl::StatusOr<QueueCounters> GetQueueCountersChange(
                    GetGnmiQueueCounters(/*port=*/port,
                                         /*queue=*/queue, gnmi));
   return queue_counters_post - queue_counters_pre;
+}
+
+// The purpose of this test is to verify that PFC Rx is working correctly.
+// We test this by sending line rate forwarded traffic from SUT Port A -> SUT
+// Port B and PFC traffic from SUT Port B -> SUT Port A. We expect the SUT to
+// pause the queue corresponding to the PFC traffic for the duration of the
+// pause time configured in the PFC traffic parameters.
+TEST_P(PfcTestWithIxia, PfcRxWithNoPacketDrops) {
+  // Pause duration in units of time for 512 bits.
+  for (const auto pause_quanta : {0x3ff, 0x1fff, 0xffff}) {
+    for (const auto [priority, queue] : *GetParam().queue_by_pfc_priority) {
+      PfcLogInfo log_info = {
+          .dscp = GetParam().dscp_by_queue->at(queue),
+          .queue = queue,
+          .priority = priority,
+          .pause_quanta = pause_quanta,
+      };
+      SCOPED_TRACE(log_info);
+      LOG(INFO) << "\n\n " << log_info;
+
+      // Setup main traffic DSCP.
+      ixia::Ipv4TrafficParameters &ip_params =
+          std::get<ixia::Ipv4TrafficParameters>(
+              main_traffic_parameters_.ip_parameters.value());
+      ip_params.priority->dscp = GetParam().dscp_by_queue->at(queue);
+      ASSERT_OK(ixia::SetTrafficParameters(main_traffic_.traffic_item,
+                                           main_traffic_parameters_,
+                                           *generic_testbed_));
+
+      // Setup PFC traffic priority and pause duration for the target queue.
+      pfc_traffic_parameters_.pfc_parameters->priority_enable_vector =
+          1 << priority;
+      for (int i = 0; i < kNumQueues; ++i) {
+        if (i == priority) {
+          pfc_traffic_parameters_.pfc_parameters->pause_quanta_per_queue[i] =
+              pause_quanta;
+        } else {
+          pfc_traffic_parameters_.pfc_parameters->pause_quanta_per_queue[i] = 0;
+        }
+      }
+
+      LOG(INFO) << "SUT interface bits per second: "
+                << ixia_links_.egress_link.sut_interface_bits_per_second;
+
+      pfc_traffic_parameters_.frame_count = 1;
+
+      ASSERT_OK(ixia::SetTrafficParameters(pfc_traffic_.traffic_item,
+                                           pfc_traffic_parameters_,
+                                           *generic_testbed_));
+
+      // Wait for queue to be empty. Try up to 3 times waiting for the queue
+      // counters to stabilize.
+      pins_test::QueueCounters queue_counters_before_test;
+      EXPECT_OK(pins::TryUpToNTimes(3, /*delay=*/absl::Seconds(30), [&] {
+        // Read counters of the target queue.
+        ASSIGN_OR_RETURN(
+            queue_counters_before_test,
+            GetGnmiQueueCounters(/*port=*/ixia_links_.egress_link.sut_interface,
+                                 /*queue=*/queue, *gnmi_stub_));
+        if (queue_counters_before_test.max_periodic_queue_len <=
+            kDefaultFrameSize) {
+          return absl::OkStatus();
+        }
+        return absl::InternalError(absl::Substitute(
+            "Max periodic queue len is not 0, $0",
+            queue_counters_before_test.max_periodic_queue_len));
+      }));
+
+      // Occasionally the Ixia API cannot keep up and starting traffic
+      // fails, so we try up to 3 times.
+      ASSERT_OK(pins::TryUpToNTimes(3, /*delay=*/absl::Seconds(1), [&] {
+        return ixia::StartTraffic(
+            {main_traffic_.traffic_item, pfc_traffic_.traffic_item},
+            ixia_connection_reference_, *generic_testbed_);
+      }));
+
+      // Send forwarding and PFC traffic for 30 seconds and then stop.
+      absl::SleepFor(absl::Seconds(30));
+      ASSERT_OK(
+          ixia::StopTraffic(pfc_traffic_.traffic_item, *generic_testbed_));
+
+      QueueCounters queue_counters_after_test, delta_counters;
+
+      // Queue statistics are updated every 30 seconds, hence try up to 3 times.
+      EXPECT_OK(pins::TryUpToNTimes(3, /*delay=*/absl::Seconds(30), [&] {
+        // Read counters of the target queue.
+        ASSIGN_OR_RETURN(
+            queue_counters_after_test,
+            GetGnmiQueueCounters(/*port=*/ixia_links_.egress_link.sut_interface,
+                                 /*queue=*/queue, *gnmi_stub_));
+
+        constexpr int kPauseQuantaBits = 512;
+        uint64_t pause_duration_ns, expected_watermark;
+        pause_duration_ns =
+            (kPauseQuantaBits * pause_quanta) /
+            (ixia_links_.egress_link.sut_interface_bits_per_second /
+             1'000'000'000);
+        expected_watermark =
+            (pause_duration_ns * port_speed_bytes_per_second_) / 1'000'000'000;
+        LOG(INFO) << "queue_counters_after_test.max_periodic_queue_len: "
+                  << queue_counters_after_test.max_periodic_queue_len
+                  << " expected watermark: " << expected_watermark;
+        const int absolute_error =
+            queue_counters_after_test.max_periodic_queue_len -
+            expected_watermark;
+        const double relative_error_percent =
+            100. * absolute_error / expected_watermark;
+        constexpr double tolerance_percent = 15;  // +-15% tolerance.
+        if (std::abs(relative_error_percent) <= tolerance_percent) {
+          LOG(INFO) << "observed watermark matches expected watermark "
+                       "(error: "
+                    << relative_error_percent << "%)";
+          return absl::OkStatus();
+        }
+        return absl::InternalError(absl::Substitute(
+            "observed watermark of $0 is not within $1% of the queue $2 PIR of "
+            "$3 (error = $4%)",
+            queue_counters_after_test.max_periodic_queue_len, tolerance_percent,
+            queue, expected_watermark, relative_error_percent));
+      }));
+      delta_counters = queue_counters_after_test - queue_counters_before_test;
+      EXPECT_EQ(delta_counters.num_packets_dropped, 0);
+
+      // Wait for queue counters to stabilize and then stop main traffic.
+      ASSERT_OK(
+          ixia::StopTraffic(main_traffic_.traffic_item, *generic_testbed_));
+      LOG(INFO) << "-- stopped " << main_traffic_.traffic_name;
+    }
+  }
 }
 
 TEST_P(PfcTestWithIxia, PfcWatchdog) {

--- a/tests/qos/pfc_test.h
+++ b/tests/qos/pfc_test.h
@@ -67,6 +67,8 @@ struct ParamsForPfcTestsWithIxia {
   absl::Duration deadlock_restoration_time;
 };
 
+constexpr int kNumQueues = 8;
+
 class PfcTestWithIxia
     : public testing::TestWithParam<ParamsForPfcTestsWithIxia> {
  protected:

--- a/tests/qos/pfc_test.h
+++ b/tests/qos/pfc_test.h
@@ -83,6 +83,7 @@ class PfcTestWithIxia
   ixia::TrafficParameters main_traffic_parameters_;
   TrafficItem pfc_traffic_;
   ixia::TrafficParameters pfc_traffic_parameters_;
+  std::string kInitialPfcRxEnable;
 
   void SetUp() override;
 


### PR DESCRIPTION
**Keyword check Result:**
/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_check.sh ./lib/.
Keyword check Passed.

**Bazel Build Result:**
sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 733 targets (260 packages loaded, 22948 targets configured).
INFO: Found 733 targets...
INFO: Deleting stale sandbox base /var/jayaragini/.cache/bazel/_bazel_jayaragini/5fd88bad78ef03829a4685c83637a020/sandbox
INFO: From Compiling tests/sflow/sflow_test.cc:
In file included from tests/gnmi/counter_timestamp_test.cc:21:
./p4_pdpi/p4_runtime_session.h:392:14: note: declared here
  392 | absl::Status ClearTableEntries(P4RuntimeSession *session);
      |              ^~~~~~~~~~~~~~~~~
INFO: Elapsed time: 194.097s, Critical Path: 36.26s
INFO: 21 processes: 2 internal, 19 linux-sandbox.
INFO: Build completed successfully, 21 total actions


**Bazel Test Result:**
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 733 targets (0 packages loaded, 383 targets configured).
INFO: Found 506 targets and 227 test targets...
INFO: Elapsed time: 225.270s, Critical Path: 142.99s
INFO: 284 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 284 total actions
//dvaas:port_id_map_test                                                 PASSED in 0.8s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.7s
//tests/lib:packet_generator_test                                        PASSED in 64.8s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 41.8s
  Stats over 50 runs: max = 41.8s, min = 0.8s, avg = 4.9s, dev = 12.2s

Executed 227 out of 227 tests: 227 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeoutINFO: Build completed successfully, 284 total actions

