### PR TITLE
[Thinkit/Tests] Add support for WCMP testing with different member sizes.

### DIFF
--- a/tests/forwarding/BUILD.bazel
+++ b/tests/forwarding/BUILD.bazel
@@ -222,6 +222,7 @@ cc_library(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
         "@com_google_absl//absl/utility",
         "@com_google_googletest//:gtest",
         "@com_googlesource_code_re2//:re2",

--- a/tests/forwarding/hash_statistics_util_test.cc
+++ b/tests/forwarding/hash_statistics_util_test.cc
@@ -29,6 +29,8 @@ namespace pins_test {
 namespace {
 
 using ::testing::DoubleNear;
+using ::testing::Ge;
+using ::testing::Le;
 
 Distribution ExpectedDistribution(const std::vector<pins::GroupMember> members,
                                   int packet_count) {
@@ -69,6 +71,34 @@ int PacketCount(const Distribution& distribution) {
 
 TEST(PercentErrorTestPacketCount, IncreasesWithTotalWeight) {
   EXPECT_GT(PercentErrorTestPacketCount(100), PercentErrorTestPacketCount(10));
+}
+
+TEST(PercentErrorTestPacketCount, IsWithinRange) {
+  // The general formula is 100 * total_weight:
+  // Minimum packets (1,000) @ 10 packets.
+  // Maximum packets (10,000) @ 100 packets.
+  for (int total_weight : {1, 5, 9, 10, 11, 55, 99, 100, 101, 555}) {
+    EXPECT_THAT(PercentErrorTestPacketCount(total_weight), Ge(1000))
+        << " for total weight: " << total_weight;
+    EXPECT_THAT(PercentErrorTestPacketCount(total_weight), Le(10000))
+        << " for total weight: " << total_weight;
+  }
+}
+
+MATCHER_P(IsAMultipleOf, divisor, "") {
+  *result_listener << "where the remainder is " << (arg % divisor);
+  return (arg % divisor) == 0;
+}
+
+TEST(PercentErrorTestPacketCount, IsAMultipleOfTotalWeight) {
+  // The general formula is 100 * total_weight:
+  // Minimum packets (1,000) @ 10 packets.
+  // Maximum packets (10,000) @ 100 packets.
+  for (int total_weight : {1, 5, 9, 10, 11, 55, 99, 100, 101, 555}) {
+    EXPECT_THAT(PercentErrorTestPacketCount(total_weight),
+                IsAMultipleOf(total_weight))
+        << " for total weight: " << total_weight;
+  }
 }
 
 TEST(ChiSquaredTestPacketCount, IncreasesWithMembers) {

--- a/tests/forwarding/multistage_hash_test.h
+++ b/tests/forwarding/multistage_hash_test.h
@@ -16,11 +16,23 @@
 #define PINS_TESTS_FORWARDING_HASH_MULTISTAGE_TEST_H_
 
 #include "tests/forwarding/hash_testfixture.h"
+#include "gtest/gtest.h"
 
 namespace pins_test {
 
+struct HashMultiStageParameters {
+  thinkit::MirrorTestbedInterface *mirror_testbed;
+  p4::config::v1::P4Info p4_info;
+};
+
 // Multistage hash test.
-class HashMultiStage : public HashTest {};
+class HashMultiStage
+    : public HashTest,
+      public testing::WithParamInterface<HashMultiStageParameters> {
+public:
+  HashMultiStage()
+      : HashTest(GetParam().mirror_testbed, std::move(GetParam().p4_info)) {}
+};
 
 }  // namespace pins_test
 


### PR DESCRIPTION
### Keyword Check:
divyagayathris@divyagayathris-16:~/Apr11/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_check.sh tests/.
Keyword check Passed.

### Build Results:
divyagayathris@0b1668e9d59a:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 743 targets (0 packages loaded, 0 targets configured).
INFO: Found 743 targets...
...
tests/integration/system/nsf/nsf_acl_flow_coverage_test.cc:114:29: warning: unused variable 'environment' [-Wunused-variable]
  114 |   thinkit::TestEnvironment& environment = std::visit(
      |                             ^~~~~~~~~~~
INFO: Elapsed time: 30.547s, Critical Path: 23.06s
INFO: 29 processes: 3 internal, 26 linux-sandbox.
INFO: Build completed successfully, 29 total actions

### Test Results:
divyagayathris@0b1668e9d59a:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 743 targets (267 packages loaded, 22389 targets configured).
INFO: Found 516 targets and 227 test targets...
INFO: Elapsed time: 194.686s, Critical Path: 131.11s
INFO: 284 processes: 338 linux-sandbox, 18 local.
INFO: Build completed successfully, 284 total actions
//dvaas:port_id_map_test                                                 PASSED in 1.9s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.8s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.9s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.3s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//gutil:collections_test                                                 PASSED in 1.6s
//gutil:io_test                                                          PASSED in 1.4s
//gutil:proto_matchers_test                                              PASSED in 1.4s
//gutil:proto_ordering_test                                              PASSED in 1.8s
//gutil:proto_test                                                       PASSED in 1.4s
//gutil:status_matchers_test                                             PASSED in 1.6s
//gutil:test_artifact_writer_test                                        PASSED in 2.1s
//gutil:testing_test                                                     PASSED in 1.3s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 8.4s
//lib:basic_switch_test                                                  PASSED in 2.4s
//lib:ixia_helper_test                                                   PASSED in 2.4s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 2.7s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 17.3s
//lib/gnmi:gnmi_helper_test                                              PASSED in 4.4s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.6s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 2.3s
//lib/utils:generic_testbed_utils_test                                   PASSED in 3.5s
//lib/utils:json_utils_test                                              PASSED in 1.5s
//lib/validator:validator_backend_test                                   PASSED in 1.0s
//lib/validator:validator_lib_test                                       PASSED in 27.3s
//p4_fuzzer:constraints_test                                             PASSED in 5.5s
//p4_fuzzer:fuzz_util_test                                               PASSED in 130.6s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 2.2s
//p4_fuzzer:oracle_util_test                                             PASSED in 3.7s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 3.3s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 3.7s
//p4_fuzzer:switch_state_test                                            PASSED in 1.6s
//p4_pdpi:built_ins_test                                                 PASSED in 1.3s
//p4_pdpi:entity_keys_test                                               PASSED in 1.3s
//p4_pdpi:ir_properties_test                                             PASSED in 1.3s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.7s
//p4_pdpi:ir_tools_test                                                  PASSED in 1.3s
//p4_pdpi:names_test                                                     PASSED in 1.4s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.5s
//p4_pdpi:p4info_union_test                                              PASSED in 1.4s
//p4_pdpi:reference_annotations_test                                     PASSED in 1.5s
//p4_pdpi:references_test                                                PASSED in 1.6s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.3s
//p4_pdpi:ternary_test                                                   PASSED in 1.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.5s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.7s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.4s
//p4_pdpi/packetlib:packetlib_debugging_test                             PASSED in 1.3s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 21.0s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.5s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 14.0s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.6s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.4s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.4s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.5s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:references_test                                        PASSED in 0.3s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.3s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.2s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 1.7s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.4s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.3s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.2s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.4s
//p4_symbolic:z3_util_test                                               PASSED in 1.6s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 2.6s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 2.8s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 2.6s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 2.3s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 2.6s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 2.3s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 2.3s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.5s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.1s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.1s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.1s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.1s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.1s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.3s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 15.6s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 19.5s
//p4_symbolic/sai:sai_test                                               PASSED in 4.5s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 3.7s
//p4_symbolic/symbolic:parser_test                                       PASSED in 2.7s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 1.3s
//p4_symbolic/symbolic:util_test                                         PASSED in 2.1s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.3s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 9.9s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 2.2s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 2.7s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 2.6s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 3.0s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 3.1s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 2.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 3.0s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 3.0s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 1.2s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 2.5s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 1.8s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.5s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.1s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 2.5s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.6s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 1.9s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 2.5s
//p4rt_app/sonic:hashing_test                                            PASSED in 2.3s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 2.2s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.3s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.1s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.5s
//p4rt_app/sonic:state_verification_test                                 PASSED in 2.0s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.2s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 1.8s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 2.0s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 4.6s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.0s
//p4rt_app/tests:action_set_test                                         PASSED in 1.5s
//p4rt_app/tests:api_access_test                                         PASSED in 1.2s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.4s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.3s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 6.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.6s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.0s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.4s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.7s
//p4rt_app/tests:packetio_test                                           PASSED in 4.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.1s
//p4rt_app/tests:resource_limits_test                                    PASSED in 5.1s
//p4rt_app/tests:response_path_test                                      PASSED in 5.1s
//p4rt_app/tests:role_test                                               PASSED in 1.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.9s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.4s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.0s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 1.6s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.3s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 3.3s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.0s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.3s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.2s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 9.0s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 3.1s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 7.6s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 2.5s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.3s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.8s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 3.2s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.7s
//tests/lib:common_ir_table_entries_test                                 PASSED in 2.1s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.7s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.2s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.2s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 8.7s
//thinkit:bazel_test_environment_test                                    PASSED in 1.3s
//thinkit:generic_testbed_test                                           PASSED in 2.0s
//thinkit:mock_control_device_test                                       PASSED in 1.4s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.4s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.5s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.7s
//tests/lib:packet_generator_test                                        PASSED in 63.3s
  Stats over 4 runs: max = 63.3s, min = 61.2s, avg = 62.1s, dev = 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.8s
  Stats over 5 runs: max = 2.8s, min = 1.7s, avg = 2.2s, dev = 0.4s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 51.7s
  Stats over 50 runs: max = 51.7s, min = 1.4s, avg = 6.0s, dev = 12.3s

Executed 227 out of 227 tests: 227 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
