### PR TITLE
[P4_PDPI] Support references for fallback groups.

### DIFF
--- a/p4_pdpi/ir.proto
+++ b/p4_pdpi/ir.proto
@@ -99,7 +99,7 @@ message IrP4ActionField {
 // representation to be used within annotations.
 enum IrBuiltInAction {
   BUILT_IN_ACTION_UNSPECIFIED = 0;
-  // Corresponds to p4::v1::Replica.
+  // Corresponds to p4::v1::Replica and p4::v1::BackupReplica.
   // String representation in annotations: "builtin::replica"
   BUILT_IN_ACTION_REPLICA = 1;
 }
@@ -109,10 +109,11 @@ enum IrBuiltInAction {
 // representation to be used within `@refers_to`/`@referenced_by` annotations.
 enum IrBuiltInParameter {
   BUILT_IN_PARAMETER_UNSPECIFIED = 0;
-  // Corresponds to p4::v1::Replica::port.
+  // Corresponds to p4::v1::Replica::port and p4::v1::BackupReplica::port.
   // String representation in annotations: "replica.port"
   BUILT_IN_PARAMETER_REPLICA_PORT = 1;
-  // Corresponds to p4::v1::Replica::instance.
+  // Corresponds to p4::v1::Replica::instance and
+  // p4::v1::BackupReplica::instance.
   // String representation in annotations: "replica.instance"
   BUILT_IN_PARAMETER_REPLICA_INSTANCE = 2;
 }

--- a/p4_pdpi/packetlib/BUILD.bazel
+++ b/p4_pdpi/packetlib/BUILD.bazel
@@ -85,6 +85,7 @@ cc_test(
         ":bit_widths",
         ":packetlib",
         ":packetlib_cc_proto",
+	"//gutil:proto_matchers",
         "//gutil:status_matchers",
 	"//gutil:testing",
         "@com_google_absl//absl/status",

--- a/p4_pdpi/packetlib/bit_widths.h
+++ b/p4_pdpi/packetlib/bit_widths.h
@@ -23,6 +23,7 @@ namespace packetlib {
 constexpr int kEthernetHeaderBitwidth = 48 * 2 + 16;
 constexpr int kStandardIpv4HeaderBitwidth = 160;
 constexpr int kIpv6HeaderBitwidth = 320;
+constexpr int kMinHopByHopOptionsHeaderBitwidth = 64;
 constexpr int kUdpHeaderBitwidth = 64;
 constexpr int kStandardTcpHeaderBitwidth = 5 * 32;
 constexpr int kArpHeaderBitwidth = 28 * 8;
@@ -68,6 +69,14 @@ constexpr int kIpFlowLabelBitwidth = 20;      // IPv6
 constexpr int kIpPayloadLengthBitwidth = 16;  // IPv6
 constexpr int kIpNextHeaderBitwidth = 8;      // IPv6
 constexpr int kIpHopLimitBitwidth = 8;        // IPv6
+
+// IPv6 hop-by-hop options extension constants.
+constexpr int kHopByHopNextHeaderBitwidth = 8;             // IPv6 Options
+constexpr int kHopByHopHeaderExtensionLengthBitwidth = 8;  // IPv6 Options
+constexpr int kHopByHopOptionsAndPaddingBitwidth = 48;     // IPv6 Options
+// Note: The rest of the `HopByHopOptionsHeader` is represented by
+// `more_options_and_padding`, which has a variable length bit-width based on
+// the `header_extension_length`.
 
 // UDP constants.
 constexpr int kUdpPortBitwidth = 16;

--- a/p4_pdpi/packetlib/packetlib.cc
+++ b/p4_pdpi/packetlib/packetlib.cc
@@ -3072,8 +3072,12 @@ absl::StatusOr<int> IcmpHeaderChecksum(Packet packet, int icmp_header_index) {
                        PacketSizeInBytes(packet, icmp_header_index));
       data.AppendBits<32>(icmpv6_size);
       data.AppendBits<24>(0);
-      RETURN_IF_ERROR(
-          SerializeBits<kIpNextHeaderBitwidth>(header.next_header(), data));
+      // The `next_header` field for a ICMP header identifies the upper-layer
+      // protocol. It differs from the typical `next_header` field in an IPv6
+      // header when there are IPV6 extension headers.
+      // The `next_header` field for a ICMP header must be 58
+      // (0x3a).
+      RETURN_IF_ERROR(SerializeBits<kIpNextHeaderBitwidth>("0x3a", data));
       break;
     }
     case Header::kIpv4Header: {
@@ -3119,6 +3123,10 @@ absl::StatusOr<int> GreHeaderChecksum(Packet packet, int gre_header_index) {
 
 std::string EtherType(uint32_t ether_type) {
   return ValidateAndConvertToHexString<kEthernetEthertypeBitwidth>(ether_type);
+}
+
+std::string VlanId(uint32_t vlan_id) {
+  return ValidateAndConvertToHexString<kVlanVlanIdentifierBitwidth>(vlan_id);
 }
 
 std::string IpVersion(uint32_t version) {

--- a/p4_pdpi/packetlib/packetlib.h
+++ b/p4_pdpi/packetlib/packetlib.h
@@ -177,6 +177,7 @@ absl::StatusOr<std::string> GetEthernetTrailer(const packetlib::Packet& packet);
 // checks if the input data is truncated because its bit width exceeds the
 // limitation.
 std::string EtherType(uint32_t ether_type);
+std::string VlanId(uint32_t vlan_id);
 std::string IpVersion(uint32_t version);
 std::string IpIhl(uint32_t ihl);
 std::string IpDscp(uint32_t dscp);

--- a/p4_pdpi/packetlib/packetlib.proto
+++ b/p4_pdpi/packetlib/packetlib.proto
@@ -69,6 +69,7 @@ message Header {
     PtpHeader ptp_header = 13;
     PspHeader psp_header = 14;
     CsigHeader csig_header = 15;
+    HopByHopOptionsHeader hop_by_hop_options_header = 16;
   }
 }
 
@@ -144,6 +145,14 @@ message Ipv6Header {
   string hop_limit = 7;         // 8 bits
   string ipv6_source = 8;       // Format::IPV6
   string ipv6_destination = 9;  // Format::IPV6
+}
+
+// An IPv6 hop-by-hop options extension header
+// (https://datatracker.ietf.org/doc/html/rfc2460#section-4.3).
+message HopByHopOptionsHeader {
+  string next_header = 1;              // 8 bits
+  string header_extension_length = 2;  // 8 bits
+  string options_and_padding = 3;      // 48 bits
 }
 
 // An ICMP header.

--- a/p4_pdpi/packetlib/packetlib_test_runner.expected
+++ b/p4_pdpi/packetlib/packetlib_test_runner.expected
@@ -3273,7 +3273,7 @@ headers {
     source_port: "0x0014"
     destination_port: "0x000a"
     length: "0x000a"
-    checksum: "0xb6d4"
+    checksum: "0xb753"
   }
 }
 payload: "Hi"

--- a/p4_pdpi/packetlib/packetlib_unit_test.cc
+++ b/p4_pdpi/packetlib/packetlib_unit_test.cc
@@ -891,5 +891,78 @@ TEST(PacketLib, UpdateComputedFieldsAddsSinglePaddingForHopByHopOptions) {
   EXPECT_THAT(parsed_packet, EqualsProto(packet));
 }
 
+TEST(PacketLib,
+     UpdateComputedFieldsAddsSinglePaddingForNPaddingForHopByHopOptions) {
+  Packet packet = gutil::ParseProtoOrDie<Packet>(R"pb(
+    headers {
+      hop_by_hop_options_header {
+        next_header: "0xfe"
+        header_extension_length: "0x00"
+        options_and_padding: "0x00000000"
+      }
+    }
+  )pb");
+  // Update adds a single padding for N-padding.
+  ASSERT_OK(packetlib::UpdateAllComputedFields(packet).status());
+  ASSERT_OK_AND_ASSIGN(std::string raw_packet,
+                       packetlib::RawSerializePacket(packet));
+  EXPECT_EQ(absl::BytesToHexString(raw_packet), "fe00000000000100");
+
+  // Verify that the round-tripped packet is the same as the original packet.
+  Packet parsed_packet =
+      ParsePacket(raw_packet, Header::kHopByHopOptionsHeader);
+  EXPECT_THAT(PacketSizeInBits(parsed_packet, 0), IsOkAndHolds(64));
+  EXPECT_THAT(parsed_packet, EqualsProto(packet));
+}
+
+TEST(PacketLib,
+     UpdateComputedFieldsAddsNPaddingForOptionsAndPaddingForHopByHopOptions) {
+  Packet packet = gutil::ParseProtoOrDie<Packet>(R"pb(
+    headers {
+      hop_by_hop_options_header {
+        next_header: "0xfe"
+        header_extension_length: "0x00"
+        options_and_padding: "0x000000"
+      }
+    }
+  )pb");
+  // Update adds a N-padding.
+  ASSERT_OK(packetlib::UpdateAllComputedFields(packet).status());
+  ASSERT_OK_AND_ASSIGN(std::string raw_packet,
+                       packetlib::RawSerializePacket(packet));
+  EXPECT_EQ(absl::BytesToHexString(raw_packet), "fe00000000010100");
+
+  // Verify that the round-tripped packet is the same as the original packet.
+  Packet parsed_packet =
+      ParsePacket(raw_packet, Header::kHopByHopOptionsHeader);
+  EXPECT_THAT(PacketSizeInBits(parsed_packet, 0), IsOkAndHolds(64));
+  EXPECT_THAT(parsed_packet, EqualsProto(packet));
+}
+
+TEST(PacketLib,
+     UpdateAllComputedFieldsHasExceedingDataLengthForHopByHopOptions) {
+  Packet packet = gutil::ParseProtoOrDie<Packet>(R"pb(
+    headers {
+      hop_by_hop_options_header {
+        next_header: "0xfe"
+        header_extension_length: "0x00"
+        # The data length of 9 exceeds the maximum.
+        options_and_padding: "0x010900000000"
+      }
+    }
+  )pb");
+  ASSERT_OK(packetlib::UpdateAllComputedFields(packet).status());
+  ASSERT_OK_AND_ASSIGN(std::string raw_packet,
+                       packetlib::RawSerializePacket(packet));
+  EXPECT_EQ(absl::BytesToHexString(raw_packet), "fe00010900000000");
+
+  // Verify that the round-tripped packet is the same as the original packet.
+  Packet parsed_packet =
+      ParsePacket(raw_packet, Header::kHopByHopOptionsHeader);
+  EXPECT_EQ(parsed_packet.reasons_invalid_size(), 1);
+  EXPECT_THAT(parsed_packet.mutable_reasons_invalid()->Get(0),
+              HasSubstr("data length exceeds"));
+}
+
 }  // namespace
 }  // namespace packetlib

--- a/p4_pdpi/pdgenlib.cc
+++ b/p4_pdpi/pdgenlib.cc
@@ -536,14 +536,20 @@ message MulticastGroupTableEntry {
 // This action is unique to `MulticastGroupTableEntry` and is not explicitly
 // present in the P4 program.
 message ReplicateAction {
+  // All `Replica`s and `BackupReplica`s must have unique (port, instance)-pairs
+  // within the scope of the `ReplicateAction` that contains them.
+  repeated Replica replicas = 1;
   // Corresponds to `Replica` in p4runtime.proto.
   message Replica {
     string port = 1;  // Format::STRING
     string instance = 2;  // Format::HEX_STRING / 16 bits
+    repeated BackupReplica backup_replicas = 3;
   }
-  // Each `Replica` must have a unique (port, instance)-pair within the scope of
-  // the `ReplicateAction` that contains it.
-  repeated Replica replicas = 1;
+  // Corresponds to `BackupReplica` in p4runtime.proto.
+  message BackupReplica {
+    string port = 1;      // Format::STRING
+    string instance = 2;  // Format::HEX_STRING / 16 bits
+  }
 }
 
 )");

--- a/p4_pdpi/references.cc
+++ b/p4_pdpi/references.cc
@@ -428,6 +428,17 @@ OutgoingConcreteTableReferences(const IrTableReference& reference_info,
             action_partial_references.emplace_back(),
             GetPartialReferenceFromReplica(
                 built_in_replica_field_to_match_field_references, replica));
+	for (const auto& backup_replica : replica.backup_replicas()) {
+          // Because primary and backup replicas share the same checks, we map
+          // the type Replica to BackupReplica in order to reuse logic.
+          p4::v1::Replica backup_replica_as_replica;
+          backup_replica_as_replica.set_port(backup_replica.port());
+          backup_replica_as_replica.set_instance(backup_replica.instance());
+          ASSIGN_OR_RETURN(action_partial_references.emplace_back(),
+                           GetPartialReferenceFromReplica(
+                               built_in_replica_field_to_match_field_references,
+                               backup_replica_as_replica));
+        }
       }
       break;
     }

--- a/p4_pdpi/testing/references_test_runner.cc
+++ b/p4_pdpi/testing/references_test_runner.cc
@@ -69,52 +69,6 @@ OutgoingConcreteTableReferencesTestCases() {
              }
            })pb");
 
-  pdpi::TableEntry p4_group_entry_with_multiple_actions =
-      gutil::ParseProtoOrDie<pdpi::TableEntry>(
-          R"pb(golden_test_friendly_wcmp_table_entry {
-                 match { key1: "key-a" key2: "key-b" }
-                 wcmp_actions {
-                   action {
-                     golden_test_friendly_action {
-                       arg1: "act1-arg1"
-                       arg2: "act1-arg2"
-                     }
-                   }
-                   weight: 1
-                 }
-                 wcmp_actions {
-                   action {
-                     golden_test_friendly_action {
-                       arg1: "act2-arg1"
-                       arg2: "act2-arg2"
-                     }
-                   }
-                   weight: 2
-                 }
-                 wcmp_actions {
-                   action {
-                     other_golden_test_friendly_action {
-                       arg1: "act3-arg1"
-                       arg2: "act3-arg2"
-                     }
-                   }
-                   weight: 3
-                 }
-               })pb");
-
-  pdpi::TableEntry built_in_entry_with_multiple_actions =
-      gutil::ParseProtoOrDie<pdpi::TableEntry>(R"pb(
-        multicast_group_table_entry {
-          match { multicast_group_id: "0x0037" }
-          action {
-            replicate {
-              replicas { port: "port_1" instance: "0x0031" }
-              replicas { port: "port_2" instance: "0x0032" }
-            }
-          }
-        }
-      )pb");
-
   // Error test cases.
   test_cases.push_back(ConcreteTableReferenceTestCase{
       .entity = p4_entry,
@@ -335,6 +289,20 @@ OutgoingConcreteTableReferencesTestCases() {
           "P4MatchField-Refers-To-BuiltInMatchField reference creates a "
           "single concrete reference.",
   });
+
+  pdpi::TableEntry built_in_entry_with_multiple_actions =
+      gutil::ParseProtoOrDie<pdpi::TableEntry>(R"pb(
+        multicast_group_table_entry {
+          match { multicast_group_id: "0x0037" }
+          action {
+            replicate {
+              replicas { port: "port_1" instance: "0x0031" }
+              replicas { port: "port_2" instance: "0x0032" }
+            }
+          }
+        }
+      )pb");
+
   test_cases.push_back(ConcreteTableReferenceTestCase{
       .entity = built_in_entry_with_multiple_actions,
       .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
@@ -379,6 +347,40 @@ OutgoingConcreteTableReferencesTestCases() {
           "BuiltInMatchField-Refers-To-BuiltInMatchField reference creates "
           "a single concrete reference.",
   });
+
+   pdpi::TableEntry p4_group_entry_with_multiple_actions =
+      gutil::ParseProtoOrDie<pdpi::TableEntry>(
+          R"pb(golden_test_friendly_wcmp_table_entry {
+                 match { key1: "key-a" key2: "key-b" }
+                 wcmp_actions {
+                   action {
+                     golden_test_friendly_action {
+                       arg1: "act1-arg1"
+                       arg2: "act1-arg2"
+                     }
+                   }
+                   weight: 1
+                 }
+                 wcmp_actions {
+                   action {
+                     golden_test_friendly_action {
+                       arg1: "act2-arg1"
+                       arg2: "act2-arg2"
+                     }
+                   }
+                   weight: 2
+                 }
+                 wcmp_actions {
+                   action {
+                     other_golden_test_friendly_action {
+                       arg1: "act3-arg1"
+                       arg2: "act3-arg2"
+                     }
+                   }
+                   weight: 3
+                 }
+               })pb");
+
   test_cases.push_back(ConcreteTableReferenceTestCase{
       .entity = p4_group_entry_with_multiple_actions,
       .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
@@ -487,6 +489,77 @@ OutgoingConcreteTableReferencesTestCases() {
       .description =
           "BuiltInActionField-Refers-To-BuiltInMatchField reference creates a "
           "concrete reference for every instance of the action.",
+  });
+
+  pdpi::TableEntry built_in_entry_with_multiple_backup_actions =
+      gutil::ParseProtoOrDie<pdpi::TableEntry>(R"pb(
+        multicast_group_table_entry {
+          match { multicast_group_id: "0x0037" }
+          action {
+            replicate {
+              replicas {
+                port: "port_1"
+                instance: "0x0031"
+                backup_replicas { port: "port_3" instance: "0x0033" }
+                backup_replicas { port: "port_4" instance: "0x0034" }
+              }
+              replicas {
+                port: "port_2"
+                instance: "0x0032"
+                backup_replicas { port: "port_5" instance: "0x0035" }
+              }
+            }
+          }
+        }
+      )pb");
+
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry_with_multiple_backup_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            action_field {
+              built_in_action_field {
+                action: BUILT_IN_ACTION_REPLICA
+                parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+      )pb"),
+      .description =
+          "BuiltInActionField-Refers-To-P4MatchField reference creates a "
+          "concrete reference for every instance of the backup-action.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry_with_multiple_backup_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            action_field {
+              built_in_action_field {
+                action: BUILT_IN_ACTION_REPLICA
+                parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+              }
+            }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+      )pb"),
+      .description =
+          "BuiltInActionField-Refers-To-BuiltInMatchField reference creates a "
+          "concrete reference for every instance of the backup-action.",
   });
 
   // NOTE: For all following test cases, output is similar whether destination

--- a/p4_pdpi/testing/sequencing_test_runner.cc
+++ b/p4_pdpi/testing/sequencing_test_runner.cc
@@ -1487,7 +1487,13 @@ void RunGetEntriesUnreachableFromRootsTests(const pdpi::IrP4Info& info) {
             multicast_group_table_entry {
               match { multicast_group_id: "0x0037" }
               action {
-                replicate { replicas { port: "port_1" instance: "0x0031" } }
+                replicate {
+                  replicas {
+                    port: "port_1"
+                    instance: "0x0031"
+                    backup_replicas { port: "port_2" instance: "0x0032" }
+                  }
+                }
               }
             }
           )pb",
@@ -1495,7 +1501,14 @@ void RunGetEntriesUnreachableFromRootsTests(const pdpi::IrP4Info& info) {
             referenced_by_multicast_replica_table_entry {
               match { port: "port_1" instance: "0x0031" }
               action { do_thing_4 {} }
-              controller_metadata: "Not Garbage"
+              controller_metadata: "Not Garbage because of primary replica"
+            }
+          )pb",
+          R"pb(
+            referenced_by_multicast_replica_table_entry {
+              match { port: "port_2" instance: "0x0032" }
+              action { do_thing_4 {} }
+              controller_metadata: "Not Garbage because of backup replica"
             }
           )pb",
           R"pb(

--- a/p4_pdpi/testing/testdata/main_p4_pd.expected
+++ b/p4_pdpi/testing/testdata/main_p4_pd.expected
@@ -536,14 +536,20 @@ message GoldenTestFriendlyAction {
 // This action is unique to `MulticastGroupTableEntry` and is not explicitly
 // present in the P4 program.
 message ReplicateAction {
+  // All `Replica`s and `BackupReplica`s must have unique (port, instance)-pairs
+  // within the scope of the `ReplicateAction` that contains them.
+  repeated Replica replicas = 1;
   // Corresponds to `Replica` in p4runtime.proto.
   message Replica {
     string port = 1;  // Format::STRING
     string instance = 2;  // Format::HEX_STRING / 16 bits
+    repeated BackupReplica backup_replicas = 3;
   }
-  // Each `Replica` must have a unique (port, instance)-pair within the scope of
-  // the `ReplicateAction` that contains it.
-  repeated Replica replicas = 1;
+  // Corresponds to `BackupReplica` in p4runtime.proto.
+  message BackupReplica {
+    string port = 1;      // Format::STRING
+    string instance = 2;  // Format::HEX_STRING / 16 bits
+  }
 }
 
 

--- a/p4_pdpi/testing/testdata/references.expected
+++ b/p4_pdpi/testing/testdata/references.expected
@@ -937,6 +937,162 @@ ConcreteTableReference{
 }
 
 =========================================================================
+OutgoingConcreteTableReferences: BuiltInActionField-Refers-To-P4MatchField reference creates a concrete reference for every instance of the backup-action.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port_1"
+        instance: "0x0031"
+        backup_replicas {
+          port: "port_3"
+          instance: "0x0033"
+        }
+        backup_replicas {
+          port: "port_4"
+          instance: "0x0034"
+        }
+      }
+      replicas {
+        port: "port_2"
+        instance: "0x0032"
+        backup_replicas {
+          port: "port_5"
+          instance: "0x0035"
+        }
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    action_field {
+      built_in_action_field {
+        action: BUILT_IN_ACTION_REPLICA
+        parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'other_field', value: 'port_1' },
+  }
+}
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'other_field', value: 'port_2' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: BuiltInActionField-Refers-To-BuiltInMatchField reference creates a concrete reference for every instance of the backup-action.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port_1"
+        instance: "0x0031"
+        backup_replicas {
+          port: "port_3"
+          instance: "0x0033"
+        }
+        backup_replicas {
+          port: "port_4"
+          instance: "0x0034"
+        }
+      }
+      replicas {
+        port: "port_2"
+        instance: "0x0032"
+        backup_replicas {
+          port: "port_5"
+          instance: "0x0035"
+        }
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    action_field {
+      built_in_action_field {
+        action: BUILT_IN_ACTION_REPLICA
+        parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'multicast_group_id', value: 'port_1' },
+  }
+}
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'multicast_group_id', value: 'port_2' },
+  }
+}
+
+=========================================================================
 OutgoingConcreteTableReferences: Multi P4MatchField-Refers-To-MatchField references create a single concrete reference.
 =========================================================================
 -- INPUT --------------------------------------------------------------

--- a/p4_pdpi/testing/testdata/sequencing.expected
+++ b/p4_pdpi/testing/testdata/sequencing.expected
@@ -2283,6 +2283,10 @@ multicast_group_table_entry {
       replicas {
         port: "port_1"
         instance: "0x0031"
+        backup_replicas {
+          port: "port_2"
+          instance: "0x0032"
+        }
       }
     }
   }
@@ -2297,7 +2301,19 @@ referenced_by_multicast_replica_table_entry {
     do_thing_4 {
     }
   }
-  controller_metadata: "Not Garbage"
+  controller_metadata: "Not Garbage because of primary replica"
+}
+
+referenced_by_multicast_replica_table_entry {
+  match {
+    port: "port_2"
+    instance: "0x0032"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+  controller_metadata: "Not Garbage because of backup replica"
 }
 
 referenced_by_multicast_replica_table_entry {
@@ -2322,7 +2338,19 @@ referenced_by_multicast_replica_table_entry {
     do_thing_4 {
     }
   }
-  controller_metadata: "Not Garbage"
+  controller_metadata: "Not Garbage because of primary replica"
+}
+
+referenced_by_multicast_replica_table_entry {
+  match {
+    port: "port_2"
+    instance: "0x0032"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+  controller_metadata: "Not Garbage because of backup replica"
 }
 
 referenced_by_multicast_replica_table_entry {

--- a/sai_p4/fixed/headers.p4
+++ b/sai_p4/fixed/headers.p4
@@ -13,6 +13,7 @@
 #define IP_PROTOCOL_ICMP   0x01
 #define IP_PROTOCOL_ICMPV6 0x3a
 #define IP_PROTOCOL_IPV6   0x29
+#define IP_PROTOCOL_V6_EXTENSION_HOP_BY_HOP 0x00
 #define IP_PROTOCOLS_GRE   0x2f
 
 typedef bit<48> ethernet_addr_t;
@@ -87,6 +88,17 @@ header ipv6_t {
   bit<8> hop_limit;
   ipv6_addr_t src_addr;
   ipv6_addr_t dst_addr;
+}
+
+header hop_by_hop_options_t {
+  bit<8> next_header;
+  bit<8> header_extension_length;
+  // options and padding = 64 bits -  next_header - header_extension_length
+  // = 64 - 8 - 8 = 48
+  bit<48> options_and_padding;
+  // Currently, we do not support `more_options_and_padding`. See b/364617104
+  // for more information. So packets with a non-zero `header_extension_length`
+  // will be rejected by the parser.
 }
 
 #define UDP_HEADER_BYTES 8

--- a/sai_p4/fixed/metadata.p4
+++ b/sai_p4/fixed/metadata.p4
@@ -344,9 +344,10 @@ struct local_metadata_t {
   bool nexthop_id_valid;
   // Nexthop id, only valid if `nexthop_id_valid` is true.
   nexthop_id_t nexthop_id_value;
-  // After execution of the `routing_lookup` stage, indicates if an entry in
-  // the `ipv4_multicast` or `ipv6_multicast` table was hit.
-  bool ipmc_table_hit;
+  // After execution of the `routing_lookup` stage, indicates if an entry in one
+  // of the routing tables was hit
+  // (`ipv{4,6}_table` or `ipv{4,6}_multicast_table`).
+  bool route_hit;
   // After execution of the `tunnel_termination` stage, indicates if an entry in
   // the `tunnel_termination` table was hit.
   bool tunnel_termination_table_hit;

--- a/sai_p4/fixed/metadata.p4
+++ b/sai_p4/fixed/metadata.p4
@@ -172,9 +172,14 @@ struct headers_t {
   ipv4_t ipv4;
   ipv6_t ipv6;
 
+  // IPv6 extension headers.
+  hop_by_hop_options_t hop_by_hop_options;
+
   // Inner IP-in-IP headers.
   ipv4_t inner_ipv4;
   ipv6_t inner_ipv6;
+
+  hop_by_hop_options_t inner_hop_by_hop_options;
 
   icmp_t icmp;
   tcp_t tcp;

--- a/sai_p4/fixed/parser.p4
+++ b/sai_p4/fixed/parser.p4
@@ -48,7 +48,7 @@ parser packet_parser(packet_in packet, out headers_t headers,
     local_metadata.wcmp_group_id_value = 0;
     local_metadata.nexthop_id_valid = false;
     local_metadata.nexthop_id_value = 0;
-    local_metadata.ipmc_table_hit = false;
+    local_metadata.route_hit = false;
     local_metadata.acl_drop = false;
     local_metadata.tunnel_termination_table_hit = false;
     local_metadata.acl_ingress_ipmc_redirect = false;

--- a/sai_p4/fixed/routing.p4
+++ b/sai_p4/fixed/routing.p4
@@ -274,17 +274,13 @@ control routing_lookup(in headers_t headers,
         if (IS_IPV4_MULTICAST_MAC(headers.ethernet.dst_addr)) {
           // Packets failing ingress VLAN checks do not go through IPMC lookup
           if (!local_metadata.marked_to_drop_by_ingress_vlan_checks) {
-            ipv4_multicast_table.apply();
-            local_metadata.ipmc_table_hit = standard_metadata.mcast_grp != 0;
-            // TODO: Use commented out code instead, once
-            // p4-symbolic supports it.
-            // local_metadata.ipmc_table_hit = ipv4_multicast_table.apply().hit()
+            local_metadata.route_hit = ipv4_multicast_table.apply().hit;
           }
         }
       } else { // IPv4 unicast.
         if (IS_UNICAST_MAC(headers.ethernet.dst_addr) &&
             local_metadata.admit_to_l3) {
-          ipv4_table.apply();
+          local_metadata.route_hit = ipv4_table.apply().hit;
         }
       }
     } else if (headers.ipv6.isValid()) {
@@ -292,17 +288,13 @@ control routing_lookup(in headers_t headers,
         if (IS_IPV6_MULTICAST_MAC(headers.ethernet.dst_addr)) {
           // Packets failing ingress VLAN checks do not go through IPMC lookup
           if (!local_metadata.marked_to_drop_by_ingress_vlan_checks) {
-            ipv6_multicast_table.apply();
-            local_metadata.ipmc_table_hit = standard_metadata.mcast_grp != 0;
-            // TODO: Use commented out code instead, once
-            // p4-symbolic supports it.
-            // local_metadata.ipmc_table_hit = ipv6_multicast_table.apply().hit()
+            local_metadata.route_hit = ipv6_multicast_table.apply().hit;
           }
         }
       } else { // IPv6 unicast.
         if (IS_UNICAST_MAC(headers.ethernet.dst_addr) &&
             local_metadata.admit_to_l3) {
-          ipv6_table.apply();
+          local_metadata.route_hit = ipv6_table.apply().hit;
         }
       }
     }

--- a/sai_p4/instantiations/google/acl_egress.p4
+++ b/sai_p4/instantiations/google/acl_egress.p4
@@ -179,7 +179,12 @@ control acl_egress(in headers_t headers,
         ip_protocol = headers.ipv4.protocol;
       } else if (headers.ipv6.isValid()) {
         dscp = headers.ipv6.dscp;
+        if (headers.hop_by_hop_options.isValid()) {
+        ip_protocol = headers.hop_by_hop_options.next_header;
+      }
+      else {
         ip_protocol = headers.ipv6.next_header;
+      }
       } else {
         ip_protocol = 0;
       }

--- a/sai_p4/instantiations/google/acl_ingress.p4
+++ b/sai_p4/instantiations/google/acl_ingress.p4
@@ -395,7 +395,9 @@ control acl_ingress(in headers_t headers,
       @proto_id(4) acl_mirror();
       @proto_id(5) acl_drop(local_metadata);
       @proto_id(6) redirect_to_l2mc_group();
+#if defined(ACL_REDIRECT_TO_NEXTHOP_CAPABLE)
       @proto_id(7) redirect_to_nexthop();
+#endif
       @proto_id(8) append_ingress_and_egress_timestamp();
       @defaultonly NoAction;
     }
@@ -721,10 +723,14 @@ control acl_ingress(in headers_t headers,
 // reference analysis will fail.
       @proto_id(4) acl_forward();
       @proto_id(1) acl_mirror();
+#if defined(ACL_REDIRECT_TO_NEXTHOP_CAPABLE)
       @proto_id(2) redirect_to_nexthop();
+#endif
       @proto_id(3) redirect_to_ipmc_group();
+#if defined(ACL_REDIRECT_TO_PORT_CAPABLE)
       @proto_id(5) redirect_to_port();
       @proto_id(6) acl_mirror_and_redirect_to_port();
+#endif
       @defaultonly NoAction;
     }
     const default_action = NoAction;

--- a/sai_p4/instantiations/google/acl_ingress.p4
+++ b/sai_p4/instantiations/google/acl_ingress.p4
@@ -706,9 +706,12 @@ control acl_ingress(in headers_t headers,
         @id(8) @name("vrf_id")
         @refers_to(vrf_table, vrf_id)
         @sai_field(SAI_ACL_TABLE_ATTR_FIELD_VRF_ID);
-      local_metadata.ipmc_table_hit : optional
+      local_metadata.route_hit : optional
+        // TODO: To accurately reflect the semantics, rename to
+        // `route_hit`, once this breaking name-change is supported on the
+        // controller side.
         @id(9) @name("ipmc_table_hit")
-        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IPMC_NPU_META_DST_HIT);
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ROUTE_NPU_META_DST_HIT);
     }
     actions = {
 // We don't usually restrict actions to instantiations because they don't

--- a/sai_p4/instantiations/google/acl_ingress.p4
+++ b/sai_p4/instantiations/google/acl_ingress.p4
@@ -394,7 +394,9 @@ control acl_ingress(in headers_t headers,
       @proto_id(1) acl_copy();
       @proto_id(2) acl_trap();
       @proto_id(3) acl_forward();
+#if defined(MIRROR_CAPABLE)
       @proto_id(4) acl_mirror();
+#endif
       @proto_id(5) acl_drop(local_metadata);
       @proto_id(6) redirect_to_l2mc_group();
 #if defined(ACL_REDIRECT_TO_NEXTHOP_CAPABLE)
@@ -724,13 +726,17 @@ control acl_ingress(in headers_t headers,
 // mirror_session_table, reference entries generation in IrP4Info and
 // reference analysis will fail.
       @proto_id(4) acl_forward();
+#if defined(MIRROR_CAPABLE)
       @proto_id(1) acl_mirror();
+#endif
 #if defined(ACL_REDIRECT_TO_NEXTHOP_CAPABLE)
       @proto_id(2) redirect_to_nexthop();
 #endif
       @proto_id(3) redirect_to_ipmc_group();
 #if defined(ACL_REDIRECT_TO_PORT_CAPABLE)
       @proto_id(5) redirect_to_port();
+#endif
+#if defined(MIRROR_CAPABLE) && defined(ACL_REDIRECT_TO_PORT_CAPABLE)
       @proto_id(6) acl_mirror_and_redirect_to_port();
 #endif
       @defaultonly NoAction;

--- a/sai_p4/instantiations/google/acl_ingress.p4
+++ b/sai_p4/instantiations/google/acl_ingress.p4
@@ -22,6 +22,8 @@ control acl_ingress(in headers_t headers,
   bit<8> ip_protocol = 0;
   // Cancels out local_metadata.marked_to_copy when true.
   bool cancel_copy = false;
+  // Hop-by-hop options header used for ACL lookup (defaults to outer header).
+  hop_by_hop_options_t hop_by_hop_options = headers.hop_by_hop_options;
 
   @id(ACL_INGRESS_METER_ID)
   @mode(single_rate_two_color)

--- a/sai_p4/instantiations/google/acl_pre_ingress.p4
+++ b/sai_p4/instantiations/google/acl_pre_ingress.p4
@@ -251,6 +251,7 @@ control acl_pre_ingress(in headers_t headers,
     }
     actions = {
       @proto_id(1) set_acl_metadata;
+      @proto_id(2) set_outer_vlan_id;
       @defaultonly NoAction;
     }
     const default_action = NoAction;

--- a/sai_p4/instantiations/google/acl_pre_ingress.p4
+++ b/sai_p4/instantiations/google/acl_pre_ingress.p4
@@ -269,7 +269,13 @@ control acl_pre_ingress(in headers_t headers,
     } else if (headers.ipv6.isValid()) {
       dscp = headers.ipv6.dscp;
       ecn = headers.ipv6.ecn;
-      ip_protocol = headers.ipv6.next_header;
+      if (headers.ipv6.next_header == 0 &&
+          headers.hop_by_hop_options.isValid()) {
+        ip_protocol = headers.hop_by_hop_options.next_header;
+      }
+      else {
+        ip_protocol = headers.ipv6.next_header;
+      }
     }
 
 #if defined(SAI_INSTANTIATION_MIDDLEBLOCK)

--- a/sai_p4/instantiations/google/fabric_border_router.p4
+++ b/sai_p4/instantiations/google/fabric_border_router.p4
@@ -1,5 +1,8 @@
 #define SAI_INSTANTIATION_FABRIC_BORDER_ROUTER
 
+#define ACL_REDIRECT_TO_NEXTHOP_CAPABLE
+#define ACL_REDIRECT_TO_PORT_CAPABLE
+
 #include <v1model.p4>
 
 // These headers have to come first, to override their fixed counterparts.

--- a/sai_p4/instantiations/google/fabric_border_router.p4
+++ b/sai_p4/instantiations/google/fabric_border_router.p4
@@ -2,6 +2,7 @@
 
 #define ACL_REDIRECT_TO_NEXTHOP_CAPABLE
 #define ACL_REDIRECT_TO_PORT_CAPABLE
+#define MIRROR_CAPABLE
 
 #include <v1model.p4>
 

--- a/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
@@ -195,6 +195,10 @@ tables {
     annotations: "@proto_id(1)"
   }
   action_refs {
+    id: 16777482
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
@@ -1393,6 +1397,20 @@ actions {
     type_name {
       name: "vrf_id_t"
     }
+  }
+}
+actions {
+  preamble {
+    id: 16777482
+    name: "ingress.acl_pre_ingress.set_outer_vlan_id"
+    alias: "set_outer_vlan_id"
+    annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD)"
+  }
+  params {
+    id: 1
+    name: "vlan_id"
+    annotations: "@sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_SET_OUTER_VLAN_ID)"
+    bitwidth: 12
   }
 }
 actions {

--- a/sai_p4/instantiations/google/middleblock.p4
+++ b/sai_p4/instantiations/google/middleblock.p4
@@ -1,5 +1,8 @@
 #define SAI_INSTANTIATION_MIDDLEBLOCK
 
+#define ACL_REDIRECT_TO_NEXTHOP_CAPABLE
+#define ACL_REDIRECT_TO_PORT_CAPABLE
+
 #include <v1model.p4>
 
 // These headers have to come first, to override their fixed counterparts.

--- a/sai_p4/instantiations/google/middleblock.p4
+++ b/sai_p4/instantiations/google/middleblock.p4
@@ -2,6 +2,7 @@
 
 #define ACL_REDIRECT_TO_NEXTHOP_CAPABLE
 #define ACL_REDIRECT_TO_PORT_CAPABLE
+#define MIRROR_CAPABLE
 
 #include <v1model.p4>
 

--- a/sai_p4/instantiations/google/middleblock.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock.p4info.pb.txt
@@ -673,7 +673,7 @@ tables {
   match_fields {
     id: 9
     name: "ipmc_table_hit"
-    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_IPMC_NPU_META_DST_HIT)"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ROUTE_NPU_META_DST_HIT)"
     bitwidth: 1
     match_type: OPTIONAL
   }

--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -1133,14 +1133,20 @@ message NoAction {}
 // This action is unique to `MulticastGroupTableEntry` and is not explicitly
 // present in the P4 program.
 message ReplicateAction {
+  // All `Replica`s and `BackupReplica`s must have unique (port, instance)-pairs
+  // within the scope of the `ReplicateAction` that contains them.
+  repeated Replica replicas = 1;
   // Corresponds to `Replica` in p4runtime.proto.
   message Replica {
     string port = 1;      // Format::STRING
     string instance = 2;  // Format::HEX_STRING / 16 bits
+    repeated BackupReplica backup_replicas = 3;
   }
-  // Each `Replica` must have a unique (port, instance)-pair within the scope of
-  // the `ReplicateAction` that contains it.
-  repeated Replica replicas = 1;
+  // Corresponds to `BackupReplica` in p4runtime.proto.
+  message BackupReplica {
+    string port = 1;      // Format::STRING
+    string instance = 2;  // Format::HEX_STRING / 16 bits
+  }
 }
 
 // -- All tables ---------------------------------------------------------------

--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -613,7 +613,10 @@ message AclPreIngressMetadataTableEntry {
   }
   Match match = 1;
   message Action {
-    SetAclMetadataAction set_acl_metadata = 1;
+    oneof action {
+      SetOuterVlanIdAction set_outer_vlan_id = 2;
+      SetAclMetadataAction set_acl_metadata = 1;
+    }
   }
   Action action = 2;
   int32 priority = 3;

--- a/sai_p4/instantiations/google/test_tools/test_entries.h
+++ b/sai_p4/instantiations/google/test_tools/test_entries.h
@@ -295,21 +295,19 @@ class EntryBuilder {
 
   // Deduplicates then installs the entities encoded by the EntryBuilder using
   // `session`.
-  absl::Status InstallDedupedEntities(pdpi::P4RuntimeSession& session,
-                                      bool allow_unsupported = false) const;
+  absl::Status InstallDedupedEntities(pdpi::P4RuntimeSession& session) const;
 
   // Extracts and deduplicates the entities encoded by the EntryBuilder using
   // `ir_p4info`, then install them using `session`. This is especially useful
   // for BMv2 where you may *NOT* wish to use the P4Info on the switch for
   // translation.
   absl::Status InstallDedupedEntities(const pdpi::IrP4Info& ir_p4info,
-                                      pdpi::P4RuntimeSession& session,
-                                      bool allow_unsupported = false) const;
+                                      pdpi::P4RuntimeSession& session) const;
 
   absl::StatusOr<std::vector<p4::v1::Entity>> GetDedupedPiEntities(
-      const pdpi::IrP4Info& ir_p4info, bool allow_unsupported = false) const;
+      const pdpi::IrP4Info& ir_p4info) const;
   absl::StatusOr<pdpi::IrEntities> GetDedupedIrEntities(
-      const pdpi::IrP4Info& ir_p4info, bool allow_unsupported = false) const;
+      const pdpi::IrP4Info& ir_p4info) const;
 
   // Convenience struct corresponding to the proto
   // `MulticastRouterInterfaceTableEntry`

--- a/sai_p4/instantiations/google/test_tools/test_entries_test.cc
+++ b/sai_p4/instantiations/google/test_tools/test_entries_test.cc
@@ -299,7 +299,7 @@ TEST(EntryBuilder,
                   .dst_mac_rewrite = std::nullopt,
               })
           .LogPdEntries()
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+          .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(entities.entities(),
               Contains(Partially(EqualsProto(
                   R"pb(table_entry {
@@ -684,12 +684,11 @@ TEST(EntryBuilder,
 
 TEST(EntryBuilder, AddEntryTunnelTerminatingAllIpInIpv6PacketsAddsEntry) {
   pdpi::IrP4Info kIrP4Info = GetIrP4Info(Instantiation::kFabricBorderRouter);
-  ASSERT_OK_AND_ASSIGN(
-      pdpi::IrEntities entities,
-      EntryBuilder()
-          .AddEntryTunnelTerminatingAllIpInIpv6Packets()
-          .LogPdEntries()
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+  ASSERT_OK_AND_ASSIGN(pdpi::IrEntities entities,
+                       EntryBuilder()
+                           .AddEntryTunnelTerminatingAllIpInIpv6Packets()
+                           .LogPdEntries()
+                           .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(entities.entities(), SizeIs(1));
 }
 TEST(EntryBuilder, AddEntryPuntingPacketsWithTtlZeroAndOneHasOneEntry) {
@@ -809,7 +808,7 @@ TEST(EntryBuilder, AddMulticastRouterInterfaceEntryAddsEntry) {
               .src_mac = netaddr::MacAddress(1, 2, 3, 4, 5, 6),
           })
           .LogPdEntries()
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+          .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(entities.entities(), ElementsAre(Partially(EqualsProto(R"pb(
                 table_entry {
                   table_name: "multicast_router_interface_table"
@@ -827,7 +826,7 @@ TEST(EntryBuilder, AddMrifEntryRewritingSrcMacAddsEntry) {
               /*egress_port=*/"\1", /*replica_instance=*/15,
               /*src_mac=*/netaddr::MacAddress(1, 2, 3, 4, 5, 6))
           .LogPdEntries()
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+          .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(entities.entities(), ElementsAre(Partially(EqualsProto(R"pb(
                 table_entry {
                   table_name: "multicast_router_interface_table"
@@ -846,7 +845,7 @@ TEST(EntryBuilder, AddMrifEntryRewritingSrcMacAndVlanIdAddsEntry) {
               /*src_mac=*/netaddr::MacAddress(1, 2, 3, 4, 5, 6),
               /*vlan_id=*/123)
           .LogPdEntries()
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+          .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(entities.entities(), ElementsAre(Partially(EqualsProto(R"pb(
                 table_entry {
                   table_name: "multicast_router_interface_table"
@@ -866,7 +865,7 @@ TEST(EntryBuilder, AddMrifEntryRewritingSrcMacDstMacAndVlanIdAddsEntry) {
               /*dst_mac=*/netaddr::MacAddress(7, 8, 9, 10, 11, 12),
               /*vlan_id=*/123)
           .LogPdEntries()
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+          .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(
       entities.entities(), ElementsAre(Partially(EqualsProto(R"pb(
         table_entry {
@@ -886,7 +885,7 @@ TEST(EntryBuilder,
               /*egress_port=*/"\1", /*replica_instance=*/15,
               /*src_mac=*/netaddr::MacAddress(1, 2, 3, 4, 5, 6))
           .LogPdEntries()
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+          .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(
       entities.entities(), ElementsAre(Partially(EqualsProto(R"pb(
         table_entry {
@@ -925,12 +924,11 @@ TEST(EntryBuilder, AddMulticastRouteAddsIpv4Entry) {
   pdpi::IrP4Info kIrP4Info = GetIrP4Info(Instantiation::kFabricBorderRouter);
   ASSERT_OK_AND_ASSIGN(auto dst_ip,
                        netaddr::Ipv4Address::OfString("225.10.20.32"));
-  ASSERT_OK_AND_ASSIGN(
-      pdpi::IrEntities entities,
-      EntryBuilder()
-          .AddMulticastRoute("vrf-1", dst_ip, 0x42)
-          .LogPdEntries()
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+  ASSERT_OK_AND_ASSIGN(pdpi::IrEntities entities,
+                       EntryBuilder()
+                           .AddMulticastRoute("vrf-1", dst_ip, 0x42)
+                           .LogPdEntries()
+                           .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(entities.entities(), Contains(Partially(EqualsProto(R"pb(
                 table_entry {
                   table_name: "ipv4_multicast_table"
@@ -958,12 +956,11 @@ TEST(EntryBuilder, AddMulticastRouteAddsIpv6Entry) {
   ASSERT_OK_AND_ASSIGN(auto dst_ip,
                        netaddr::Ipv6Address::OfString(
                            "ff00:8888:1111:2222:3333:4444:5555:6666"));
-  ASSERT_OK_AND_ASSIGN(
-      pdpi::IrEntities entities,
-      EntryBuilder()
-          .AddMulticastRoute("vrf-2", dst_ip, 0x123)
-          .LogPdEntries()
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+  ASSERT_OK_AND_ASSIGN(pdpi::IrEntities entities,
+                       EntryBuilder()
+                           .AddMulticastRoute("vrf-2", dst_ip, 0x123)
+                           .LogPdEntries()
+                           .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(entities.entities(), Contains(Partially(EqualsProto(R"pb(
                 table_entry {
                   table_name: "ipv6_multicast_table"
@@ -1045,7 +1042,7 @@ TEST(EntryBuilder, AddMirrorSessionTableEntry) {
           .LogPdEntries()
           // TODO: Remove unsupported once the
           // switch supports mirroring-related tables.
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+          .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(entities.entities(), ElementsAre(Partially(EqualsProto(R"pb(
                 table_entry { table_name: "mirror_session_table" }
               )pb"))));
@@ -1053,17 +1050,16 @@ TEST(EntryBuilder, AddMirrorSessionTableEntry) {
 
 TEST(EntryBuilder, AddMarkToMirrorAclEntryTest) {
   pdpi::IrP4Info kIrP4Info = GetIrP4Info(Instantiation::kTor);
-  ASSERT_OK_AND_ASSIGN(
-      pdpi::IrEntities entities,
-      EntryBuilder()
-          .AddMarkToMirrorAclEntry(MarkToMirrorParams{
-              .ingress_port = "1",
-              .mirror_session_id = "id",
-          })
-          .LogPdEntries()
-          // TODO: Remove unsupported once the
-          // switch supports mirroring-related tables.
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+  ASSERT_OK_AND_ASSIGN(pdpi::IrEntities entities,
+                       EntryBuilder()
+                           .AddMarkToMirrorAclEntry(MarkToMirrorParams{
+                               .ingress_port = "1",
+                               .mirror_session_id = "id",
+                           })
+                           .LogPdEntries()
+                           // TODO: Remove unsupported once the
+                           // switch supports mirroring-related tables.
+                           .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(
       entities.entities(), ElementsAre(Partially(EqualsProto(R"pb(
         table_entry { table_name: "acl_ingress_mirror_and_redirect_table" }
@@ -1127,14 +1123,11 @@ TEST(EntryBuilder,
 
 TEST(EntryBuilder, AddIngressAclEntryRedirectingToMulticastGroupAddsEntry) {
   pdpi::IrP4Info kIrP4Info = GetIrP4Info(Instantiation::kTor);
-  ASSERT_OK_AND_ASSIGN(
-      pdpi::IrEntities entities,
-      EntryBuilder()
-          .AddIngressAclEntryRedirectingToMulticastGroup(123)
-          .LogPdEntries()
-	  // TODO: Remove `allow_unsupported` flag once the
-          // switch supports multicast-related entries.
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+  ASSERT_OK_AND_ASSIGN(pdpi::IrEntities entities,
+                       EntryBuilder()
+                           .AddIngressAclEntryRedirectingToMulticastGroup(123)
+                           .LogPdEntries()
+                           .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(
       entities.entities(), ElementsAre(Partially(EqualsProto(R"pb(
         table_entry { table_name: "acl_ingress_mirror_and_redirect_table" }
@@ -1168,9 +1161,7 @@ TEST(EntryBuilder,
       EntryBuilder()
           .AddIngressAclEntryRedirectingToMulticastGroup(123, match_fields)
           .LogPdEntries()
-          // TODO: Remove `allow_unsupported` flag once the switch
-          // supports multicast-related entries.
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+	  .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(entities.entities(), Contains(Partially(EqualsProto(R"pb(
                 table_entry {
                   table_name: "acl_ingress_mirror_and_redirect_table"
@@ -1187,12 +1178,11 @@ TEST(EntryBuilder,
 
 TEST(EntryBuilder, AddDisableIngressVlanChecksEntryAddsCorrectEntry) {
   pdpi::IrP4Info kIrP4Info = GetIrP4Info(Instantiation::kTor);
-  ASSERT_OK_AND_ASSIGN(
-      pdpi::IrEntities entities,
-      EntryBuilder()
-          .AddDisableIngressVlanChecksEntry()
-          .LogPdEntries()
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+  ASSERT_OK_AND_ASSIGN(pdpi::IrEntities entities,
+                       EntryBuilder()
+                           .AddDisableIngressVlanChecksEntry()
+                           .LogPdEntries()
+                           .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(entities.entities(), ElementsAre(Partially(EqualsProto(R"pb(
                 table_entry { table_name: "disable_ingress_vlan_checks_table" }
               )pb"))));
@@ -1200,12 +1190,11 @@ TEST(EntryBuilder, AddDisableIngressVlanChecksEntryAddsCorrectEntry) {
 
 TEST(EntryBuilder, AddDisableEgressVlanChecksEntryAddsCorrectEntry) {
   pdpi::IrP4Info kIrP4Info = GetIrP4Info(Instantiation::kTor);
-  ASSERT_OK_AND_ASSIGN(
-      pdpi::IrEntities entities,
-      EntryBuilder()
-          .AddDisableEgressVlanChecksEntry()
-          .LogPdEntries()
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+  ASSERT_OK_AND_ASSIGN(pdpi::IrEntities entities,
+                       EntryBuilder()
+                           .AddDisableEgressVlanChecksEntry()
+                           .LogPdEntries()
+                           .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(entities.entities(), ElementsAre(Partially(EqualsProto(R"pb(
                 table_entry { table_name: "disable_egress_vlan_checks_table" }
               )pb"))));
@@ -1216,7 +1205,7 @@ TEST(EntryBuilder, AddVlanEntryAddsCorrectEntry) {
   ASSERT_OK_AND_ASSIGN(
       pdpi::IrEntities entities,
       EntryBuilder().AddVlanEntry("0x00a").LogPdEntries().GetDedupedIrEntities(
-          kIrP4Info, /*allow_unsupported=*/true));
+          kIrP4Info));
   EXPECT_THAT(entities.entities(), ElementsAre((EqualsProto(R"pb(
                 table_entry {
                   table_name: "vlan_table"
@@ -1239,7 +1228,7 @@ TEST(EntryBuilder, AddVlanMembershipEntryAddsCorrectEntry) {
           .AddVlanMembershipEntry(/*vlan_id_hexstr=*/"0x00b", /*port=*/"2",
                                   VlanTaggingMode::kUntagged)
           .LogPdEntries()
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+	  .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(entities.entities(),
               UnorderedElementsAre(EqualsProto(R"pb(
                                      table_entry {
@@ -1278,7 +1267,7 @@ TEST(EntryBuilder, AddPreIngressAclEntryMatchingInPortForVrfWithPriority) {
       EntryBuilder()
           .AddPreIngressAclTableEntry("vrf-1", {.in_port = "ingress-port-1"})
           .LogPdEntries()
-          .GetDedupedIrEntities(kIrP4Info, /*allow_unsupported=*/true));
+          .GetDedupedIrEntities(kIrP4Info));
   EXPECT_THAT(entities.entities(), ElementsAre(Partially(EqualsProto(R"pb(
                 table_entry {
                   table_name: "acl_pre_ingress_table"

--- a/sai_p4/instantiations/google/tests/p4_fuzzer_integration_test.cc
+++ b/sai_p4/instantiations/google/tests/p4_fuzzer_integration_test.cc
@@ -57,14 +57,16 @@ absl::Status AddReferenceableEntries(const FuzzerConfig& config,
                        .AddEntriesForwardingIpPacketsToGivenPort(
                            egress_port.GetP4rtEncoding())
                        .GetDedupedPiEntities(config.GetIrP4Info()));
-  ASSIGN_OR_RETURN(pdpi::IrTableDefinition mirror_session_table,
-                   gutil::FindOrStatus(config.GetIrP4Info().tables_by_name(),
-                                       "mirror_session_table"));
-  p4::v1::Entity mirror_session_entity;
-  ASSIGN_OR_RETURN(
-      *mirror_session_entity.mutable_table_entry(),
-      FuzzValidTableEntry(&gen, config, switch_state, mirror_session_table));
-  referable_entities.push_back(mirror_session_entity);
+
+  if (config.GetIrP4Info().tables_by_name().contains("mirror_session_table")) {
+    pdpi::IrTableDefinition mirror_session_table =
+        config.GetIrP4Info().tables_by_name().at("mirror_session_table");
+    p4::v1::Entity mirror_session_entity;
+    ASSIGN_OR_RETURN(
+        *mirror_session_entity.mutable_table_entry(),
+        FuzzValidTableEntry(&gen, config, switch_state, mirror_session_table));
+    referable_entities.push_back(mirror_session_entity);
+  }
 
   p4::v1::Entity multicast_group_entity;
   ASSIGN_OR_RETURN(

--- a/sai_p4/instantiations/google/tor.p4
+++ b/sai_p4/instantiations/google/tor.p4
@@ -13,6 +13,9 @@
 // limitations under the License.
 #define SAI_INSTANTIATION_TOR
 
+#define ACL_REDIRECT_TO_NEXTHOP_CAPABLE
+#define ACL_REDIRECT_TO_PORT_CAPABLE
+
 #include <v1model.p4>
 
 // These headers have to come first, to override their fixed counterparts.

--- a/sai_p4/instantiations/google/tor.p4
+++ b/sai_p4/instantiations/google/tor.p4
@@ -15,6 +15,7 @@
 
 #define ACL_REDIRECT_TO_NEXTHOP_CAPABLE
 #define ACL_REDIRECT_TO_PORT_CAPABLE
+#define MIRROR_CAPABLE
 
 #include <v1model.p4>
 

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -965,7 +965,7 @@ tables {
   match_fields {
     id: 9
     name: "ipmc_table_hit"
-    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_IPMC_NPU_META_DST_HIT)"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ROUTE_NPU_META_DST_HIT)"
     bitwidth: 1
     match_type: OPTIONAL
   }

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -263,6 +263,10 @@ tables {
     annotations: "@proto_id(1)"
   }
   action_refs {
+    id: 16777482
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -1513,7 +1513,7 @@ tables {
   match_fields {
     id: 9
     name: "ipmc_table_hit"
-    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_IPMC_NPU_META_DST_HIT)"
+    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ROUTE_NPU_META_DST_HIT)"
     bitwidth: 1
     match_type: OPTIONAL
   }

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -223,6 +223,10 @@ tables {
     annotations: "@proto_id(1)"
   }
   action_refs {
+    id: 16777482
+    annotations: "@proto_id(2)"
+  }
+  action_refs {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
@@ -1905,6 +1909,20 @@ actions {
 }
 actions {
   preamble {
+    id: 16777482
+    name: "ingress.acl_pre_ingress.set_outer_vlan_id"
+    alias: "set_outer_vlan_id"
+    annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD)"
+  }
+  params {
+    id: 1
+    name: "vlan_id"
+    annotations: "@sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_SET_OUTER_VLAN_ID)"
+    bitwidth: 12
+  }
+}
+actions {
+  preamble {
     id: 16777483
     name: "ingress.acl_pre_ingress.set_acl_metadata"
     alias: "set_acl_metadata"
@@ -2735,20 +2753,6 @@ actions {
     type_name {
       name: "port_id_t"
     }
-  }
-}
-actions {
-  preamble {
-    id: 16777482
-    name: "ingress.acl_pre_ingress.set_outer_vlan_id"
-    alias: "set_outer_vlan_id"
-    annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD)"
-  }
-  params {
-    id: 1
-    name: "vlan_id"
-    annotations: "@sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_SET_OUTER_VLAN_ID)"
-    bitwidth: 12
   }
 }
 actions {


### PR DESCRIPTION
### **PR Description:**
Support references for fallback groups.

### **Keyword Check:**
bibhuprasad@bibhuprasad87:~/sonic_build_image_2025-06-23/sonic-buildimage/src/sonic-p4rt/sonic-pins/sai_p4$ sh ~/keyword_check.sh .
Keyword check Passed.

### **Build Results:**
bibhuprasad@cc8b5015ed50:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 753 targets (0 packages loaded, 0 targets configured).
INFO: Found 753 targets...
INFO: Elapsed time: 0.358s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### **UT Results:**
bibhuprasad@cc8b5015ed50:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 753 targets (0 packages loaded, 0 targets configured).
INFO: Found 524 targets and 229 test targets...
INFO: Elapsed time: 199.326s, Critical Path: 142.08s
INFO: 286 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 286 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.3s
//dvaas:dataplane_validation_test                                        PASSED in 0.2s
//dvaas:port_id_map_test                                                 PASSED in 1.7s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.2s
//dvaas:test_run_validation_test                                         PASSED in 2.0s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.2s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.7s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//gutil:collections_test                                                 PASSED in 1.7s
//gutil:io_test                                                          PASSED in 1.4s
//gutil:proto_matchers_test                                              PASSED in 1.3s
//gutil:proto_ordering_test                                              PASSED in 1.1s
//gutil:proto_test                                                       PASSED in 1.7s
//gutil:status_matchers_test                                             PASSED in 1.7s
//gutil:test_artifact_writer_test                                        PASSED in 2.1s
//gutil:testing_test                                                     PASSED in 1.5s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 4.7s
//lib:basic_switch_test                                                  PASSED in 2.4s
//lib:ixia_helper_test                                                   PASSED in 2.6s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 2.8s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 17.3s
//lib/gnmi:gnmi_helper_test                                              PASSED in 4.1s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.4s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.6s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 2.7s
//lib/utils:generic_testbed_utils_test                                   PASSED in 4.0s
//lib/utils:json_utils_test                                              PASSED in 1.2s
//lib/validator:validator_backend_test                                   PASSED in 1.3s
//lib/validator:validator_lib_test                                       PASSED in 27.2s
//p4_fuzzer:constraints_test                                             PASSED in 10.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 141.9s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 2.6s
//p4_fuzzer:oracle_util_test                                             PASSED in 4.8s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 4.2s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 4.1s
//p4_fuzzer:switch_state_test                                            PASSED in 2.5s
//p4_pdpi:built_ins_test                                                 PASSED in 1.4s
//p4_pdpi:entity_keys_test                                               PASSED in 1.7s
//p4_pdpi:ir_properties_test                                             PASSED in 1.6s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 2.1s
//p4_pdpi:names_test                                                     PASSED in 2.4s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.9s
//p4_pdpi:p4info_union_test                                              PASSED in 1.7s
//p4_pdpi:reference_annotations_test                                     PASSED in 2.3s
//p4_pdpi:references_test                                                PASSED in 2.0s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.3s
//p4_pdpi:ternary_test                                                   PASSED in 1.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.3s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.4s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.4s
//p4_pdpi/packetlib:packetlib_debugging_test                             PASSED in 1.4s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 21.6s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.7s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 7.2s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.5s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.6s
//p4_pdpi/testing:info_test                                              PASSED in 0.4s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.3s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.2s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 2.1s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.3s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.2s
//p4_pdpi/testing:references_test                                        PASSED in 0.3s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.3s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.3s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.3s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.3s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.2s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 1.9s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.3s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.3s
//p4_pdpi/utils:ir_test                                                  PASSED in 2.0s
//p4_symbolic:z3_util_test                                               PASSED in 1.5s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 2.8s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 2.8s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 2.9s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 2.7s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 3.3s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 3.2s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 3.5s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.3s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.1s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.1s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.1s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.2s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.2s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.2s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.1s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.2s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.5s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 36.1s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 41.4s
//p4_symbolic/sai:sai_test                                               PASSED in 8.3s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 4.2s
//p4_symbolic/symbolic:parser_test                                       PASSED in 3.1s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.2s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 2.6s
//p4_symbolic/symbolic:util_test                                         PASSED in 2.0s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.6s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 21.0s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 3.8s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 2.6s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 2.5s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 3.2s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 3.7s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 2.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 3.3s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 2.9s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 1.7s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 2.0s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 1.9s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.4s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.1s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 2.8s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 2.5s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.0s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 2.4s
//p4rt_app/sonic:hashing_test                                            PASSED in 2.1s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 2.0s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.7s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.3s
//p4rt_app/sonic:state_verification_test                                 PASSED in 1.8s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.5s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 2.1s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.6s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.5s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.2s
//p4rt_app/tests:action_set_test                                         PASSED in 1.6s
//p4rt_app/tests:api_access_test                                         PASSED in 1.3s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.5s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.5s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 8.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.6s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.0s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.4s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.9s
//p4rt_app/tests:packetio_test                                           PASSED in 4.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.2s
//p4rt_app/tests:response_path_test                                      PASSED in 5.3s
//p4rt_app/tests:role_test                                               PASSED in 1.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 3.0s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 2.0s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.4s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.6s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.6s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.8s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.4s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 4.9s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 3.5s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 7.2s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 2.2s
//sai_p4/tools:p4info_tools_test                                         PASSED in 2.2s
//sai_p4/tools:packetio_tools_test                                       PASSED in 2.2s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 3.4s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.4s
//tests/lib:common_ir_table_entries_test                                 PASSED in 1.7s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 2.1s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.3s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 8.1s
//thinkit:bazel_test_environment_test                                    PASSED in 1.6s
//thinkit:generic_testbed_test                                           PASSED in 2.0s
//thinkit:mock_control_device_test                                       PASSED in 1.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 2.0s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.8s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.6s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 1.9s
//tests/lib:packet_generator_test                                        PASSED in 64.3s
  Stats over 4 runs: max = 64.3s, min = 62.5s, avg = 63.6s, dev = 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.2s
  Stats over 5 runs: max = 2.2s, min = 1.5s, avg = 1.8s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 46.0s
  Stats over 50 runs: max = 46.0s, min = 1.2s, avg = 4.2s, dev = 8.6s

Executed 229 out of 229 tests: 229 tests pass.