### PR TITLE
[Thinkit/Tests] Add test case to confirm replication to same port is successful.

### DIFF
--- a/tests/forwarding/l3_multicast_test.cc
+++ b/tests/forwarding/l3_multicast_test.cc
@@ -40,7 +40,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "gutil/status.h"
-#include "gutil/status_matchers.h"  // IWYU pragma: keep
+#include "gutil/status_matchers.h"
 #include "lib/gnmi/gnmi_helper.h"
 #include "lib/gnmi/openconfig.pb.h"
 #include "net/google::protobuf/contrib/fixtures/proto-fixture-repository.h"
@@ -89,13 +89,14 @@ enum class IpmcGroupAssignmentMechanism { kAclRedirect, kIpMulticastTable };
 // Multicast IPv4 addresses of the form 226.10.#.#. The last two bytes
 // are computed based on the multicast group ID.
 absl::StatusOr<netaddr::Ipv4Address> GetIpv4AddressForReplica(
-    int multicast_group_id) {
-  if (multicast_group_id >= 0 && multicast_group_id < 511) {
-    return netaddr::Ipv4Address(226, 10, ((multicast_group_id + 1) >> 8) & 0xff,
-                                (multicast_group_id + 1) & 0xff);
+    int multicast_group_index) {
+  if (multicast_group_index >= 0 && multicast_group_index < 511) {
+    return netaddr::Ipv4Address(226, 10,
+                                ((multicast_group_index + 1) >> 8) & 0xff,
+                                (multicast_group_index + 1) & 0xff);
   } else {
     return absl::FailedPreconditionError(
-        absl::StrCat("Multicast group ID '", multicast_group_id,
+        absl::StrCat("Multicast group index '", multicast_group_index,
                      "' is larger than test's maximum value of 510"));
   }
 }
@@ -103,30 +104,29 @@ absl::StatusOr<netaddr::Ipv4Address> GetIpv4AddressForReplica(
 // Multicast IPv6 addresses of the form ff00:0:1111:2222:3333:4444:5555.#.
 // The last 16-bits of the address are based on the multicast group ID.
 absl::StatusOr<netaddr::Ipv6Address> GetIpv6AddressForReplica(
-    int multicast_group_id) {
-  if (multicast_group_id >= 0 && (multicast_group_id + 1) < 0xffff) {
+    int multicast_group_index) {
+  if (multicast_group_index >= 0 && (multicast_group_index + 1) < 0xffff) {
     return netaddr::Ipv6Address(0xff00, 0x0, 0x1111, 0x2222, 0x3333, 0x4444,
-                                0x5555, multicast_group_id + 1);
+                                0x5555, multicast_group_index + 1);
   } else {
     return absl::FailedPreconditionError(
-        absl::StrCat("Multicast group ID '", multicast_group_id,
+        absl::StrCat("Multicast group index '", multicast_group_index,
                      "' is larger than test's maximum value of ", 0xfffe));
   }
 }
 
-absl::StatusOr<netaddr::MacAddress> GetSrcMacForReplica(int multicast_group_id,
-                                                        int replicas_per_group,
-                                                        int replicas_number) {
-  if (multicast_group_id * replicas_per_group + replicas_number < 0xff) {
+absl::StatusOr<netaddr::MacAddress> GetSrcMacForReplica(
+    int multicast_group_index, int replicas_per_group, int replicas_number) {
+  if (multicast_group_index * replicas_per_group + replicas_number < 0xff) {
     return netaddr::MacAddress(
         0x00, 0x20, 0x30, 0x40, 0x50,
-        multicast_group_id * replicas_per_group + replicas_number);
+        multicast_group_index * replicas_per_group + replicas_number);
   } else {
-    return absl::FailedPreconditionError(
-        absl::StrCat("Combination of multicast group ID '", multicast_group_id,
-                     "', replicas per group '", replicas_per_group,
-                     "', and replicas_number '", replicas_number,
-                     "' is larger than test's maximum value of ", 0xfe));
+    return absl::FailedPreconditionError(absl::StrCat(
+        "Combination of multicast group index '", multicast_group_index,
+        "', replicas per group '", replicas_per_group,
+        "', and replicas_number '", replicas_number,
+        "' is larger than test's maximum value of ", 0xfe));
   }
 }
 
@@ -799,15 +799,411 @@ TEST_P(L3MulticastTestFixture, BasicReplicationProgrammingWithAclRedirect) {
   EXPECT_OK(validation_result.HasSuccessRateOfAtLeast(1.0));
 }
 
-// TEST_P(L3MulticastTestFixture, UnregisteredParticipantProgramming) {
-//   GTEST_SKIP() << "Skipping because this test is not implemented yet.";
-// }
-// TEST_P(L3MulticastTestFixture, FixedDelayProgramming) {
-//   GTEST_SKIP() << "Skipping because this test is not implemented yet.";
-// }
-// TEST_P(L3MulticastTestFixture, MulticastGroupAssignmentLPMSemantics) {
-//   GTEST_SKIP() << "Skipping because this test is not implemented yet.";
-// }
+// This test confirms that fixed delay programming is achievable by adding
+// group members where the replications are always dropped.
+// Part of our use case requires us to replicate packets that must be dropped,
+// which adds a fixed amount of time before a "real" replicated packet emerges.
+// This test is disabled due to an issue with ACL drop rules.
+// TODO: Re-enable test.
+TEST_P(L3MulticastTestFixture, DISABLED_ConfirmFixedDelayProgramming) {
+
+  thinkit::MirrorTestbed& testbed =
+      GetParam().mirror_testbed->GetMirrorTestbed();
+  constexpr int kNumberMulticastGroupsInTest = 1;
+  // We'll use 4 "drop" replicas and 2 expected replications.
+  constexpr int kPortsToUseInTest = 6;
+
+  // Get set of ports on the SUT and control switch to test on.
+  ASSERT_OK_AND_ASSIGN(
+      const std::vector<std::string> sut_ports_ids,
+      GetNUpInterfaceIDs(GetParam().mirror_testbed->GetMirrorTestbed().Sut(),
+                         kPortsToUseInTest + 1));
+
+  // Setup 6 RIFs, 2 with valid source MAC addresses and 4 with the drop MAC
+  // address.
+  std::vector<p4::v1::Entity> entities_created;
+  ASSERT_OK(SetupDefaultMulticastProgramming(
+      *sut_p4rt_session_, ir_p4info_, p4::v1::Update::INSERT,
+      kNumberMulticastGroupsInTest, /*replicas_per_group=*/kPortsToUseInTest,
+      sut_ports_ids, IpmcGroupAssignmentMechanism::kIpMulticastTable,
+      entities_created));
+  LOG(INFO) << "Added " << entities_created.size() << " entities.";
+
+  // Add the 4 drop RIFs using the first 4 ports for replication.
+  constexpr int kDropInstance = 33;
+  for (int port_index = 1; port_index <= 4; ++port_index) {
+    ASSERT_OK_AND_ASSIGN(
+        auto rif_entities,
+        CreateRifTableEntities(ir_p4info_, sut_ports_ids[port_index],
+                               kDropInstance, kDropSrcMacAddress));
+    ASSERT_OK(pdpi::InstallPiEntities(sut_p4rt_session_.get(), ir_p4info_,
+                                      rif_entities));
+  }
+
+  // Create the Egress ACL entry to drop relevant Ethernet source MAC.
+  // Replicas to be dropped will rewrite their source MAC address to be the
+  // "drop" MAC address.
+  ASSERT_OK_AND_ASSIGN(auto proto_entry,
+                       gutil::ParseTextProto<pdpi::IrTableEntry>(
+                           R"pb(table_name: "acl_egress_table"
+                                priority: 1
+                                matches {
+                                  name: "src_mac"
+                                  ternary {
+                                    value { mac: "02:2a:10:00:00:02" }
+                                    mask { mac: "ff:ff:ff:ff:ff:ff" }
+                                  }
+                                }
+                                action { name: "acl_drop" }
+                           )pb"));
+
+  EXPECT_OK(pdpi::InstallIrTableEntry(*sut_p4rt_session_.get(), proto_entry));
+
+  // Override default programming to have first 4 replicas be dropped.
+  std::vector<ReplicaPair> replicas;
+  replicas.push_back({sut_ports_ids[1], kDropInstance});
+  replicas.push_back({sut_ports_ids[2], kDropInstance});
+  replicas.push_back({sut_ports_ids[3], kDropInstance});
+  replicas.push_back({sut_ports_ids[4], kDropInstance});
+  // The last two replicas are unchanged.   We expect these replicas to emerge.
+  replicas.push_back({sut_ports_ids[5], /*.instance=*/4});
+  replicas.push_back({sut_ports_ids[6], /*.instance=*/5});
+  ASSERT_OK_AND_ASSIGN(auto update_multicast_group_entities,
+                       CreateMulticastGroupEntities(
+                           ir_p4info_, /*multicast_group_id=*/1, replicas));
+  ASSERT_OK(
+      pdpi::SendPiUpdates(sut_p4rt_session_.get(),
+                          pdpi::CreatePiUpdates(update_multicast_group_entities,
+                                                p4::v1::Update::MODIFY)));
+
+  // Send traffic and confirm only 2 replicas received (instead of 6).
+  // 4 of the "prefix" replicas should have been dropped.
+  ASSERT_OK_AND_ASSIGN(
+      auto update_vectors,
+      BuildInputOutputVectors(sut_ports_ids,
+                              /*input_group_index=*/0,
+                              /*output_group_index=*/0,
+                              /*replicas_per_group=*/kPortsToUseInTest,
+                              /*output_replica_start_index=*/4));
+  LOG(INFO) << "Sending traffic to verify added multicast programming.";
+  dvaas::DataplaneValidationParams dvaas_params =
+      dvaas::DefaultpinsDataplaneValidationParams();
+  // Ensure the port map for the control switch can map to the SUT (for
+  // situations where the config differs for SUT and control switch).
+  auto interface_to_peer_entity_map = gtl::ValueOrDie(
+      pins::ControlP4rtPortIdBySutP4rtPortIdFromSwitchConfig());
+  dvaas_params.mirror_testbed_port_map_override = gtl::ValueOrDie(
+      dvaas::MirrorTestbedP4rtPortIdMap::CreateFromControlSwitchToSutPortMap(
+          interface_to_peer_entity_map));
+  dvaas_params.packet_test_vector_override = update_vectors;
+
+  ASSERT_OK_AND_ASSIGN(
+      dvaas::ValidationResult update_validation_result,
+      GetParam().dvaas->ValidateDataplane(testbed, dvaas_params));
+  // Validate traffic.
+  update_validation_result.LogStatistics();
+  EXPECT_OK(update_validation_result.HasSuccessRateOfAtLeast(1.0));
+}
+
+// This test confirms replicating N times to the same port (using different
+// replica instances) will produce N output packets.
+TEST_P(L3MulticastTestFixture, ReplicatingNTimesToSamePortProducesNCopies) {
+
+  thinkit::MirrorTestbed& testbed =
+      GetParam().mirror_testbed->GetMirrorTestbed();
+  constexpr int kNumberMulticastGroupsInTest = 1;
+  constexpr int kOutputPortsToUseInTest = 1;
+  constexpr int kInitialReplicasPerGroup = 1;
+
+  // Get set of ports on the SUT and control switch to test on.
+  ASSERT_OK_AND_ASSIGN(
+      const std::vector<std::string> sut_ports_ids,
+      GetNUpInterfaceIDs(GetParam().mirror_testbed->GetMirrorTestbed().Sut(),
+                         kOutputPortsToUseInTest + 1));
+
+  // Setup 3 RIFs, all on same port but that use different instances.
+  // We will expect that the multicast group will produce three copies.
+  // Setup default programming assuming only 1 replica to start, since default
+  // programming wants to output on different ports.
+  std::vector<p4::v1::Entity> entities_created;
+  ASSERT_OK(SetupDefaultMulticastProgramming(
+      *sut_p4rt_session_, ir_p4info_, p4::v1::Update::INSERT,
+      kNumberMulticastGroupsInTest,
+      /*replicas_per_group=*/kInitialReplicasPerGroup, sut_ports_ids,
+      IpmcGroupAssignmentMechanism::kIpMulticastTable, entities_created));
+  LOG(INFO) << "Added " << entities_created.size() << " entities.";
+
+  // Add additional active RIF that will replicate to the same port.
+  ASSERT_OK_AND_ASSIGN(
+      const netaddr::MacAddress kExtraSrcMac,
+      GetSrcMacForReplica(/*multicast_group_index=*/0, kInitialReplicasPerGroup,
+                          /*replicas_number=*/1));
+  constexpr int kExtraInstance = 1;
+  constexpr int kExtraInstanceTwo = 2;
+  ASSERT_OK_AND_ASSIGN(auto rif_entities,
+                       CreateRifTableEntities(ir_p4info_, sut_ports_ids[1],
+                                              kExtraInstance, kExtraSrcMac));
+  // Create another RIF with different instance but same src MAC.
+  ASSERT_OK_AND_ASSIGN(auto rif_entities2,
+                       CreateRifTableEntities(ir_p4info_, sut_ports_ids[1],
+                                              kExtraInstanceTwo, kExtraSrcMac));
+  ASSERT_OK(pdpi::InstallPiEntities(sut_p4rt_session_.get(), ir_p4info_,
+                                    rif_entities));
+  ASSERT_OK(pdpi::InstallPiEntities(sut_p4rt_session_.get(), ir_p4info_,
+                                    rif_entities2));
+
+  // Update multicast group entity to include new replicas.
+  std::vector<ReplicaPair> replicas;
+  replicas.push_back({sut_ports_ids[1], /*.instance=*/0});    // unchanged
+  replicas.push_back({sut_ports_ids[1], kExtraInstance});     // added
+  replicas.push_back({sut_ports_ids[1], kExtraInstanceTwo});  // added
+  ASSERT_OK_AND_ASSIGN(auto update_multicast_group_entities,
+                       CreateMulticastGroupEntities(
+                           ir_p4info_, /*multicast_group_id=*/1, replicas));
+  ASSERT_OK(
+      pdpi::SendPiUpdates(sut_p4rt_session_.get(),
+                          pdpi::CreatePiUpdates(update_multicast_group_entities,
+                                                p4::v1::Update::MODIFY)));
+
+  // Build custom test packets.
+  std::vector<dvaas::PacketTestVector> expectations;
+
+  // All packets will be injected on the same port.
+  const std::string& in_port = sut_ports_ids[0];
+  int unique_payload_ids = 1;
+
+  // We will inject an IPv4 packet that will activate the multicast group.
+  ASSERT_OK_AND_ASSIGN(const auto input_ipv4_address,
+                       GetIpv4AddressForReplica(/*multicast_group_index=*/0));
+  ProtoFixtureRepository repo;
+  repo.RegisterValue("@ingress_port", in_port)
+      .RegisterValue("@egress_src_mac", kOriginalSrcMacAddress.ToString())
+      .RegisterValue("@ttl", "0x40")
+      .RegisterValue("@hop_limit", "0x50")
+      .RegisterValue("@decremented_hop_limit", "0x4f")
+      .RegisterValue("@decremented_ttl", "0x3f")
+      .RegisterValue("@ipv4_dst", input_ipv4_address.ToString())
+      .RegisterValue("@payload_ipv4", dvaas::MakeTestPacketTagFromUniqueId(
+                                          unique_payload_ids++));
+
+  // Build headers.
+  repo.RegisterSnippetOrDie<packetlib::Header>("@ethernet_ipv4", R"pb(
+        ethernet_header {
+          ethernet_destination: "01:00:5e:01:01:01"
+          ethernet_source: @egress_src_mac
+          ethertype: "0x0800"  # IPv4
+        }
+      )pb")
+      .RegisterSnippetOrDie<packetlib::Header>("@ipv4", R"pb(
+        ipv4_header {
+          version: "0x4"
+          ihl: "0x5"
+          dscp: "0x00"
+          ecn: "0x0"
+          # total_length: filled in automatically.
+          identification: "0x0000"
+          flags: "0x0"
+          fragment_offset: "0x0000"
+          ttl: @ttl
+          protocol: "0x11"
+          # checksum: filled in automatically
+          ipv4_source: "128.252.7.36"
+          ipv4_destination: @ipv4_dst
+        }
+      )pb")
+      .RegisterSnippetOrDie<packetlib::Header>("@udp", R"pb(
+        udp_header {
+          source_port: "0x0567"       # 1383
+          destination_port: "0x1234"  # 4660
+          # length: filled in automatically
+          # checksum: filled in automatically
+        }
+      )pb")
+      .RegisterMessage("@input_packet_ipv4",
+                       ParsePacketAndPadToMinimumSize(repo,
+                                                      R"pb(
+                                                        headers: @ethernet_ipv4
+                                                        headers: @ipv4
+                                                        headers: @udp
+                                                        payload: @payload_ipv4
+                                                      )pb"));
+
+  // Build up acceptable_outputs string, to account for each replica.
+  dvaas::SwitchOutput expected_ipv4_output;
+  ASSERT_OK_AND_ASSIGN(
+      netaddr::MacAddress src_mac_replica0,
+      GetSrcMacForReplica(/*multicast_group_index=*/0,
+                          /*replicas_per_group=*/kInitialReplicasPerGroup,
+                          /*replicas_number=*/0));
+  ASSERT_OK_AND_ASSIGN(
+      netaddr::MacAddress src_mac_replica1,
+      GetSrcMacForReplica(/*multicast_group_index=*/0,
+                          /*replicas_per_group=*/kInitialReplicasPerGroup,
+                          /*replicas_number=*/1));
+
+  // IPv4
+  *expected_ipv4_output.add_packets() =
+      repo.RegisterValue("@egress_port", sut_ports_ids[1])
+          .RegisterValue("@egress_src_mac", src_mac_replica0.ToString())
+          .RegisterMessage(
+              "@output_packet", ParsePacketAndPadToMinimumSize(repo, R"pb(
+                headers: @ethernet_ipv4 {
+                  ethernet_header { ethernet_source: @egress_src_mac }
+                }
+                headers: @ipv4 { ipv4_header { ttl: @decremented_ttl } }
+                headers: @udp
+                payload: @payload_ipv4
+              )pb"))
+          .ParseTextOrDie<dvaas::Packet>(R"pb(
+            port: @egress_port
+            parsed: @output_packet
+          )pb");
+  *expected_ipv4_output.add_packets() =
+      repo.RegisterValue("@egress_port", sut_ports_ids[1])
+          .RegisterValue("@egress_src_mac", src_mac_replica1.ToString())
+          .RegisterMessage(
+              "@output_packet", ParsePacketAndPadToMinimumSize(repo, R"pb(
+                headers: @ethernet_ipv4 {
+                  ethernet_header { ethernet_source: @egress_src_mac }
+                }
+                headers: @ipv4 { ipv4_header { ttl: @decremented_ttl } }
+                headers: @udp
+                payload: @payload_ipv4
+              )pb"))
+          .ParseTextOrDie<dvaas::Packet>(R"pb(
+            port: @egress_port
+            parsed: @output_packet
+          )pb");
+  // Expect another packet with same source MAC.
+  *expected_ipv4_output.add_packets() =
+      repo.RegisterValue("@egress_port", sut_ports_ids[1])
+          .RegisterValue("@egress_src_mac", src_mac_replica1.ToString())
+          .RegisterMessage(
+              "@output_packet", ParsePacketAndPadToMinimumSize(repo, R"pb(
+                headers: @ethernet_ipv4 {
+                  ethernet_header { ethernet_source: @egress_src_mac }
+                }
+                headers: @ipv4 { ipv4_header { ttl: @decremented_ttl } }
+                headers: @udp
+                payload: @payload_ipv4
+              )pb"))
+          .ParseTextOrDie<dvaas::Packet>(R"pb(
+            port: @egress_port
+            parsed: @output_packet
+          )pb");
+  LOG(INFO) << "Packets will be sent on port " << in_port;
+
+  expectations.emplace_back() =
+      repo.RegisterMessage("@expected_ipv4_output", expected_ipv4_output)
+          .ParseTextOrDie<dvaas::PacketTestVector>(R"pb(
+            input {
+              type: DATAPLANE
+              packet { port: @ingress_port parsed: @input_packet_ipv4 }
+            }
+            acceptable_outputs: @expected_ipv4_output
+          )pb");
+
+  LOG(INFO) << "Sending traffic to verify added multicast programming.";
+  dvaas::DataplaneValidationParams dvaas_params =
+      dvaas::DefaultpinsDataplaneValidationParams();
+  // Ensure the port map for the control switch can map to the SUT (for
+  // situations where the config differs for SUT and control switch).
+  ASSERT_OK_AND_ASSIGN(
+      auto interface_to_peer_entity_map,
+      pins::ControlP4rtPortIdBySutP4rtPortIdFromSwitchConfig());
+  ASSERT_OK_AND_ASSIGN(
+      dvaas_params.mirror_testbed_port_map_override,
+      dvaas::MirrorTestbedP4rtPortIdMap::CreateFromControlSwitchToSutPortMap(
+          interface_to_peer_entity_map));
+  dvaas_params.packet_test_vector_override = expectations;
+
+  ASSERT_OK_AND_ASSIGN(
+      dvaas::ValidationResult validation_result,
+      GetParam().dvaas->ValidateDataplane(testbed, dvaas_params));
+  // Validate traffic.
+  validation_result.LogStatistics();
+  EXPECT_OK(validation_result.HasSuccessRateOfAtLeast(1.0));
+}
+
+TEST_P(L3MulticastTestFixture, ConfirmAclRedirectOverridesIpMulticastTable) {
+  if (!pins::TableHasMatchField(
+          ir_p4info_, "acl_ingress_mirror_and_redirect_table", "in_port")) {
+    GTEST_SKIP()
+        << "Skipping because match field 'in_port' is not available in table "
+        << "'acl_ingress_mirror_and_redirect_table'";
+  }
+
+  // Setup two multicast groups, one assigned via the IPMC table and one via
+  // ACL redirect.  Have both paths match.  Expect the ACL redirect to win.
+
+  thinkit::MirrorTestbed& testbed =
+      GetParam().mirror_testbed->GetMirrorTestbed();
+  constexpr int kNumberMulticastGroupsInTest = 2;
+  constexpr int kPortsToUseInTest = 2;
+
+  // Get set of ports on the SUT and control switch to test on.
+  ASSERT_OK_AND_ASSIGN(
+      const std::vector<std::string> sut_ports_ids,
+      GetNUpInterfaceIDs(GetParam().mirror_testbed->GetMirrorTestbed().Sut(),
+                         kPortsToUseInTest + 1));
+
+  std::vector<p4::v1::Entity> entities_created;
+  ASSERT_OK(SetupDefaultMulticastProgramming(
+      *sut_p4rt_session_, ir_p4info_, p4::v1::Update::INSERT,
+      kNumberMulticastGroupsInTest, /*replicas_per_group=*/kPortsToUseInTest,
+      sut_ports_ids, IpmcGroupAssignmentMechanism::kIpMulticastTable,
+      entities_created));
+
+  // Setup the ACL redirect path to use multicast group 2.
+  constexpr int kMulticastGroup2 = 2;
+  const std::string& input_port_id = sut_ports_ids[0];
+  ASSERT_OK_AND_ASSIGN(
+      std::vector<p4::v1::Entity> acl_entities,
+      sai::EntryBuilder()
+          // .AddIngressAclEntryRedirectingToMulticastGroup(
+          //     kMulticastGroup2,
+          //     {.in_port = input_port_id, .ipmc_table_hit = false})
+          .AddIngressAclEntryRedirectingToMulticastGroup(
+              kMulticastGroup2,
+              {.in_port = input_port_id, .ipmc_table_hit = true})
+          .LogPdEntries()
+          .GetDedupedPiEntities(ir_p4info_));
+  ASSERT_OK(pdpi::InstallPiEntities(sut_p4rt_session_.get(), ir_p4info_,
+                                    acl_entities));
+  entities_created.insert(entities_created.end(), acl_entities.begin(),
+                          acl_entities.end());
+  LOG(INFO) << "Added " << entities_created.size() << " entities.";
+
+  // Inject test packets that would match the IP multicast table that would
+  // assign to multicast group 1.  However, expect the ACL redirect path to
+  // override the IPMC table assignment such that multicast group 2 will be
+  // the outputs.
+  ASSERT_OK_AND_ASSIGN(
+      auto vectors,
+      BuildInputOutputVectors(sut_ports_ids, /*input_group_index=*/0,
+                              /*output_group_index=*/1,
+                              /*replicas_per_group=*/kPortsToUseInTest));
+
+  // Send test packets.
+  LOG(INFO) << "Sending traffic to verify added multicast programming.";
+  dvaas::DataplaneValidationParams dvaas_params =
+      dvaas::DefaultpinsDataplaneValidationParams();
+  // Ensure the port map for the control switch can map to the SUT (for
+  // situations where the config differs for SUT and control switch).
+  auto interface_to_peer_entity_map = gtl::ValueOrDie(
+      pins::ControlP4rtPortIdBySutP4rtPortIdFromSwitchConfig());
+  dvaas_params.mirror_testbed_port_map_override = gtl::ValueOrDie(
+      dvaas::MirrorTestbedP4rtPortIdMap::CreateFromControlSwitchToSutPortMap(
+          interface_to_peer_entity_map));
+  dvaas_params.packet_test_vector_override = vectors;
+
+  ASSERT_OK_AND_ASSIGN(
+      dvaas::ValidationResult validation_result,
+      GetParam().dvaas->ValidateDataplane(testbed, dvaas_params));
+  // Validate traffic.
+  validation_result.LogStatistics();
+  EXPECT_OK(validation_result.HasSuccessRateOfAtLeast(1.0));
+}
 
 TEST_P(L3MulticastTestFixture, AddMulticastRifForUnknownPortFails) {
   // Unable to add an entry if the port does not exist.
@@ -1161,7 +1557,7 @@ TEST_P(L3MulticastTestFixture, AbleToProgramExpectedMulticastRifCapacity) {
   for (int r = 0; r < kMaxRifs; ++r) {
     const std::string& port_id = sut_ports_ids[r % kPortsToUseInTest];
     ASSERT_OK_AND_ASSIGN(netaddr::MacAddress src_mac,
-                         GetSrcMacForReplica(/*multicast_group_id=*/r,
+                         GetSrcMacForReplica(/*multicast_group_index=*/r,
                                              /*replicas_per_group=*/1,
                                              /*replicas_number=*/0));
     ASSERT_OK_AND_ASSIGN(
@@ -1201,7 +1597,7 @@ TEST_P(L3MulticastTestFixture, AbleToProgramExpectedMulticastGroupCapacity) {
     replicas.push_back({port_id, kDefaultInstance});
     ASSERT_OK_AND_ASSIGN(
         netaddr::MacAddress src_mac,
-        GetSrcMacForReplica(/*multicast_group_id=*/1,
+        GetSrcMacForReplica(/*multicast_group_index=*/1,
                             /*replicas_per_group=*/kPortsToUseInTest,
                             /*replicas_number=*/port_index));
 


### PR DESCRIPTION
Keyword Check:
/tests_sonic-pins/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.



Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 754 targets (2 packages loaded, 44 targets configured).
INFO: Found 754 targets...
INFO: Elapsed time: 56.239s, Critical Path: 48.42s
INFO: 7 processes: 1 internal, 6 linux-sandbox.
INFO: Build completed successfully, 7 total actions



Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 754 targets (0 packages loaded, 0 targets configured).
INFO: Found 525 targets and 229 test targets...
INFO: Elapsed time: 273.420s, Critical Path: 150.30s
INFO: 286 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 286 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 2.6s
//dvaas:dataplane_validation_test                                        PASSED in 2.5s
//dvaas:port_id_map_test                                                 PASSED in 10.0s
//dvaas:test_run_validation_golden_test                                  PASSED in 2.3s
//dvaas:test_run_validation_test                                         PASSED in 10.1s
//dvaas:test_run_validation_test_runner                                  PASSED in 1.4s
//dvaas:test_vector_stats_diff_test                                      PASSED in 1.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.3s
//dvaas:test_vector_test                                                 PASSED in 7.4s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.6s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.6s
//gutil:collections_test                                                 PASSED in 7.2s
//gutil:io_test                                                          PASSED in 6.7s
//gutil:proto_matchers_test                                              PASSED in 6.7s
//gutil:proto_ordering_test                                              PASSED in 1.0s
//gutil:proto_test                                                       PASSED in 0.9s
//gutil:status_matchers_test                                             PASSED in 0.8s
//gutil:test_artifact_writer_test                                        PASSED in 1.1s
//gutil:testing_test                                                     PASSED in 0.9s
//gutil:timer_test                                                       PASSED in 5.0s
//tests/lib:common_ir_table_entries_test                                 PASSED in 1.1s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.2s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.2s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.5s
//thinkit:bazel_test_environment_test                                    PASSED in 0.9s
//thinkit:generic_testbed_test                                           PASSED in 1.3s
//thinkit:mock_control_device_test                                       PASSED in 0.9s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.2s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.9s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.0s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.2s
//tests/lib:packet_generator_test                                        PASSED in 65.9s
  Stats over 4 runs: max = 65.9s, min = 62.1s, avg = 64.2s, dev = 1.5s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.7s
  Stats over 5 runs: max = 1.7s, min = 0.9s, avg = 1.2s, dev = 0.3s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 47.6s
  Stats over 50 runs: max = 47.6s, min = 1.1s, avg = 3.4s, dev = 9.1s

Executed 229 out of 229 tests: 229 tests pass.
