### PR TITLE
[Thinkit/Tests] Add test cases for non-congestion related out discards.

### DIFF
--- a/tests/gnmi/blackhole_congestion_counters_without_ixia_test.h
+++ b/tests/gnmi/blackhole_congestion_counters_without_ixia_test.h
@@ -37,6 +37,14 @@ struct LpmMissCounters {
   uint64_t switch_blackhole_events;
 };
 
+struct OutDiscardCounters {
+  uint64_t port_out_packets;
+  uint64_t port_out_discard_packets;
+  uint64_t port_blackhole_out_discard_events;
+  uint64_t switch_blackhole_out_discard_events;
+  uint64_t switch_blackhole_events;
+};
+
 class BlackholeCongestionCountersWithoutIxiaTestFixture
     : public thinkit::GenericTestbedFixture<> {
  protected:
@@ -45,6 +53,8 @@ class BlackholeCongestionCountersWithoutIxiaTestFixture
   absl::StatusOr<LpmMissCounters> TriggerLpmMisses(
       sai::IpVersion ip_version, uint32_t lpm_miss_packets_count,
       uint32_t lpm_hit_packets_count);
+  absl::StatusOr<OutDiscardCounters> TriggerOutDiscards(
+      uint32_t out_discards_count, uint32_t out_packets_count);
   std::unique_ptr<thinkit::GenericTestbed> generic_testbed_;
   std::unique_ptr<gnmi::gNMI::StubInterface> gnmi_stub_;
   std::vector<InterfaceLink> control_links_;


### PR DESCRIPTION
Keyword Check:
/tests_sonic-pins/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.

Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 755 targets (0 packages loaded, 0 targets configured).
INFO: Found 755 targets...
INFO: Elapsed time: 31.156s, Critical Path: 30.31s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions


Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 755 targets (0 packages loaded, 0 targets configured).
INFO: Found 526 targets and 229 test targets...
INFO: Elapsed time: 254.455s, Critical Path: 147.98s
INFO: 286 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 286 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.1s
//dvaas:dataplane_validation_test                                        PASSED in 0.1s
//dvaas:port_id_map_test                                                 PASSED in 1.1s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.2s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 0.9s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 0.8s
//gutil:io_test                                                          PASSED in 0.8s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.2s
//thinkit:bazel_test_environment_test                                    PASSED in 0.8s
//thinkit:generic_testbed_test                                           PASSED in 1.3s
//thinkit:mock_control_device_test                                       PASSED in 0.8s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.0s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.9s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.0s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.0s
//tests/lib:packet_generator_test                                        PASSED in 66.1s
  Stats over 4 runs: max = 66.1s, min = 63.8s, avg = 65.4s, dev = 0.9s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.3s
  Stats over 5 runs: max = 1.3s, min = 1.1s, avg = 1.1s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 48.2s
  Stats over 50 runs: max = 48.2s, min = 1.1s, avg = 5.1s, dev = 12.4s

Executed 229 out of 229 tests: 229 tests pass.