### PR TITLE
[Thinkit/Tests] Standardize config artifacts for No Config Push NSF Upgrade scenario.

### DIFF
--- a/tests/integration/system/nsf/BUILD.bazel
+++ b/tests/integration/system/nsf/BUILD.bazel
@@ -88,7 +88,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
-        "@com_google_absl//absl/types:span",
+        "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest",
     ],
     alwayslink = True,

--- a/tests/integration/system/nsf/interfaces/BUILD.bazel
+++ b/tests/integration/system/nsf/interfaces/BUILD.bazel
@@ -51,6 +51,7 @@ cc_library(
     deps = [
         ":testbed",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/time",
     ],
 )
 

--- a/tests/integration/system/nsf/interfaces/traffic_helper.h
+++ b/tests/integration/system/nsf/interfaces/traffic_helper.h
@@ -16,6 +16,7 @@
 #define PINS_TESTS_INTEGRATION_SYSTEM_NSF_INTERFACES_TRAFFIC_HELPER_H_
 
 #include "absl/status/status.h"
+#include "absl/time/time.h"
 #include "tests/integration/system/nsf/interfaces/testbed.h"
 
 namespace pins_test {
@@ -37,11 +38,16 @@ class TrafficHelper {
   virtual absl::Status StopTraffic(Testbed& testbed) = 0;
 
   // Validates traffic in the testbed.
+  // The `max_acceptable_outage` is the upper limit of the traffic disruption
+  // duration. If the total duration of the traffic disruption detected during
+  // the entire flow of traffic is found to be less than the
+  // `max_acceptable_outage` duration, it will be considered permissible and
+  // would not cause traffic validation failure.
+  virtual absl::Status ValidateTraffic(
+      Testbed& testbed, absl::Duration max_acceptable_outage) = 0;
   absl::Status ValidateTraffic(Testbed& testbed) {
-    return ValidateTraffic(testbed, 0);
+    return ValidateTraffic(testbed, absl::ZeroDuration());
   };
-  virtual absl::Status ValidateTraffic(Testbed& testbed,
-                                       int error_percentage) = 0;
 };
 
 }  // namespace pins_test

--- a/tests/integration/system/nsf/nsf_acl_flow_coverage_test.cc
+++ b/tests/integration/system/nsf/nsf_acl_flow_coverage_test.cc
@@ -110,8 +110,8 @@ TEST_P(NsfAclFlowCoverageTestFixture, NsfAclFlowCoverageTest) {
   // progress to narrow down when the traffic loss occurred (i.e. before
   // reboot, during reboot or after reconciliation).
   LOG(INFO) << "Validating the traffic";
-  ASSERT_OK(traffic_helper_->ValidateTraffic(testbed_,
-                                             kNsfTrafficLossErrorPercentage));
+  ASSERT_OK(
+      traffic_helper_->ValidateTraffic(testbed_, kNsfTrafficLossDuration));
 
   // Selectively clear flows (eg. not clearing nexthop entries for host
   // testbeds).

--- a/tests/integration/system/nsf/nsf_concurrent_config_push_flow_programming_test.cc
+++ b/tests/integration/system/nsf/nsf_concurrent_config_push_flow_programming_test.cc
@@ -177,8 +177,8 @@ TEST_P(NsfConcurrentConfigPushFlowProgrammingTestFixture,
   // progress to narrow down when the traffic loss occurred (i.e. before
   // reboot, during reboot or after reconciliation).
   LOG(INFO) << "Validating the traffic";
-  ASSERT_OK(traffic_helper_->ValidateTraffic(testbed_,
-                                             kNsfTrafficLossErrorPercentage));
+  ASSERT_OK(
+      traffic_helper_->ValidateTraffic(testbed_, kNsfTrafficLossDuration));
 
   LOG(INFO) << "Clearing the flows";
   ASSERT_OK(flow_programmer_->ClearFlows(testbed_));

--- a/tests/integration/system/nsf/traffic_helpers/BUILD.bazel
+++ b/tests/integration/system/nsf/traffic_helpers/BUILD.bazel
@@ -33,6 +33,7 @@ cc_library(
         "//tests/integration/system/nsf/interfaces:traffic_helper",
         "//thinkit:generic_testbed",
         "//thinkit:mirror_testbed",
+        "@com_github_google_glog//:glog",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_otg_models//:otg_cc_proto",
         "@com_github_otg_models//:otg_grpc_proto",

--- a/tests/integration/system/nsf/traffic_helpers/otg_helper.h
+++ b/tests/integration/system/nsf/traffic_helpers/otg_helper.h
@@ -16,6 +16,7 @@
 #define PINS_TESTS_INTEGRATION_SYSTEM_NSF_TRAFFIC_HELPERS_OTG_HELPER_H_
 
 #include "absl/status/status.h"
+#include "absl/time/time.h"
 #include "tests/integration/system/nsf/interfaces/testbed.h"
 #include "tests/integration/system/nsf/interfaces/traffic_helper.h"
 
@@ -26,7 +27,8 @@ class OtgHelper : public TrafficHelper {
   OtgHelper(bool enable_linerate = false) : enable_linerate_(enable_linerate) {}
   absl::Status StartTraffic(Testbed& testbed) override;
   absl::Status StopTraffic(Testbed& testbed) override;
-  absl::Status ValidateTraffic(Testbed& testbed, int error_percentage) override;
+  absl::Status ValidateTraffic(Testbed& testbed,
+                               absl::Duration max_acceptable_outage) override;
 
  private:
   bool enable_linerate_;

--- a/tests/integration/system/nsf/upgrade_test.h
+++ b/tests/integration/system/nsf/upgrade_test.h
@@ -21,10 +21,10 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/types/span.h"
 #include "gtest/gtest.h"
 #include "tests/integration/system/nsf/interfaces/component_validator.h"
 #include "tests/integration/system/nsf/interfaces/flow_programmer.h"
+#include "tests/integration/system/nsf/interfaces/image_config_params.h"
 #include "tests/integration/system/nsf/interfaces/test_params.h"
 #include "tests/integration/system/nsf/interfaces/testbed.h"
 #include "tests/integration/system/nsf/interfaces/traffic_helper.h"
@@ -36,7 +36,7 @@ namespace pins_test {
 // NSF Upgrade test scenarios related to gNMI config push and P4 flow
 // programming.
 enum class NsfUpgradeScenario {
-  // kNoConfigPush,
+  kNoConfigPush,
   kOnlyConfigPush,
   kConfigPushBeforeAclFlowProgram,
   kConfigPushAfterAclFlowProgram,

--- a/tests/integration/system/nsf/util.h
+++ b/tests/integration/system/nsf/util.h
@@ -37,8 +37,8 @@
 
 namespace pins_test {
 
-// Percentage of error margin allowed for traffic loss during NSF reboot.
-constexpr int kNsfTrafficLossErrorPercentage = 0;
+// Duration of traffic loss permissible during NSF reboot.
+constexpr absl::Duration kNsfTrafficLossDuration = absl::ZeroDuration();
 
 struct PinsSoftwareInfo {
   std::string name;
@@ -191,6 +191,7 @@ absl::Status DoNsfRebootAndWaitForSwitchReady(
     absl::Span<const std::string> interfaces = {});
 
 // Pushes the given `gnmi_config` and `p4_info` on the `thinkit_switch`.
+// The `config_label` is required solely for debugging purposes.
 //
 // In case `clear_config` is not set, we assume that a P4 Info is already
 // present on the switch. This is a valid scenario when we want to configure
@@ -198,7 +199,7 @@ absl::Status DoNsfRebootAndWaitForSwitchReady(
 absl::Status PushConfig(thinkit::Switch& thinkit_switch,
                         absl::string_view gnmi_config,
                         const p4::config::v1::P4Info& p4_info,
-                        bool clear_config);
+                        absl::string_view config_label, bool clear_config);
 absl::Status PushConfig(const ImageConfigParams& image_config_param,
                         Testbed& testbed, thinkit::SSHClient& ssh_client,
                         bool clear_config = false,


### PR DESCRIPTION
Keyword Check:
/tests_sonic-pins/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.

Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 753 targets (0 packages loaded, 0 targets configured).
INFO: Found 753 targets...
INFO: Elapsed time: 0.617s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action



Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 750 targets (0 packages loaded, 0 targets configured).
INFO: Found 521 targets and 229 test targets...
INFO: Elapsed time: 279.733s, Critical Path: 143.63s
INFO: 286 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 286 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 3.4s
//dvaas:dataplane_validation_test                                        PASSED in 3.4s
//dvaas:port_id_map_test                                                 PASSED in 10.4s
//dvaas:test_run_validation_golden_test                                  PASSED in 3.2s
//dvaas:test_run_validation_test                                         PASSED in 10.3s
//dvaas:test_run_validation_test_runner                                  PASSED in 2.2s
//dvaas:test_vector_stats_diff_test                                      PASSED in 1.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 6.8s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.5s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.3s
//gutil:collections_test                                                 PASSED in 6.8s
//gutil:io_test                                                          PASSED in 6.5s
//gutil:proto_matchers_test                                              PASSED in 6.3s
//gutil:proto_ordering_test                                              PASSED in 0.8s
//gutil:proto_test                                                       PASSED in 0.7s
//gutil:status_matchers_test                                             PASSED in 0.7s
//gutil:test_artifact_writer_test                                        PASSED in 0.8s
//gutil:testing_test                                                     PASSED in 0.8s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.1s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 1.6s
//tests/forwarding:hash_statistics_util_test                             PASSED in 1.7s
//tests/lib:common_ir_table_entries_test                                 PASSED in 0.9s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.7s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 1.2s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.9s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.2s
//tests/sflow:sflow_util_test                                            PASSED in 7.1s
//thinkit:bazel_test_environment_test                                    PASSED in 0.8s
//thinkit:generic_testbed_test                                           PASSED in 1.1s
//thinkit:mock_control_device_test                                       PASSED in 0.7s
//thinkit:mock_generic_testbed_test                                      PASSED in 0.9s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.0s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.9s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 0.9s
//tests/lib:packet_generator_test                                        PASSED in 63.7s
  Stats over 4 runs: max = 63.7s, min = 60.7s, avg = 61.9s, dev = 1.1s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.4s
  Stats over 5 runs: max = 2.4s, min = 0.9s, avg = 1.2s, dev = 0.6s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 46.1s
  Stats over 50 runs: max = 46.1s, min = 1.0s, avg = 4.0s, dev = 10.3s

Executed 229 out of 229 tests: 229 tests pass.