### PR TITLE
[Thinkit/Tests] Add telemetry validator for NSF.

### DIFF
--- a/tests/forwarding/l3_multicast_test.cc
+++ b/tests/forwarding/l3_multicast_test.cc
@@ -799,12 +799,6 @@ TEST_P(L3MulticastTestFixture, BasicReplicationProgrammingWithAclRedirect) {
   EXPECT_OK(validation_result.HasSuccessRateOfAtLeast(1.0));
 }
 
-// This test confirms that fixed delay programming is achievable by adding
-// group members where the replications are always dropped.
-// Part of our use case requires us to replicate packets that must be dropped,
-// which adds a fixed amount of time before a "real" replicated packet emerges.
-// This test is disabled due to an issue with ACL drop rules.
-// TODO: Re-enable test.
 TEST_P(L3MulticastTestFixture, DISABLED_ConfirmFixedDelayProgramming) {
 
   thinkit::MirrorTestbed& testbed =

--- a/tests/integration/system/nsf/component_validators/BUILD.bazel
+++ b/tests/integration/system/nsf/component_validators/BUILD.bazel
@@ -73,3 +73,23 @@ cc_library(
         "@com_google_absl//absl/strings:string_view",
     ],
 )
+
+cc_library(
+    name = "telemetry_validator",
+    testonly = True,
+    srcs = ["telemetry_validator.cc"],
+    hdrs = ["telemetry_validator.h"],
+    deps = [
+        "//tests/integration/system/nsf:util",
+        "//tests/integration/system/nsf/interfaces:component_validator",
+        "//tests/integration/system/nsf/interfaces:testbed",
+        "//thinkit:ssh_client",
+        "//thinkit:switch",
+        "@com_github_google_glog//:glog",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/time",
+    ],
+)

--- a/tests/integration/system/nsf/component_validators/telemetry_validator.cc
+++ b/tests/integration/system/nsf/component_validators/telemetry_validator.cc
@@ -1,0 +1,45 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tests/integration/system/nsf/component_validators/telemetry_validator.h"
+
+#include <string>
+
+#include "absl/status/status.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
+#include "absl/time/time.h"
+#include "glog/logging.h"
+#include "grpcpp/support/status.h"
+#include "tests/integration/system/nsf/interfaces/testbed.h"
+#include "tests/integration/system/nsf/util.h"
+#include "thinkit/ssh_client.h"
+#include "thinkit/switch.h"
+
+namespace pins_test {
+namespace {
+
+absl::Status ValidateTelemetryWarmboot(Testbed& testbed,
+                                       thinkit::SSHClient& ssh_client) {
+  return absl::OkStatus();
+}
+}  // namespace
+
+absl::Status TelemetryValidator::OnNsfReboot(absl::string_view version,
+                                             Testbed& testbed,
+                                             thinkit::SSHClient& ssh_client) {
+  return ValidateTelemetryWarmboot(testbed, ssh_client);
+}
+
+}  // namespace pins_test

--- a/tests/integration/system/nsf/component_validators/telemetry_validator.h
+++ b/tests/integration/system/nsf/component_validators/telemetry_validator.h
@@ -1,0 +1,34 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PINS_TESTS_INTEGRATION_SYSTEM_NSF_COMPONENT_VALIDATORS_TELEMETRY_VALIDATOR_H_
+#define PINS_TESTS_INTEGRATION_SYSTEM_NSF_COMPONENT_VALIDATORS_TELEMETRY_VALIDATOR_H_
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "glog/logging.h"
+#include "tests/integration/system/nsf/interfaces/component_validator.h"
+#include "tests/integration/system/nsf/interfaces/testbed.h"
+#include "thinkit/ssh_client.h"
+
+namespace pins_test {
+
+class TelemetryValidator : public ComponentValidator {
+  absl::Status OnNsfReboot(absl::string_view version, Testbed& testbed,
+                           thinkit::SSHClient& ssh_client) override;
+};
+
+}  // namespace pins_test
+
+#endif  // PINS_TESTS_INTEGRATION_SYSTEM_NSF_COMPONENT_VALIDATORS_TELEMETRY_VALIDATOR_H_


### PR DESCRIPTION
Keyword Check:
/tests_sonic-pins/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.



Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 752 targets (269 packages loaded, 22408 targets configured).
INFO: Found 752 targets...
INFO: Elapsed time: 261.867s, Critical Path: 53.66s
INFO: 84 processes: 17 internal, 67 linux-sandbox.
INFO: Build completed successfully, 84 total actions





Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 752 targets (0 packages loaded, 383 targets configured).
INFO: Found 523 targets and 229 test targets...
INFO: Elapsed time: 308.734s, Critical Path: 157.69s
INFO: 287 processes: 341 linux-sandbox, 18 local.
INFO: Build completed successfully, 287 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.9s
//dvaas:dataplane_validation_test                                        PASSED in 0.3s
//dvaas:port_id_map_test                                                 PASSED in 18.8s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.9s
//dvaas:test_run_validation_test                                         PASSED in 18.0s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 1.4s
//dvaas:test_vector_stats_test                                           PASSED in 1.2s
//dvaas:test_vector_test                                                 PASSED in 1.0s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.7s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.8s
//gutil:collections_test                                                 PASSED in 15.4s
//gutil:io_test                                                          PASSED in 15.2s
//gutil:proto_matchers_test                                              PASSED in 0.8s
//gutil:proto_ordering_test                                              PASSED in 0.8s
//gutil:proto_test                                                       PASSED in 0.8s
//gutil:status_matchers_test                                             PASSED in 0.7s
//tests/forwarding:hash_statistics_util_test                             PASSED in 1.9s
//tests/lib:common_ir_table_entries_test                                 PASSED in 1.2s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.2s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.2s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.3s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.3s
//tests/sflow:sflow_util_test                                            PASSED in 7.4s
//thinkit:bazel_test_environment_test                                    PASSED in 1.0s
//thinkit:generic_testbed_test                                           PASSED in 1.3s
//thinkit:mock_control_device_test                                       PASSED in 0.9s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.1s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.0s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.2s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 18.7s
//tests/lib:packet_generator_test                                        PASSED in 67.2s
  Stats over 4 runs: max = 67.2s, min = 63.8s, avg = 65.4s, dev = 1.3s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.2s
  Stats over 5 runs: max = 1.2s, min = 1.0s, avg = 1.1s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 48.2s
  Stats over 50 runs: max = 48.2s, min = 1.1s, avg = 5.4s, dev = 12.7s

Executed 229 out of 229 tests: 229 tests pass.