### PR TITLE
[P4_PDPI] Support IR <-> PD for Fallback groups.

### DIFF
--- a/p4_pdpi/ir.proto
+++ b/p4_pdpi/ir.proto
@@ -485,9 +485,15 @@ message IrPacketReplicationEngineEntry {
   }
 }
 
+message IrBackupReplica {
+  string port = 1;
+  uint32 instance = 2;
+}
+
 message IrReplica {
   string port = 1;
   uint32 instance = 2;
+  repeated IrBackupReplica backup_replicas = 3;
 }
 
 message IrMulticastGroupEntry {

--- a/p4_pdpi/p4_runtime_session_extras.cc
+++ b/p4_pdpi/p4_runtime_session_extras.cc
@@ -80,8 +80,13 @@ absl::Status InstallIrEntities(P4RuntimeSession& p4rt,
                                      "to pull P4Info from switch: ");
 
   // Convert entries to PI representation.
+  // TODO: Remove this option once we have a better way to handle
+  // unsupported fields.
+  // `allow_unsupported` is a workaround that allows BMv2 on DVaaS to install
+  // entities from the switch./
   ASSIGN_OR_RETURN(std::vector<p4::v1::Entity> pi_entities,
-                   IrEntitiesToPi(info, ir_entities));
+                   IrEntitiesToPi(info, ir_entities,
+                                  /*options=*/{.allow_unsupported = true}));
 
   // Install entries.
   return InstallPiEntities(&p4rt, info, pi_entities);
@@ -198,7 +203,12 @@ absl::StatusOr<IrEntities> ReadIrEntitiesSorted(P4RuntimeSession& p4rt) {
 
   ASSIGN_OR_RETURN(std::vector<p4::v1::Entity> entities,
                    ReadPiEntitiesSorted(p4rt));
-  return PiEntitiesToIr(info, entities);
+  // TODO: Remove this option once we have a better way to handle
+  // unsupported fields.
+  // `allow_unsupported` is a workaround that allows BMv2 on DVaaS to read
+  // entities from the switch.
+  return PiEntitiesToIr(info, entities,
+                        /*options=*/{.allow_unsupported = true});
 }
 
 absl::StatusOr<IrTableEntries> ReadIrTableEntriesSorted(

--- a/p4_pdpi/packetlib/BUILD.bazel
+++ b/p4_pdpi/packetlib/BUILD.bazel
@@ -86,6 +86,7 @@ cc_test(
         ":packetlib",
         ":packetlib_cc_proto",
         "//gutil:status_matchers",
+	"//gutil:testing",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
@@ -122,6 +123,21 @@ cc_test(
         "//gutil:testing",
         "@com_google_googletest//:gtest_main",
         "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_test(
+    name = "packetlib_debugging_test",
+    srcs = ["packetlib_debugging_test.cc"],
+    deps = [
+        ":packetlib",
+        ":packetlib_cc_proto",
+	"//gutil:status_matchers",
+        "//gutil:testing",
+        "//p4_pdpi/string_encodings:readable_byte_string",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/p4_pdpi/packetlib/packetlib.cc
+++ b/p4_pdpi/packetlib/packetlib.cc
@@ -138,6 +138,7 @@ absl::StatusOr<NextHeader> GetNextHeader(const UdpHeader& header) {
     return Header::kIpfixHeader;
   if (dest_port == 319)
     return Header::kPtpHeader;
+  if (dest_port == 320) return Header::kPtpHeader;
   if (dest_port == 1000) return Header::kPspHeader;
   return Header::HEADER_NOT_SET;
 }

--- a/p4_pdpi/packetlib/packetlib.cc
+++ b/p4_pdpi/packetlib/packetlib.cc
@@ -79,6 +79,7 @@ absl::StatusOr<NextHeader> GetNextHeaderForEtherType(
   if (ethertype == 0x86dd) return Header::kIpv6Header;
   if (ethertype == 0x0806) return Header::kArpHeader;
   if (ethertype == 0x8100) return Header::kVlanHeader;
+  if (ethertype == 0x88f7) return Header::kPtpHeader;
   if (ethertype == 0x9900) return Header::kCsigHeader;
   return UnsupportedNextHeader{
       .reason = absl::StrFormat("%s.ethertype %s: unsupported", header_name,

--- a/p4_pdpi/packetlib/packetlib.cc
+++ b/p4_pdpi/packetlib/packetlib.cc
@@ -1062,21 +1062,6 @@ void Ipv6HeaderInvalidReasons(const Ipv6Header& header,
   }
 }
 
-// The UDP checksum is allowed to be zero for tunneling packets:
-//   https://datatracker.ietf.org/doc/html/rfc6935.
-// IpFix should enable UDP checksums, but we make an exception here:
-//   https://datatracker.ietf.org/doc/html/rfc5153
-bool AllowZeroChecksumForUdp(Packet packet, int udp_header_index) {
-  if (udp_header_index + 1 >= packet.headers_size()) {
-    return false;
-  }
-
-  Header::HeaderCase next_header =
-      packet.headers(udp_header_index + 1).header_case();
-  return next_header == Header::kPspHeader ||
-         next_header == Header::kIpfixHeader;
-}
-
 void UdpHeaderInvalidReasons(const UdpHeader& header,
                              const std::string& field_prefix,
                              const Packet& packet, int header_index,
@@ -1108,42 +1093,23 @@ void UdpHeaderInvalidReasons(const UdpHeader& header,
     }
   }
   // Check computed field: checksum.
-  if (header_index <= 0) {
-    output.push_back(absl::StrCat(
-        field_prefix,
-        "checksum: UDP header must be preceded by IP header for checksum to be "
-        "defined; found no header instead"));
-  } else if (auto previous = packet.headers(header_index - 1).header_case();
-             previous != Header::kIpv4Header &&
-             previous != Header::kIpv6Header &&
-             previous != Header::kPspHeader) {
-    output.push_back(absl::StrCat(
-        field_prefix,
-        "checksum: UDP header must be preceded by IP header for checksum to be "
-        "defined; found ",
-        HeaderCaseName(previous), " at headers[", (header_index - 1),
-        "] instead"));
-  } else if (!checksum_invalid) {
-    if (auto checksum = UdpHeaderChecksum(packet, header_index);
+  if (!checksum_invalid) {
+    if (absl::StatusOr<std::optional<int>> checksum =
+            UdpHeaderChecksum(packet, header_index);
         !checksum.ok()) {
       output.push_back(absl::StrCat(
           field_prefix, "checksum: Couldn't compute expected checksum: ",
           checksum.status().ToString()));
-    } else if (packet.headers_size() > header_index + 1) {
-      if (header.checksum() != UdpChecksum(0) &&
-          AllowZeroChecksumForUdp(packet, header_index)) {
-        output.push_back(absl::StrCat(field_prefix,
-                                      "checksum: Must be 0, but was ",
-                                      header.checksum(), " instead."));
-      }
-    } else if (checksum->has_value()) {
-      if (std::string expected = pdpi::BitsetToHexString(
-              std::bitset<kUdpChecksumBitwidth>(checksum->value()));
-          header.checksum() != expected) {
-        output.push_back(absl::StrCat(field_prefix, "checksum: Must be ",
-                                      expected, ", but was ", header.checksum(),
-                                      " instead."));
-      }
+    } else if (header.checksum() == UdpChecksum(0) || !checksum->has_value()) {
+      // We always allow the UDP checksum to be zero. In certain cases we also
+      // allow the checksum to be anything (i.e. UdpHeaderChecksum returns
+      // nullopt).
+    } else if (std::string expected = pdpi::BitsetToHexString(
+                   std::bitset<kUdpChecksumBitwidth>(checksum->value()));
+               header.checksum() != expected) {
+      output.push_back(absl::StrCat(field_prefix, "checksum: Must be ",
+                                    expected, ", but was ", header.checksum(),
+                                    " instead."));
     }
   }
 }
@@ -2311,8 +2277,13 @@ absl::StatusOr<std::string> SerializePacket(
 absl::StatusOr<bool> UpdateComputedFields(Packet& packet, bool overwrite) {
   bool changes = false;
 
-  int header_index = 0;
-  for (Header& header : *packet.mutable_headers()) {
+  // When updating fields we start with the innermost header. This is important
+  // for things like checksum computations. For example, IPFIX headers are
+  // inside a UDP header and we would want to update IPFIX's length before
+  // updating UDP's checksum.
+  for (int header_index = packet.headers_size() - 1; header_index >= 0;
+       --header_index) {
+    Header& header = *packet.mutable_headers(header_index);
     std::string error_prefix =
         absl::StrFormat("%s: failed to compute packet.headers[%d].",
                         HeaderCaseName(header.header_case()), header_index);
@@ -2416,13 +2387,20 @@ absl::StatusOr<bool> UpdateComputedFields(Packet& packet, bool overwrite) {
           ASSIGN_OR_RETURN(std::optional<int> checksum,
                            UdpHeaderChecksum(packet, header_index),
                            _.SetPrepend() << error_prefix << "checksum: ");
+	  // If UdpHeaderChecksum returns a value then we will always use that
+          // expected value. If it did not return a value that means the
+          // checksum can be anything. So we take into consideration the current
+          // header:
+          //   * checksum was set then leave it as is.
+          //   * checksum is empty then assign it 0.
           if (checksum.has_value()) {
             udp_header.set_checksum(pdpi::BitsetToHexString(
                 std::bitset<kUdpChecksumBitwidth>(*checksum)));
-          } else {
+	      changes = true;
+          } else if (udp_header.checksum().empty()) {
             udp_header.set_checksum(UdpChecksum(0));
+            changes = true;
           }
-          changes = true;
         }
         break;
       }
@@ -2561,7 +2539,6 @@ absl::StatusOr<bool> UpdateComputedFields(Packet& packet, bool overwrite) {
                << "Invalid packet with HEADER_NOT_SET: "
                << packet.DebugString();
     }
-    header_index += 1;
   }
 
   return changes;
@@ -2765,25 +2742,25 @@ absl::StatusOr<int> Ipv4HeaderChecksum(Ipv4Header header) {
 
 absl::StatusOr<std::optional<int>> UdpHeaderChecksum(Packet packet,
                                                      int udp_header_index) {
-  auto invalid_argument = gutil::InvalidArgumentErrorBuilder()
-                          << "UdpHeaderChecksum(packet, udp_header_index = "
-                          << udp_header_index << "): ";
-  if (udp_header_index < 1 || udp_header_index >= packet.headers().size()) {
-    return invalid_argument
-           << "udp_header_index must be in [1, " << packet.headers().size()
-           << ") since the given packet has " << packet.headers().size()
-           << " headers and the UDP header must be preceded by an IP or PSP "
-           << "header";
+  if (udp_header_index < 1) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("UDP header must be preceded by an IP or PSP header, "
+                        "but no header was found"));
   }
-  if (AllowZeroChecksumForUdp(packet, udp_header_index)) {
-    return 0;
+  if (udp_header_index >= packet.headers().size()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("UDP header index %d is too large for the packet which "
+                        "only has %d header(s).",
+                        udp_header_index, packet.headers().size()));
   }
   const Header& preceding_header = packet.headers(udp_header_index - 1);
   if (auto header_case = packet.headers(udp_header_index).header_case();
       header_case != Header::kUdpHeader) {
-    return invalid_argument << "packet.headers[" << udp_header_index
-                            << "] is a " << HeaderCaseName(header_case)
-                            << ", expected UdpHeader";
+    return gutil::InvalidArgumentErrorBuilder()
+           << "UdpHeaderChecksum(packet, udp_header_index = "
+           << udp_header_index << "): packet.headers[" << udp_header_index
+           << "] is a " << HeaderCaseName(header_case)
+           << ", expected UdpHeader";
   }
   UdpHeader& udp_header =
       *packet.mutable_headers(udp_header_index)->mutable_udp_header();
@@ -2821,9 +2798,9 @@ absl::StatusOr<std::optional<int>> UdpHeaderChecksum(Packet packet,
       return std::nullopt;
     }
     default:
-      return invalid_argument << "expected packet.headers[udp_header_index - "
-                                 "1] to be an IP or PSP header, got "
-                              << HeaderCaseName(preceding_header.header_case());
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "UDP header must be preceded by an IP or PSP header, but got %s",
+          HeaderCaseName(preceding_header.header_case())));
   }
   RETURN_IF_ERROR(RawSerializePacket(packet, udp_header_index, data));
   return OnesComplementChecksum(std::move(data));

--- a/p4_pdpi/packetlib/packetlib.h
+++ b/p4_pdpi/packetlib/packetlib.h
@@ -14,9 +14,11 @@
 #ifndef PINS_P4_PDPI_PACKETLIB_PACKETLIB_H_
 #define PINS_P4_PDPI_PACKETLIB_PACKETLIB_H_
 
+#include <bitset>
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "absl/numeric/bits.h"
 #include "absl/status/statusor.h"
@@ -159,6 +161,16 @@ absl::StatusOr<int> IcmpHeaderChecksum(Packet packet, int icmp_header_index);
 absl::StatusOr<int> GreHeaderChecksum(Packet packet, int gre_header_index);
 
 std::string HeaderCaseName(Header::HeaderCase header_case);
+
+// Returns the Ethernet trailer of the given packet as a raw byte string. If
+// there is no Ethernet trailer, returns the empty string. The Ethernet trailer
+// is defined to be the suffix of the packet that is not upper protocol data,
+// where "upper protocols" means ARP, IPv4, or IPv6 (see e.g.
+// https://ask.wireshark.org/question/8809/what-is-the-trailer-in-the-ethernet-frame-and-why-is-the-fcs-incorrect/
+// for more details).Returns an error if the packet does not start with an
+// ethernet header or if there are no headers after the "lower protocol" headers
+// (Ethernet/VLAN/CSIG).
+absl::StatusOr<std::string> GetEthernetTrailer(const packetlib::Packet& packet);
 
 // Helper functions to translate the header fields to hex string. It abstracts
 // the bitwidth limitation away from the client and provides the validation that

--- a/p4_pdpi/packetlib/packetlib_debugging_test.cc
+++ b/p4_pdpi/packetlib/packetlib_debugging_test.cc
@@ -1,0 +1,110 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <string>
+
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status_matchers.h"
+#include "gutil/testing.h"
+#include "p4_pdpi/packetlib/packetlib.h"
+#include "p4_pdpi/packetlib/packetlib.pb.h"
+#include "p4_pdpi/string_encodings/readable_byte_string.h"
+
+// This file contains tests for manually debugging the packetlib library. If
+// you're adding a new test it should focus on general library behaviors:
+//   * Parsing a byte string
+//   * Update computable fields and validate the packet
+
+namespace packetlib {
+namespace {
+
+using ::testing::IsEmpty;
+
+class PacketlibParsingTest : public testing::Test {
+ public:
+  std::string ByteStringToTest() const {
+    auto byte_string =
+        pdpi::ReadableByteStringToByteString(readable_byte_string_);
+    CHECK_OK(byte_string.status());  // CRASH OK
+    return *byte_string;
+  }
+
+  const Header::HeaderCase first_header_ = Header::kEthernetHeader;
+  const std::string readable_byte_string_ = R"pb(
+    # ethernet header
+    ethernet_destination: 0xaabbccddeeff
+    ethernet_source: 0x112233445566
+    ether_type: 0x002e
+    # payload
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff
+    payload: 0x00 11 22 33 44 55 66 77 88 99 aa bb cc dd
+  )pb";
+};
+
+TEST_F(PacketlibParsingTest, CanParseThePacket) {
+  Packet result = ParsePacket(ByteStringToTest(), first_header_);
+  EXPECT_THAT(result.reason_not_fully_parsed(), IsEmpty());
+  EXPECT_THAT(result.reasons_invalid(), IsEmpty());
+}
+
+TEST_F(PacketlibParsingTest, CanUpdateAndParseThePacket) {
+  Packet packet = ParsePacket(ByteStringToTest(), first_header_);
+
+  ASSERT_OK(PadPacketToMinimumSize(packet));
+  ASSERT_OK(UpdateAllComputedFields(packet));
+  packet.clear_reason_not_fully_parsed();
+  packet.clear_reasons_invalid();
+
+  LOG(INFO) << "Updated packet: " << packet.ShortDebugString();
+  EXPECT_OK(ValidatePacket(packet));
+}
+
+class PacketlibProtoPacketTest : public testing::Test {
+ public:
+  Packet PacketToTest() const {
+    return gutil::ParseProtoOrDie<Packet>(packet_proto_string_);
+  }
+
+  const Header::HeaderCase first_header_ = Header::kEthernetHeader;
+  const std::string packet_proto_string_ = R"pb(
+    headers {
+      ethernet_header {
+        ethernet_destination: "aa:bb:cc:dd:ee:ff"
+        ethernet_source: "11:22:33:44:55:66"
+        ethertype: "0x000f"
+      }
+    }
+    payload: "random payload."
+  )pb";
+};
+
+TEST_F(PacketlibProtoPacketTest, IsAValidPacket) {
+  EXPECT_OK(ValidatePacket(PacketToTest()));
+}
+
+TEST_F(PacketlibProtoPacketTest, UpdatedPacketIsAValid) {
+  Packet packet = PacketToTest();
+  ASSERT_OK(PadPacketToMinimumSize(packet));
+  ASSERT_OK(UpdateAllComputedFields(packet));
+
+  
+  LOG(INFO) << "Updated packet: " << packet.ShortDebugString();
+  EXPECT_OK(ValidatePacket(packet));
+} 
+
+}  // namespace
+}  // namespace packetlib

--- a/p4_pdpi/packetlib/packetlib_test_runner.cc
+++ b/p4_pdpi/packetlib/packetlib_test_runner.cc
@@ -652,7 +652,57 @@ void RunPacketParseTests() {
     # other headers:
     payload: 0x12
   )pb");
-
+    RunPacketParseTest("PTP in L2 packet (valid)",
+                     R"pb(
+                       # Ethernet header.
+                       ethernet_destination: 0xffeeddccbbaa
+                       ethernet_source: 0x554433221100
+                       ethertype: 0x88F7
+                       # PTP Header
+                       transport_specific: 0x0
+                       message_type: 0x0
+                       reserved0: 0x0
+                       version_ptp: 0x0
+                       message_length: 0x0034
+                       domain_number: 0x00
+                       reserved1: 0x00
+                       flags: 0x0000
+                       correction_field: 0x0000000000000000
+                       reserved2: 0x00000000
+                       source_port_identity: 0x00000000000000000000
+                       sequence_id: 0x0000
+                       control_field: 0x00
+                       log_message_interval: 0x00
+                       # Payload - 18 octets
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22
+                     )pb");
+  RunPacketParseTest("PTP in L2 packet (short)",
+                     R"pb(
+                       # Ethernet header.
+                       ethernet_destination: 0xffeeddccbbaa
+                       ethernet_source: 0x554433221100
+                       ethertype: 0x88F7
+                       # PTP Header
+                       transport_specific: 0x0
+                       message_type: 0x0
+                       reserved0: 0x0
+                       version_ptp: 0x0
+                       message_length: 0x0034
+                       domain_number: 0x00
+                       reserved1: 0x00
+                       flags: 0x0000
+                       correction_field: 0x0000000000000000
+                       reserved2: 0x00000000
+                       source_port_identity: 0x00000000000000000000
+                       sequence_id: 0x0000
+                       control_field: 0x00
+                       log_message_interval: 0x00
+                       # Payload - 10 octets (short) - correct is 18
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22
+                     )pb");
   RunPacketParseTest("Packet too short to parse a GRE header (Invalid)", R"pb(
     # Ethernet header
     ethernet_destination: 0x c2 01 51 fa 00 00
@@ -2378,6 +2428,100 @@ void RunProtoPacketTests() {
                                 }
                               }
                               payload: "ABCDABCDABCDABCDABCD"  # 20 octets
+                         )pb"));
+  RunProtoPacketTest("PTP in L2 packet (valid)",
+                     gutil::ParseProtoOrDie<Packet>(
+                         R"pb(headers {
+                                ethernet_header {
+                                  ethernet_destination: "00:ee:dd:cc:bb:aa"
+                                  ethernet_source: "00:44:33:22:11:00"
+                                  ethertype: "0x88f7"
+                                }
+                              }
+                              headers {
+                                ptp_header {
+                                  transport_specific: "0x0"
+                                  message_type: "0x0"
+                                  reserved0: "0x0"
+                                  version_ptp: "0x0"
+                                  message_length: "0x0036"
+                                  domain_number: "0x00"
+                                  reserved1: "0x00"
+                                  flags: "0x0000"
+                                  correction_field: "0x0000000000000000"
+                                  reserved2: "0x00000000"
+                                  source_port_identity: "0x00000000000000000000"
+                                  sequence_id: "0x0000"
+                                  control_field: "0x00"
+                                  log_message_interval: "0x00"
+                                }
+                              }
+                              payload: "ABCDABCDABCDABCDABCD"  # 20 octets
+                         )pb"));
+  RunProtoPacketTest("PTP in L2 packet without payload (invalid)",
+                     gutil::ParseProtoOrDie<Packet>(
+                         R"pb(headers {
+                                ethernet_header {
+                                  ethernet_destination: "00:ee:dd:cc:bb:aa"
+                                  ethernet_source: "00:44:33:22:11:00"
+                                  ethertype: "0x88f7"
+                                }
+                              }
+                              payload: "123456789012345678901234567890"
+                                       "12345678901234"
+                         )pb"));
+  RunProtoPacketTest("PTP in L2 packet incorrect L3 header (invalid)",
+                     gutil::ParseProtoOrDie<Packet>(
+                         R"pb(headers {
+                                ethernet_header {
+                                  ethernet_destination: "00:ee:dd:cc:bb:aa"
+                                  ethernet_source: "00:44:33:22:11:00"
+                                  ethertype: "0x88f7"
+                                }
+                              }
+                              headers {
+                                arp_header {
+                                  hardware_type: "0x0001"
+                                  protocol_type: "0x0800"
+                                  hardware_length: "0x06"
+                                  protocol_length: "0x04"
+                                  operation: "0x0001"
+                                  sender_hardware_address: "00:11:22:33:44:55"
+                                  sender_protocol_address: "10.0.0.1"
+                                  target_hardware_address: "00:00:00:00:00:00"
+                                  target_protocol_address: "10.0.0.2"
+                                }
+                              }
+                              payload: "12345678901234567890123456789012345678"
+                         )pb"));
+  RunProtoPacketTest("PTP in L2 packet message_length incorrect (invalid)",
+                     gutil::ParseProtoOrDie<Packet>(
+                         R"pb(headers {
+                                ethernet_header {
+                                  ethernet_destination: "00:ee:dd:cc:bb:aa"
+                                  ethernet_source: "00:44:33:22:11:00"
+                                  ethertype: "0x88f7"
+                                }
+                              }
+                              headers {
+                                ptp_header {
+                                  transport_specific: "0x0"
+                                  message_type: "0x0"
+                                  reserved0: "0x0"
+                                  version_ptp: "0x0"
+                                  message_length: "0x0036"
+                                  domain_number: "0x00"
+                                  reserved1: "0x00"
+                                  flags: "0x0000"
+                                  correction_field: "0x0000000000000000"
+                                  reserved2: "0x00000000"
+                                  source_port_identity: "0x00000000000000000000"
+                                  sequence_id: "0x0000"
+                                  control_field: "0x00"
+                                  log_message_interval: "0x00"
+                                }
+                              }
+                              payload: "123456789012"  # 12 octets
                          )pb"));
   RunProtoPacketTest("PTP packet does not set message_length (valid)",
                      gutil::ParseProtoOrDie<Packet>(

--- a/p4_pdpi/packetlib/packetlib_test_runner.cc
+++ b/p4_pdpi/packetlib/packetlib_test_runner.cc
@@ -1093,7 +1093,7 @@ void RunPacketParseTests() {
         payload: 0x 22 22 22 22 22 22 22 22
         payload: 0x 22 22
       )pb");
-  RunPacketParseTest("PTP packet (valid)",
+  RunPacketParseTest("PTP event packet (valid)",
                      R"pb(
                        # Ethernet header.
                        ethernet_destination: 0xffeeddccbbaa
@@ -1112,6 +1112,47 @@ void RunPacketParseTests() {
                        # UDP Header
                        source_port: 0x08ae       # 2222
                        destination_port: 0x013f  # 319
+                       length: 0x003c
+                       checksum: 0x0000
+                       # PTP Header
+                       transport_specific: 0x0
+                       message_type: 0x0
+                       reserved0: 0x0
+                       version_ptp: 0x0
+                       message_length: 0x0034
+                       domain_number: 0x00
+                       reserved1: 0x00
+                       flags: 0x0000
+                       correction_field: 0x0000000000000000
+                       reserved2: 0x00000000
+                       source_port_identity: 0x00000000000000000000
+                       sequence_id: 0x0000
+                       control_field: 0x00
+                       log_message_interval: 0x00
+                       # Payload - 18 octets
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22
+                     )pb");
+  RunPacketParseTest("PTP general packet (valid)",
+                     R"pb(
+                       # Ethernet header.
+                       ethernet_destination: 0xffeeddccbbaa
+                       ethernet_source: 0x554433221100
+                       ethertype: 0x86DD
+                       # IPv6 header.
+                       version: 0x6
+                       dscp: 0b000000
+                       ecn: 0b00
+                       flow_label: 0x12345
+                       payload_length: 0x003c
+                       next_header: 0x11  # UDP
+                       hop_limit: 0x42
+                       ipv6_source: 0x00001111222233334444555566667777
+                       ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+                       # UDP Header
+                       source_port: 0x08ae       # 2222
+                       destination_port: 0x0140  # 320
                        length: 0x003c
                        checksum: 0x0000
                        # PTP Header
@@ -2264,6 +2305,56 @@ void RunProtoPacketTests() {
                                 udp_header {
                                   source_port: "0x08ae"       # 2222
                                   destination_port: "0x013f"  # 319
+                                  length: "0x003e"
+                                  checksum: "0x0000"
+                                }
+                              }
+                              headers {
+                                ptp_header {
+                                  transport_specific: "0x0"
+                                  message_type: "0x0"
+                                  reserved0: "0x0"
+                                  version_ptp: "0x0"
+                                  message_length: "0x0036"
+                                  domain_number: "0x00"
+                                  reserved1: "0x00"
+                                  flags: "0x0000"
+                                  correction_field: "0x0000000000000000"
+                                  reserved2: "0x00000000"
+                                  source_port_identity: "0x00000000000000000000"
+                                  sequence_id: "0x0000"
+                                  control_field: "0x00"
+                                  log_message_interval: "0x00"
+                                }
+                              }
+                              payload: "ABCDABCDABCDABCDABCD"  # 20 octets
+                         )pb"));
+  RunProtoPacketTest("PTP packet with UDP port 320 (valid)",
+                     gutil::ParseProtoOrDie<Packet>(
+                         R"pb(headers {
+                                ethernet_header {
+                                  ethernet_destination: "00:ee:dd:cc:bb:aa"
+                                  ethernet_source: "00:44:33:22:11:00"
+                                  ethertype: "0x86dd"
+                                }
+                              }
+                              headers {
+                                ipv6_header {
+                                  version: "0x6"
+                                  dscp: "0x00"
+                                  ecn: "0x0"
+                                  flow_label: "0x12345"
+                                  payload_length: "0x003e"
+                                  next_header: "0x11"  # UDP
+                                  hop_limit: "0x42"
+                                  ipv6_source: "2607:f8b0:11::"
+                                  ipv6_destination: "2607:f8b0:12::"
+                                }
+                              }
+                              headers {
+                                udp_header {
+                                  source_port: "0x08ae"       # 2222
+                                  destination_port: "0x0140"  # 320
                                   length: "0x003e"
                                   checksum: "0x0000"
                                 }

--- a/p4_pdpi/packetlib/packetlib_test_runner.expected
+++ b/p4_pdpi/packetlib/packetlib_test_runner.expected
@@ -1072,6 +1072,120 @@ UpdateAllComputedFields(packet) = false
 ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
 - headers[1]: header missing - expected CsigHeader
 ================================================================================
+Parsing test: PTP in L2 packet (valid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+# Ethernet header.
+                       ethernet_destination: 0xffeeddccbbaa
+                       ethernet_source: 0x554433221100
+                       ethertype: 0x88F7
+                       # PTP Header
+                       transport_specific: 0x0
+                       message_type: 0x0
+                       reserved0: 0x0
+                       version_ptp: 0x0
+                       message_length: 0x0034
+                       domain_number: 0x00
+                       reserved1: 0x00
+                       flags: 0x0000
+                       correction_field: 0x0000000000000000
+                       reserved2: 0x00000000
+                       source_port_identity: 0x00000000000000000000
+                       sequence_id: 0x0000
+                       control_field: 0x00
+                       log_message_interval: 0x00
+                       # Payload - 18 octets
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22
+-- OUTPUT ----------------------------------------------------------------------
+headers {
+  ethernet_header {
+    ethernet_destination: "ff:ee:dd:cc:bb:aa"
+    ethernet_source: "55:44:33:22:11:00"
+    ethertype: "0x88f7"
+  }
+}
+headers {
+  ptp_header {
+    transport_specific: "0x0"
+    message_type: "0x0"
+    reserved0: "0x0"
+    version_ptp: "0x0"
+    message_length: "0x0034"
+    domain_number: "0x00"
+    reserved1: "0x00"
+    flags: "0x0000"
+    correction_field: "0x0000000000000000"
+    reserved2: "0x00000000"
+    source_port_identity: "0x00000000000000000000"
+    sequence_id: "0x0000"
+    control_field: "0x00"
+    log_message_interval: "0x00"
+  }
+}
+payload: "\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\""
+
+================================================================================
+Parsing test: PTP in L2 packet (short)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+# Ethernet header.
+                       ethernet_destination: 0xffeeddccbbaa
+                       ethernet_source: 0x554433221100
+                       ethertype: 0x88F7
+                       # PTP Header
+                       transport_specific: 0x0
+                       message_type: 0x0
+                       reserved0: 0x0
+                       version_ptp: 0x0
+                       message_length: 0x0034
+                       domain_number: 0x00
+                       reserved1: 0x00
+                       flags: 0x0000
+                       correction_field: 0x0000000000000000
+                       reserved2: 0x00000000
+                       source_port_identity: 0x00000000000000000000
+                       sequence_id: 0x0000
+                       control_field: 0x00
+                       log_message_interval: 0x00
+                       # Payload - 10 octets (short) - correct is 18
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22
+-- OUTPUT ----------------------------------------------------------------------
+headers {
+  ethernet_header {
+    ethernet_destination: "ff:ee:dd:cc:bb:aa"
+    ethernet_source: "55:44:33:22:11:00"
+    ethertype: "0x88f7"
+  }
+}
+headers {
+  ptp_header {
+    transport_specific: "0x0"
+    message_type: "0x0"
+    reserved0: "0x0"
+    version_ptp: "0x0"
+    message_length: "0x0034"
+    domain_number: "0x00"
+    reserved1: "0x00"
+    flags: "0x0000"
+    correction_field: "0x0000000000000000"
+    reserved2: "0x00000000"
+    source_port_identity: "0x00000000000000000000"
+    sequence_id: "0x0000"
+    control_field: "0x00"
+    log_message_interval: "0x00"
+  }
+}
+payload: "\"\"\"\"\"\"\"\"\"\""
+reasons_invalid: "in EthernetHeader headers[0]: expected at least 46 bytes of Ethernet payload, but got only 44"
+reasons_invalid: "in PtpHeader headers[1]: message_length: Must be 0x002c, but was 0x0034 instead."
+
+PadPacketToMinimumSize(packet) = true
+UpdateAllComputedFields(packet) = true
+ValidatePacket(packet) = OK
+================================================================================
 Parsing test: Packet too short to parse a GRE header (Invalid)
 ================================================================================
 -- INPUT -----------------------------------------------------------------------
@@ -4675,6 +4789,151 @@ payload: "ABCDABCDABCDABCDABCD"
 ValidatePacket(packet) = OK
 
 Serialize(Packet) = OK
+
+================================================================================
+Proto packet test: PTP in L2 packet (valid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+packet =
+headers {
+  ethernet_header {
+    ethernet_destination: "00:ee:dd:cc:bb:aa"
+    ethernet_source: "00:44:33:22:11:00"
+    ethertype: "0x88f7"
+  }
+}
+headers {
+  ptp_header {
+    transport_specific: "0x0"
+    message_type: "0x0"
+    reserved0: "0x0"
+    version_ptp: "0x0"
+    message_length: "0x0036"
+    domain_number: "0x00"
+    reserved1: "0x00"
+    flags: "0x0000"
+    correction_field: "0x0000000000000000"
+    reserved2: "0x00000000"
+    source_port_identity: "0x00000000000000000000"
+    sequence_id: "0x0000"
+    control_field: "0x00"
+    log_message_interval: "0x00"
+  }
+}
+payload: "ABCDABCDABCDABCDABCD"
+
+-- OUTPUT ----------------------------------------------------------------------
+ValidatePacket(packet) = OK
+
+Serialize(Packet) = OK
+
+================================================================================
+Proto packet test: PTP in L2 packet without payload (invalid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+packet =
+headers {
+  ethernet_header {
+    ethernet_destination: "00:ee:dd:cc:bb:aa"
+    ethernet_source: "00:44:33:22:11:00"
+    ethertype: "0x88f7"
+  }
+}
+payload: "12345678901234567890123456789012345678901234"
+
+-- OUTPUT ----------------------------------------------------------------------
+ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in EthernetHeader headers[0]: expected at least 46 bytes of Ethernet payload, but got only 44
+- headers[1]: header missing - expected PtpHeader
+
+PadPacketToMinimumSize(packet) = true
+new payload: "12345678901234567890123456789012345678901234\000\000"
+
+UpdateMissingComputedFields(packet) = false
+
+Serialize(Packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- headers[1]: header missing - expected PtpHeader
+
+================================================================================
+Proto packet test: PTP in L2 packet incorrect L3 header (invalid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+packet =
+headers {
+  ethernet_header {
+    ethernet_destination: "00:ee:dd:cc:bb:aa"
+    ethernet_source: "00:44:33:22:11:00"
+    ethertype: "0x88f7"
+  }
+}
+headers {
+  arp_header {
+    hardware_type: "0x0001"
+    protocol_type: "0x0800"
+    hardware_length: "0x06"
+    protocol_length: "0x04"
+    operation: "0x0001"
+    sender_hardware_address: "00:11:22:33:44:55"
+    sender_protocol_address: "10.0.0.1"
+    target_hardware_address: "00:00:00:00:00:00"
+    target_protocol_address: "10.0.0.2"
+  }
+}
+payload: "12345678901234567890123456789012345678"
+
+-- OUTPUT ----------------------------------------------------------------------
+ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in ArpHeader headers[1]: expected PtpHeader (because the previous header demands it), got ArpHeader
+
+PadPacketToMinimumSize(packet) = false
+
+UpdateMissingComputedFields(packet) = false
+
+Serialize(Packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in ArpHeader headers[1]: expected PtpHeader (because the previous header demands it), got ArpHeader
+
+================================================================================
+Proto packet test: PTP in L2 packet message_length incorrect (invalid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+packet =
+headers {
+  ethernet_header {
+    ethernet_destination: "00:ee:dd:cc:bb:aa"
+    ethernet_source: "00:44:33:22:11:00"
+    ethertype: "0x88f7"
+  }
+}
+headers {
+  ptp_header {
+    transport_specific: "0x0"
+    message_type: "0x0"
+    reserved0: "0x0"
+    version_ptp: "0x0"
+    message_length: "0x0036"
+    domain_number: "0x00"
+    reserved1: "0x00"
+    flags: "0x0000"
+    correction_field: "0x0000000000000000"
+    reserved2: "0x00000000"
+    source_port_identity: "0x00000000000000000000"
+    sequence_id: "0x0000"
+    control_field: "0x00"
+    log_message_interval: "0x00"
+  }
+}
+payload: "123456789012"
+
+-- OUTPUT ----------------------------------------------------------------------
+ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in PtpHeader headers[1]: message_length: Must be 0x002e, but was 0x0036 instead.
+
+PadPacketToMinimumSize(packet) = false
+
+UpdateMissingComputedFields(packet) = false
+
+Serialize(Packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in PtpHeader headers[1]: message_length: Must be 0x002e, but was 0x0036 instead.
 
 ================================================================================
 Proto packet test: PTP packet does not set message_length (valid)

--- a/p4_pdpi/packetlib/packetlib_test_runner.expected
+++ b/p4_pdpi/packetlib/packetlib_test_runner.expected
@@ -2041,7 +2041,7 @@ headers {
 payload: "\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\""
 reasons_invalid: "in Ipv6Header headers[1]: payload_length: Must be 0x0046, but was 0x0000 instead."
 reasons_invalid: "in UdpHeader headers[2]: length: Must be 0x0046, but was 0x0000 instead."
-reasons_invalid: "in UdpHeader headers[2]: checksum: Must be 0, but was 0x0012 instead."
+reasons_invalid: "in UdpHeader headers[2]: checksum: Must be 0xbb79, but was 0x0012 instead."
 reasons_invalid: "in IpfixHeader headers[3]: length: Must be 0x003e, but was 0x0000 instead."
 reasons_invalid: "in PsampHeader headers[4]: length: Must be 0x002e, but was 0x0000 instead."
 reasons_invalid: "in PsampHeader headers[4]: packet_sampled_length: Must be 0x0012, but was 0x0013 instead."
@@ -2214,6 +2214,304 @@ PadPacketToMinimumSize(packet) = false
 UpdateAllComputedFields(packet) = true
 ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
 - headers[3]: header missing - expected PtpHeader
+================================================================================
+Parsing test: Inner and outer UDP checksums can both be zero (valid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+# Ethernet header
+                       ethernet_destination: 0xaabbccddeeff
+                       ethernet_source: 0x112233445566
+                       ethertype: 0x86DD
+                       # IPv6 header.
+                       version: 0x6
+                       dscp: 0b000000
+                       ecn: 0b00
+                       flow_label: 0x12345
+                       payload_length: 0x0032
+                       next_header: 0x11  # UDP
+                       hop_limit: 0x42
+                       ipv6_source: 0x00001111222233334444555566667777
+                       ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+                       # UDP header
+                       source_port: 0x0014
+                       destination_port: 0x03e8  # 1000
+                       length: 0x0032
+                       checksum: 0x0000
+                       # PSP Header
+                       next_header: 0x11  # UDP
+                       header_ext_length: 0x00
+                       reserved0: 0b00
+                       crypt_offset: 0b000010
+                       sample_bit: 0b0
+                       drop_bit: 0b0
+                       version: 0x1
+                       virtualization_cookie_present: 0b0
+                       reserved1: 0b1
+                       security_parameters_index: 0x00000000
+                       initialization_vector: 0x0000000000000000
+                       # Inner UDP Header
+                       source_port: 0xbeef
+                       destination_port: 0xabcd
+                       length: 0x001a
+                       checksum: 0x0000
+                       # Payload - 18 octets
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22
+-- OUTPUT ----------------------------------------------------------------------
+headers {
+  ethernet_header {
+    ethernet_destination: "aa:bb:cc:dd:ee:ff"
+    ethernet_source: "11:22:33:44:55:66"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x0032"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "0:1111:2222:3333:4444:5555:6666:7777"
+    ipv6_destination: "8888:9999:aaaa:bbbb:cccc:dddd:eeee:ffff"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x0014"
+    destination_port: "0x03e8"
+    length: "0x0032"
+    checksum: "0x0000"
+  }
+}
+headers {
+  psp_header {
+    next_header: "0x11"
+    header_ext_length: "0x00"
+    reserved0: "0x0"
+    crypt_offset: "0x02"
+    sample_bit: "0x0"
+    drop_bit: "0x0"
+    version: "0x1"
+    virtualization_cookie_present: "0x0"
+    reserved1: "0x1"
+    security_parameters_index: "0x00000000"
+    initialization_vector: "0x0000000000000000"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0xbeef"
+    destination_port: "0xabcd"
+    length: "0x001a"
+    checksum: "0x0000"
+  }
+}
+payload: "\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\""
+
+================================================================================
+Parsing test: Inner UDP checksum can be anything, but the outer checksum must be correct (valid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+# Ethernet header
+        ethernet_destination: 0xaabbccddeeff
+        ethernet_source: 0x112233445566
+        ethertype: 0x86DD
+        # IPv6 header.
+        version: 0x6
+        dscp: 0b000000
+        ecn: 0b00
+        flow_label: 0x12345
+        payload_length: 0x0032
+        next_header: 0x11  # UDP
+        hop_limit: 0x42
+        ipv6_source: 0x00001111222233334444555566667777
+        ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+        # UDP header
+        source_port: 0x0014
+        destination_port: 0x03e8  # 1000
+        length: 0x0032
+        checksum: 0x4a7d
+        # PSP Header
+        next_header: 0x11  # UDP
+        header_ext_length: 0x00
+        reserved0: 0b00
+        crypt_offset: 0b000010
+        sample_bit: 0b0
+        drop_bit: 0b0
+        version: 0x1
+        virtualization_cookie_present: 0b0
+        reserved1: 0b1
+        security_parameters_index: 0x00000000
+        initialization_vector: 0x0000000000000000
+        # Inner UDP Header
+        source_port: 0xbeef
+        destination_port: 0xabcd
+        length: 0x001a
+        checksum: 0x0002
+        # Payload - 18 octets
+        payload: 0x 22 22 22 22 22 22 22 22
+        payload: 0x 22 22 22 22 22 22 22 22
+        payload: 0x 22 22
+-- OUTPUT ----------------------------------------------------------------------
+headers {
+  ethernet_header {
+    ethernet_destination: "aa:bb:cc:dd:ee:ff"
+    ethernet_source: "11:22:33:44:55:66"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x0032"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "0:1111:2222:3333:4444:5555:6666:7777"
+    ipv6_destination: "8888:9999:aaaa:bbbb:cccc:dddd:eeee:ffff"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x0014"
+    destination_port: "0x03e8"
+    length: "0x0032"
+    checksum: "0x4a7d"
+  }
+}
+headers {
+  psp_header {
+    next_header: "0x11"
+    header_ext_length: "0x00"
+    reserved0: "0x0"
+    crypt_offset: "0x02"
+    sample_bit: "0x0"
+    drop_bit: "0x0"
+    version: "0x1"
+    virtualization_cookie_present: "0x0"
+    reserved1: "0x1"
+    security_parameters_index: "0x00000000"
+    initialization_vector: "0x0000000000000000"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0xbeef"
+    destination_port: "0xabcd"
+    length: "0x001a"
+    checksum: "0x0002"
+  }
+}
+payload: "\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\""
+
+================================================================================
+Parsing test: Inner UDP checksum can be anything, but the outer checksum must be correct (invalid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+# Ethernet header
+        ethernet_destination: 0xaabbccddeeff
+        ethernet_source: 0x112233445566
+        ethertype: 0x86DD
+        # IPv6 header.
+        version: 0x6
+        dscp: 0b000000
+        ecn: 0b00
+        flow_label: 0x12345
+        payload_length: 0x0032
+        next_header: 0x11  # UDP
+        hop_limit: 0x42
+        ipv6_source: 0x00001111222233334444555566667777
+        ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+        # UDP header
+        source_port: 0x0014
+        destination_port: 0x03e8  # 1000
+        length: 0x0032
+        checksum: 0x0001
+        # PSP Header
+        next_header: 0x11  # UDP
+        header_ext_length: 0x00
+        reserved0: 0b00
+        crypt_offset: 0b000010
+        sample_bit: 0b0
+        drop_bit: 0b0
+        version: 0x1
+        virtualization_cookie_present: 0b0
+        reserved1: 0b1
+        security_parameters_index: 0x00000000
+        initialization_vector: 0x0000000000000000
+        # Inner UDP Header
+        source_port: 0xbeef
+        destination_port: 0xabcd
+        length: 0x001a
+        checksum: 0x0001
+        # Payload - 18 octets
+        payload: 0x 22 22 22 22 22 22 22 22
+        payload: 0x 22 22 22 22 22 22 22 22
+        payload: 0x 22 22
+-- OUTPUT ----------------------------------------------------------------------
+headers {
+  ethernet_header {
+    ethernet_destination: "aa:bb:cc:dd:ee:ff"
+    ethernet_source: "11:22:33:44:55:66"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x0032"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "0:1111:2222:3333:4444:5555:6666:7777"
+    ipv6_destination: "8888:9999:aaaa:bbbb:cccc:dddd:eeee:ffff"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x0014"
+    destination_port: "0x03e8"
+    length: "0x0032"
+    checksum: "0x0001"
+  }
+}
+headers {
+  psp_header {
+    next_header: "0x11"
+    header_ext_length: "0x00"
+    reserved0: "0x0"
+    crypt_offset: "0x02"
+    sample_bit: "0x0"
+    drop_bit: "0x0"
+    version: "0x1"
+    virtualization_cookie_present: "0x0"
+    reserved1: "0x1"
+    security_parameters_index: "0x00000000"
+    initialization_vector: "0x0000000000000000"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0xbeef"
+    destination_port: "0xabcd"
+    length: "0x001a"
+    checksum: "0x0001"
+  }
+}
+payload: "\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\""
+reasons_invalid: "in UdpHeader headers[2]: checksum: Must be 0x4a7e, but was 0x0001 instead."
+
+PadPacketToMinimumSize(packet) = false
+UpdateAllComputedFields(packet) = true
+ValidatePacket(packet) = OK
 ================================================================================
 Parsing test: PSP packet unencrypted UDP (valid)
 ================================================================================
@@ -2548,7 +2846,6 @@ headers {
 }
 payload: "\021\000\000\005\000\000\000\000"
 reasons_invalid: "Packet is too short to parse a PSP header next. Only 64 bits left, need at least 128."
-reasons_invalid: "in UdpHeader headers[2]: checksum: Must be 0xeacd, but was 0x0000 instead."
 reasons_invalid: "headers[3]: header missing - expected PspHeader"
 
 PadPacketToMinimumSize(packet) = false
@@ -2572,14 +2869,14 @@ payload: "Hi"
 
 -- OUTPUT ----------------------------------------------------------------------
 ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
-- in UdpHeader headers[0]: checksum: UDP header must be preceded by IP header for checksum to be defined; found no header instead
+- in UdpHeader headers[0]: checksum: Couldn't compute expected checksum: INVALID_ARGUMENT: UDP header must be preceded by an IP or PSP header, but no header was found
 
 PadPacketToMinimumSize(packet) = false
 
 UpdateMissingComputedFields(packet) = false
 
 Serialize(Packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
-- in UdpHeader headers[0]: checksum: UDP header must be preceded by IP header for checksum to be defined; found no header instead
+- in UdpHeader headers[0]: checksum: Couldn't compute expected checksum: INVALID_ARGUMENT: UDP header must be preceded by an IP or PSP header, but no header was found
 
 ================================================================================
 Proto packet test: UDP header not preceded by IP header
@@ -2605,7 +2902,7 @@ payload: "Hi"
 
 -- OUTPUT ----------------------------------------------------------------------
 ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
-- in UdpHeader headers[1]: checksum: UDP header must be preceded by IP header for checksum to be defined; found EthernetHeader at headers[0] instead
+- in UdpHeader headers[1]: checksum: Couldn't compute expected checksum: INVALID_ARGUMENT: UDP header must be preceded by an IP or PSP header, but got EthernetHeader
 - in UdpHeader headers[1]: expected no header (because the previous header demands either no header or an unsupported header), got UdpHeader
 
 PadPacketToMinimumSize(packet) = true
@@ -2616,7 +2913,7 @@ UpdateMissingComputedFields(packet) = false
 Serialize(Packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
 - in EthernetHeader headers[0]: ethertype: value 0x000a is <= 1500 and should thus match payload size, but payload size is 46 bytes
 - in UdpHeader headers[1]: length: Must be 0x002e, but was 0x000a instead.
-- in UdpHeader headers[1]: checksum: UDP header must be preceded by IP header for checksum to be defined; found EthernetHeader at headers[0] instead
+- in UdpHeader headers[1]: checksum: Couldn't compute expected checksum: INVALID_ARGUMENT: UDP header must be preceded by an IP or PSP header, but got EthernetHeader
 - in UdpHeader headers[1]: expected no header (because the previous header demands either no header or an unsupported header), got UdpHeader
 
 ================================================================================
@@ -4163,14 +4460,14 @@ payload: "AAAAAAAAAAAAAAAAAA"
 
 -- OUTPUT ----------------------------------------------------------------------
 ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
-- in UdpHeader headers[2]: checksum: Must be 0, but was 0x0011 instead.
+- in UdpHeader headers[2]: checksum: Must be 0x28a1, but was 0x0011 instead.
 
 PadPacketToMinimumSize(packet) = false
 
 UpdateMissingComputedFields(packet) = false
 
 Serialize(Packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
-- in UdpHeader headers[2]: checksum: Must be 0, but was 0x0011 instead.
+- in UdpHeader headers[2]: checksum: Must be 0x28a1, but was 0x0011 instead.
 
 ================================================================================
 Proto packet test: PTP packet with UDP port 319 (valid)
@@ -4603,7 +4900,7 @@ ValidatePacket(packet) = OK
 Serialize(Packet) = OK
 
 ================================================================================
-Proto packet test: PSP packet with inner UDP checksum empty (valid)
+Proto packet test: PSP packet with empty computed fields (valid except for computed fields)
 ================================================================================
 -- INPUT -----------------------------------------------------------------------
 packet =
@@ -4620,7 +4917,6 @@ headers {
     dscp: "0x00"
     ecn: "0x0"
     flow_label: "0x12345"
-    payload_length: "0x0034"
     next_header: "0x11"
     hop_limit: "0x42"
     ipv6_source: "2607:f8b0:11::"
@@ -4631,8 +4927,6 @@ headers {
   udp_header {
     source_port: "0x08ae"
     destination_port: "0x03e8"
-    length: "0x0034"
-    checksum: "0x0000"
   }
 }
 headers {
@@ -4654,13 +4948,16 @@ headers {
   udp_header {
     source_port: "0xbeef"
     destination_port: "0xabcd"
-    length: "0x001c"
   }
 }
 payload: "ABCDABCDABCDABCDABCD"
 
 -- OUTPUT ----------------------------------------------------------------------
 ValidatePacket(packet) = INVALID_ARGUMENT: Packet invalid for the following reasons:
+- in Ipv6Header headers[1]: payload_length: missing
+- in UdpHeader headers[2]: length: missing
+- in UdpHeader headers[2]: checksum: missing
+- in UdpHeader headers[4]: length: missing
 - in UdpHeader headers[4]: checksum: missing
 
 PadPacketToMinimumSize(packet) = false
@@ -4692,7 +4989,7 @@ headers {
     source_port: "0x08ae"
     destination_port: "0x03e8"
     length: "0x0034"
-    checksum: "0x0000"
+    checksum: "0xa0de"
   }
 }
 headers {

--- a/p4_pdpi/packetlib/packetlib_test_runner.expected
+++ b/p4_pdpi/packetlib/packetlib_test_runner.expected
@@ -2050,7 +2050,7 @@ PadPacketToMinimumSize(packet) = false
 UpdateAllComputedFields(packet) = true
 ValidatePacket(packet) = OK
 ================================================================================
-Parsing test: PTP packet (valid)
+Parsing test: PTP event packet (valid)
 ================================================================================
 -- INPUT -----------------------------------------------------------------------
 # Ethernet header.
@@ -2116,6 +2116,97 @@ headers {
   udp_header {
     source_port: "0x08ae"
     destination_port: "0x013f"
+    length: "0x003c"
+    checksum: "0x0000"
+  }
+}
+headers {
+  ptp_header {
+    transport_specific: "0x0"
+    message_type: "0x0"
+    reserved0: "0x0"
+    version_ptp: "0x0"
+    message_length: "0x0034"
+    domain_number: "0x00"
+    reserved1: "0x00"
+    flags: "0x0000"
+    correction_field: "0x0000000000000000"
+    reserved2: "0x00000000"
+    source_port_identity: "0x00000000000000000000"
+    sequence_id: "0x0000"
+    control_field: "0x00"
+    log_message_interval: "0x00"
+  }
+}
+payload: "\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\""
+
+================================================================================
+Parsing test: PTP general packet (valid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+# Ethernet header.
+                       ethernet_destination: 0xffeeddccbbaa
+                       ethernet_source: 0x554433221100
+                       ethertype: 0x86DD
+                       # IPv6 header.
+                       version: 0x6
+                       dscp: 0b000000
+                       ecn: 0b00
+                       flow_label: 0x12345
+                       payload_length: 0x003c
+                       next_header: 0x11  # UDP
+                       hop_limit: 0x42
+                       ipv6_source: 0x00001111222233334444555566667777
+                       ipv6_destination: 0x88889999aaaabbbbccccddddeeeeffff
+                       # UDP Header
+                       source_port: 0x08ae       # 2222
+                       destination_port: 0x0140  # 320
+                       length: 0x003c
+                       checksum: 0x0000
+                       # PTP Header
+                       transport_specific: 0x0
+                       message_type: 0x0
+                       reserved0: 0x0
+                       version_ptp: 0x0
+                       message_length: 0x0034
+                       domain_number: 0x00
+                       reserved1: 0x00
+                       flags: 0x0000
+                       correction_field: 0x0000000000000000
+                       reserved2: 0x00000000
+                       source_port_identity: 0x00000000000000000000
+                       sequence_id: 0x0000
+                       control_field: 0x00
+                       log_message_interval: 0x00
+                       # Payload - 18 octets
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22 22 22 22 22 22 22
+                       payload: 0x 22 22
+-- OUTPUT ----------------------------------------------------------------------
+headers {
+  ethernet_header {
+    ethernet_destination: "ff:ee:dd:cc:bb:aa"
+    ethernet_source: "55:44:33:22:11:00"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x003c"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "0:1111:2222:3333:4444:5555:6666:7777"
+    ipv6_destination: "8888:9999:aaaa:bbbb:cccc:dddd:eeee:ffff"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x08ae"
+    destination_port: "0x0140"
     length: "0x003c"
     checksum: "0x0000"
   }
@@ -4498,6 +4589,64 @@ headers {
   udp_header {
     source_port: "0x08ae"
     destination_port: "0x013f"
+    length: "0x003e"
+    checksum: "0x0000"
+  }
+}
+headers {
+  ptp_header {
+    transport_specific: "0x0"
+    message_type: "0x0"
+    reserved0: "0x0"
+    version_ptp: "0x0"
+    message_length: "0x0036"
+    domain_number: "0x00"
+    reserved1: "0x00"
+    flags: "0x0000"
+    correction_field: "0x0000000000000000"
+    reserved2: "0x00000000"
+    source_port_identity: "0x00000000000000000000"
+    sequence_id: "0x0000"
+    control_field: "0x00"
+    log_message_interval: "0x00"
+  }
+}
+payload: "ABCDABCDABCDABCDABCD"
+
+-- OUTPUT ----------------------------------------------------------------------
+ValidatePacket(packet) = OK
+
+Serialize(Packet) = OK
+
+================================================================================
+Proto packet test: PTP packet with UDP port 320 (valid)
+================================================================================
+-- INPUT -----------------------------------------------------------------------
+packet =
+headers {
+  ethernet_header {
+    ethernet_destination: "00:ee:dd:cc:bb:aa"
+    ethernet_source: "00:44:33:22:11:00"
+    ethertype: "0x86dd"
+  }
+}
+headers {
+  ipv6_header {
+    version: "0x6"
+    dscp: "0x00"
+    ecn: "0x0"
+    flow_label: "0x12345"
+    payload_length: "0x003e"
+    next_header: "0x11"
+    hop_limit: "0x42"
+    ipv6_source: "2607:f8b0:11::"
+    ipv6_destination: "2607:f8b0:12::"
+  }
+}
+headers {
+  udp_header {
+    source_port: "0x08ae"
+    destination_port: "0x0140"
     length: "0x003e"
     checksum: "0x0000"
   }

--- a/p4_pdpi/testing/table_entry_test_runner.cc
+++ b/p4_pdpi/testing/table_entry_test_runner.cc
@@ -144,6 +144,83 @@ static void RunPiMulticastTest(const pdpi::IrP4Info& info) {
                     }
                   )pb"),
                   /*validity=*/INPUT_IS_VALID);
+  RunPiEntityTest(
+      info, "valid multicast group entry with backup replicas",
+      gutil::ParseProtoOrDie<p4::v1::Entity>(R"pb(
+        packet_replication_engine_entry {
+          multicast_group_entry {
+            multicast_group_id: 7
+            replicas {
+              port: "some_port"
+              instance: 1
+              backup_replicas { port: "some_other_port" instance: 2 }
+              backup_replicas { port: "third_port" instance: 1 }
+            }
+            replicas {
+              port: "some_other_port"
+              instance: 1
+              backup_replicas { port: "some_port" instance: 2 }
+              backup_replicas { port: "third_port" instance: 2 }
+            }
+          }
+        }
+      )pb"),
+      /*validity=*/INPUT_IS_VALID);
+  RunPiEntityTest(
+      info,
+      "multicast group entry with a backup replica that has the same port as "
+      "the primary replica",
+      gutil::ParseProtoOrDie<p4::v1::Entity>(R"pb(
+        packet_replication_engine_entry {
+          multicast_group_entry {
+            multicast_group_id: 7
+            replicas {
+              port: "some_port"
+              instance: 1
+              backup_replicas { port: "some_port" instance: 2 }
+              backup_replicas { port: "some_other_port" instance: 2 }
+            }
+          }
+        }
+      )pb"));
+   RunPiEntityTest(
+      info,
+      "multicast group entry with a backup replica that has the same port "
+      "instance pair as another primary replica",
+      gutil::ParseProtoOrDie<p4::v1::Entity>(R"pb(
+        packet_replication_engine_entry {
+          multicast_group_entry {
+            multicast_group_id: 7
+            replicas {
+              port: "some_port"
+              instance: 1
+              backup_replicas { port: "some_other_port" instance: 2 }
+            }
+            replicas { port: "some_other_port" instance: 2 }
+          }
+        }
+      )pb"));
+   RunPiEntityTest(
+      info,
+      "multicast group entry with a backup replica that has the same port "
+      "instance pair as another backup replica",
+      gutil::ParseProtoOrDie<p4::v1::Entity>(R"pb(
+        packet_replication_engine_entry {
+          multicast_group_entry {
+            multicast_group_id: 7
+            replicas {
+              port: "some_port"
+              instance: 1
+              backup_replicas { port: "some_other_port" instance: 2 }
+            }
+            replicas {
+              port: "third_port"
+              instance: 1
+              backup_replicas { port: "some_other_port" instance: 2 }
+            }
+          }
+        }
+      )pb"));
 }
 
 static void RunPiCloneSessionTest(const pdpi::IrP4Info& info) {
@@ -995,6 +1072,98 @@ static void RunIrMulticastTest(const pdpi::IrP4Info& info) {
                   IrTestConfig{
                       .validity = INPUT_IS_VALID,
                   });
+  RunIrEntityTest(
+      info, "valid multicast group entry with backup replicas",
+      gutil::ParseProtoOrDie<pdpi::IrEntity>(R"pb(
+        packet_replication_engine_entry {
+          multicast_group_entry {
+            multicast_group_id: 7
+            replicas {
+              port: "some_port"
+              instance: 1
+              backup_replicas { port: "some_other_port" instance: 2 }
+              backup_replicas { port: "third_port" instance: 1 }
+            }
+            replicas {
+              port: "some_other_port"
+              instance: 1
+              backup_replicas { port: "some_port" instance: 2 }
+              backup_replicas { port: "third_port" instance: 2 }
+            }
+          }
+        }
+      )pb"),
+      IrTestConfig{
+          .validity = INPUT_IS_VALID,
+          .test_ir_to_pd = false,
+      });
+  RunIrEntityTest(
+      info,
+      "multicast group entry with a backup replica that has the same port as "
+      "the primary replica",
+      gutil::ParseProtoOrDie<pdpi::IrEntity>(R"pb(
+        packet_replication_engine_entry {
+          multicast_group_entry {
+            multicast_group_id: 7
+            replicas {
+              port: "some_port"
+              instance: 1
+              backup_replicas { port: "some_port" instance: 2 }
+              backup_replicas { port: "some_other_port" instance: 1 }
+            }
+          }
+        }
+      )pb"),
+      IrTestConfig{
+          .validity = INPUT_IS_INVALID,
+          .test_ir_to_pd = false,
+      });
+  RunIrEntityTest(
+      info,
+      "multicast group entry with a backup replica that has the same port "
+      "instance pair as another primary replica",
+      gutil::ParseProtoOrDie<pdpi::IrEntity>(R"pb(
+        packet_replication_engine_entry {
+          multicast_group_entry {
+            multicast_group_id: 7
+            replicas {
+              port: "some_port"
+              instance: 1
+              backup_replicas { port: "some_other_port" instance: 2 }
+            }
+            replicas { port: "some_other_port" instance: 2 }
+          }
+        }
+      )pb"),
+      IrTestConfig{
+          .validity = INPUT_IS_INVALID,
+          .test_ir_to_pd = false,
+      });
+  RunIrEntityTest(
+      info,
+      "multicast group entry with a backup replica that has the same port "
+      "instance pair as another backup replica",
+      gutil::ParseProtoOrDie<pdpi::IrEntity>(R"pb(
+        packet_replication_engine_entry {
+          multicast_group_entry {
+            multicast_group_id: 7
+            replicas {
+              port: "some_port"
+              instance: 1
+              backup_replicas { port: "some_other_port" instance: 2 }
+            }
+            replicas {
+              port: "third_port"
+              instance: 3
+              backup_replicas { port: "some_other_port" instance: 2 }
+            }
+          }
+        }
+      )pb"),
+      IrTestConfig{
+          .validity = INPUT_IS_INVALID,
+          .test_ir_to_pd = false,
+      });
 }
 
 static void RunIrCloneSessionTest(const pdpi::IrP4Info& info) {

--- a/p4_pdpi/testing/testdata/table_entry.expected
+++ b/p4_pdpi/testing/testdata/table_entry.expected
@@ -1310,7 +1310,7 @@ packet_replication_engine_entry {
 }
 
 --- PI is invalid/unsupported:
-INVALID_ARGUMENT: MulticastGroupEntry with group id '7' is invalid: Each replica must have a unique (port, instance)-pair, but found multiple replicas with pair ('some_port', 1).
+INVALID_ARGUMENT: MulticastGroupEntry with group id '7' is invalid: Each replica must have a unique (port, instance)-pair, but found multiple primary/backup replicas with pair ('some_port', 1).
 
 =========================================================================
 valid multicast group entry
@@ -1385,6 +1385,155 @@ packet_replication_engine_entry {
   }
 }
 
+
+=========================================================================
+valid multicast group entry with backup replicas
+=========================================================================
+
+--- PI (Input):
+packet_replication_engine_entry {
+  multicast_group_entry {
+    multicast_group_id: 7
+    replicas {
+      instance: 1
+      port: "some_port"
+      backup_replicas {
+        port: "some_other_port"
+        instance: 2
+      }
+      backup_replicas {
+        port: "third_port"
+        instance: 1
+      }
+    }
+    replicas {
+      instance: 1
+      port: "some_other_port"
+      backup_replicas {
+        port: "some_port"
+        instance: 2
+      }
+      backup_replicas {
+        port: "third_port"
+        instance: 2
+      }
+    }
+  }
+}
+
+--- IR:
+packet_replication_engine_entry {
+  multicast_group_entry {
+    multicast_group_id: 7
+    replicas {
+      port: "some_port"
+      instance: 1
+      backup_replicas {
+        port: "some_other_port"
+        instance: 2
+      }
+      backup_replicas {
+        port: "third_port"
+        instance: 1
+      }
+    }
+    replicas {
+      port: "some_other_port"
+      instance: 1
+      backup_replicas {
+        port: "some_port"
+        instance: 2
+      }
+      backup_replicas {
+        port: "third_port"
+        instance: 2
+      }
+    }
+  }
+}
+
+
+=========================================================================
+multicast group entry with a backup replica that has the same port as the primary replica
+=========================================================================
+
+--- PI (Input):
+packet_replication_engine_entry {
+  multicast_group_entry {
+    multicast_group_id: 7
+    replicas {
+      instance: 1
+      port: "some_port"
+      backup_replicas {
+        port: "some_port"
+        instance: 2
+      }
+      backup_replicas {
+        port: "some_other_port"
+        instance: 2
+      }
+    }
+  }
+}
+
+--- PI is invalid/unsupported:
+INVALID_ARGUMENT: MulticastGroupEntry with group id '7' is invalid: A primary replica and its backup replicas must have unique ports. Replica and its backups contained duplicates of port 'some_port'.
+
+=========================================================================
+multicast group entry with a backup replica that has the same port instance pair as another primary replica
+=========================================================================
+
+--- PI (Input):
+packet_replication_engine_entry {
+  multicast_group_entry {
+    multicast_group_id: 7
+    replicas {
+      instance: 1
+      port: "some_port"
+      backup_replicas {
+        port: "some_other_port"
+        instance: 2
+      }
+    }
+    replicas {
+      instance: 2
+      port: "some_other_port"
+    }
+  }
+}
+
+--- PI is invalid/unsupported:
+INVALID_ARGUMENT: MulticastGroupEntry with group id '7' is invalid: Each replica must have a unique (port, instance)-pair, but found multiple primary/backup replicas with pair ('some_other_port', 2).
+
+=========================================================================
+multicast group entry with a backup replica that has the same port instance pair as another backup replica
+=========================================================================
+
+--- PI (Input):
+packet_replication_engine_entry {
+  multicast_group_entry {
+    multicast_group_id: 7
+    replicas {
+      instance: 1
+      port: "some_port"
+      backup_replicas {
+        port: "some_other_port"
+        instance: 2
+      }
+    }
+    replicas {
+      instance: 1
+      port: "third_port"
+      backup_replicas {
+        port: "some_other_port"
+        instance: 2
+      }
+    }
+  }
+}
+
+--- PI is invalid/unsupported:
+INVALID_ARGUMENT: MulticastGroupEntry with group id '7' is invalid: Each backup replica must have a unique (port, instance)-pair, but found multiple primary/backup replicas with pair ('some_other_port', 2).
 
 =========================================================================
 valid clone session group entry
@@ -3482,7 +3631,7 @@ packet_replication_engine_entry {
 }
 
 --- IR (converting to PI) is invalid/unsupported:
-INVALID_ARGUMENT: MulticastGroupEntry with group id '7' is invalid: Each replica must have a unique (port, instance)-pair, but found multiple replicas with pair ('some_port', 1).
+INVALID_ARGUMENT: MulticastGroupEntry with group id '7' is invalid: Each replica must have a unique (port, instance)-pair, but found multiple primary/backup replicas with pair ('some_port', 1).
 
 =========================================================================
 multicast group entry with duplicate replica (IR -> PD)
@@ -3663,6 +3812,155 @@ multicast_group_table_entry {
   }
 }
 
+
+=========================================================================
+valid multicast group entry with backup replicas (IR -> PI)
+=========================================================================
+
+--- IR (Input):
+packet_replication_engine_entry {
+  multicast_group_entry {
+    multicast_group_id: 7
+    replicas {
+      port: "some_port"
+      instance: 1
+      backup_replicas {
+        port: "some_other_port"
+        instance: 2
+      }
+      backup_replicas {
+        port: "third_port"
+        instance: 1
+      }
+    }
+    replicas {
+      port: "some_other_port"
+      instance: 1
+      backup_replicas {
+        port: "some_port"
+        instance: 2
+      }
+      backup_replicas {
+        port: "third_port"
+        instance: 2
+      }
+    }
+  }
+}
+
+--- PI:
+packet_replication_engine_entry {
+  multicast_group_entry {
+    multicast_group_id: 7
+    replicas {
+      instance: 1
+      port: "some_port"
+      backup_replicas {
+        port: "some_other_port"
+        instance: 2
+      }
+      backup_replicas {
+        port: "third_port"
+        instance: 1
+      }
+    }
+    replicas {
+      instance: 1
+      port: "some_other_port"
+      backup_replicas {
+        port: "some_port"
+        instance: 2
+      }
+      backup_replicas {
+        port: "third_port"
+        instance: 2
+      }
+    }
+  }
+}
+
+
+=========================================================================
+multicast group entry with a backup replica that has the same port as the primary replica (IR -> PI)
+=========================================================================
+
+--- IR (Input):
+packet_replication_engine_entry {
+  multicast_group_entry {
+    multicast_group_id: 7
+    replicas {
+      port: "some_port"
+      instance: 1
+      backup_replicas {
+        port: "some_port"
+        instance: 2
+      }
+      backup_replicas {
+        port: "some_other_port"
+        instance: 1
+      }
+    }
+  }
+}
+
+--- IR (converting to PI) is invalid/unsupported:
+INVALID_ARGUMENT: MulticastGroupEntry with group id '7' is invalid: A primary replica and its backup replicas must have unique ports. Replica and its backups contained duplicates of port 'some_port'.
+
+=========================================================================
+multicast group entry with a backup replica that has the same port instance pair as another primary replica (IR -> PI)
+=========================================================================
+
+--- IR (Input):
+packet_replication_engine_entry {
+  multicast_group_entry {
+    multicast_group_id: 7
+    replicas {
+      port: "some_port"
+      instance: 1
+      backup_replicas {
+        port: "some_other_port"
+        instance: 2
+      }
+    }
+    replicas {
+      port: "some_other_port"
+      instance: 2
+    }
+  }
+}
+
+--- IR (converting to PI) is invalid/unsupported:
+INVALID_ARGUMENT: MulticastGroupEntry with group id '7' is invalid: Each replica must have a unique (port, instance)-pair, but found multiple primary/backup replicas with pair ('some_other_port', 2).
+
+=========================================================================
+multicast group entry with a backup replica that has the same port instance pair as another backup replica (IR -> PI)
+=========================================================================
+
+--- IR (Input):
+packet_replication_engine_entry {
+  multicast_group_entry {
+    multicast_group_id: 7
+    replicas {
+      port: "some_port"
+      instance: 1
+      backup_replicas {
+        port: "some_other_port"
+        instance: 2
+      }
+    }
+    replicas {
+      port: "third_port"
+      instance: 3
+      backup_replicas {
+        port: "some_other_port"
+        instance: 2
+      }
+    }
+  }
+}
+
+--- IR (converting to PI) is invalid/unsupported:
+INVALID_ARGUMENT: MulticastGroupEntry with group id '7' is invalid: Each backup replica must have a unique (port, instance)-pair, but found multiple primary/backup replicas with pair ('some_other_port', 2).
 
 =========================================================================
 clone session entry with duplicate replica (IR -> PI)

--- a/p4_pdpi/testing/testdata/table_entry.expected
+++ b/p4_pdpi/testing/testdata/table_entry.expected
@@ -3653,7 +3653,7 @@ packet_replication_engine_entry {
 }
 
 --- IR (converting to PD) is invalid/unsupported:
-INVALID_ARGUMENT: MulticastGroupEntry with group id '7' is invalid: Each replica must have a unique (port, instance)-pair, but found multiple replicas with pair ('some_port', 1).
+INVALID_ARGUMENT: MulticastGroupEntry with group id '7' is invalid: Each replica must have a unique (port, instance)-pair, but found multiple primary/backup replicas with pair ('some_port', 1).
 
 =========================================================================
 valid multicast group entry (IR -> PI)
@@ -7201,7 +7201,7 @@ multicast_group_table_entry {
 }
 
 --- PD is invalid/unsupported:
-INVALID_ARGUMENT: MulticastGroupEntry with group id '7' is invalid: Each replica must have a unique (port, instance)-pair, but found multiple replicas with pair ('some_port', 1).
+INVALID_ARGUMENT: MulticastGroupEntry with group id '7' is invalid: Each replica must have a unique (port, instance)-pair, but found multiple primary/backup replicas with pair ('some_port', 1).
 =========================================================================
 valid multicast group entry
 pdpi::TranslationOptions{.key_only = false, .allow_unsupported = false}

--- a/p4_pdpi/utils/ir.cc
+++ b/p4_pdpi/utils/ir.cc
@@ -66,9 +66,8 @@ using ::pdpi::IrValue;
 
 absl::StatusOr<std::string> ArbitraryToNormalizedByteString(
     const std::string &bytes, int expected_bitwidth) {
-  // https://screenshot.googleplex.com/AGyHaea3Zkzpjcm
   if (bytes.empty()) {
-    return gutil::InvalidArgumentErrorBuilder()
+    return gutil::OutOfRangeErrorBuilder()
            << "Bytestrings must have non-zero length.";
   }
   std::string canonical_string = ArbitraryToCanonicalByteString(bytes);
@@ -187,9 +186,8 @@ absl::StatusOr<Format> GetFormat(const std::vector<std::string> &annotations,
 absl::StatusOr<IrValue> ArbitraryByteStringToIrValue(Format format,
                                                      const int bitwidth,
                                                      const std::string &bytes) {
-  // https://screenshot.googleplex.com/AGyHaea3Zkzpjcm
   if (bytes.empty()) {
-    return gutil::InvalidArgumentErrorBuilder()
+    return gutil::OutOfRangeErrorBuilder()
            << "Bytestrings must have non-zero length.";
   }
 
@@ -324,9 +322,8 @@ absl::StatusOr<std::string> IrValueToNormalizedByteString(
       return ipv6.ToPaddedByteString();
     }
     case IrValue::kStr: {
-      // https://screenshot.googleplex.com/AGyHaea3Zkzpjcm
       if (ir_value.str().empty()) {
-        return gutil::InvalidArgumentErrorBuilder()
+        return gutil::OutOfRangeErrorBuilder()
                << "Bytestrings must have non-zero length.";
       }
       return ir_value.str();

--- a/p4_pdpi/utils/ir_test.cc
+++ b/p4_pdpi/utils/ir_test.cc
@@ -444,20 +444,20 @@ TEST(ArbitraryByteStringToIrValueTest, EmptyBytestringReturnsError) {
   EXPECT_THAT(
       ArbitraryByteStringToIrValue(Format::IPV6, /*bitwidth=*/kNumBitsInIpv6,
                                    /*bytes=*/""),
-      StatusIs(absl::StatusCode::kInvalidArgument));
+      StatusIs(absl::StatusCode::kOutOfRange));
 }
 
 TEST(ArbitraryToNormalizedByteString, EmptyBytestringReturnsError) {
   EXPECT_THAT(
       ArbitraryToNormalizedByteString(/*bytes=*/"", /*expected_bitwidth=*/8),
-      StatusIs(absl::StatusCode::kInvalidArgument));
+      StatusIs(absl::StatusCode::kOutOfRange));
 }
 
 TEST(IrValueToNormalizedByteString, kStrWithEmptyStringReturnsError) {
   IrValue empty_string;
   empty_string.set_str("");
   EXPECT_THAT(IrValueToNormalizedByteString(empty_string, /*bitwidth=*/8),
-              StatusIs(absl::StatusCode::kInvalidArgument));
+              StatusIs(absl::StatusCode::kOutOfRange));
 }
 
 class Ipv6BitwidthTest : public testing::TestWithParam<int> {};

--- a/pins_infra_deps.bzl
+++ b/pins_infra_deps.bzl
@@ -142,9 +142,10 @@ def pins_infra_deps():
         # rather than a release.
         http_archive(
             name = "com_github_p4lang_p4runtime",
-            # Newest commit on main as of 2024-09-19.
-            urls = ["https://github.com/p4lang/p4runtime/archive/dda9d669cfa846c46116b5e7543479ffe96098b6.zip"],
-            strip_prefix = "p4runtime-dda9d669cfa846c46116b5e7543479ffe96098b6/proto",
+	    # Newest commit on main as of 2025-05-09.
+            urls = ["https://github.com/p4lang/p4runtime/archive/81527931abed0e488d1305f7d2061539aad7021b.zip"],
+            strip_prefix = "p4runtime-81527931abed0e488d1305f7d2061539aad7021b/proto",
+            sha256 = "5826d9385bce7deafd41c081be7ecd2c875904c45d07d8e234570e7fffbc7852",
         )
     if not native.existing_rule("com_github_p4lang_p4_constraints"):
         http_archive(


### PR DESCRIPTION
### **PR Description:**
Support IR <-> PD for Fallback groups.

### **Keyword Check:**
bibhuprasad@bibhuprasad87:~/sonic_build_image_16_Jun/sonic-buildimage/src/sonic-p4rt/sonic-pins/p4_pdpi$ sh ~/keyword_check.sh .
Keyword check Passed.

### **Build Results:**
bibhuprasad@f18c49371431:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 741 targets (0 packages loaded, 0 targets configured).
INFO: Found 741 targets...
INFO: Elapsed time: 0.394s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### **UT Results:**
bibhuprasad@f18c49371431:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 741 targets (0 packages loaded, 0 targets configured).
INFO: Found 513 targets and 228 test targets...
INFO: Elapsed time: 199.451s, Critical Path: 145.01s
INFO: 285 processes: 341 linux-sandbox, 18 local.
INFO: Build completed successfully, 285 total actions
//dvaas:port_id_map_test                                                 PASSED in 2.1s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.7s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.4s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//gutil:collections_test                                                 PASSED in 1.1s
//gutil:io_test                                                          PASSED in 1.4s
//gutil:proto_matchers_test                                              PASSED in 1.4s
//gutil:proto_ordering_test                                              PASSED in 1.7s
//gutil:proto_test                                                       PASSED in 1.3s
//gutil:status_matchers_test                                             PASSED in 1.0s
//gutil:test_artifact_writer_test                                        PASSED in 1.9s
//gutil:testing_test                                                     PASSED in 1.2s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 4.7s
//lib:basic_switch_test                                                  PASSED in 2.1s
//lib:ixia_helper_test                                                   PASSED in 2.6s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 2.8s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 17.1s
//lib/gnmi:gnmi_helper_test                                              PASSED in 4.5s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.2s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 2.3s
//lib/utils:generic_testbed_utils_test                                   PASSED in 3.1s
//lib/utils:json_utils_test                                              PASSED in 1.3s
//lib/validator:validator_backend_test                                   PASSED in 1.6s
//lib/validator:validator_lib_test                                       PASSED in 27.3s
//p4_fuzzer:constraints_test                                             PASSED in 7.2s
//p4_fuzzer:fuzz_util_test                                               PASSED in 144.8s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 2.2s
//p4_fuzzer:oracle_util_test                                             PASSED in 5.1s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 3.9s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 3.8s
//p4_fuzzer:switch_state_test                                            PASSED in 2.5s
//p4_pdpi:built_ins_test                                                 PASSED in 1.6s
//p4_pdpi:entity_keys_test                                               PASSED in 1.4s
//p4_pdpi:ir_properties_test                                             PASSED in 1.4s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.7s
//p4_pdpi:ir_tools_test                                                  PASSED in 2.0s
//p4_pdpi:names_test                                                     PASSED in 2.0s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.4s
//p4_pdpi:p4info_union_test                                              PASSED in 1.9s
//p4_pdpi:reference_annotations_test                                     PASSED in 2.0s
//p4_pdpi:references_test                                                PASSED in 1.3s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.8s
//p4_pdpi:ternary_test                                                   PASSED in 1.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.1s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.4s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.6s
//p4_pdpi/packetlib:packetlib_debugging_test                             PASSED in 1.8s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 21.2s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.4s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 7.0s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.2s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.2s
//p4_pdpi/testing:helper_function_test                                   PASSED in 2.2s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.6s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test PASSED in 0.2s
//p4_pdpi/testing:old_get_entries_unreachable_from_roots_with_matchfield_reference_test_runner PASSED in 0.2s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.2s
//p4_pdpi/testing:references_test                                        PASSED in 0.2s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.3s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.3s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 1.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.6s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.7s
//p4_symbolic:z3_util_test                                               PASSED in 1.7s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.2s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 3.2s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.2s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 3.3s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 3.3s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.2s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 3.2s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.3s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 3.3s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 3.1s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.3s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 3.1s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.9s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.2s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.2s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.1s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.2s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.2s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.2s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.3s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 17.6s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 21.6s
//p4_symbolic/sai:sai_test                                               PASSED in 5.7s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 4.1s
//p4_symbolic/symbolic:parser_test                                       PASSED in 2.0s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 2.5s
//p4_symbolic/symbolic:util_test                                         PASSED in 2.0s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.7s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 11.5s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 3.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 2.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 2.3s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 3.2s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 2.7s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 2.8s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 3.3s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 2.6s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 1.4s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 2.5s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 2.2s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.1s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.3s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 2.6s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.0s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 2.3s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.0s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 1.8s
//p4rt_app/sonic:hashing_test                                            PASSED in 2.4s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 2.1s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.4s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 1.8s
//p4rt_app/sonic:state_verification_test                                 PASSED in 1.8s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.5s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 2.0s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 2.2s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.8s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.1s
//p4rt_app/tests:action_set_test                                         PASSED in 1.6s
//p4rt_app/tests:api_access_test                                         PASSED in 1.4s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.4s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.2s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 6.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.6s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 0.9s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.5s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.7s
//p4rt_app/tests:packetio_test                                           PASSED in 4.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.2s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.3s
//p4rt_app/tests:response_path_test                                      PASSED in 5.1s
//p4rt_app/tests:role_test                                               PASSED in 1.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.9s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 1.8s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.4s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.4s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.6s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.3s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 5.1s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 3.0s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 6.8s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 2.5s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.6s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.5s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.6s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.1s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.9s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.2s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.9s
//thinkit:bazel_test_environment_test                                    PASSED in 1.3s
//thinkit:generic_testbed_test                                           PASSED in 1.9s
//thinkit:mock_control_device_test                                       PASSED in 1.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.5s
//thinkit:mock_mirror_testbed_test                                       PASSED in 2.1s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 1.7s
//tests/lib:packet_generator_test                                        PASSED in 64.0s
  Stats over 4 runs: max = 64.0s, min = 62.0s, avg = 62.8s, dev = 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.4s
  Stats over 5 runs: max = 2.4s, min = 1.6s, avg = 2.0s, dev = 0.3s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 45.9s
  Stats over 50 runs: max = 45.9s, min = 1.4s, avg = 5.0s, dev = 10.4s

Executed 228 out of 228 tests: 228 tests pass.