### PR TITLE
[SAI_P4] Enable AppendIngressAndEgressTimestampAction in SAI P4 and Add new AddRouterInterfaceTableEntry function.

### DIFF
--- a/sai_p4/instantiations/google/acl_ingress.p4
+++ b/sai_p4/instantiations/google/acl_ingress.p4
@@ -236,7 +236,11 @@ control acl_ingress(in headers_t headers,
 
   @id(ACL_INGRESS_APPEND_INGRESS_AND_EGRESS_TIMESTAMP_ACTION_ID)
   @sai_action(SAI_PACKET_ACTION_FORWARD)
+#ifdef SAI_INSTANTIATION_TOR
+  // TODO: Remove unsupported from ToR when we order ACL
+  // insert/deletes during reconcile.
   @unsupported
+#endif
   action append_ingress_and_egress_timestamp(
     @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_INSERT_INGRESS_TIMESTAMP)
     bit<8> append_ingress_timestamp,

--- a/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
@@ -1769,7 +1769,6 @@ actions {
     name: "ingress.acl_ingress.append_ingress_and_egress_timestamp"
     alias: "append_ingress_and_egress_timestamp"
     annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD)"
-    annotations: "@unsupported"
   }
   params {
     id: 1

--- a/sai_p4/instantiations/google/middleblock.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock.p4info.pb.txt
@@ -1535,7 +1535,6 @@ actions {
     name: "ingress.acl_ingress.append_ingress_and_egress_timestamp"
     alias: "append_ingress_and_egress_timestamp"
     annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD)"
-    annotations: "@unsupported"
   }
   params {
     id: 1

--- a/sai_p4/instantiations/google/test_tools/table_entry_generator.cc
+++ b/sai_p4/instantiations/google/test_tools/table_entry_generator.cc
@@ -429,6 +429,9 @@ const absl::flat_hash_set<std::string>& KnownUnsupportedTables() {
           // TODO: Remove this table once the entire fleet's P4
           // programs support ingress cloning.
           "mirror_port_to_pre_session_table",
+	  // TODO: Enable this table when it has been removed from
+          // unsupported roles.
+          "mirror_session_table",
 	  // TODO: Re-enable once the released version supports
           // the action used in this table.
           "acl_ingress_mirror_and_redirect_table",
@@ -463,7 +466,9 @@ absl::StatusOr<TableEntryGenerator> GetGenerator(
       {"acl_ingress_qos_table", AclIngressQosTableGenerator},
       {"acl_ingress_security_table", AclIngressSecurityTableGenerator},
       {"acl_ingress_counting_table", AclIngressCountingTableGenerator},
-      {"mirror_session_table", MirrorSessionGenerator},
+      // TODO: Enable this table when it has been removed from
+      // unsupported roles.
+      // {"mirror_session_table", MirrorSessionGenerator},
       {"acl_egress_table", AclEgressTableGenerator},
       {"acl_egress_l2_table", AclEgressL2TableGenerator},
       {"acl_egress_dhcp_to_host_table", AclEgressDhcpToHostTableGenerator},

--- a/sai_p4/instantiations/google/test_tools/test_entries.h
+++ b/sai_p4/instantiations/google/test_tools/test_entries.h
@@ -102,6 +102,10 @@ struct SetWcmpGroupId {
   std::string wcmp_group_id;
 };
 
+struct SetVlanId {
+  std::string vlan_id;
+};
+
 // -- Match Fields and Params --------------------------------------------------
 
 // Rewrite-related options for nexthop action generation.
@@ -201,6 +205,13 @@ struct IpTableEntryParams {
   std::string vrf;
   using IpTableAction = std::variant<SetNextHopId, SetWcmpGroupId>;
   IpTableAction action;
+};
+
+struct RouterInterfaceTableParams {
+  std::string router_interface_id;
+  std::string egress_port;
+  netaddr::MacAddress src_mac;
+  std::optional<std::string> vlan_id;
 };
 
 // Convenience struct corresponding to the protos `p4::v1::Replica` and


### PR DESCRIPTION
### **PR Description:**
Enable AppendIngressAndEgressTimestampAction in SAI P4 and Add new AddRouterInterfaceTableEntry function.

### **Keyword Check:**
bibhuprasad@bibhuprasad87:~/sonic_build_image_2025-06-23/sonic-buildimage/src/sonic-p4rt/sonic-pins/sai_p4$ sh ~/keyword_check.sh .
Keyword check Passed.

### **Build Results:**
bibhuprasad@b53a70426c59:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 744 targets (0 packages loaded, 0 targets configured).
INFO: Found 744 targets...
INFO: Elapsed time: 0.457s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### **UT Results:**
bibhuprasad@b53a70426c59:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 744 targets (0 packages loaded, 0 targets configured).
INFO: Found 517 targets and 227 test targets...
INFO: Elapsed time: 192.397s, Critical Path: 135.96s
INFO: 284 processes: 338 linux-sandbox, 18 local.
INFO: Build completed successfully, 284 total actions
//dvaas:port_id_map_test                                                 PASSED in 2.0s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.8s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.9s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//gutil:collections_test                                                 PASSED in 1.6s
//gutil:io_test                                                          PASSED in 1.4s
//gutil:proto_matchers_test                                              PASSED in 1.5s
//gutil:proto_ordering_test                                              PASSED in 1.8s
//gutil:proto_test                                                       PASSED in 1.5s
//gutil:status_matchers_test                                             PASSED in 1.5s
//gutil:test_artifact_writer_test                                        PASSED in 2.0s
//gutil:testing_test                                                     PASSED in 1.4s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 4.7s
//lib:basic_switch_test                                                  PASSED in 2.3s
//lib:ixia_helper_test                                                   PASSED in 2.7s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 3.0s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 17.3s
//lib/gnmi:gnmi_helper_test                                              PASSED in 4.4s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.4s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.6s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 1.8s
//lib/utils:generic_testbed_utils_test                                   PASSED in 2.9s
//lib/utils:json_utils_test                                              PASSED in 1.5s
//lib/validator:validator_backend_test                                   PASSED in 1.5s
//lib/validator:validator_lib_test                                       PASSED in 27.4s
//p4_fuzzer:constraints_test                                             PASSED in 11.0s
//p4_fuzzer:fuzz_util_test                                               PASSED in 135.8s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 1.9s
//p4_fuzzer:oracle_util_test                                             PASSED in 5.3s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 4.0s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 4.0s
//p4_fuzzer:switch_state_test                                            PASSED in 1.9s
//p4_pdpi:built_ins_test                                                 PASSED in 1.4s
//p4_pdpi:entity_keys_test                                               PASSED in 1.6s
//p4_pdpi:ir_properties_test                                             PASSED in 1.4s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 2.2s
//p4_pdpi:names_test                                                     PASSED in 1.9s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.8s
//p4_pdpi:p4info_union_test                                              PASSED in 1.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 1.8s
//p4_pdpi:references_test                                                PASSED in 1.8s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.8s
//p4_pdpi:ternary_test                                                   PASSED in 1.4s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.8s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.4s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.4s
//p4_pdpi/packetlib:packetlib_debugging_test                             PASSED in 1.8s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 21.4s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.8s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 7.0s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.4s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.8s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.3s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 2.2s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.2s
//p4_pdpi/testing:references_test                                        PASSED in 0.2s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.3s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 2.0s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.4s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.5s
//p4_symbolic:z3_util_test                                               PASSED in 1.5s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.2s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 3.1s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 3.1s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.2s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 3.0s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.2s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 3.0s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 3.2s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 3.4s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 3.0s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.9s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.3s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.2s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.2s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.2s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.2s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.2s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.2s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.1s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.2s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.2s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.2s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.2s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.5s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 30.4s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 25.4s
//p4_symbolic/sai:sai_test                                               PASSED in 7.6s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 4.1s
//p4_symbolic/symbolic:parser_test                                       PASSED in 2.4s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 2.1s
//p4_symbolic/symbolic:util_test                                         PASSED in 2.1s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.4s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 18.3s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 3.2s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 2.8s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 2.4s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 2.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 3.0s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 2.8s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 1.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 2.8s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 1.4s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 2.5s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 2.4s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.1s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.4s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 2.5s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.4s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 1.8s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.0s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 2.2s
//p4rt_app/sonic:hashing_test                                            PASSED in 1.9s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 2.1s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.3s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.8s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.0s
//p4rt_app/sonic:state_verification_test                                 PASSED in 1.9s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.2s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 1.6s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.9s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.8s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.1s
//p4rt_app/tests:action_set_test                                         PASSED in 1.6s
//p4rt_app/tests:api_access_test                                         PASSED in 1.2s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.4s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.4s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 8.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.6s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.4s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.8s
//p4rt_app/tests:packetio_test                                           PASSED in 4.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.6s
//p4rt_app/tests:response_path_test                                      PASSED in 5.2s
//p4rt_app/tests:role_test                                               PASSED in 1.7s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.9s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.4s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.3s
//p4rt_app/utils:table_utility_test                                      PASSED in 1.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.6s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.4s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.3s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 4.8s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 3.1s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 7.6s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 2.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.9s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.5s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.0s
//tests/lib:common_ir_table_entries_test                                 PASSED in 1.9s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 2.0s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.2s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.3s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.2s
//tests/sflow:sflow_util_test                                            PASSED in 8.0s
//thinkit:bazel_test_environment_test                                    PASSED in 1.6s
//thinkit:generic_testbed_test                                           PASSED in 2.4s
//thinkit:mock_control_device_test                                       PASSED in 1.4s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.8s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 2.1s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.9s
//tests/lib:packet_generator_test                                        PASSED in 65.1s
  Stats over 4 runs: max = 65.1s, min = 61.9s, avg = 63.1s, dev = 1.2s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.3s
  Stats over 5 runs: max = 2.3s, min = 1.8s, avg = 2.0s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 46.6s
  Stats over 50 runs: max = 46.6s, min = 1.3s, avg = 4.3s, dev = 8.8s

Executed 227 out of 227 tests: 227 tests pass.