### PR TITLE
[P4_Symbolic] Prevent synthesizing packets ingressing on ports that are configured to be

### DIFF
--- a/dvaas/test_vector_stats_test.expected
+++ b/dvaas/test_vector_stats_test.expected
@@ -15,4 +15,3 @@ All of 2 test vectors attempted had deterministically reproducible failures
 4 test vectors forwarded, producing 6 forwarded output packets
 3 test vectors punted, producing 3 punted output packets
 1 test vectors produced no output packets
-1 of 3 test vectors with failures were deterministically reproducible

--- a/p4_symbolic/ir/table_entries.cc
+++ b/p4_symbolic/ir/table_entries.cc
@@ -93,8 +93,9 @@ absl::StatusOr<TableEntries> ParseTableEntries(
   // pdpi.ir.IrTableEntry.
   TableEntries output;
   for (const p4::v1::Entity &pi_entity : entities) {
-    ASSIGN_OR_RETURN(pdpi::IrEntity ir_entity,
-                     pdpi::PiEntityToIr(p4info, pi_entity));
+    ASSIGN_OR_RETURN(
+        pdpi::IrEntity ir_entity,
+        pdpi::PiEntityToIr(p4info, pi_entity, {.allow_unsupported = true}));
     // TODO: Consider removing this function call if we switch to
     // using aliases as table/action names in P4-Symbolic.
     RETURN_IF_ERROR(UseFullyQualifiedNamesInEntity(p4info, ir_entity));

--- a/p4_symbolic/packet_synthesizer/BUILD.bazel
+++ b/p4_symbolic/packet_synthesizer/BUILD.bazel
@@ -28,6 +28,7 @@ cc_library(
         "//p4_pdpi/string_encodings:decimal_string",
         "//p4_pdpi/utils:ir",
         "//p4_symbolic:z3_util",
+	"//p4_symbolic/sai",
         "//p4_symbolic/symbolic",
         "//p4_symbolic/symbolic:operators",
         "//p4_symbolic/symbolic:solver_state",

--- a/p4_symbolic/packet_synthesizer/util.cc
+++ b/p4_symbolic/packet_synthesizer/util.cc
@@ -14,12 +14,14 @@
 
 #include "p4_symbolic/packet_synthesizer/util.h"
 
+#include "absl/status/status.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "gutil/status.h"
 #include "p4_pdpi/netaddr/ipv6_address.h"
 #include "p4_pdpi/string_encodings/decimal_string.h"
 #include "p4_pdpi/utils/ir.h"
+#include "p4_symbolic/sai/sai.h"
 #include "p4_symbolic/symbolic/operators.h"
 #include "p4_symbolic/symbolic/symbolic.h"
 #include "p4_symbolic/symbolic/util.h"
@@ -135,6 +137,11 @@ absl::StatusOr<z3::expr> IrValueToZ3Bitvector(const pdpi::IrValue& value,
 // function would disappear.
 absl::Status AddSanePacketConstraints(
     p4_symbolic::symbolic::SolverState& state) {
+  // TODO: Remove when these constraints are provided as part of
+  // synthesis request.
+  // RETURN_IF_ERROR(
+  //    AddConstraintsPreventingIngressPortBeingInLoopbackMode(state));
+
   z3::context& z3_context = *state.context.z3_context;
 
   // ======Ethernet constraints======

--- a/p4_symbolic/sai/BUILD.bazel
+++ b/p4_symbolic/sai/BUILD.bazel
@@ -22,6 +22,7 @@ cc_library(
     srcs = ["sai.cc"],
     hdrs = ["sai.h"],
     deps = [
+	"//gutil:collections",
         "//gutil:status",
         "//p4_pdpi:ir_cc_proto",
         "//p4_pdpi/internal:ordered_map",
@@ -36,6 +37,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+	"@com_google_absl//absl/strings:str_format",
     ],
 )
 
@@ -94,6 +96,7 @@ cc_test(
         "//sai_p4/instantiations/google:sai_nonstandard_platforms_cc",
         "//sai_p4/instantiations/google:sai_p4info_cc",
         "//sai_p4/instantiations/google:sai_pd_cc_proto",
+	"@com_github_google_glog//:glog",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",

--- a/p4_symbolic/sai/sai.h
+++ b/p4_symbolic/sai/sai.h
@@ -76,6 +76,13 @@ absl::Status AddConstraintsToForbidVrfZero(symbolic::SolverState& state);
 // P4-Constraints is integrated with P4-Symbolic.
 absl::Status AddConstraintsForAclPreIngressTable(symbolic::SolverState& state);
 
+// For any entry in "egress_port_loopback_table" matching on port `p`, add a
+// constraint avoiding `p` as ingress port.
+// TODO: Remove when these constraints are provided as part of
+// synthesis request.
+absl::Status AddConstraintsPreventingIngressPortBeingInLoopbackMode(
+    symbolic::SolverState& state);
+
 // Adds solver constraints for "acl_ingress_table" (for middleblock).
 // Reference:
 // third_party/pins_infra/sai_p4/instantiations/google/acl_ingress.p4.


### PR DESCRIPTION
### **PR Description:**
Prevent synthesizing packets ingressing on ports that are configured to be

### **Keyword Check:**
bibhuprasad@bibhuprasad87:~/sonic_build_image_2025-06-23/sonic-buildimage/src/sonic-p4rt/sonic-pins/p4_symbolic$ sh ~/keyword_check.sh .
Keyword check Passed.

### **Build Results:**
bibhuprasad@b5d6b9918c77:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 740 targets (0 packages loaded, 0 targets configured).
INFO: Found 740 targets...
INFO: Elapsed time: 0.314s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### **UT Results:**
bibhuprasad@b5d6b9918c77:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 740 targets (0 packages loaded, 0 targets configured).
INFO: Found 514 targets and 226 test targets...
INFO: Elapsed time: 198.993s, Critical Path: 143.20s
INFO: 283 processes: 337 linux-sandbox, 18 local.
INFO: Build completed successfully, 283 total actions
//dvaas:port_id_map_test                                                 PASSED in 2.3s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.8s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.7s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 1.4s
//gutil:io_test                                                          PASSED in 1.5s
//gutil:proto_matchers_test                                              PASSED in 1.4s
//gutil:proto_ordering_test                                              PASSED in 1.8s
//gutil:proto_test                                                       PASSED in 1.3s
//gutil:status_matchers_test                                             PASSED in 1.2s
//gutil:test_artifact_writer_test                                        PASSED in 1.9s
//gutil:testing_test                                                     PASSED in 2.0s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 5.2s
//lib:basic_switch_test                                                  PASSED in 2.6s
//lib:ixia_helper_test                                                   PASSED in 3.1s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 2.7s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 18.5s
//lib/gnmi:gnmi_helper_test                                              PASSED in 4.4s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.9s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 2.3s
//lib/utils:generic_testbed_utils_test                                   PASSED in 4.0s
//lib/utils:json_utils_test                                              PASSED in 1.5s
//lib/validator:validator_backend_test                                   PASSED in 1.6s
//lib/validator:validator_lib_test                                       PASSED in 27.6s
//p4_fuzzer:constraints_test                                             PASSED in 8.3s
//p4_fuzzer:fuzz_util_test                                               PASSED in 143.0s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 2.6s
//p4_fuzzer:oracle_util_test                                             PASSED in 5.8s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 4.0s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 3.9s
//p4_fuzzer:switch_state_test                                            PASSED in 2.2s
//p4_pdpi:built_ins_test                                                 PASSED in 1.5s
//p4_pdpi:entity_keys_test                                               PASSED in 2.1s
//p4_pdpi:ir_properties_test                                             PASSED in 2.0s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.9s
//p4_pdpi:ir_tools_test                                                  PASSED in 2.2s
//p4_pdpi:names_test                                                     PASSED in 2.4s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 2.2s
//p4_pdpi:p4info_union_test                                              PASSED in 2.0s
//p4_pdpi:reference_annotations_test                                     PASSED in 1.6s
//p4_pdpi:references_test                                                PASSED in 2.2s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.9s
//p4_pdpi:ternary_test                                                   PASSED in 1.8s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.7s
//p4_pdpi/packetlib:packetlib_debugging_test                             PASSED in 1.6s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 22.0s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.2s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 7.9s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.2s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 2.4s
//p4_pdpi/testing:info_test                                              PASSED in 0.4s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 2.1s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.2s
//p4_pdpi/testing:references_test                                        PASSED in 0.3s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.3s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.3s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.3s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 2.6s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.3s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.8s
//p4_pdpi/utils:ir_test                                                  PASSED in 2.0s
//p4_symbolic:z3_util_test                                               PASSED in 1.7s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 3.8s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 4.1s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 4.1s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 3.5s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 2.9s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 3.6s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 3.5s
//p4_symbolic/ir:cfg_test                                                PASSED in 2.0s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.1s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.1s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.4s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.3s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.3s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.0s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.3s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.3s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.3s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.3s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.3s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.2s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.2s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.9s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 28.2s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 25.7s
//p4_symbolic/sai:sai_test                                               PASSED in 7.7s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 4.6s
//p4_symbolic/symbolic:parser_test                                       PASSED in 2.5s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 2.6s
//p4_symbolic/symbolic:util_test                                         PASSED in 2.3s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.8s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 17.4s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 3.4s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 3.8s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 3.8s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 3.8s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 3.1s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 3.7s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 3.2s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 3.3s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 1.2s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 2.2s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 2.2s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.2s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 3.7s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.6s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 2.2s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.6s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 2.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 2.8s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 2.0s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.8s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.2s
//p4rt_app/sonic:state_verification_test                                 PASSED in 2.3s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.8s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 2.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.7s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 1.0s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.2s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.1s
//p4rt_app/tests:action_set_test                                         PASSED in 1.7s
//p4rt_app/tests:api_access_test                                         PASSED in 1.4s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.5s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.5s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 7.1s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.7s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.5s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.8s
//p4rt_app/tests:packetio_test                                           PASSED in 4.7s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.2s
//p4rt_app/tests:resource_limits_test                                    PASSED in 5.3s
//p4rt_app/tests:response_path_test                                      PASSED in 5.4s
//p4rt_app/tests:role_test                                               PASSED in 1.7s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.9s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 1.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.3s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.9s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.7s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.3s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 5.2s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 3.3s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 7.3s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 2.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 2.1s
//sai_p4/tools:packetio_tools_test                                       PASSED in 2.0s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 3.0s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.5s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 2.7s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.3s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.2s
//tests/sflow:sflow_util_test                                            PASSED in 8.5s
//thinkit:bazel_test_environment_test                                    PASSED in 1.3s
//thinkit:generic_testbed_test                                           PASSED in 2.4s
//thinkit:mock_control_device_test                                       PASSED in 1.8s
//thinkit:mock_generic_testbed_test                                      PASSED in 2.0s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 2.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 1.8s
//tests/lib:packet_generator_test                                        PASSED in 65.2s
  Stats over 4 runs: max = 65.2s, min = 63.0s, avg = 63.9s, dev = 0.9s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.6s
  Stats over 5 runs: max = 2.6s, min = 1.9s, avg = 2.3s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 46.2s
  Stats over 50 runs: max = 46.2s, min = 1.6s, avg = 5.0s, dev = 10.4s

Executed 226 out of 226 tests: 226 tests pass.