### PR TITLE
[SAI_P4] Increase the maximum number of members for each SUM_OF_MEMBERS group to 512 and Add a header file to define meaningful annotations in SAI p4 programs.

### DIFF
--- a/sai_p4/instantiations/google/BUILD.bazel
+++ b/sai_p4/instantiations/google/BUILD.bazel
@@ -385,6 +385,14 @@ cc_test(
     ],
 )
 
+cc_library(
+    name = "annotations",
+    hdrs = ["annotations.h"],
+    deps = [
+        "@com_google_absl//absl/strings",
+    ],
+)
+
 # Auxiliary target, see go/totw/128.
 cc_embed_data(
     name = "sai_nonstandard_platforms_embed",

--- a/sai_p4/instantiations/google/annotations.h
+++ b/sai_p4/instantiations/google/annotations.h
@@ -1,0 +1,184 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PINS_SAI_P4_INSTANTIATIONS_ANNOTATIONS_H_
+#define PINS_SAI_P4_INSTANTIATIONS_ANNOTATIONS_H_
+
+#include "absl/strings/string_view.h"
+
+// This file lists meaningful annotations for sai p4 programs.
+
+namespace sai {
+namespace annotation {
+
+// General SAI P4 annotations
+
+// @format(<format>) indicates the expected format of the value on the wire.
+//
+// Applies to: table match fields, action parameters
+// Values:
+//   IPV4_ADDRESS: IPv4 address. E.g. 1.2.3.4
+//   IPV6_ADDRESS: IPv6 address. E.g. 1234:5678:0:0::
+//   MAC_ADDRESS: MAC address. E.g. aa:bb:cc:dd:ee:ff
+inline constexpr absl::string_view kFormat = "format";
+
+// TODO: Remove this annotation when we update acl_ingress.p4 to
+// use the new standard meter annotations.
+//
+// @mode(<meter_mode>) indicates the mode of the meter object.
+//
+// Applies to: direct_meter objects
+// Values:
+//   single_rate_two_color: single rate meter creating red & green
+//   single_rate_three_color: single rate meter creating red, yellow, & green
+//   two_rate_three_color, two rate meter creating red, yellow, & green
+inline constexpr absl::string_view kMeterMode = "mode";
+
+// @refers_to(<table>, <match_field>) indicates that this field refers to one or
+// more entries in a separate table identifiable by the value in the specified
+// match_field.
+//
+// When using a refers-to value, the referenced entry must first exist.
+//
+// See go/p4-references-and-multicast, go/p4-use, and go/p4-sequencing for more
+// information.
+//
+// Applies to: Table match fields, action parameters
+// Values:
+//   table: the name of table containing the entry being referenced.
+//   key: the name of the table match field that corresponds to the value.
+inline constexpr absl::string_view kRefersTo = "refers_to";
+
+// TODO: Describe @referenced_by
+inline constexpr absl::string_view kReferencedBy = "referenced_by";
+
+// @entry_restriction(<restriction>) defines the set of rules indicating whether
+// an entry is valid for this table. These rules can be used to reject an entry
+// during a Write request.
+//
+// Applies to: table objects
+// Value:
+//   P4 constraints string: github.com/p4lang/p4-constraints
+inline constexpr absl::string_view kEntryRestriction = "entry_restriction";
+
+// @action_restriction(<restriction>) defines the set of rules indicating
+// whether the set of action parameters is valid. These rules can be used to
+// reject an entry during a Write request.
+//
+// Applies to: action objects
+// Value:
+//   P4 constraints string: github.com/p4lang/p4-constraints
+inline constexpr absl::string_view kActionRestriction = "action_restriction";
+
+// @unsupported indicates that this object is not fully supported today and
+// should not be made available for use yet. This can be helpful for guarding a
+// new feature while still enabling development, simulation and testing before
+// full switch support is available. Any P4Runtime entity that refers to an
+// unsupported object will be rejected by the switch.
+//
+// See go/unblocking-sai-p4 for more details.
+//
+// Applies to: action objects, table objects
+inline constexpr absl::string_view kUnsupported = "unsupported";
+
+// ACL-Related Annotations
+
+// @sai_acl(<stage>) denotes an ACL table. The body indicates the stage of the
+// ACL table.
+//
+// Applies to: table objects
+// Values: PRE_INGRESS, INGRESS, EGRESS
+inline constexpr absl::string_view kSaiAcl = "sai_acl";
+
+// @sai_acl_priority(<priority>) denotes the relative priority of an ACL table.
+//
+// Applies to: table objects
+// Value: Integer Priority (higher is higher)
+inline constexpr absl::string_view kSaiAclPriority = "sai_acl_priority";
+
+// @sai_field(<sai_field>) denotes the SAI match field referred to by this P4
+// match key.
+//
+// Applies to: table match keys
+// Value: SAI_ACL_TABLE_ATTR_FIELD_* values defined in in saiacl.h
+inline constexpr absl::string_view kSaiField = "sai_field";
+
+// @sai_udf(base=<base>, offset=<offset>, length=<length>) indicates a SAI UDF
+// represented by this P4 match key.
+//
+// Applies to: table match keys
+// Value:
+//   <base>: SAI_UDF_BASE_L2, SAI_UDF_BASE_L3, SAI_UDF_BASE_L4
+//   <offset>: Integer byte offset from base.
+//   <length>: Integer length of UDF field in bytes.
+inline constexpr absl::string_view kSaiUdf = "sai_udf";
+
+// @composite_field(<field1>, [<field2>, ..., <fieldN>]) indicates this match
+// key is a composite of multiple SAI match fields. The composite key bitwidth
+// must be the sum of the bitwidths of each component field. Fields are ordered
+// from MSB to LSB of the key value.
+//
+// Applies to: table match keys
+// Value: Each <field> is must be either a @sai_field or @sai_udf annotation.
+inline constexpr absl::string_view kCompositeField = "composite_field";
+
+// @sai_action(<sai_action>[, color]) denotes the SAI action performed by this
+// action.
+//
+// Applies to: action objects
+// Values:
+//   sai_action: Unparameterized SAI action, SAI_PACKET_ACTION_* defined in
+//               saiacl.h
+//   color: Optional parameter, limits sai_action to packets of X color.
+//          SAI_PACKET_COLOR_RED, SAI_PACKET_COLOR_YELLOW,
+//          SAI_PACKET_COLOR_GREEN
+inline constexpr absl::string_view kSaiAction = "sai_action";
+
+// @sai_action_param(<sai_param>) denotes the SAI action & value associated with
+// this action parameter.
+//
+// Applies to: action parameters
+// Values: SAI_ACL_ENTRY_ATTR_ACTION_* values from saiacl.h
+//         Custom values may also exist depending on implementation.
+inline constexpr absl::string_view kSaiActionParam = "sai_action_param";
+
+// @sai_action_param_object_type(<sai_object_type>) indicates the SAI object
+// type that this parameter may refer to.
+//
+// Applies to: action parameters
+// values: SAI_OBJECT_TYPE_* defined in saibridge.h
+inline constexpr absl::string_view kSaiActionParamObjectType =
+    "sai_action_param_object_type";
+
+// @nonessential_for_upgrade indicates that the entries in this table may be
+// removed for a short period during a P4info reconciliation.
+//
+// Applies to: table objects
+inline constexpr absl::string_view kNonessentialForUpgrade =
+    "nonessential_for_upgrade";
+
+// @reinstall_during_upgrade indicates that this table should be reinstalled
+// during a P4Info reconcile even if there is no change to the table semantics.
+// This may be used to test table reconciliation or, if combined with
+// @nonessential_for_upgrade, used to provide space for another, essential
+// table to reconcile.
+//
+// Applies to: table objects
+inline constexpr absl::string_view kReinstallDuringUpgrade =
+    "reinstall_during_upgrade";
+
+}  // namespace annotation
+}  // namespace sai
+
+#endif  // PINS_SAI_P4_INSTANTIATIONS_ANNOTATIONS_H_

--- a/sai_p4/instantiations/google/minimum_guaranteed_sizes.h
+++ b/sai_p4/instantiations/google/minimum_guaranteed_sizes.h
@@ -75,7 +75,9 @@
 // The maximum sum of weights for each wcmp group.
 #define WCMP_GROUP_SELECTOR_SUM_OF_WEIGHTS_MAX_GROUP_SIZE_NON_TOR 512
 #define WCMP_GROUP_SELECTOR_SUM_OF_WEIGHTS_MAX_GROUP_SIZE_TOR 256
-#define WCMP_GROUP_SELECTOR_SUM_OF_MEMBERS_MAX_GROUP_SIZE 256
+
+// The maximum number of members for each SUM_OF_MEMBERS group.
+#define WCMP_GROUP_SELECTOR_SUM_OF_MEMBERS_MAX_GROUP_SIZE 512
 
 // The max weight of an individual member when using the SUM_OF_MEMBERS size 
 // semantics.

--- a/sai_p4/instantiations/google/test_tools/test_entries.h
+++ b/sai_p4/instantiations/google/test_tools/test_entries.h
@@ -46,6 +46,7 @@ namespace sai {
 // TODO: Clean up these predefined bit widths once further
 // refactors are completed.
 constexpr int kVlanIdBitwidth = 12;
+constexpr int kAclMetadataBitwidth = 8;
 // NOTE: The actual bit-width of a multicast group ID is 16 bits, but we
 // reserve the uppermost bit for a possible solution to handling L2/L3 multicast
 // dependencies. 2^15 groups is more than sufficient for foreseeable use cases.
@@ -231,6 +232,7 @@ struct MirrorAndRedirectMatchFields {
   std::optional<bool> is_ipv6;
   std::optional<sai::P4RuntimeTernary<netaddr::Ipv6Address>> dst_ipv6;
   std::optional<absl::string_view> vrf;
+  pdpi::Ternary<std::bitset<kAclMetadataBitwidth>> acl_metadata;
 };
 
 // Queue settings for ACL table entry action.
@@ -255,6 +257,14 @@ struct AclPreIngressMatchFields {
   std::optional<std::string> in_port;
   pdpi::Ternary<std::bitset<kVlanIdBitwidth>> vlan_id;
   std::optional<pdpi::Ternary<netaddr::Ipv6Address>> dst_ipv6;
+};
+
+struct AclPreIngressVlanTableMatchFields {
+  pdpi::Ternary<std::bitset<kVlanIdBitwidth>> vlan_id;
+  std::optional<bool> is_ip;
+  std::optional<bool> is_ipv4;
+  std::optional<bool> is_ipv6;
+  std::optional<std::string> in_port;
 };
 
 // -- Entry Builder ------------------------------------------------------------
@@ -420,8 +430,12 @@ class EntryBuilder {
   EntryBuilder& AddDisableVlanChecksEntry();
   EntryBuilder& AddDisableIngressVlanChecksEntry();
   EntryBuilder& AddDisableEgressVlanChecksEntry();
+  EntryBuilder& AddPreIngressAclEntrySettingVlanAndAclMetadata(
+      absl::string_view vlan_id_hexstr, absl::string_view acl_metadata_hexstr,
+      const AclPreIngressVlanTableMatchFields& match_fields = {},
+      int priority = 1);
   EntryBuilder& AddEntrySettingVlanIdInPreIngress(
-      absl::string_view set_vlan_id_hexstr,
+      absl::string_view vlan_id_hexstr,
       std::optional<absl::string_view> match_vlan_id_hexstr = std::nullopt,
       int priority = 1);
   EntryBuilder& AddIngressAclEntryRedirectingToNexthop(

--- a/sai_p4/instantiations/google/versions.h
+++ b/sai_p4/instantiations/google/versions.h
@@ -79,6 +79,11 @@
 // after the first failed one.
 #define SAI_P4_PKGINFO_VERSION_USES_FAIL_ON_FIRST "3.1.0"
 
+// Indicates the switch supports 512 duplicate WCMP members per group in native
+// mode.
+#define SAI_P4_PKGINFO_VERSION_SUPPORTS_512_DUPLICATE_WCMP_MEMBERS_IN_NATIVE \
+  "3.1.1"
+
 // Indicates that the switch supports unicast_set_port_and_src_mac action, which
 // at the SAI level translates to port type RIFs that do NOT program l3_admit
 // table (i.e. MyMac at SAI) under the hood.
@@ -93,6 +98,13 @@
 // name for ACL keys with
 // `@sai_field(SAI_ACL_ENTRY_ATTR_FIELD_ROUTE_NPU_META_DST_HIT)`.
 #define SAI_P4_PKGINFO_VERSION_USES_ROUTE_HIT_ACL_QUALIFIER_NAME "
+
+// Indicates that the switch supports unicast_set_port_and_src_mac_and_vlan_id
+// action, which at the SAI level translates to sub_port type RIFs that do NOT
+// program l3_admit table (i.e. MyMac at SAI) under the hood.
+#define SAI_P4_PKGINFO_VERSION_USES_UNICAST_SET_PORT_AND_SRC_MAC_AND_VLAN_\
+ID_ACTION \
+  "5.0.0"
 
 // Macro that always points to the latest SAI P4 version.
 #define SAI_P4_PKGINFO_VERSION_LATEST SAI_P4_PKGINFO_VERSION_USES_FAIL_ON_FIRST


### PR DESCRIPTION
### **PR Description:**
Increase the maximum number of members for each SUM_OF_MEMBERS group to 512 and Add a header file to define meaningful annotations in SAI p4 programs.

### **Keyword Check:**
bibhuprasad@bibhuprasad87:~/sonic_build_image_2025-06-23/sonic-buildimage/src/sonic-p4rt/sonic-pins/sai_p4$ sh ~/keyword_check.sh .
Keyword check Passed.

### **Build Results:**
bibhuprasad@b53a70426c59:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 747 targets (0 packages loaded, 0 targets configured).
INFO: Found 747 targets...
INFO: Elapsed time: 0.424s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### **UT Results:**
bibhuprasad@b53a70426c59:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 747 targets (0 packages loaded, 70 targets configured).
INFO: Found 518 targets and 229 test targets...
INFO: Elapsed time: 200.355s, Critical Path: 143.71s
INFO: 286 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 286 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.2s
//dvaas:dataplane_validation_test                                        PASSED in 0.1s
//dvaas:port_id_map_test                                                 PASSED in 2.1s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.5s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.3s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//gutil:collections_test                                                 PASSED in 1.0s
//gutil:io_test                                                          PASSED in 1.2s
//gutil:proto_matchers_test                                              PASSED in 1.2s
//gutil:proto_ordering_test                                              PASSED in 1.4s
//gutil:proto_test                                                       PASSED in 1.2s
//gutil:status_matchers_test                                             PASSED in 1.4s
//gutil:test_artifact_writer_test                                        PASSED in 1.8s
//gutil:testing_test                                                     PASSED in 1.1s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 4.2s
//lib:basic_switch_test                                                  PASSED in 2.6s
//lib:ixia_helper_test                                                   PASSED in 2.2s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 2.9s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 17.1s
//lib/gnmi:gnmi_helper_test                                              PASSED in 4.2s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 2.3s
//lib/utils:generic_testbed_utils_test                                   PASSED in 3.6s
//lib/utils:json_utils_test                                              PASSED in 1.2s
//lib/validator:validator_backend_test                                   PASSED in 1.1s
//lib/validator:validator_lib_test                                       PASSED in 27.3s
//p4_fuzzer:constraints_test                                             PASSED in 10.0s
//p4_fuzzer:fuzz_util_test                                               PASSED in 143.5s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 2.0s
//p4_fuzzer:oracle_util_test                                             PASSED in 5.2s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 4.1s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 4.1s
//p4_fuzzer:switch_state_test                                            PASSED in 2.7s
//p4_pdpi:built_ins_test                                                 PASSED in 1.3s
//p4_pdpi:entity_keys_test                                               PASSED in 1.7s
//p4_pdpi:ir_properties_test                                             PASSED in 1.3s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.6s
//p4_pdpi:ir_tools_test                                                  PASSED in 1.8s
//p4_pdpi:names_test                                                     PASSED in 1.8s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.9s
//p4_pdpi:p4info_union_test                                              PASSED in 1.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 2.0s
//p4_pdpi:references_test                                                PASSED in 1.8s
//p4_pdpi:sequencing_util_test                                           PASSED in 2.0s
//p4_pdpi:ternary_test                                                   PASSED in 1.2s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.2s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.7s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.5s
//p4_pdpi/packetlib:packetlib_debugging_test                             PASSED in 1.7s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 21.5s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.4s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 7.0s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.6s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.1s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.8s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.7s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:references_test                                        PASSED in 0.2s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.3s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.3s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 2.3s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.3s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.8s
//p4_symbolic:z3_util_test                                               PASSED in 1.7s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 3.0s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 2.9s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 2.9s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 2.9s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 2.9s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 3.5s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 3.5s
//p4_symbolic/ir:cfg_test                                                PASSED in 2.0s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.1s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.1s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.1s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.3s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.3s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.3s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.3s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.2s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.2s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.2s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.2s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.6s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 30.1s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 25.2s
//p4_symbolic/sai:sai_test                                               PASSED in 7.7s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 3.8s
//p4_symbolic/symbolic:parser_test                                       PASSED in 2.8s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.0s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 1.9s
//p4_symbolic/symbolic:util_test                                         PASSED in 2.4s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.6s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 17.9s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 2.4s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 2.4s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 2.4s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 2.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 3.3s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 3.2s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 3.3s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 2.5s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 1.4s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 2.0s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 1.9s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.2s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.8s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 2.8s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.3s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 2.2s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.2s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 2.1s
//p4rt_app/sonic:hashing_test                                            PASSED in 2.1s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 1.9s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.5s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.5s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.1s
//p4rt_app/sonic:state_verification_test                                 PASSED in 2.2s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.2s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 2.2s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 2.3s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.5s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.2s
//p4rt_app/tests:action_set_test                                         PASSED in 1.5s
//p4rt_app/tests:api_access_test                                         PASSED in 1.2s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.4s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.4s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 9.0s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.6s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.4s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.8s
//p4rt_app/tests:packetio_test                                           PASSED in 4.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.2s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.7s
//p4rt_app/tests:response_path_test                                      PASSED in 5.3s
//p4rt_app/tests:role_test                                               PASSED in 1.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.9s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.4s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 2.3s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.2s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 2.0s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 2.1s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.8s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.7s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 4.9s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 3.2s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 7.6s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 2.4s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.7s
//sai_p4/tools:packetio_tools_test                                       PASSED in 2.3s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.6s
//tests/forwarding:hash_statistics_util_test                             PASSED in 1.9s
//tests/lib:common_ir_table_entries_test                                 PASSED in 2.3s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 2.2s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.4s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.3s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 8.0s
//thinkit:bazel_test_environment_test                                    PASSED in 1.5s
//thinkit:generic_testbed_test                                           PASSED in 2.3s
//thinkit:mock_control_device_test                                       PASSED in 1.7s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 2.0s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 2.0s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 1.8s
//tests/lib:packet_generator_test                                        PASSED in 63.1s
  Stats over 4 runs: max = 63.1s, min = 61.5s, avg = 62.4s, dev = 0.6s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.3s
  Stats over 5 runs: max = 2.3s, min = 1.7s, avg = 2.1s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 45.7s
  Stats over 50 runs: max = 45.7s, min = 1.4s, avg = 3.1s, dev = 6.2s

Executed 229 out of 229 tests: 229 tests pass.