### PR TITLE
[Comb] Add auxiliary entries for v1model_auxiliary_vlan_membership_table given switch table entries.

### DIFF
--- a/sai_p4/tools/BUILD.bazel
+++ b/sai_p4/tools/BUILD.bazel
@@ -54,7 +54,6 @@ cc_library(
     deps = [
         "//lib/gnmi:gnmi_helper",
         "//p4_pdpi:ir_cc_proto",
-        "//p4_pdpi:p4_runtime_session",
         "//sai_p4/fixed:p4_ids",
         "//sai_p4/instantiations/google:sai_pd_cc_proto",
         "@com_github_gnmi//proto/gnmi:gnmi_cc_grpc_proto",
@@ -62,6 +61,8 @@ cc_library(
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+	"@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
     ],
 )
 

--- a/sai_p4/tools/auxiliary_entries_for_v1model_targets.cc
+++ b/sai_p4/tools/auxiliary_entries_for_v1model_targets.cc
@@ -14,10 +14,14 @@
 
 #include "sai_p4/tools/auxiliary_entries_for_v1model_targets.h"
 
+#include <optional>
 #include <string>
 
 #include "absl/container/btree_set.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
 #include "gutil/status.h"
 #include "lib/gnmi/gnmi_helper.h"
 #include "p4/v1/p4runtime.pb.h"
@@ -42,30 +46,87 @@ p4::v1::Entity MakeV1modelPacketReplicationEngineEntryRequiredForPunts() {
   return entity;
 }
 
-absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryTableEntries(
-    gnmi::gNMI::StubInterface& gnmi_stub, pdpi::IrP4Info ir_p4info) {
-  // Get the loopback mode map from the gNMI stub
+absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
+    pdpi::IrEntities ir_entities, gnmi::gNMI::StubInterface& gnmi_stub,
+    pdpi::IrP4Info ir_p4info) {
+  // Get the loopback mode map from the gNMI stub.
   absl::btree_set<std::string> loopback_mode_port_set;
   ASSIGN_OR_RETURN(
       loopback_mode_port_set,
       pins_test::GetP4rtIdOfInterfacesInAsicMacLocalLoopbackMode(gnmi_stub));
 
-  // Create IrEntities by using the gNMI loopback mode map to fill the loopback
-  // table entries.
-  pdpi::IrEntities ir_entities;
+  // For each port configured to be in loopback mode in gNMI, add an entry to
+  // the loopback table.
+  pdpi::IrEntities auxiliary_ir_entities;
   for (const auto& loopback_mode_port : loopback_mode_port_set) {
-    pdpi::IrEntity* ir_entity = ir_entities.add_entities();
-    ir_entity->mutable_table_entry()->set_table_name(
+    pdpi::IrEntity& aux_ir_entity = *auxiliary_ir_entities.add_entities();
+    aux_ir_entity.mutable_table_entry()->set_table_name(
         "egress_port_loopback_table");
-    pdpi::IrMatch* match =
-        ir_entity->mutable_table_entry()->mutable_matches()->Add();
-    match->set_name("out_port");
-    match->mutable_exact()->set_str(loopback_mode_port);
-    ir_entity->mutable_table_entry()->mutable_action()->set_name(
+    pdpi::IrMatch& match =
+        *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
+    match.set_name("out_port");
+    match.mutable_exact()->set_str(loopback_mode_port);
+    aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
         "egress_loopback");
   }
 
-  return ir_entities;
+  // For each entry in VLAN membership table, create an entry for v1model
+  // auxiliary VLAN membership table.
+  for (const auto& ir_entity : ir_entities.entities()) {
+    if (ir_entity.table_entry().table_name() != "vlan_membership_table") {
+      continue;
+    }
+
+    std::optional<absl::string_view> vlan_id;
+    std::optional<absl::string_view> port;
+    for (const auto& match : ir_entity.table_entry().matches()) {
+      if (match.name() == "vlan_id") {
+        vlan_id = match.exact().hex_str();
+      } else if (match.name() == "port") {
+        port = match.exact().str();
+      } else {
+        return absl::FailedPreconditionError(absl::StrCat(
+            "Unexpected match '", match.name(),
+            "' in vlan_membership_table, got ", ir_entity.ShortDebugString()));
+      }
+    }
+    if (!vlan_id.has_value()) {
+      return absl::FailedPreconditionError(
+          absl::StrCat("Expected match on field `vlan_id` in "
+                       "vlan_membership_table_entry, but got ",
+                       ir_entity.table_entry().ShortDebugString()));
+    }
+    if (!port.has_value()) {
+      return absl::FailedPreconditionError(
+          absl::StrCat("Expected match on field `port` in "
+                       "vlan_membership_table_entry, but got ",
+                       ir_entity.table_entry().ShortDebugString()));
+    }
+
+    pdpi::IrEntity& aux_ir_entity = *auxiliary_ir_entities.add_entities();
+    aux_ir_entity.mutable_table_entry()->set_table_name(
+        "v1model_auxiliary_vlan_membership_table");
+    pdpi::IrMatch& vlan_match =
+        *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
+    vlan_match.set_name("vlan_id");
+    vlan_match.mutable_exact()->set_hex_str(*vlan_id);
+    pdpi::IrMatch& port_match =
+        *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
+    port_match.set_name("port");
+    port_match.mutable_exact()->set_str(*port);
+    if (ir_entity.table_entry().action().name() == "make_tagged_member") {
+      aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
+          "v1model_auxiliary_make_tagged_member");
+    } else if (ir_entity.table_entry().action().name() ==
+               "make_untagged_member") {
+      aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
+          "v1model_auxiliary_make_untagged_member");
+    } else {
+      return absl::InternalError("Unsupported action in vlan_membership_table");
+    }
+  }
+
+  return auxiliary_ir_entities;
 }
 
 }  // namespace sai

--- a/sai_p4/tools/auxiliary_entries_for_v1model_targets.h
+++ b/sai_p4/tools/auxiliary_entries_for_v1model_targets.h
@@ -24,7 +24,8 @@
 
 #include "absl/status/statusor.h"
 #include "p4/v1/p4runtime.pb.h"
-#include "p4_pdpi/p4_runtime_session.h"
+#include "p4_pdpi/ir.pb.h"
+#include "proto/gnmi/gnmi.grpc.pb.h"
 
 namespace sai {
 
@@ -36,11 +37,13 @@ namespace sai {
 // Not required by PINS targets, since PINS has this config built-in.
 p4::v1::Entity MakeV1modelPacketReplicationEngineEntryRequiredForPunts();
 
-// Creates entries for v1Model auxiliary tables that model the effects of the
-// given gNMI configuration in on packet forwarding (e.g. port loopback mode).
-absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryTableEntries(
-    gnmi::gNMI::StubInterface& gnmi_stub, pdpi::IrP4Info ir_p4info);
+// Creates entities for v1Model auxiliary tables that model the effects of the
+// given entities (e.g. VLAN membership) and gNMI configuration (e.g. port
+// loopback mode).
+absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
+    pdpi::IrEntities ir_entities, gnmi::gNMI::StubInterface& gnmi_stub,
+    pdpi::IrP4Info ir_p4info);
 
 }  // namespace sai
 
-#endif // PINS_SAI_P4_TOOLS_AUXILIARY_ENTRIES_FOR_V1MODEL_TARGETS_H_
+#endif  // PINS_SAI_P4_TOOLS_AUXILIARY_ENTRIES_FOR_V1MODEL_TARGETS_H_

--- a/sai_p4/tools/auxiliary_entries_for_v1model_targets_test.cc
+++ b/sai_p4/tools/auxiliary_entries_for_v1model_targets_test.cc
@@ -18,7 +18,7 @@ using testing::DoAll;
 using testing::Return;
 using testing::SetArgPointee;
 
-TEST(AuxilaryEntriesForV1ModelTarget, V1ModelAuxTableEntries) {
+TEST(AuxiliaryIrEntitiesForV1ModelTarget, GenerateAuxiliaryLoopbackEntities) {
   gnmi::GetResponse response;
   *response.add_notification()
        ->add_update()
@@ -29,21 +29,21 @@ TEST(AuxilaryEntriesForV1ModelTarget, V1ModelAuxTableEntries) {
         "interface": [
           {
             "name":"EthernetEnabled0",
-             "state":{
+            "state":{
               "loopback-mode":"ASIC_MAC_LOCAL",
               "openconfig-p4rt:id": 2
             }
           },
           {
             "name":"EthernetEnabled1",
-             "state":{
+            "state":{
               "loopback-mode":"NOT_ASIC_MAC_LOCAL",
               "openconfig-p4rt:id": 4
             }
           },
           {
             "name":"EthernetEnabled2",
-             "state":{
+            "state":{
               "loopback-mode":"ASIC_MAC_LOCAL",
               "openconfig-p4rt:id": 5
             }
@@ -95,11 +95,13 @@ TEST(AuxilaryEntriesForV1ModelTarget, V1ModelAuxTableEntries) {
           DoAll(SetArgPointee<2>(response), Return(grpc::Status::OK)));
 
   pdpi::IrP4Info ir_p4info = sai::GetIrP4Info(sai::Instantiation::kTor);
+  pdpi::IrEntities ir_entities;
 
-  ASSERT_OK_AND_ASSIGN(
-      pdpi::IrEntities entities,
-      sai::CreateV1ModelAuxiliaryTableEntries(mock_gnmi_stub, ir_p4info));
-  EXPECT_THAT(entities, gutil::EqualsProto(expected_entities));
+  ASSERT_OK_AND_ASSIGN(pdpi::IrEntities auxiliary_ir_entities,
+                       sai::CreateV1ModelAuxiliaryEntities(
+                           ir_entities, mock_gnmi_stub, ir_p4info));
+  EXPECT_THAT(auxiliary_ir_entities, gutil::EqualsProto(expected_entities));
 }
 
 }  // namespace
+


### PR DESCRIPTION
### **PR Description:**
Add auxiliary entries for v1model_auxiliary_vlan_membership_table given switch table entries.

### **Keyword Check:**
bibhuprasad@bibhuprasad87:~/sonic_build_image_2025-06-23/sonic-buildimage/src/sonic-p4rt/sonic-pins/sai_p4$ sh ~/keyword_check.sh .
Keyword check Passed.

### **Build Results:**
bibhuprasad@0c2403497cee:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 756 targets (0 packages loaded, 0 targets configured).
INFO: Found 756 targets...
INFO: Elapsed time: 0.468s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### **UT Results:**
bibhuprasad@8b3c841bfe91:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 754 targets (0 packages loaded, 0 targets configured).
INFO: Found 525 targets and 229 test targets...
INFO: Elapsed time: 199.505s, Critical Path: 142.63s
INFO: 287 processes: 341 linux-sandbox, 18 local.
INFO: Build completed successfully, 287 total actions
//dvaas:dataplane_validation_diff_test PASSED in 0.1s
//dvaas:dataplane_validation_test PASSED in 0.1s
//dvaas:port_id_map_test PASSED in 2.1s
//dvaas:test_run_validation_golden_test PASSED in 0.1s
//dvaas:test_run_validation_test PASSED in 2.1s
//dvaas:test_run_validation_test_runner PASSED in 0.1s
//dvaas:test_vector_stats_diff_test PASSED in 0.1s
//dvaas:test_vector_stats_test PASSED in 0.1s
//dvaas:test_vector_test PASSED in 1.6s
//dvaas:user_provided_packet_test_vector_diff_test PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test PASSED in 0.2s
//gutil:collections_test PASSED in 1.6s
//gutil:io_test PASSED in 1.1s
//gutil:proto_matchers_test PASSED in 1.2s
//gutil:proto_ordering_test PASSED in 1.4s
//gutil:proto_test PASSED in 1.6s
//gutil:status_matchers_test PASSED in 1.4s
//gutil:test_artifact_writer_test PASSED in 1.9s
//gutil:testing_test PASSED in 1.5s
//gutil:timer_test PASSED in 5.1s
//gutil:version_test PASSED in 4.8s
//lib:basic_switch_test PASSED in 2.2s
//lib:ixia_helper_test PASSED in 2.9s
//lib/basic_traffic:basic_p4rt_util_test PASSED in 2.5s
//lib/basic_traffic:basic_traffic_test PASSED in 17.2s
//lib/gnmi:gnmi_helper_test PASSED in 4.2s
//lib/gnoi:gnoi_helper_test PASSED in 1.7s
//lib/p4rt:p4rt_port_test PASSED in 1.2s
//lib/p4rt:p4rt_programming_context_test PASSED in 2.6s
//lib/utils:generic_testbed_utils_test PASSED in 3.4s
//lib/utils:json_utils_test PASSED in 1.4s
//lib/validator:validator_backend_test PASSED in 1.7s
//lib/validator:validator_lib_test PASSED in 27.1s
//p4_fuzzer:constraints_test PASSED in 10.7s
//p4_fuzzer:fuzz_util_test PASSED in 142.5s
//p4_fuzzer:fuzzer_config_test PASSED in 2.3s
//p4_fuzzer:oracle_util_test PASSED in 5.0s
//p4_fuzzer:switch_state_assert_entry_equality_test PASSED in 4.1s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner PASSED in 4.2s
//p4_fuzzer:switch_state_test PASSED in 2.6s
//p4_pdpi:built_ins_test PASSED in 1.3s
//p4_pdpi:entity_keys_test PASSED in 1.3s
//p4_pdpi:ir_properties_test PASSED in 1.8s
//p4_pdpi:ir_to_ir_test PASSED in 2.0s
//p4_pdpi:ir_tools_test PASSED in 1.5s
//p4_pdpi:names_test PASSED in 2.2s
//p4_pdpi:p4_runtime_matchers_test PASSED in 1.7s
//p4_pdpi:p4info_union_test PASSED in 1.8s
//p4_pdpi:reference_annotations_test PASSED in 2.1s
//p4_pdpi:references_test PASSED in 1.7s
//p4_pdpi:sequencing_util_test PASSED in 1.5s
//p4_pdpi:ternary_test PASSED in 1.4s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test PASSED in 1.7s
//p4_pdpi/netaddr:ipv6_address_test PASSED in 1.0s
//p4_pdpi/netaddr:mac_address_test PASSED in 1.2s
//p4_pdpi/packetlib:packetlib_debugging_test PASSED in 1.4s
//p4_pdpi/packetlib:packetlib_fuzzer_test PASSED in 22.2s
//p4_pdpi/packetlib:packetlib_matchers_test PASSED in 1.6s
//p4_pdpi/packetlib:packetlib_test PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test PASSED in 7.2s
//p4_pdpi/string_encodings:bit_string_test PASSED in 1.7s
//p4_pdpi/string_encodings:byte_string_test PASSED in 1.5s
//p4_pdpi/string_encodings:decimal_string_test PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test_runner PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test PASSED in 1.5s
//p4_pdpi/testing:helper_function_test PASSED in 2.0s
//p4_pdpi/testing:info_test PASSED in 0.3s
//p4_pdpi/testing:info_test_runner PASSED in 0.3s
//p4_pdpi/testing:main_pd_test PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test PASSED in 2.0s
//p4_pdpi/testing:packet_io_test PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner PASSED in 0.2s
//p4_pdpi/testing:references_test PASSED in 0.2s
//p4_pdpi/testing:references_test_runner PASSED in 0.2s
//p4_pdpi/testing:rpc_test PASSED in 0.3s
//p4_pdpi/testing:rpc_test_runner PASSED in 0.2s
//p4_pdpi/testing:sequencing_test PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test_runner PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test PASSED in 2.3s
//p4_pdpi/testing:table_entry_test PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner PASSED in 0.3s
//p4_pdpi/utils:annotation_parser_test PASSED in 1.6s
//p4_pdpi/utils:ir_test PASSED in 1.4s
//p4_symbolic:z3_util_test PASSED in 1.7s
//p4_symbolic/bmv2:ipv4_routing_exact_test PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test PASSED in 2.7s
//p4_symbolic/bmv2:port_hardcoded_exact_test PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test PASSED in 3.4s
//p4_symbolic/bmv2:port_table_exact_test PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test PASSED in 4.1s
//p4_symbolic/bmv2:reflector_exact_test PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test PASSED in 3.8s
//p4_symbolic/bmv2:set_invalid_exact_test PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test PASSED in 3.0s
//p4_symbolic/bmv2:table_hit_1_exact_test PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_1_subset_test PASSED in 4.4s
//p4_symbolic/bmv2:table_hit_2_exact_test PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_2_subset_test PASSED in 4.3s
//p4_symbolic/ir:cfg_test PASSED in 1.7s
//p4_symbolic/ir:complex_conditional_test PASSED in 0.2s
//p4_symbolic/ir:conditional_sequence_test PASSED in 0.1s
//p4_symbolic/ir:conditional_test PASSED in 0.1s
//p4_symbolic/ir:default_transition_test PASSED in 0.1s
//p4_symbolic/ir:extract_parser_operation_test PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test PASSED in 0.3s
//p4_symbolic/ir:hex_string_transition_test PASSED in 0.3s
//p4_symbolic/ir:ipv4_routing_test PASSED in 0.2s
//p4_symbolic/ir:partial_icmp_test PASSED in 0.2s
//p4_symbolic/ir:port_hardcoded_test PASSED in 0.2s
//p4_symbolic/ir:port_table_test PASSED in 0.2s
//p4_symbolic/ir:primitive_parser_operation_test PASSED in 0.2s
//p4_symbolic/ir:reflector_test PASSED in 0.2s
//p4_symbolic/ir:sai_parser_test PASSED in 0.2s
//p4_symbolic/ir:set_invalid_test PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test PASSED in 0.1s
//p4_symbolic/ir:string_optional_test PASSED in 0.2s
//p4_symbolic/ir:table_hit_1_test PASSED in 0.2s
//p4_symbolic/ir:table_hit_2_test PASSED in 0.2s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test PASSED in 1.3s
//p4_symbolic/sai:criteria_generator_test PASSED in 35.2s
//p4_symbolic/sai:packet_synthesizer_test PASSED in 36.4s
//p4_symbolic/sai:sai_test PASSED in 8.6s
//p4_symbolic/symbolic:conditional_sequence_test_packets PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets PASSED in 0.2s
//p4_symbolic/symbolic:deparser_test PASSED in 4.0s
//p4_symbolic/symbolic:parser_test PASSED in 2.7s
//p4_symbolic/symbolic:port_hardcoded_test_packets PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test PASSED in 2.6s
//p4_symbolic/symbolic:util_test PASSED in 2.1s
//p4_symbolic/symbolic:values_test PASSED in 1.7s
//p4_symbolic/tests:sai_p4_integration_test PASSED in 20.4s
//p4_symbolic/tests:symbolic_table_entries_test PASSED in 3.7s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test PASSED in 2.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 3.1s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test PASSED in 2.2s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test PASSED in 3.1s
//p4rt_app/event_monitoring:config_db_port_table_event_test PASSED in 2.6s
//p4rt_app/event_monitoring:debug_data_dump_events_test PASSED in 2.4s
//p4rt_app/event_monitoring:state_verification_events_test PASSED in 2.8s
//p4rt_app/p4runtime:cpu_queue_translator_test PASSED in 1.3s
//p4rt_app/p4runtime:ir_translation_test PASSED in 2.9s
//p4rt_app/p4runtime:p4info_reconcile_test PASSED in 1.8s
//p4rt_app/p4runtime:p4info_verification_schema_test PASSED in 2.4s
//p4rt_app/p4runtime:p4info_verification_test PASSED in 2.8s
//p4rt_app/p4runtime:packetio_helpers_test PASSED in 3.4s
//p4rt_app/p4runtime:resource_utilization_test PASSED in 2.4s
//p4rt_app/sonic:app_db_acl_def_table_manager_test PASSED in 2.1s
//p4rt_app/sonic:app_db_manager_test PASSED in 2.3s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test PASSED in 2.3s
//p4rt_app/sonic:hashing_test PASSED in 1.9s
//p4rt_app/sonic:packet_replication_entry_translation_test PASSED in 1.9s
//p4rt_app/sonic:packetio_impl_test PASSED in 1.4s
//p4rt_app/sonic:packetio_port_test PASSED in 1.5s
//p4rt_app/sonic:response_handler_test PASSED in 1.9s
//p4rt_app/sonic:state_verification_test PASSED in 1.7s
//p4rt_app/sonic:swss_utils_test PASSED in 1.7s
//p4rt_app/sonic:vlan_entry_translation_test PASSED in 2.0s
//p4rt_app/sonic:vrf_entry_translation_test PASSED in 2.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test PASSED in 0.9s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test PASSED in 0.1s
//p4rt_app/tests:acl_table_test PASSED in 2.1s
//p4rt_app/tests:action_set_test PASSED in 1.6s
//p4rt_app/tests:api_access_test PASSED in 1.3s
//p4rt_app/tests:arbitration_test PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test PASSED in 2.6s
//p4rt_app/tests:debug_data_dump_test PASSED in 1.5s
//p4rt_app/tests:fixed_l3_tables_test PASSED in 4.4s
//p4rt_app/tests:forwarding_pipeline_config_test PASSED in 8.9s
//p4rt_app/tests:grpc_behavior_test PASSED in 5.6s
//p4rt_app/tests:p4_constraints_test PASSED in 1.0s
//p4rt_app/tests:p4_constraints_test_runner PASSED in 0.5s
//p4rt_app/tests:p4_programs_test PASSED in 2.4s
//p4rt_app/tests:packet_replication_table_test PASSED in 2.7s
//p4rt_app/tests:packetio_test PASSED in 4.6s
//p4rt_app/tests:port_name_and_id_test PASSED in 4.2s
//p4rt_app/tests:resource_limits_test PASSED in 5.0s
//p4rt_app/tests:response_path_test PASSED in 5.2s
//p4rt_app/tests:role_test PASSED in 1.7s
//p4rt_app/tests:state_verification_test PASSED in 3.0s
//p4rt_app/tests:vrf_table_test PASSED in 2.4s
//p4rt_app/tests/lib:app_db_entry_builder_test PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test PASSED in 0.1s
//p4rt_app/utils:table_utility_test PASSED in 1.8s
//sai_p4/instantiations/google:clos_stage_test PASSED in 1.4s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test PASSED in 1.2s
//sai_p4/instantiations/google:sai_p4info_fetcher_test PASSED in 1.8s
//sai_p4/instantiations/google:sai_p4info_test PASSED in 2.6s
//sai_p4/instantiations/google:sai_pd_proto_test PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test PASSED in 1.7s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test PASSED in 0.3s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 5.0s
//sai_p4/instantiations/google/test_tools:test_entries_test PASSED in 3.5s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test PASSED in 7.4s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test PASSED in 1.2s
//sai_p4/tools:p4info_tools_test PASSED in 1.7s
//sai_p4/tools:packetio_tools_test PASSED in 2.4s
//tests:thinkit_gnmi_interface_util_tests PASSED in 3.1s
//tests/forwarding:hash_statistics_util_test PASSED in 2.1s
//tests/lib:common_ir_table_entries_test PASSED in 2.2s
//tests/lib:p4rt_fixed_table_programming_helper_test PASSED in 2.4s
//tests/lib:switch_test_setup_helpers_golden_test PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner PASSED in 0.2s
//tests/qos:gnmi_parsers_test PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner PASSED in 0.1s
//tests/sflow:sflow_util_test PASSED in 8.1s
//thinkit:bazel_test_environment_test PASSED in 1.2s
//thinkit:generic_testbed_test PASSED in 2.1s
//thinkit:mock_control_device_test PASSED in 1.3s
//thinkit:mock_generic_testbed_test PASSED in 1.8s
//thinkit:mock_mirror_testbed_test PASSED in 1.4s
//thinkit:mock_ssh_client_test PASSED in 0.1s
//thinkit:mock_switch_test PASSED in 2.0s
//thinkit:mock_test_environment_test PASSED in 0.2s
//thinkit:switch_test PASSED in 1.8s
//tests/lib:packet_generator_test PASSED in 63.6s
Stats over 4 runs: max = 63.6s, min = 62.4s, avg = 62.9s, dev = 0.5s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test PASSED in 2.3s
Stats over 5 runs: max = 2.3s, min = 1.5s, avg = 1.8s, dev = 0.3s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test PASSED in 45.4s
Stats over 50 runs: max = 45.4s, min = 1.3s, avg = 6.5s, dev = 12.9s

Executed 229 out of 229 tests: 229 tests pass.