### PR TITLE
[Comb] Add auxiliary VLAN membership entries for SUB_PORT RIFS to v1model targets.

### DIFF
--- a/p4_pdpi/packetlib/packetlib_unit_test.cc
+++ b/p4_pdpi/packetlib/packetlib_unit_test.cc
@@ -942,5 +942,30 @@ TEST(PacketLib,
   EXPECT_THAT(parsed_packet, EqualsProto(packet));
 }
 
+TEST(PacketLib,
+     UpdateAllComputedFieldsHasExceedingDataLengthForHopByHopOptions) {
+  Packet packet = gutil::ParseProtoOrDie<Packet>(R"pb(
+    headers {
+      hop_by_hop_options_header {
+        next_header: "0xfe"
+        header_extension_length: "0x00"
+        # The data length of 9 exceeds the maximum.
+        options_and_padding: "0x010900000000"
+      }
+    }
+  )pb");
+  ASSERT_OK(packetlib::UpdateAllComputedFields(packet).status());
+  ASSERT_OK_AND_ASSIGN(std::string raw_packet,
+                       packetlib::RawSerializePacket(packet));
+  EXPECT_EQ(absl::BytesToHexString(raw_packet), "fe00010900000000");
+
+  // Verify that the round-tripped packet is the same as the original packet.
+  Packet parsed_packet =
+      ParsePacket(raw_packet, Header::kHopByHopOptionsHeader);
+  EXPECT_EQ(parsed_packet.reasons_invalid_size(), 1);
+  EXPECT_THAT(parsed_packet.mutable_reasons_invalid()->Get(0),
+              HasSubstr("data length exceeds"));
+}
+
 }  // namespace
 }  // namespace packetlib

--- a/p4_symbolic/tests/sai_p4_integration_test.cc
+++ b/p4_symbolic/tests/sai_p4_integration_test.cc
@@ -460,21 +460,15 @@ TEST(P4SymbolicIntegrationTest,
                   sai::Replica{.egress_port = "1", .instance = 1},
                   sai::Replica{.egress_port = "2", .instance = 20},
               })
-          .AddMulticastRouterInterfaceEntry({
-              .multicast_replica_port = "1",
-              .multicast_replica_instance = 0,
-              .src_mac = kEgressSrcMac,
-          })
-          .AddMulticastRouterInterfaceEntry({
-              .multicast_replica_port = "1",
-              .multicast_replica_instance = 1,
-              .src_mac = kEgressSrcMac,
-          })
-          .AddMulticastRouterInterfaceEntry({
-              .multicast_replica_port = "2",
-              .multicast_replica_instance = 20,
-              .src_mac = kEgressSrcMac,
-          })
+	  .AddMrifEntryRewritingSrcMac(
+              /*egress_port=*/"1", /*replica_instance=*/0,
+              /*src_mac=*/kEgressSrcMac)
+          .AddMrifEntryRewritingSrcMac(
+              /*egress_port=*/"1", /*replica_instance=*/1,
+              /*src_mac=*/kEgressSrcMac)
+          .AddMrifEntryRewritingSrcMac(
+              /*egress_port=*/"2", /*replica_instance=*/20,
+              /*src_mac=*/kEgressSrcMac)
           .LogPdEntries()
           .GetDedupedPiEntities(ir_p4info));
 

--- a/sai_p4/instantiations/google/test_tools/table_entry_generator.cc
+++ b/sai_p4/instantiations/google/test_tools/table_entry_generator.cc
@@ -281,7 +281,7 @@ TableEntryGenerator MulticastRouterInterfaceTableGenerator(
       exact { str: "1" }
     }
     action {
-      name: "set_multicast_src_mac"
+      name: "multicast_set_src_mac"
       params {
         name: "src_mac"
         value { mac: "06:05:04:03:02:01" }

--- a/sai_p4/instantiations/google/test_tools/test_entries.cc
+++ b/sai_p4/instantiations/google/test_tools/test_entries.cc
@@ -513,19 +513,6 @@ EntryBuilder& EntryBuilder::AddMulticastGroupEntry(
   return AddMulticastGroupEntry(multicast_group_id, replicas);
 }
 
-EntryBuilder& EntryBuilder::AddMulticastRouterInterfaceEntry(
-    const MulticastRouterInterfaceTableEntry& entry) {
-  sai::MulticastRouterInterfaceTableEntry& pd_entry =
-      *entries_.add_entries()->mutable_multicast_router_interface_table_entry();
-  auto& match = *pd_entry.mutable_match();
-  match.set_multicast_replica_port(entry.multicast_replica_port);
-  match.set_multicast_replica_instance(
-      pdpi::BitsetToHexString<16>(entry.multicast_replica_instance));
-  auto& action = *pd_entry.mutable_action()->mutable_set_multicast_src_mac();
-  action.set_src_mac(entry.src_mac.ToString());
-  return *this;
-}
-
 namespace {
 // Returns a basic MulticastRouterInterfaceTableEntry without any action.
 sai::MulticastRouterInterfaceTableEntry ActionlessMrifEntry(

--- a/sai_p4/instantiations/google/test_tools/test_entries.h
+++ b/sai_p4/instantiations/google/test_tools/test_entries.h
@@ -309,15 +309,6 @@ class EntryBuilder {
   absl::StatusOr<pdpi::IrEntities> GetDedupedIrEntities(
       const pdpi::IrP4Info& ir_p4info) const;
 
-  // Convenience struct corresponding to the proto
-  // `MulticastRouterInterfaceTableEntry`
-  // in `sai_pd.proto`.
-  struct MulticastRouterInterfaceTableEntry {
-    std::string multicast_replica_port;
-    int multicast_replica_instance = 0;
-    netaddr::MacAddress src_mac;
-  };
-
   // Adds an entry that matches all packets and punts them according to
   // `action`.
   EntryBuilder& AddEntryPuntingAllPackets(PuntAction action);
@@ -404,11 +395,6 @@ class EntryBuilder {
                                        absl::Span<const Replica> replicas);
   EntryBuilder& AddMulticastGroupEntry(
       int multicast_group_id, absl::Span<const std::string> egress_ports);
-  // TODO: Remove once `mulitcast_set_src_mac` is exclusively used
-  // and such an image is rolled out. Replace all calls with
-  // `AddMrifEntryRewritingSrcMac`.
-  EntryBuilder& AddMulticastRouterInterfaceEntry(
-      const MulticastRouterInterfaceTableEntry& entry);
   EntryBuilder& AddMrifEntryRewritingSrcMac(absl::string_view egress_port,
                                             int replica_instance,
                                             const netaddr::MacAddress& src_mac);

--- a/sai_p4/instantiations/google/test_tools/test_entries_test.cc
+++ b/sai_p4/instantiations/google/test_tools/test_entries_test.cc
@@ -797,26 +797,6 @@ TEST(EntryBuilder, AddMulticastGroupEntryPortOverloadAddsUniqueReplicas) {
   EXPECT_NE(replicas[1].instance(), replicas[2].instance());
 }
 
-TEST(EntryBuilder, AddMulticastRouterInterfaceEntryAddsEntry) {
-  pdpi::IrP4Info kIrP4Info = GetIrP4Info(Instantiation::kFabricBorderRouter);
-  ASSERT_OK_AND_ASSIGN(
-      pdpi::IrEntities entities,
-      EntryBuilder()
-          .AddMulticastRouterInterfaceEntry({
-              .multicast_replica_port = "\1",
-              .multicast_replica_instance = 15,
-              .src_mac = netaddr::MacAddress(1, 2, 3, 4, 5, 6),
-          })
-          .LogPdEntries()
-          .GetDedupedIrEntities(kIrP4Info));
-  EXPECT_THAT(entities.entities(), ElementsAre(Partially(EqualsProto(R"pb(
-                table_entry {
-                  table_name: "multicast_router_interface_table"
-                  action { name: "set_multicast_src_mac" }
-                }
-              )pb"))));
-}
-
 TEST(EntryBuilder, AddMrifEntryRewritingSrcMacAddsEntry) {
   pdpi::IrP4Info kIrP4Info = GetIrP4Info(Instantiation::kFabricBorderRouter);
   ASSERT_OK_AND_ASSIGN(

--- a/sai_p4/tools/BUILD.bazel
+++ b/sai_p4/tools/BUILD.bazel
@@ -54,7 +54,6 @@ cc_library(
     deps = [
         "//lib/gnmi:gnmi_helper",
         "//p4_pdpi:ir_cc_proto",
-        "//p4_pdpi:p4_runtime_session",
         "//sai_p4/fixed:p4_ids",
         "//sai_p4/instantiations/google:sai_pd_cc_proto",
         "@com_github_gnmi//proto/gnmi:gnmi_cc_grpc_proto",
@@ -62,6 +61,8 @@ cc_library(
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+	"@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
     ],
 )
 

--- a/sai_p4/tools/auxiliary_entries_for_v1model_targets.cc
+++ b/sai_p4/tools/auxiliary_entries_for_v1model_targets.cc
@@ -31,24 +31,44 @@
 #include "sai_p4/instantiations/google/sai_pd.pb.h"
 
 namespace sai {
+namespace {
 
-p4::v1::Entity MakeV1modelPacketReplicationEngineEntryRequiredForPunts() {
-  p4::v1::Entity entity;
+enum class TaggingMode {
+  kTagged,
+  kUntagged,
+};
 
-  p4::v1::CloneSessionEntry& clone_session =
-      *entity.mutable_packet_replication_engine_entry()
-           ->mutable_clone_session_entry();
-  clone_session.set_session_id(COPY_TO_CPU_SESSION_ID);
-  p4::v1::Replica& replica = *clone_session.add_replicas();
-  replica.set_egress_port(SAI_P4_CPU_PORT);
-  replica.set_instance(SAI_P4_REPLICA_INSTANCE_PACKET_IN);
-
-  return entity;
+absl::StatusOr<pdpi::IrEntity> CreateVlanMembershipEntity(
+    absl::string_view vlan_id, absl::string_view port, TaggingMode tagging_mode,
+    bool auxiliary_table = false) {
+  pdpi::IrEntity aux_ir_entity;
+  aux_ir_entity.mutable_table_entry()->set_table_name(
+      auxiliary_table ? "v1model_auxiliary_vlan_membership_table"
+                      : "vlan_membership_table");
+  pdpi::IrMatch& vlan_match =
+      *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
+  vlan_match.set_name("vlan_id");
+  vlan_match.mutable_exact()->set_hex_str(vlan_id);
+  pdpi::IrMatch& port_match =
+      *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
+  port_match.set_name("port");
+  port_match.mutable_exact()->set_str(port);
+  if (tagging_mode == TaggingMode::kTagged) {
+    aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
+        auxiliary_table ? "v1model_auxiliary_make_tagged_member"
+                        : "make_tagged_member");
+  } else if (tagging_mode == TaggingMode::kUntagged) {
+    aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
+        auxiliary_table ? "v1model_auxiliary_make_untagged_member"
+                        : "make_untagged_member");
+  } else {
+    return absl::InternalError("Unsupported action in vlan_membership_table");
+  }
+  return aux_ir_entity;
 }
 
-absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
-    pdpi::IrEntities ir_entities, gnmi::gNMI::StubInterface& gnmi_stub,
-    pdpi::IrP4Info ir_p4info) {
+absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntitiesForLoopbackPorts(
+    gnmi::gNMI::StubInterface& gnmi_stub) {
   // Get the loopback mode map from the gNMI stub.
   absl::btree_set<std::string> loopback_mode_port_set;
   ASSIGN_OR_RETURN(
@@ -69,9 +89,15 @@ absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
     aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
         "egress_loopback");
   }
+  return auxiliary_ir_entities;
+}
 
+absl::StatusOr<pdpi::IrEntities>
+CreateV1ModelAuxiliaryVlanMembershipTableEntities(
+    pdpi::IrEntities ir_entities) {
   // For each entry in VLAN membership table, create an entry for v1model
   // auxiliary VLAN membership table.
+  pdpi::IrEntities auxiliary_ir_entities;
   for (const auto& ir_entity : ir_entities.entities()) {
     if (ir_entity.table_entry().table_name() != "vlan_membership_table") {
       continue;
@@ -92,40 +118,109 @@ absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
     }
     if (!vlan_id.has_value()) {
       return absl::FailedPreconditionError(
-          absl::StrCat("Expected match on field `vlan_id` in "
-                       "vlan_membership_table_entry, but got ",
+          absl::StrCat("Expected match on field `vlan_id` in ",
+                       ir_entity.table_entry().table_name(), ", but got ",
                        ir_entity.table_entry().ShortDebugString()));
     }
     if (!port.has_value()) {
       return absl::FailedPreconditionError(
-          absl::StrCat("Expected match on field `port` in "
-                       "vlan_membership_table_entry, but got ",
+          absl::StrCat("Expected match on field `port` in ",
+                       ir_entity.table_entry().table_name(), ", but got ",
                        ir_entity.table_entry().ShortDebugString()));
     }
 
-    pdpi::IrEntity& aux_ir_entity = *auxiliary_ir_entities.add_entities();
-    aux_ir_entity.mutable_table_entry()->set_table_name(
-        "v1model_auxiliary_vlan_membership_table");
-    pdpi::IrMatch& vlan_match =
-        *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
-    vlan_match.set_name("vlan_id");
-    vlan_match.mutable_exact()->set_hex_str(*vlan_id);
-    pdpi::IrMatch& port_match =
-        *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
-    port_match.set_name("port");
-    port_match.mutable_exact()->set_str(*port);
-    if (ir_entity.table_entry().action().name() == "make_tagged_member") {
-      aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
-          "v1model_auxiliary_make_tagged_member");
-    } else if (ir_entity.table_entry().action().name() ==
-               "make_untagged_member") {
-      aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
-          "v1model_auxiliary_make_untagged_member");
-    } else {
-      return absl::InternalError("Unsupported action in vlan_membership_table");
-    }
+    ASSIGN_OR_RETURN(
+        *auxiliary_ir_entities.add_entities(),
+        CreateVlanMembershipEntity(
+            *vlan_id, *port,
+            ir_entity.table_entry().action().name() == "make_tagged_member"
+                ? TaggingMode::kTagged
+                : TaggingMode::kUntagged,
+            /*auxiliary_table=*/true));
   }
+  return auxiliary_ir_entities;
+}
 
+// TODO: Remove this function once we switch to SUB_PORT RIFS that
+// do not manipulate VLAN membership.
+absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntitiesForSubPortRifs(
+    pdpi::IrEntities ir_entities) {
+  // For each SUB_PORT RIF (i.e. entry in router_interface_table with action
+  // set_port_and_src_mac_and_vlan_id with port `p` and vlan `v`), add auxiliary
+  // entries to make `p` a tagged member of `v`.
+  pdpi::IrEntities auxiliary_ir_entities;
+  for (const auto& ir_entity : ir_entities.entities()) {
+    if (!(ir_entity.table_entry().table_name() == "router_interface_table" &&
+          ir_entity.table_entry().action().name() ==
+              "set_port_and_src_mac_and_vlan_id")) {
+      continue;
+    }
+    std::optional<absl::string_view> vlan_id;
+    std::optional<absl::string_view> port;
+
+    for (const auto& param : ir_entity.table_entry().action().params()) {
+      if (param.name() == "vlan_id") {
+        vlan_id = param.value().hex_str();
+      } else if (param.name() == "port") {
+        port = param.value().str();
+      }
+    }
+    if (!vlan_id.has_value()) {
+      return absl::FailedPreconditionError(absl::StrCat(
+          "Expected param `vlan_id` in ", ir_entity.table_entry().table_name(),
+          ", but got ", ir_entity.table_entry().ShortDebugString()));
+    }
+    if (!port.has_value()) {
+      return absl::FailedPreconditionError(absl::StrCat(
+          "Expected param `port` in ", ir_entity.table_entry().table_name(),
+          ", but got ", ir_entity.table_entry().ShortDebugString()));
+    }
+
+    ASSIGN_OR_RETURN(
+        *auxiliary_ir_entities.add_entities(),
+        CreateVlanMembershipEntity(*vlan_id, *port, TaggingMode::kTagged,
+                                   /*auxiliary_table=*/false));
+    ASSIGN_OR_RETURN(
+        *auxiliary_ir_entities.add_entities(),
+        CreateVlanMembershipEntity(*vlan_id, *port, TaggingMode::kTagged,
+                                   /*auxiliary_table=*/true));
+  }
+  return auxiliary_ir_entities;
+}
+
+}  // namespace
+
+p4::v1::Entity MakeV1modelPacketReplicationEngineEntryRequiredForPunts() {
+  p4::v1::Entity entity;
+
+  p4::v1::CloneSessionEntry& clone_session =
+      *entity.mutable_packet_replication_engine_entry()
+           ->mutable_clone_session_entry();
+  clone_session.set_session_id(COPY_TO_CPU_SESSION_ID);
+  p4::v1::Replica& replica = *clone_session.add_replicas();
+  replica.set_egress_port(SAI_P4_CPU_PORT);
+  replica.set_instance(SAI_P4_REPLICA_INSTANCE_PACKET_IN);
+
+  return entity;
+}
+
+absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
+    pdpi::IrEntities ir_entities, gnmi::gNMI::StubInterface& gnmi_stub) {
+  pdpi::IrEntities auxiliary_ir_entities;
+  ASSIGN_OR_RETURN(pdpi::IrEntities loopback_ports_entities,
+                   CreateV1ModelAuxiliaryEntitiesForLoopbackPorts(gnmi_stub));
+  auxiliary_ir_entities.MergeFrom(loopback_ports_entities);
+
+  ASSIGN_OR_RETURN(
+      pdpi::IrEntities vlan_membership_entities,
+      CreateV1ModelAuxiliaryVlanMembershipTableEntities(ir_entities));
+  auxiliary_ir_entities.MergeFrom(vlan_membership_entities);
+
+  // TODO: Remove this function once we switch to SUB_PORT RIFS
+  // that do not manipulate VLAN membership.
+  ASSIGN_OR_RETURN(pdpi::IrEntities sub_port_rifs_entities,
+                   CreateV1ModelAuxiliaryEntitiesForSubPortRifs(ir_entities));
+  auxiliary_ir_entities.MergeFrom(sub_port_rifs_entities);
   return auxiliary_ir_entities;
 }
 

--- a/sai_p4/tools/auxiliary_entries_for_v1model_targets.cc
+++ b/sai_p4/tools/auxiliary_entries_for_v1model_targets.cc
@@ -14,10 +14,14 @@
 
 #include "sai_p4/tools/auxiliary_entries_for_v1model_targets.h"
 
+#include <optional>
 #include <string>
 
 #include "absl/container/btree_set.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
 #include "gutil/status.h"
 #include "lib/gnmi/gnmi_helper.h"
 #include "p4/v1/p4runtime.pb.h"
@@ -42,30 +46,87 @@ p4::v1::Entity MakeV1modelPacketReplicationEngineEntryRequiredForPunts() {
   return entity;
 }
 
-absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryTableEntries(
-    gnmi::gNMI::StubInterface& gnmi_stub, pdpi::IrP4Info ir_p4info) {
-  // Get the loopback mode map from the gNMI stub
+absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
+    pdpi::IrEntities ir_entities, gnmi::gNMI::StubInterface& gnmi_stub,
+    pdpi::IrP4Info ir_p4info) {
+  // Get the loopback mode map from the gNMI stub.
   absl::btree_set<std::string> loopback_mode_port_set;
   ASSIGN_OR_RETURN(
       loopback_mode_port_set,
       pins_test::GetP4rtIdOfInterfacesInAsicMacLocalLoopbackMode(gnmi_stub));
 
-  // Create IrEntities by using the gNMI loopback mode map to fill the loopback
-  // table entries.
-  pdpi::IrEntities ir_entities;
+  // For each port configured to be in loopback mode in gNMI, add an entry to
+  // the loopback table.
+  pdpi::IrEntities auxiliary_ir_entities;
   for (const auto& loopback_mode_port : loopback_mode_port_set) {
-    pdpi::IrEntity* ir_entity = ir_entities.add_entities();
-    ir_entity->mutable_table_entry()->set_table_name(
+    pdpi::IrEntity& aux_ir_entity = *auxiliary_ir_entities.add_entities();
+    aux_ir_entity.mutable_table_entry()->set_table_name(
         "egress_port_loopback_table");
-    pdpi::IrMatch* match =
-        ir_entity->mutable_table_entry()->mutable_matches()->Add();
-    match->set_name("out_port");
-    match->mutable_exact()->set_str(loopback_mode_port);
-    ir_entity->mutable_table_entry()->mutable_action()->set_name(
+    pdpi::IrMatch& match =
+        *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
+    match.set_name("out_port");
+    match.mutable_exact()->set_str(loopback_mode_port);
+    aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
         "egress_loopback");
   }
 
-  return ir_entities;
+  // For each entry in VLAN membership table, create an entry for v1model
+  // auxiliary VLAN membership table.
+  for (const auto& ir_entity : ir_entities.entities()) {
+    if (ir_entity.table_entry().table_name() != "vlan_membership_table") {
+      continue;
+    }
+
+    std::optional<absl::string_view> vlan_id;
+    std::optional<absl::string_view> port;
+    for (const auto& match : ir_entity.table_entry().matches()) {
+      if (match.name() == "vlan_id") {
+        vlan_id = match.exact().hex_str();
+      } else if (match.name() == "port") {
+        port = match.exact().str();
+      } else {
+        return absl::FailedPreconditionError(absl::StrCat(
+            "Unexpected match '", match.name(),
+            "' in vlan_membership_table, got ", ir_entity.ShortDebugString()));
+      }
+    }
+    if (!vlan_id.has_value()) {
+      return absl::FailedPreconditionError(
+          absl::StrCat("Expected match on field `vlan_id` in "
+                       "vlan_membership_table_entry, but got ",
+                       ir_entity.table_entry().ShortDebugString()));
+    }
+    if (!port.has_value()) {
+      return absl::FailedPreconditionError(
+          absl::StrCat("Expected match on field `port` in "
+                       "vlan_membership_table_entry, but got ",
+                       ir_entity.table_entry().ShortDebugString()));
+    }
+
+    pdpi::IrEntity& aux_ir_entity = *auxiliary_ir_entities.add_entities();
+    aux_ir_entity.mutable_table_entry()->set_table_name(
+        "v1model_auxiliary_vlan_membership_table");
+    pdpi::IrMatch& vlan_match =
+        *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
+    vlan_match.set_name("vlan_id");
+    vlan_match.mutable_exact()->set_hex_str(*vlan_id);
+    pdpi::IrMatch& port_match =
+        *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
+    port_match.set_name("port");
+    port_match.mutable_exact()->set_str(*port);
+    if (ir_entity.table_entry().action().name() == "make_tagged_member") {
+      aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
+          "v1model_auxiliary_make_tagged_member");
+    } else if (ir_entity.table_entry().action().name() ==
+               "make_untagged_member") {
+      aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
+          "v1model_auxiliary_make_untagged_member");
+    } else {
+      return absl::InternalError("Unsupported action in vlan_membership_table");
+    }
+  }
+
+  return auxiliary_ir_entities;
 }
 
 }  // namespace sai

--- a/sai_p4/tools/auxiliary_entries_for_v1model_targets.h
+++ b/sai_p4/tools/auxiliary_entries_for_v1model_targets.h
@@ -41,8 +41,7 @@ p4::v1::Entity MakeV1modelPacketReplicationEngineEntryRequiredForPunts();
 // given entities (e.g. VLAN membership) and gNMI configuration (e.g. port
 // loopback mode).
 absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
-    pdpi::IrEntities ir_entities, gnmi::gNMI::StubInterface& gnmi_stub,
-    pdpi::IrP4Info ir_p4info);
+    pdpi::IrEntities ir_entities, gnmi::gNMI::StubInterface& gnmi_stub);
 
 }  // namespace sai
 

--- a/sai_p4/tools/auxiliary_entries_for_v1model_targets.h
+++ b/sai_p4/tools/auxiliary_entries_for_v1model_targets.h
@@ -24,7 +24,8 @@
 
 #include "absl/status/statusor.h"
 #include "p4/v1/p4runtime.pb.h"
-#include "p4_pdpi/p4_runtime_session.h"
+#include "p4_pdpi/ir.pb.h"
+#include "proto/gnmi/gnmi.grpc.pb.h"
 
 namespace sai {
 
@@ -36,11 +37,13 @@ namespace sai {
 // Not required by PINS targets, since PINS has this config built-in.
 p4::v1::Entity MakeV1modelPacketReplicationEngineEntryRequiredForPunts();
 
-// Creates entries for v1Model auxiliary tables that model the effects of the
-// given gNMI configuration in on packet forwarding (e.g. port loopback mode).
-absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryTableEntries(
-    gnmi::gNMI::StubInterface& gnmi_stub, pdpi::IrP4Info ir_p4info);
+// Creates entities for v1Model auxiliary tables that model the effects of the
+// given entities (e.g. VLAN membership) and gNMI configuration (e.g. port
+// loopback mode).
+absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
+    pdpi::IrEntities ir_entities, gnmi::gNMI::StubInterface& gnmi_stub,
+    pdpi::IrP4Info ir_p4info);
 
 }  // namespace sai
 
-#endif // PINS_SAI_P4_TOOLS_AUXILIARY_ENTRIES_FOR_V1MODEL_TARGETS_H_
+#endif  // PINS_SAI_P4_TOOLS_AUXILIARY_ENTRIES_FOR_V1MODEL_TARGETS_H_

--- a/sai_p4/tools/auxiliary_entries_for_v1model_targets_test.cc
+++ b/sai_p4/tools/auxiliary_entries_for_v1model_targets_test.cc
@@ -94,12 +94,11 @@ TEST(AuxiliaryIrEntitiesForV1ModelTarget, GenerateAuxiliaryLoopbackEntities) {
       .WillRepeatedly(
           DoAll(SetArgPointee<2>(response), Return(grpc::Status::OK)));
 
-  pdpi::IrP4Info ir_p4info = sai::GetIrP4Info(sai::Instantiation::kTor);
   pdpi::IrEntities ir_entities;
 
-  ASSERT_OK_AND_ASSIGN(pdpi::IrEntities auxiliary_ir_entities,
-                       sai::CreateV1ModelAuxiliaryEntities(
-                           ir_entities, mock_gnmi_stub, ir_p4info));
+  ASSERT_OK_AND_ASSIGN(
+      pdpi::IrEntities auxiliary_ir_entities,
+      sai::CreateV1ModelAuxiliaryEntities(ir_entities, mock_gnmi_stub));
   EXPECT_THAT(auxiliary_ir_entities, gutil::EqualsProto(expected_entities));
 }
 
@@ -128,8 +127,6 @@ TEST(AuxiliaryIrEntitiesForV1ModelTarget,
   EXPECT_CALL(mock_gnmi_stub, Get)
       .WillRepeatedly(
           DoAll(SetArgPointee<2>(response), Return(grpc::Status::OK)));
-
-  pdpi::IrP4Info ir_p4info = sai::GetIrP4Info(sai::Instantiation::kTor);
 
   ASSERT_OK_AND_ASSIGN(pdpi::IrEntities auxiliary_ir_entities,
                        sai::CreateV1ModelAuxiliaryEntities(
@@ -164,7 +161,7 @@ TEST(AuxiliaryIrEntitiesForV1ModelTarget,
                                    }
                                  }
                                )pb"),
-                           mock_gnmi_stub, ir_p4info));
+                           mock_gnmi_stub));
 
   EXPECT_THAT(
       auxiliary_ir_entities,
@@ -209,6 +206,84 @@ TEST(AuxiliaryIrEntitiesForV1ModelTarget,
               }
             }
           )pb")));
+}
+
+// TODO: Remove this test once auxiliary vlan membership entries
+// are no longer generated for SUB_PORT RIFS.
+TEST(AuxiliaryIrEntitiesForV1ModelTarget,
+     GenerateAuxiliaryVlanMembershipTableForSubRifPortEntries) {
+  gnmi::GetResponse response;
+  *response.add_notification()
+       ->add_update()
+       ->mutable_val()
+       ->mutable_json_ietf_val() = R"(
+    {
+      "openconfig-interfaces:interfaces": {
+        "interface": [
+        ]
+      }
+    })";
+
+  gnmi::MockgNMIStub mock_gnmi_stub;
+  EXPECT_CALL(mock_gnmi_stub, Get)
+      .WillRepeatedly(
+          DoAll(SetArgPointee<2>(response), Return(grpc::Status::OK)));
+
+  ASSERT_OK_AND_ASSIGN(pdpi::IrEntities auxiliary_ir_entities,
+                       sai::CreateV1ModelAuxiliaryEntities(
+                           gutil::ParseProtoOrDie<pdpi::IrEntities>(
+                               R"pb(
+                                 entities {
+                                   table_entry {
+                                     table_name: "router_interface_table"
+                                     action {
+                                       name: "set_port_and_src_mac_and_vlan_id"
+                                       params {
+                                         name: "vlan_id"
+                                         value { hex_str: "0x1" }
+                                       }
+                                       params {
+                                         name: "port"
+                                         value { str: "1" }
+                                       }
+                                     }
+                                   }
+                                 }
+                               )pb"),
+                           mock_gnmi_stub));
+
+  EXPECT_THAT(auxiliary_ir_entities,
+              gutil::EqualsProto(gutil::ParseProtoOrDie<pdpi::IrEntities>(
+                  R"pb(
+                    entities {
+                      table_entry {
+                        table_name: "v1model_auxiliary_vlan_membership_table"
+                        matches {
+                          name: "vlan_id"
+                          exact { hex_str: "0x1" }
+                        }
+                        matches {
+                          name: "port"
+                          exact { str: "1" }
+                        }
+                        action { name: "v1model_auxiliary_make_tagged_member" }
+                      }
+                    }
+                    entities {
+                      table_entry {
+                        table_name: "vlan_membership_table"
+                        matches {
+                          name: "vlan_id"
+                          exact { hex_str: "0x1" }
+                        }
+                        matches {
+                          name: "port"
+                          exact { str: "1" }
+                        }
+                        action { name: "make_tagged_member" }
+                      }
+                    }
+                  )pb")));
 }
 
 }  // namespace

--- a/sai_p4/tools/auxiliary_entries_for_v1model_targets_test.cc
+++ b/sai_p4/tools/auxiliary_entries_for_v1model_targets_test.cc
@@ -18,7 +18,7 @@ using testing::DoAll;
 using testing::Return;
 using testing::SetArgPointee;
 
-TEST(AuxilaryEntriesForV1ModelTarget, V1ModelAuxTableEntries) {
+TEST(AuxiliaryIrEntitiesForV1ModelTarget, GenerateAuxiliaryLoopbackEntities) {
   gnmi::GetResponse response;
   *response.add_notification()
        ->add_update()
@@ -29,21 +29,21 @@ TEST(AuxilaryEntriesForV1ModelTarget, V1ModelAuxTableEntries) {
         "interface": [
           {
             "name":"EthernetEnabled0",
-             "state":{
+            "state":{
               "loopback-mode":"ASIC_MAC_LOCAL",
               "openconfig-p4rt:id": 2
             }
           },
           {
             "name":"EthernetEnabled1",
-             "state":{
+            "state":{
               "loopback-mode":"NOT_ASIC_MAC_LOCAL",
               "openconfig-p4rt:id": 4
             }
           },
           {
             "name":"EthernetEnabled2",
-             "state":{
+            "state":{
               "loopback-mode":"ASIC_MAC_LOCAL",
               "openconfig-p4rt:id": 5
             }
@@ -95,11 +95,121 @@ TEST(AuxilaryEntriesForV1ModelTarget, V1ModelAuxTableEntries) {
           DoAll(SetArgPointee<2>(response), Return(grpc::Status::OK)));
 
   pdpi::IrP4Info ir_p4info = sai::GetIrP4Info(sai::Instantiation::kTor);
+  pdpi::IrEntities ir_entities;
 
-  ASSERT_OK_AND_ASSIGN(
-      pdpi::IrEntities entities,
-      sai::CreateV1ModelAuxiliaryTableEntries(mock_gnmi_stub, ir_p4info));
-  EXPECT_THAT(entities, gutil::EqualsProto(expected_entities));
+  ASSERT_OK_AND_ASSIGN(pdpi::IrEntities auxiliary_ir_entities,
+                       sai::CreateV1ModelAuxiliaryEntities(
+                           ir_entities, mock_gnmi_stub, ir_p4info));
+  EXPECT_THAT(auxiliary_ir_entities, gutil::EqualsProto(expected_entities));
+}
+
+TEST(AuxiliaryIrEntitiesForV1ModelTarget,
+     GenerateAuxiliaryVlanMembershipTableEntries) {
+  gnmi::GetResponse response;
+  *response.add_notification()
+       ->add_update()
+       ->mutable_val()
+       ->mutable_json_ietf_val() = R"(
+    {
+      "openconfig-interfaces:interfaces": {
+        "interface": [
+          {
+            "name":"EthernetEnabled0",
+            "state":{
+              "loopback-mode":"ASIC_MAC_LOCAL",
+              "openconfig-p4rt:id": 2
+            }
+          }
+        ]
+      }
+    })";
+
+  gnmi::MockgNMIStub mock_gnmi_stub;
+  EXPECT_CALL(mock_gnmi_stub, Get)
+      .WillRepeatedly(
+          DoAll(SetArgPointee<2>(response), Return(grpc::Status::OK)));
+
+  pdpi::IrP4Info ir_p4info = sai::GetIrP4Info(sai::Instantiation::kTor);
+
+  ASSERT_OK_AND_ASSIGN(pdpi::IrEntities auxiliary_ir_entities,
+                       sai::CreateV1ModelAuxiliaryEntities(
+                           gutil::ParseProtoOrDie<pdpi::IrEntities>(
+                               R"pb(
+                                 entities {
+                                   table_entry {
+                                     table_name: "vlan_membership_table"
+                                     matches {
+                                       name: "vlan_id"
+                                       exact { hex_str: "0x1" }
+                                     }
+                                     matches {
+                                       name: "port"
+                                       exact { str: "1" }
+                                     }
+                                     action { name: "make_tagged_member" }
+                                   }
+                                 }
+                                 entities {
+                                   table_entry {
+                                     table_name: "vlan_membership_table"
+                                     matches {
+                                       name: "vlan_id"
+                                       exact { hex_str: "0x2" }
+                                     }
+                                     matches {
+                                       name: "port"
+                                       exact { str: "2" }
+                                     }
+                                     action { name: "make_untagged_member" }
+                                   }
+                                 }
+                               )pb"),
+                           mock_gnmi_stub, ir_p4info));
+
+  EXPECT_THAT(
+      auxiliary_ir_entities,
+      gutil::EqualsProto(gutil::ParseProtoOrDie<pdpi::IrEntities>(
+          R"pb(
+            entities {
+              table_entry {
+                table_name: "egress_port_loopback_table"
+                matches {
+                  name: "out_port"
+                  exact { str: "2" }
+                }
+                action { name: "egress_loopback" }
+              }
+            }
+            entities {
+              table_entry {
+                table_name: "v1model_auxiliary_vlan_membership_table"
+                matches {
+                  name: "vlan_id"
+                  exact { hex_str: "0x1" }
+                }
+                matches {
+                  name: "port"
+                  exact { str: "1" }
+                }
+                action { name: "v1model_auxiliary_make_tagged_member" }
+              }
+            }
+            entities {
+              table_entry {
+                table_name: "v1model_auxiliary_vlan_membership_table"
+                matches {
+                  name: "vlan_id"
+                  exact { hex_str: "0x2" }
+                }
+                matches {
+                  name: "port"
+                  exact { str: "2" }
+                }
+                action { name: "v1model_auxiliary_make_untagged_member" }
+              }
+            }
+          )pb")));
 }
 
 }  // namespace
+

--- a/tests/forwarding/l3_multicast_test.cc
+++ b/tests/forwarding/l3_multicast_test.cc
@@ -170,10 +170,7 @@ absl::StatusOr<std::vector<p4::v1::Entity>> CreateRifTableEntities(
     const int instance, const netaddr::MacAddress& src_mac) {
   ASSIGN_OR_RETURN(std::vector<p4::v1::Entity> entities,
                    sai::EntryBuilder()
-                       .AddMulticastRouterInterfaceEntry(
-                           {.multicast_replica_port = port_id,
-                            .multicast_replica_instance = instance,
-                            .src_mac = src_mac})
+		       .AddMrifEntryRewritingSrcMac(port_id, instance, src_mac)
                        .LogPdEntries()
                        .GetDedupedPiEntities(ir_p4info,
                                              /*allow_unsupported=*/true));
@@ -1207,15 +1204,9 @@ TEST_P(L3MulticastTestFixture, AbleToProgramExpectedMulticastGroupCapacity) {
 
     // Add a normal replication RIF and a "drop" RIF to correspond to the state
     // a multicast group member is allowed to be in.
-    rif_builder
-        .AddMulticastRouterInterfaceEntry(
-            {.multicast_replica_port = port_id,
-             .multicast_replica_instance = kDefaultInstance,
-             .src_mac = src_mac})
-        .AddMulticastRouterInterfaceEntry(
-            {.multicast_replica_port = port_id,
-             .multicast_replica_instance = kDefaultInstance + 1,
-             .src_mac = kDropSrcMacAddress});
+    rif_builder.AddMrifEntryRewritingSrcMac(port_id, kDefaultInstance, src_mac)
+        .AddMrifEntryRewritingSrcMac(port_id, kDefaultInstance + 1,
+                                     kDropSrcMacAddress);
   }
   ASSERT_OK_AND_ASSIGN(
       std::vector<p4::v1::Entity> rif_entities,

--- a/tests/qos/frontpanel_qos_test.cc
+++ b/tests/qos/frontpanel_qos_test.cc
@@ -174,11 +174,8 @@ ConstructEntriesToForwardMcastTrafficToGivenPort(
               {
                   sai::Replica{.egress_port = p4rt_port_id, .instance = 0},
               })
-          .AddMulticastRouterInterfaceEntry({
-              .multicast_replica_port = p4rt_port_id,
-              .multicast_replica_instance = 0,
-              .src_mac = netaddr::MacAddress(1, 0, 0, 0, 0, 0),
-          })
+	  .AddMrifEntryRewritingSrcMac(p4rt_port_id, /*instance=*/0,
+                                       netaddr::MacAddress(1, 0, 0, 0, 0, 0))
           .LogPdEntries()
           .GetDedupedPiEntities(ir_p4info));
   std::vector<p4::v1::Entity> pi_route_entities;


### PR DESCRIPTION
### **PR Description:**
Add auxiliary VLAN membership entries for SUB_PORT RIFS to v1model targets.

### **Keyword Check:**
bibhuprasad@bibhuprasad87:~/sonic_build_image_2025-06-23/sonic-buildimage/src/sonic-p4rt/sonic-pins/sai_p4$ sh ~/keyword_check.sh .
Keyword check Passed.

### **Build Results:**
bibhuprasad@0c2403497cee:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 756 targets (0 packages loaded, 0 targets configured).
INFO: Found 756 targets...
INFO: Elapsed time: 0.601s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### **UT Results:**
bibhuprasad@0c2403497cee:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 756 targets (0 packages loaded, 223 targets configured).
INFO: Found 526 targets and 230 test targets...
INFO: Elapsed time: 221.085s, Critical Path: 158.85s
INFO: 287 processes: 341 linux-sandbox, 18 local.
INFO: Build completed successfully, 287 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.3s
//dvaas:dataplane_validation_test                                        PASSED in 0.2s
//dvaas:port_id_map_test                                                 PASSED in 3.0s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.2s
//dvaas:test_run_validation_test                                         PASSED in 2.3s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.2s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.2s
//dvaas:test_vector_stats_test                                           PASSED in 0.2s
//dvaas:test_vector_test                                                 PASSED in 3.6s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.3s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.3s
//gutil:collections_test                                                 PASSED in 2.2s
//gutil:io_test                                                          PASSED in 1.5s
//gutil:proto_matchers_test                                              PASSED in 2.8s
//gutil:proto_ordering_test                                              PASSED in 1.6s
//gutil:proto_test                                                       PASSED in 3.0s
//gutil:status_matchers_test                                             PASSED in 2.1s
//gutil:test_artifact_writer_test                                        PASSED in 3.5s
//gutil:testing_test                                                     PASSED in 3.6s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 8.1s
//lib:basic_switch_test                                                  PASSED in 4.3s
//lib:ixia_helper_test                                                   PASSED in 3.0s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 5.0s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 18.9s
//lib/gnmi:gnmi_helper_test                                              PASSED in 6.4s
//lib/gnoi:gnoi_helper_test                                              PASSED in 2.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.7s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 4.9s
//lib/utils:generic_testbed_utils_test                                   PASSED in 6.7s
//lib/utils:json_test_utils_test                                         PASSED in 3.4s
//lib/utils:json_utils_test                                              PASSED in 2.2s
//lib/validator:validator_backend_test                                   PASSED in 2.2s
//lib/validator:validator_lib_test                                       PASSED in 28.3s
//p4_fuzzer:constraints_test                                             PASSED in 13.6s
//p4_fuzzer:fuzz_util_test                                               PASSED in 158.7s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 2.4s
//p4_fuzzer:oracle_util_test                                             PASSED in 7.2s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 5.4s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 5.1s
//p4_fuzzer:switch_state_test                                            PASSED in 5.4s
//p4_pdpi:built_ins_test                                                 PASSED in 1.5s
//p4_pdpi:entity_keys_test                                               PASSED in 3.6s
//p4_pdpi:ir_properties_test                                             PASSED in 3.6s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 2.7s
//p4_pdpi:ir_tools_test                                                  PASSED in 3.1s
//p4_pdpi:names_test                                                     PASSED in 2.8s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 2.8s
//p4_pdpi:p4info_union_test                                              PASSED in 3.4s
//p4_pdpi:reference_annotations_test                                     PASSED in 4.7s
//p4_pdpi:references_test                                                PASSED in 3.2s
//p4_pdpi:sequencing_util_test                                           PASSED in 2.9s
//p4_pdpi:ternary_test                                                   PASSED in 2.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 3.3s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 3.7s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.5s
//p4_pdpi/packetlib:packetlib_debugging_test                             PASSED in 1.1s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 25.1s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 2.2s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.6s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 10.8s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.5s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.2s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 4.0s
//p4_pdpi/testing:helper_function_test                                   PASSED in 2.5s
//p4_pdpi/testing:info_test                                              PASSED in 0.6s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.7s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 4.0s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.3s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.3s
//p4_pdpi/testing:references_test                                        PASSED in 0.6s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.6s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.6s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.6s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.6s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.3s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.5s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.2s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 4.3s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.6s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.3s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 2.2s
//p4_pdpi/utils:ir_test                                                  PASSED in 3.4s
//p4_symbolic:z3_util_test                                               PASSED in 2.0s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.2s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 0.7s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 0.5s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 0.5s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.3s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 0.4s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.6s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 1.0s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.4s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 0.9s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.4s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 0.6s
//p4_symbolic/ir:cfg_test                                                PASSED in 3.1s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.4s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.2s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.1s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.1s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.5s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.3s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.3s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.3s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.3s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.3s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.2s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.3s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.2s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 2.0s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 39.3s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 46.3s
//p4_symbolic/sai:sai_test                                               PASSED in 12.0s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.2s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.2s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 6.5s
//p4_symbolic/symbolic:parser_test                                       PASSED in 3.2s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.2s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.2s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 3.5s
//p4_symbolic/symbolic:util_test                                         PASSED in 2.7s
//p4_symbolic/symbolic:values_test                                       PASSED in 2.0s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 26.9s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 3.6s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 5.3s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 3.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 5.2s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 5.2s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 4.2s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 5.3s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 5.2s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 1.7s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 4.8s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 2.8s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 3.3s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 5.2s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 3.5s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 4.8s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 2.8s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 4.6s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 4.2s
//p4rt_app/sonic:hashing_test                                            PASSED in 2.6s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 4.5s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 3.5s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 2.3s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.5s
//p4rt_app/sonic:state_verification_test                                 PASSED in 3.8s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 2.4s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 2.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 4.0s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 1.0s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.2s
//p4rt_app/tests:action_set_test                                         PASSED in 1.9s
//p4rt_app/tests:api_access_test                                         PASSED in 1.5s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.8s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.9s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.5s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.8s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 10.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.8s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.4s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.5s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.9s
//p4rt_app/tests:packetio_test                                           PASSED in 4.7s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.5s
//p4rt_app/tests:resource_limits_test                                    PASSED in 7.1s
//p4rt_app/tests:response_path_test                                      PASSED in 5.4s
//p4rt_app/tests:role_test                                               PASSED in 1.7s
//p4rt_app/tests:state_verification_test                                 PASSED in 3.0s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 3.4s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.7s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 3.6s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 3.4s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 3.7s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 2.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.3s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 8.3s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 5.5s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 11.8s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 2.5s
//sai_p4/tools:p4info_tools_test                                         PASSED in 2.5s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.9s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 3.9s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.7s
//tests/lib:common_ir_table_entries_test                                 PASSED in 2.4s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 2.6s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.5s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.5s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.4s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 9.5s
//thinkit:bazel_test_environment_test                                    PASSED in 1.7s
//thinkit:generic_testbed_test                                           PASSED in 2.9s
//thinkit:mock_control_device_test                                       PASSED in 2.1s
//thinkit:mock_generic_testbed_test                                      PASSED in 3.1s
//thinkit:mock_mirror_testbed_test                                       PASSED in 3.1s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 2.1s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 2.5s
//tests/lib:packet_generator_test                                        PASSED in 70.5s
  Stats over 4 runs: max = 70.5s, min = 64.9s, avg = 67.1s, dev = 2.2s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 3.6s
  Stats over 5 runs: max = 3.6s, min = 1.9s, avg = 2.6s, dev = 0.6s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 51.8s
  Stats over 50 runs: max = 51.8s, min = 1.9s, avg = 6.9s, dev = 12.9s

Executed 230 out of 230 tests: 230 tests pass.
