### PR TITLE
[Thinkit/Tests] Validate traffic and ACL flows across NSF upgrade using snapshot comparisons.

### DIFF
--- a/tests/integration/system/nsf/BUILD.bazel
+++ b/tests/integration/system/nsf/BUILD.bazel
@@ -88,6 +88,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest",

--- a/tests/integration/system/nsf/upgrade_test.h
+++ b/tests/integration/system/nsf/upgrade_test.h
@@ -50,9 +50,10 @@ class NsfUpgradeTest : public testing::TestWithParam<NsfTestParams> {
   // override the `next_image_config.gnmi_config` and will used for subsequent
   // validations.
   absl::Status NsfUpgradeOrReboot(NsfUpgradeScenario scenario,
-                                  ImageConfigParams& curr_image_config,
-                                  ImageConfigParams& next_image_config,
-                                  bool enable_interface_validation_during_nsf);
+                                  ImageConfigParams &curr_image_config,
+                                  ImageConfigParams &next_image_config,
+                                  bool enable_interface_validation_during_nsf,
+                                  bool &continue_on_failure);
 
   std::unique_ptr<FlowProgrammer> flow_programmer_;
   std::unique_ptr<TrafficHelper> traffic_helper_;


### PR DESCRIPTION
Keyword Check:
/tests_sonic-pins/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.



Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 754 targets (1 packages loaded, 27 targets configured).
INFO: Found 754 targets...
INFO: Elapsed time: 42.241s, Critical Path: 41.11s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions



Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 754 targets (0 packages loaded, 0 targets configured).
INFO: Found 525 targets and 229 test targets...
INFO: Elapsed time: 287.463s, Critical Path: 142.72s
INFO: 286 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 286 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.1s
//dvaas:dataplane_validation_test                                        PASSED in 0.1s
//dvaas:port_id_map_test                                                 PASSED in 1.1s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.2s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 0.8s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 0.7s
//gutil:io_test                                                          PASSED in 0.7s
//gutil:proto_matchers_test                                              PASSED in 0.8s
//gutil:proto_ordering_test                                              PASSED in 0.7s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.2s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 1.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 3.1s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 2.0s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 6.7s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 1.3s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.1s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.1s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 1.5s
//tests/forwarding:hash_statistics_util_test                             PASSED in 1.3s
//tests/lib:common_ir_table_entries_test                                 PASSED in 1.1s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.0s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.2s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.1s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.1s
//thinkit:bazel_test_environment_test                                    PASSED in 0.8s
//thinkit:generic_testbed_test                                           PASSED in 1.3s
//thinkit:mock_control_device_test                                       PASSED in 0.8s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.0s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.9s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 0.9s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 1.0s
//tests/lib:packet_generator_test                                        PASSED in 66.8s
  Stats over 4 runs: max = 66.8s, min = 64.3s, avg = 65.0s, dev = 1.0s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.8s
  Stats over 5 runs: max = 1.8s, min = 1.0s, avg = 1.2s, dev = 0.3s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 91.2s
  Stats over 50 runs: max = 91.2s, min = 1.1s, avg = 5.1s, dev = 15.2s

Executed 229 out of 229 tests: 229 tests pass.
