### PR TITLE
[Dvaas] Refactor `ValidateTestRun` and `ValidateTestRuns` to return a `StatusOr`.

### DIFF
--- a/dvaas/BUILD.bazel
+++ b/dvaas/BUILD.bazel
@@ -37,7 +37,6 @@ cc_library(
         ":validation_result",
         "//gutil:proto",
         "//gutil:proto_ordering",
-        "//gutil:status",
         "//gutil:test_artifact_writer",
         "//gutil:version",
         "//lib/gnmi:gnmi_helper",
@@ -112,6 +111,7 @@ cc_library(
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",
     ],
 )
@@ -155,11 +155,10 @@ cc_library(
     srcs = ["test_run_validation.cc"],
     hdrs = ["test_run_validation.h"],
     deps = [
-        ":output_writer",
         ":test_vector_cc_proto",
         "//gutil:proto",
         "//gutil:proto_ordering",
-        "//gutil:status",
+        "//gutil:status_matchers",
         "//p4_pdpi:ir_cc_proto",
         "//p4_pdpi/packetlib:packetlib_cc_proto",
         "@com_github_google_glog//:glog",
@@ -192,13 +191,12 @@ cc_library(
         "//p4_pdpi:p4_runtime_session",
         "//p4_pdpi:p4_runtime_session_extras",
         "//sai_p4/instantiations/google/test_tools:test_entries",
-        "//thinkit:mirror_testbed",
         "@com_github_google_glog//:glog",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
-        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
     ],
 )
 
@@ -470,13 +468,12 @@ cc_test(
     linkstatic = True,
     deps = [
         ":test_run_validation",
-        ":test_vector",
         ":test_vector_cc_proto",
         "//gutil:testing",
-        "//p4_pdpi/packetlib",
+        "//p4_pdpi:ir_cc_proto",
         "//p4_pdpi/packetlib:packetlib_cc_proto",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/types:optional",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/status:statusor",
     ],
 )
 

--- a/dvaas/arriba_test_vector_validation.cc
+++ b/dvaas/arriba_test_vector_validation.cc
@@ -17,7 +17,6 @@
 #include <utility>
 #include <vector>
 
-#include "absl/status/status.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "dvaas/packet_injection.h"
@@ -89,8 +88,9 @@ absl::StatusOr<ValidationResult> ValidateAgainstArribaTestVector(
 
   // Compare the switch output with expected output for each test vector.
   LOG(INFO) << "Validating test runs";
-  PacketTestOutcomes test_outcomes =
-      ValidateTestRuns(test_runs, params.switch_output_diff_params);
+  ASSIGN_OR_RETURN(
+      PacketTestOutcomes test_outcomes,
+      ValidateTestRuns(test_runs, params.switch_output_diff_params));
   RETURN_IF_ERROR(artifact_writer.AppendToTestArtifact(
       "test_outcomes.txtpb", gutil::PrintTextProto(test_outcomes)));
 

--- a/dvaas/arriba_test_vector_validation.h
+++ b/dvaas/arriba_test_vector_validation.h
@@ -15,16 +15,14 @@
 #ifndef PINS_DVAAS_ARRIBA_TEST_VECTOR_VALIDATION_H_
 #define PINS_DVAAS_ARRIBA_TEST_VECTOR_VALIDATION_H_
 
-#include <vector>
+#include <optional>
 
-#include "absl/container/flat_hash_set.h"
 #include "absl/status/statusor.h"
 #include "dvaas/packet_injection.h"
 #include "dvaas/test_run_validation.h"
 #include "dvaas/test_vector.pb.h"
 #include "dvaas/validation_result.h"
 #include "p4_pdpi/p4_runtime_session.h"
-#include "thinkit/mirror_testbed.h"
 
 namespace dvaas {
 

--- a/dvaas/dataplane_validation.cc
+++ b/dvaas/dataplane_validation.cc
@@ -121,9 +121,10 @@ absl::Status DetermineReproducibilityRate(
                                        test_vectors, parameters, statistics,
                                        /*log_injection_progress=*/false));
 
-  ValidationResult validation_result =
-      ValidationResult(test_runs, params.switch_output_diff_params,
-                       /*packet_synthesis_result=*/{});
+  ASSIGN_OR_RETURN(
+      ValidationResult validation_result,
+      ValidationResult::Create(test_runs, params.switch_output_diff_params,
+                               /*packet_synthesis_result=*/{}));
 
   test_outcome.mutable_test_result()
       ->mutable_failure()
@@ -744,8 +745,9 @@ DataplaneValidator::ValidateDataplaneUsingExistingSwitchApis(
       "test_runs.textproto", gutil::PrintTextProto(test_runs)));
 
   // Validate test runs to create test outcomes.
-  dvaas::PacketTestOutcomes test_outcomes =
-      dvaas::ValidateTestRuns(test_runs, params.switch_output_diff_params);
+  ASSIGN_OR_RETURN(
+      dvaas::PacketTestOutcomes test_outcomes,
+      dvaas::ValidateTestRuns(test_runs, params.switch_output_diff_params));
 
   // Store the packet trace for all failed test outcomes.
   ASSIGN_OR_RETURN(P4Specification p4_spec,
@@ -836,9 +838,9 @@ DataplaneValidator::ValidateDataplaneUsingExistingSwitchApis(
                       packet_injection_params, statistics,
                       /*log_injection_progress=*/false));
               // Validate test runs to create test outcomes.
-              return ValidationResult(test_runs,
-                                      params.switch_output_diff_params,
-                                      /*packet_synthesis_result=*/{});
+              return ValidationResult::Create(test_runs,
+                                              params.switch_output_diff_params,
+                                              /*packet_synthesis_result=*/{});
             });
         if (!status.ok()) {
           LOG(WARNING) << "Got error when post-processing failure: "

--- a/dvaas/test_run_validation.cc
+++ b/dvaas/test_run_validation.cc
@@ -28,7 +28,6 @@
 #include "absl/strings/strip.h"
 #include "absl/strings/substitute.h"
 #include "absl/types/optional.h"
-#include "dvaas/output_writer.h"
 #include "dvaas/test_vector.pb.h"
 #include "glog/logging.h"
 #include "google/protobuf/descriptor.h"
@@ -36,6 +35,7 @@
 #include "gutil/proto.h"
 #include "gutil/proto_ordering.h"
 #include "gutil/status.h"
+#include "gutil/status_matchers.h"
 #include "p4_pdpi/ir.pb.h"
 #include "p4_pdpi/packetlib/packetlib.pb.h"
 #include "gmock/gmock.h"
@@ -323,7 +323,63 @@ static constexpr absl::string_view kExpectationBanner =
     "=============================================================";
 }  // namespace
 
-PacketTestValidationResult ValidateTestRun(
+absl::StatusOr<std::vector<const google::protobuf::FieldDescriptor*>>
+GetAllFieldDescriptorsOfHeaders(
+    const absl::flat_hash_set<packetlib::Header::HeaderCase>& header_cases) {
+  std::vector<const google::protobuf::FieldDescriptor*> descriptors;
+
+  for (packetlib::Header::HeaderCase header_case : header_cases) {
+    const auto* reflection = packetlib::Header::GetReflection();
+    if (reflection == nullptr) {
+      return absl::NotFoundError("Reflection for packetlib::Header not found");
+    }
+    const auto* oneof_descriptor =
+        packetlib::Header::GetDescriptor()->FindOneofByName("header");
+    if (oneof_descriptor == nullptr) {
+      return absl::NotFoundError(
+          "Oneof descriptor for packetlib::Header not found");
+    }
+
+    // Find the index of `header_case`.
+    // Unfortunately, HeaderCases are tag numbers and don't use zero-based
+    // indexing (proto tags can have arbitrary value with gaps in between). So
+    // to find the index of a header case to call OneOfDescriptor::field(),
+    // we need to iterate through all header cases to find its index in the
+    // header.
+    std::optional<int> header_case_index;
+    for (int i = 0; i < oneof_descriptor->field_count(); ++i) {
+      if (oneof_descriptor->field(i)->number() == header_case) {
+        header_case_index = i;
+        break;
+      }
+    }
+    if (header_case_index == std::nullopt) {
+      return absl::NotFoundError(absl::StrCat("Header case with tag number ",
+                                              header_case,
+                                              " is not found in packetlib"));
+    }
+    const auto* oneof_field_descriptor =
+        oneof_descriptor->field(*header_case_index);
+
+    if (oneof_field_descriptor == nullptr) {
+      return absl::NotFoundError(
+          "Oneof field descriptor for packetlib::Header not found");
+    }
+    const auto* header_message_descriptor =
+        oneof_field_descriptor->message_type();
+    if (header_message_descriptor == nullptr) {
+      return absl::NotFoundError(
+          "Oneof message descriptor for packetlib::Header not found");
+    }
+    int field_count = header_message_descriptor->field_count();
+    for (int i = 0; i < field_count; ++i) {
+      descriptors.push_back(header_message_descriptor->field(i));
+    }
+  }
+  return descriptors;
+}
+
+absl::StatusOr<PacketTestValidationResult> ValidateTestRun(
     const PacketTestRun& test_run, const SwitchOutputDiffParams& diff_params) {
   PacketTestValidationResult result;
 
@@ -393,16 +449,17 @@ PacketTestValidationResult ValidateTestRun(
   return result;
 }
 
-PacketTestOutcomes ValidateTestRuns(const PacketTestRuns& test_runs,
-                                    const SwitchOutputDiffParams& diff_params) {
+absl::StatusOr<PacketTestOutcomes> ValidateTestRuns(
+    const PacketTestRuns& test_runs,
+    const SwitchOutputDiffParams& diff_params) {
   PacketTestOutcomes test_outcomes;
   test_outcomes.mutable_outcomes()->Reserve(test_runs.test_runs_size());
 
   for (const auto& test_run : test_runs.test_runs()) {
     PacketTestOutcome& test_outcome = *test_outcomes.add_outcomes();
     *test_outcome.mutable_test_run() = test_run;
-    *test_outcome.mutable_test_result() =
-        ValidateTestRun(test_run, diff_params);
+    ASSIGN_OR_RETURN(*test_outcome.mutable_test_result(),
+                     ValidateTestRun(test_run, diff_params));
   }
 
   return test_outcomes;

--- a/dvaas/test_run_validation.h
+++ b/dvaas/test_run_validation.h
@@ -19,8 +19,7 @@
 #include <vector>
 
 #include "absl/container/flat_hash_set.h"
-#include "absl/status/status.h"
-#include "dvaas/output_writer.h"
+#include "absl/status/statusor.h"
 #include "dvaas/test_vector.pb.h"
 #include "google/protobuf/descriptor.h"
 #include "p4_pdpi/packetlib/packetlib.pb.h"
@@ -55,13 +54,13 @@ struct SwitchOutputDiffParams {
 
 // Validates the given `test_vector` using the parameters in `params` and
 // returns the result.
-PacketTestValidationResult
-ValidateTestRun(const PacketTestRun &test_run,
-                const SwitchOutputDiffParams &diff_params = {});
+absl::StatusOr<PacketTestValidationResult> ValidateTestRun(
+    const PacketTestRun& test_run,
+    const SwitchOutputDiffParams& diff_params = {});
 
 // Like `ValidateTestRun`, but for a collection of `test_runs`.
-PacketTestOutcomes ValidateTestRuns(const PacketTestRuns& test_runs,
-                                    const SwitchOutputDiffParams& diff_params);
+absl::StatusOr<PacketTestOutcomes> ValidateTestRuns(
+    const PacketTestRuns& test_runs, const SwitchOutputDiffParams& diff_params);
 
 } // namespace dvaas
 

--- a/dvaas/test_run_validation_test_runner.cc
+++ b/dvaas/test_run_validation_test_runner.cc
@@ -16,13 +16,12 @@
 #include <string>
 #include <vector>
 
-#include "absl/strings/substitute.h"
-#include "absl/types/optional.h"
+#include "absl/status/statusor.h"
 #include "dvaas/test_run_validation.h"
-#include "dvaas/test_vector.h"
 #include "dvaas/test_vector.pb.h"
+#include "glog/logging.h"
 #include "gutil/testing.h"
-#include "p4_pdpi/packetlib/packetlib.h"
+#include "p4_pdpi/ir.pb.h"
 #include "p4_pdpi/packetlib/packetlib.pb.h"
 
 namespace dvaas {
@@ -606,14 +605,15 @@ void main() {
     PacketTestRun test_run;
     *test_run.mutable_test_vector() = test.test_vector;
     *test_run.mutable_actual_output() = test.actual_output;
-    PacketTestValidationResult result =
+    absl::StatusOr<PacketTestValidationResult> result =
         ValidateTestRun(test_run, test.diff_params);
-    CHECK(result.has_failure())  // Crash OK: this is test code.
+    CHECK_OK(result.status());    // Crash OK: this is test code.
+    CHECK(result->has_failure())  // Crash OK: this is test code.
         << "for test case with description '" << test.description << "'";
     std::cout << std::string(80, '=')
               << "\nValidateTestRun Test: " << test.description << "\n"
               << std::string(80, '=') << "\n"
-              << result.failure().description() << "\n\n";
+              << result->failure().description() << "\n\n";
   }
 }
 

--- a/dvaas/traffic_generator.cc
+++ b/dvaas/traffic_generator.cc
@@ -16,7 +16,6 @@
 
 #include <memory>
 #include <optional>
-#include <string>
 #include <thread>  // NOLINT: third_party code.
 #include <utility>
 #include <vector>
@@ -193,7 +192,7 @@ absl::StatusOr<ValidationResult> SimpleTrafficGenerator::GetValidationResult() {
   test_runs_mutex_.Lock();
   PacketTestRuns test_runs = test_runs_;
   test_runs_mutex_.Unlock();
-  return ValidationResult(
+  return ValidationResult::Create(
       test_runs, params_.validation_params.switch_output_diff_params,
       generate_test_vectors_result_.packet_synthesis_result);
 }
@@ -205,7 +204,7 @@ SimpleTrafficGenerator::GetAndClearValidationResult() {
   test_runs_.clear_test_runs();
   test_runs_mutex_.Unlock();
 
-  return ValidationResult(
+  return ValidationResult::Create(
       test_runs, params_.validation_params.switch_output_diff_params,
       generate_test_vectors_result_.packet_synthesis_result);
 }
@@ -597,9 +596,10 @@ TrafficGeneratorWithGuaranteedRate::GetValidationResult() {
         collected_traffic_by_id.erase(injected_traffic.tag);
       }
       // Validate test runs to create test outcomes.
-      *test_outcome->mutable_test_result() =
+      ASSIGN_OR_RETURN(
+          *test_outcome->mutable_test_result(),
           ValidateTestRun(*packet_test_run,
-                          params_.validation_params.switch_output_diff_params);
+                          params_.validation_params.switch_output_diff_params));
       if (test_outcome->test_result().has_failure()) {
         failed_switch_inputs.push_back(
             test_outcome->test_run().test_vector().input());

--- a/dvaas/validation_result.cc
+++ b/dvaas/validation_result.cc
@@ -35,12 +35,12 @@ ValidationResult::ValidationResult(
       test_vector_stats_(ComputeTestVectorStats(test_outcomes)),
       packet_synthesis_result_(packet_synthesis_result) {}
 
-ValidationResult::ValidationResult(
+absl::StatusOr<ValidationResult> ValidationResult::Create(
     const PacketTestRuns& test_runs, const SwitchOutputDiffParams& diff_params,
     const PacketSynthesisResult& packet_synthesis_result) {
-  test_outcomes_ = ValidateTestRuns(test_runs, diff_params);
-  test_vector_stats_ = ComputeTestVectorStats(test_outcomes_);
-  packet_synthesis_result_ = packet_synthesis_result;
+  ASSIGN_OR_RETURN(PacketTestOutcomes test_outcomes,
+                   ValidateTestRuns(test_runs, diff_params));
+  return ValidationResult(packet_synthesis_result, test_outcomes);
 }
 
 std::string ExplainFailure(const PacketTestValidationResult::Failure& failure) {


### PR DESCRIPTION
Keyword Check:
sk/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.



Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 746 targets (267 packages loaded, 22396 targets configured).
INFO: Found 746 targets...
INFO: From Compiling dvaas/arriba_test_vector_validation.cc:
In file included from ./gutil/proto.h:26,
                 from dvaas/arriba_test_vector_validation.cc:29:
dvaas/arriba_test_vector_validation.cc: In function 'absl::lts_20240116::StatusOr<dvaas::ValidationResult> dvaas::ValidateAgainstArribaTestVector(pdpi::P4RuntimeSession&, pdpi::P4RuntimeSession&, const ArribaTestVector&, const ArribaTestVectorValidationParams&)':
dvaas/arriba_test_vector_validation.cc:56:42: warning: 'absl::lts_20240116::Status pdpi::ClearTableEntries(P4RuntimeSession*)' is deprecated: Use ClearEntities instead. [-Wdeprecated-declarations]
   56 |   RETURN_IF_ERROR(pdpi::ClearTableEntries(&control_switch));
      |                   ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
./gutil/status.h:275:30: note: in definition of macro 'RETURN_IF_ERROR'
  275 |   for (absl::Status status = expr; !status.ok();)                              \
      |                              ^~~~
In file included from ./dvaas/packet_injection.h:27,
                 from ./dvaas/arriba_test_vector_validation.h:21,
                 from dvaas/arriba_test_vector_validation.cc:15:
./p4_pdpi/p4_runtime_session.h:413:14: note: declared here
  413 | absl::Status ClearTableEntries(P4RuntimeSession *session);
      |              ^~~~~~~~~~~~~~~~~
dvaas/arriba_test_vector_validation.cc:61:42: warning: 'absl::lts_20240116::Status pdpi::ClearTableEntries(P4RuntimeSession*)' is deprecated: Use ClearEntities instead. [-Wdeprecated-declarations]
   61 |   RETURN_IF_ERROR(pdpi::ClearTableEntries(&sut));
      |                   ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
./gutil/status.h:275:30: note: in definition of macro 'RETURN_IF_ERROR'
  275 |   for (absl::Status status = expr; !status.ok();)                              \
      |                              ^~~~
./p4_pdpi/p4_runtime_session.h:413:14: note: declared here
  413 | absl::Status ClearTableEntries(P4RuntimeSession *session);
      |              ^~~~~~~~~~~~~~~~~
INFO: From Compiling tests/forwarding/ouroboros_test.cc:
tests/forwarding/ouroboros_test.cc:122:3: note: in expansion of macro 'ASSIGN_OR_RETURN'
  122 |   ASSIGN_OR_RETURN(
      |   ^~~~~~~~~~~~~~~~
In file included from tests/forwarding/ouroboros_test.cc:55:
./tests/lib/switch_test_setup_helpers.h:132:1: note: declared here
  132 | ConfigureSwitchPairAndReturnP4RuntimeSessionPair(
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO: From Compiling dvaas/traffic_generator.cc:
dvaas/traffic_generator.cc: In member function 'virtual absl::lts_20240116::StatusOr<dvaas::ValidationResult> dvaas::TrafficGeneratorWithGuaranteedRate::GetValidationResult()':
dvaas/traffic_generator.cc:626:27: warning: comparison of integer expressions of different signedness: 'int' and 'absl::lts_20240116::container_internal::btree_container<absl::lts_20240116::container_internal::btree<absl::lts_20240116::container_internal::map_params<int, dvaas::PacketTestVector, std::less<int>, std::allocator<std::pair<const int, dvaas::PacketTestVector> >, 256, false> > >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  626 |       packet_trace_count_ <
      |       ~~~~~~~~~~~~~~~~~~~~^
  627 |           generate_test_vectors_result_.packet_test_vector_by_id.size()) {
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO: Elapsed time: 240.021s, Critical Path: 44.94s
INFO: 28 processes: 3 internal, 25 linux-sandbox.
INFO: Build completed successfully, 28 total actions




Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 746 targets (0 packages loaded, 383 targets configured).
INFO: Found 517 targets and 229 test targets...
INFO: Elapsed time: 265.113s, Critical Path: 144.62s
INFO: 286 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 286 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.6s
//dvaas:dataplane_validation_test                                        PASSED in 0.2s
//dvaas:port_id_map_test                                                 PASSED in 1.4s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.6s
//dvaas:test_run_validation_test                                         PASSED in 1.1s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.0s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.3s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 0.9s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 0.7s
//gutil:io_test                                                          PASSED in 0.7s
//gutil:proto_matchers_test                                              PASSED in 0.7s
//gutil:proto_ordering_test                                              PASSED in 0.8s
//gutil:proto_test                                                       PASSED in 0.7s
//gutil:status_matchers_test                                             PASSED in 0.8s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 5.3s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 1.2s
//sai_p4/tools:p4info_tools_test                                         PASSED in 0.7s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.0s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 1.5s
//tests/forwarding:hash_statistics_util_test                             PASSED in 1.2s
//tests/lib:common_ir_table_entries_test                                 PASSED in 1.1s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.0s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.1s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.2s
//thinkit:bazel_test_environment_test                                    PASSED in 1.8s
//thinkit:generic_testbed_test                                           PASSED in 1.3s
//thinkit:mock_control_device_test                                       PASSED in 1.0s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.1s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.0s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 0.9s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.0s
//tests/lib:packet_generator_test                                        PASSED in 61.8s
  Stats over 4 runs: max = 61.8s, min = 61.0s, avg = 61.4s, dev = 0.3s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.0s
  Stats over 5 runs: max = 1.0s, min = 0.8s, avg = 0.9s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 44.4s
  Stats over 50 runs: max = 44.4s, min = 1.0s, avg = 3.8s, dev = 10.3s

Executed 229 out of 229 tests: 229 tests pass.