### PR TITLE
[Thinkit/Tests] Update the OTG config related to TCP header and flow rate

### DIFF
--- a/tests/forwarding/BUILD.bazel
+++ b/tests/forwarding/BUILD.bazel
@@ -521,6 +521,7 @@ cc_library(
         "//p4_pdpi/packetlib:packetlib_cc_proto",
         "//p4_pdpi/string_encodings:decimal_string",
         "//sai_p4/instantiations/google:sai_pd_cc_proto",
+        "//sai_p4/instantiations/google/test_tools:test_entries",
         "//tests:thinkit_sanity_tests",
         "//tests/lib:p4rt_fixed_table_programming_helper",
         "//tests/lib:switch_test_setup_helpers",

--- a/tests/integration/system/nsf/traffic_helpers/otg_helper.cc
+++ b/tests/integration/system/nsf/traffic_helpers/otg_helper.cc
@@ -44,6 +44,15 @@
 namespace pins_test {
 namespace {
 
+const int kDefaultMtu = 9000;
+const int kDefaultPacketSize = 256;
+const int kFlowRate = 10;
+const int kFlowRateAtLinerate = 98;
+// RToR tests use L4 ports ranging from 0x3e00(15872) to 0x3eff(16127)
+// inclusively at the destination host.
+const int kFlowTcpDstPortRangeStart = 0x3e00;
+const int kFlowTcpDstPortRangeEnd = 0x3eff;
+
 // Struct to hold the per-flow traffic metrics.
 // `traffic_outage` is the total duration of time the traffic was dropped during
 // the entire duration of traffic flow.
@@ -150,11 +159,11 @@ absl::Status OtgHelper::StartTraffic(Testbed& testbed,
             }
 
             // Set MTU.
-            layer1->set_mtu(9000);
+            layer1->set_mtu(kDefaultMtu);
 
             // Create flow.
             auto* flow = config->add_flows();
-            flow->set_name("Host Traffic flow");
+            flow->set_name(absl::StrCat(otg_src_port, "->", otg_dst_port));
 
             // Set Tx / Rx ports.
             flow->mutable_tx_rx()->set_choice(otg::FlowTxRx::Choice::port);
@@ -163,7 +172,7 @@ absl::Status OtgHelper::StartTraffic(Testbed& testbed,
 
             // Set packet size.
             flow->mutable_size()->set_choice(otg::FlowSize::Choice::fixed);
-            flow->mutable_size()->set_fixed(256);
+            flow->mutable_size()->set_fixed(kDefaultPacketSize);
 
             // Set transmission duration.
             flow->mutable_duration()->set_choice(
@@ -172,9 +181,9 @@ absl::Status OtgHelper::StartTraffic(Testbed& testbed,
             // Set transmission rate.
             flow->mutable_rate()->set_choice(otg::FlowRate::Choice::percentage);
             if (enable_linerate_) {
-              flow->mutable_rate()->set_percentage(98);
+              flow->mutable_rate()->set_percentage(kFlowRateAtLinerate);
             } else {
-              flow->mutable_rate()->set_percentage(5);
+              flow->mutable_rate()->set_percentage(kFlowRate);
             }
 
             // Set capture metrics.
@@ -206,6 +215,18 @@ absl::Status OtgHelper::StartTraffic(Testbed& testbed,
                 otg::PatternFlowIpv6Dst::Choice::value);
             ip_packet->mutable_ipv6()->mutable_src()->set_value(otg_src_ip);
             ip_packet->mutable_ipv6()->mutable_dst()->set_value(otg_dst_ip);
+
+            // Set TCP header.
+            auto* tcp_packet = flow->add_packet();
+            tcp_packet->set_choice(otg::FlowHeader::Choice::tcp);
+            auto* tcp_dst_port = tcp_packet->mutable_tcp()->mutable_dst_port();
+            tcp_dst_port->set_choice(
+                otg::PatternFlowTcpDstPort::Choice::increment);
+            tcp_dst_port->mutable_increment()->set_start(
+                kFlowTcpDstPortRangeStart);
+            tcp_dst_port->mutable_increment()->set_step(1);
+            tcp_dst_port->mutable_increment()->set_count(
+                kFlowTcpDstPortRangeEnd - kFlowTcpDstPortRangeStart + 1);
 
             // Set the config.
             otg::Openapi::StubInterface* stub = testbed->GetTrafficClient();
@@ -315,13 +336,11 @@ absl::Status OtgHelper::ValidateTraffic(Testbed& testbed,
                 continue;
 
               errors.push_back(absl::StrCat(
-                  "Flow name:\t\t\t\t\t\t\t\t", flow_metric.name(),
-                  "\nTraffic outage:\t\t\t\t\t\t",
-                  traffic_metrics.outage_duration,
+                  "Flow name:\t\t\t", flow_metric.name(),
+                  "\nTraffic outage:\t\t\t", traffic_metrics.outage_duration,
                   "\nMax acceptable outage:\t\t", max_acceptable_outage,
-                  "\nFrames dropped:\t\t\t\t\t\t",
-                  traffic_metrics.frames_dropped,
-                  "\nBytes dropped:\t\t\t\t\t\t", traffic_metrics.bytes_dropped,
+                  "\nFrames dropped:\t\t\t", traffic_metrics.frames_dropped,
+                  "\nBytes dropped:\t\t\t", traffic_metrics.bytes_dropped,
                   transmission_stopped ? ""
                                        : "\nTransmission not completed within "
                                          "the expected time."));

--- a/tests/qos/frontpanel_qos_test.cc
+++ b/tests/qos/frontpanel_qos_test.cc
@@ -557,10 +557,10 @@ TEST_P(FrontpanelQosTest,
 
   // Fix test parameters and PIRs (peak information rates, in bytes
   // per second) for each DSCP.
-  constexpr int64_t kTestFrameSizeInBytes = 2000;                // 2 KB
+  constexpr int64_t kTestFrameSizeInBytes = 1000;                // 1 KB
   constexpr int64_t kTestFrameCount = 30'000'000;                // 30 GB
   constexpr int64_t kTestFramesPerSecond = kTestFrameCount / 3;  // for 3 s
-  constexpr int64_t kTestFrameSpeedInBytesPerSecond =            // 20 GB/s
+  constexpr int64_t kTestFrameSpeedInBytesPerSecond =            // 10 GB/s
       kTestFramesPerSecond * kTestFrameSizeInBytes;
 
   // Get strictly prioritized queues.
@@ -675,14 +675,20 @@ TEST_P(FrontpanelQosTest,
     constexpr int64_t kSpeed200g = 200000000000;
 
     if (kSutEgressPortSpeedInBitsPerSecond != kSpeed200g) {
-      ASSERT_OK(SetPortSpeedInBitsPerSecond(PortSpeed(kSpeed200g),
-                                            kSutEgressPort, *gnmi_stub));
+      auto status = SetPortSpeedInBitsPerSecond(PortSpeed(kSpeed200g),
+                                                kSutEgressPort, *gnmi_stub);
+      if (!status.ok()) {
+        LOG(WARNING) << "Failed to toggle port speed for : " << kSutEgressPort;
+      }
       ASSERT_OK(SetPortSpeedInBitsPerSecond(
           PortSpeed(kSutEgressPortSpeedInBitsPerSecond), kSutEgressPort,
           *gnmi_stub));
     } else {
-      ASSERT_OK(SetPortSpeedInBitsPerSecond(PortSpeed(kSpeed100g),
-                                            kSutEgressPort, *gnmi_stub));
+      auto status = SetPortSpeedInBitsPerSecond(PortSpeed(kSpeed100g),
+                                                kSutEgressPort, *gnmi_stub);
+      if (!status.ok()) {
+        LOG(WARNING) << "Failed to toggle port speed for : " << kSutEgressPort;
+      }
       ASSERT_OK(SetPortSpeedInBitsPerSecond(
           PortSpeed(kSutEgressPortSpeedInBitsPerSecond), kSutEgressPort,
           *gnmi_stub));


### PR DESCRIPTION
Keyword Check:
/tests_sonic-pins/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.

Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 756 targets (2 packages loaded, 42 targets configured).
INFO: Found 756 targets...
INFO: From Compiling tests/integration/system/nsf/nsf_acl_flow_coverage_test.cc:
tests/integration/system/nsf/nsf_acl_flow_coverage_test.cc: In member function 'virtual void pins_test::NsfAclFlowCoverageTestFixture_NsfAclFlowCoverageTest_Test::TestBody()':
tests/integration/system/nsf/nsf_acl_flow_coverage_test.cc:52:29: warning: unused variable 'environment' [-Wunused-variable]
   52 |   thinkit::TestEnvironment &environment = GetTestEnvironment(testbed_);
      |                             ^~~~~~~~~~~
INFO: From Compiling tests/integration/system/nsf/util.cc:
tests/integration/system/nsf/util.cc:153:6: warning: 'void pins_test::{anonymous}::AppendIgnoredP4SnapshotFields(google::protobuf::util::MessageDifferencer*)' defined but not used [-Wunused-function]
  153 | void AppendIgnoredP4SnapshotFields(MessageDifferencer* differencer) {
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO: From Compiling tests/gnoi/bert_tests.cc:
tests/gnoi/bert_tests.cc: In function 'void bert::{anonymous}::GetAndVerifyBertResultsWithAdminDownInterfaces(const gnoi::diag::StartBERTRequest&, const gnoi::diag::GetBERTResultResponse&, const std::vector<std::__cxx11::basic_string<char> >&, const std::vector<std::__cxx11::basic_string<char> >&, absl::lts_20240116::Duration)':
tests/gnoi/bert_tests.cc:545:30: warning: comparison of integer expressions of different signedness: 'unsigned int' and 'int' [-Wsign-compare]
  545 |   for (unsigned idx = 0; idx < result_response.per_port_responses_size();
      |                          ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tests/gnoi/bert_tests.cc: In function 'std::vector<std::__cxx11::basic_string<char> > bert::{anonymous}::SelectNInterfacesFromList(int, std::vector<std::__cxx11::basic_string<char> >)':
tests/gnoi/bert_tests.cc:644:25: warning: comparison of integer expressions of different signedness: 'std::vector<std::__cxx11::basic_string<char> >::size_type' {aka 'long unsigned int'} and 'int' [-Wsign-compare]
  644 |   if (interfaces.size() < port_count_to_select) {
      |       ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
INFO: From Compiling tests/sflow/sflow_test.cc:
In file included from ./gutil/collections.h:29,
                 from tests/sflow/sflow_test.cc:49:
tests/sflow/sflow_test.cc: In function 'absl::lts_20240116::Status pins::{anonymous}::SetUpAclPunt(pdpi::P4RuntimeSession&, const pdpi::IrP4Info&, int)':
./gutil/status_matchers.h:63:43: note: in definition of macro 'ASSERT_OK_AND_ASSIGN'
   63 |   auto __ASSIGN_OR_RETURN_VAL(__LINE__) = expression;                          \
      |                                           ^~~~~~~~~~
./tests/lib/switch_test_setup_helpers.h:132:1: note: declared here
  132 | ConfigureSwitchPairAndReturnP4RuntimeSessionPair(
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tests/qos/cpu_qos_test.cc: In member function 'virtual void pins_test::{anonymous}::CpuQosTestWithoutIxia_P4CpuQueueMappingByNameIsCorrect_Test::TestBody()':
tests/qos/cpu_qos_test.cc:1268:66: warning: 'absl::lts_20240116::StatusOr<std::pair<std::unique_ptr<pdpi::P4RuntimeSession>, std::unique_ptr<pdpi::P4RuntimeSession> > > pins_test::ConfigureSwitchPairAndReturnP4RuntimeSessionPair(thinkit::Switch&, thinkit::Switch&, const std::optional<std::basic_string_view<char> >&, const std::optional<p4::config::v1::P4Info>&, const pdpi::P4RuntimeSessionOptionalArgs&)' is deprecated: Use `ConfigureSwitchPair` instead, since this function works only for mirror testbeds. [-Wdeprecated-declarations]
 1268 |       pins_test::ConfigureSwitchPairAndReturnP4RuntimeSessionPair(
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 1269 |           Sut(), ControlSwitch(), GetParam().gnmi_config, p4info));
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
./gutil/status_matchers.h:63:43: note: in definition of macro 'ASSERT_OK_AND_ASSIGN'
   63 |   auto __ASSIGN_OR_RETURN_VAL(__LINE__) = expression;                          \
      |                                           ^~~~~~~~~~
./tests/lib/switch_test_setup_helpers.h:132:1: note: declared here
  132 | ConfigureSwitchPairAndReturnP4RuntimeSessionPair(
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO: Elapsed time: 125.517s, Critical Path: 70.62s
INFO: 34 processes: 7 internal, 27 linux-sandbox.
INFO: Build completed successfully, 34 total actions



Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 756 targets (0 packages loaded, 2 targets configured).
INFO: Found 526 targets and 230 test targets...
INFO: Elapsed time: 273.835s, Critical Path: 162.06s
INFO: 287 processes: 341 linux-sandbox, 18 local.
INFO: Build completed successfully, 287 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.5s
//dvaas:dataplane_validation_test                                        PASSED in 0.5s
//dvaas:port_id_map_test                                                 PASSED in 11.1s
//dvaas:test_run_validation_golden_test                                  PASSED in 1.0s
//dvaas:test_run_validation_test                                         PASSED in 11.1s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.9s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 10.5s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 10.1s
//gutil:io_test                                                          PASSED in 10.1s
//gutil:proto_matchers_test                                              PASSED in 10.0s
//gutil:proto_ordering_test                                              PASSED in 0.7s
//gutil:proto_test                                                       PASSED in 0.7s
//gutil:status_matchers_test                                             PASSED in 0.7s
//gutil:test_artifact_writer_test                                        PASSED in 0.8s
//gutil:testing_test                                                     PASSED in 0.7s
//gutil:timer_test                                                       PASSED in 6.9s
//gutil:version_test                                                     PASSED in 6.2s
//lib:basic_switch_test                                                  PASSED in 1.2s
//lib:ixia_helper_test                                                   PASSED in 1.4s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 7.1s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 22.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 8.5s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 1.5s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.0s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.2s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 1.6s
//tests/forwarding:hash_statistics_util_test                             PASSED in 1.6s
//tests/integration/system/nsf:compare_p4flows_test                      PASSED in 1.0s
//tests/lib:common_ir_table_entries_test                                 PASSED in 1.0s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.1s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.2s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.3s
//thinkit:bazel_test_environment_test                                    PASSED in 0.7s
//thinkit:generic_testbed_test                                           PASSED in 1.3s
//thinkit:mock_control_device_test                                       PASSED in 0.9s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.0s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.9s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.1s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.0s
//tests/lib:packet_generator_test                                        PASSED in 66.3s
  Stats over 4 runs: max = 66.3s, min = 64.3s, avg = 65.0s, dev = 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 3.7s
  Stats over 5 runs: max = 3.7s, min = 1.0s, avg = 1.7s, dev = 1.0s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 46.8s
  Stats over 50 runs: max = 46.8s, min = 1.1s, avg = 4.9s, dev = 12.2s

Executed 230 out of 230 tests: 230 tests pass.