### PR TITLE
[Thinkit/tests] Adding Helper function to build a Ipv4 in Ipv6 packet

### DIFF
--- a/tests/forwarding/tunnel_decap_test.cc
+++ b/tests/forwarding/tunnel_decap_test.cc
@@ -260,6 +260,98 @@ dvaas::PacketTestVector Ipv4InIpv6DecapTestVector(
   return test_vector;
 }
 
+// Helper function to build a Ipv4 in Ipv6 packet
+dvaas::PacketTestVector Ipv4InIpv6NoDecapTestVector(
+    const TunnelDecapTestVectorParams &packet_vector_param) {
+  ProtoFixtureRepository repo;
+
+  repo.RegisterValue("@payload", dvaas::MakeTestPacketTagFromUniqueId(1) +
+                                     "Testing IPv4-in-Ipv6 packets")
+      .RegisterValue("@ingress_port", packet_vector_param.in_port)
+      .RegisterValue("@egress_port", packet_vector_param.out_port)
+      .RegisterValue("@dst_ip", packet_vector_param.inner_dst_ipv4.ToString())
+      .RegisterValue("@dst_ipv6", packet_vector_param.dst_ipv6.ToString())
+      .RegisterValue("@dst_mac", packet_vector_param.dst_mac.ToString())
+      .RegisterValue("@ttl", "0x10")
+      .RegisterValue("@decremented_hop", "0x41");
+
+  dvaas::PacketTestVector test_vector =
+      repo.RegisterSnippetOrDie<packetlib::Header>("@ethernet", R"pb(
+            ethernet_header {
+              ethernet_destination: @dst_mac,
+              ethernet_source: "00:00:22:22:00:00"
+              ethertype: "0x86dd"  # Udp
+            }
+          )pb")
+          .RegisterSnippetOrDie<packetlib::Header>("@ipv6", R"pb(
+            ipv6_header {
+              version: "0x6"
+              dscp: "0x1b"
+              ecn: "0x1"
+              flow_label: "0x12345"
+              # payload_length: filled in automatically.
+              next_header: "0x04"  # next is ipv4
+              hop_limit: 0x42
+              ipv6_source: "1122:1122:3344:3344:5566:5566:7788:7788"
+              ipv6_destination: @dst_ipv6
+            }
+          )pb")
+          .RegisterSnippetOrDie<packetlib::Header>("@ipv4", R"pb(
+            ipv4_header {
+              version: "0x4"
+              dscp: "0x1b"
+              ecn: "0x1"
+              ihl: "0x5"
+              identification: "0x0000"
+              flags: "0x0"
+              ttl: @ttl
+              fragment_offset: "0x0000"
+              # payload_length: filled in automatically.
+              protocol: "0x11"
+              ipv4_source: "10.0.0.8"
+              ipv4_destination: @dst_ip
+            }
+          )pb")
+          .RegisterSnippetOrDie<packetlib::Header>("@udp", R"pb(
+            udp_header { source_port: "0x0014" destination_port: "0x000a" }
+          )pb")
+          .RegisterMessage("@input_packet",
+                           ParsePacketAndFillInComputedFields(repo,
+                                                              R"pb(
+                                                  headers: @ethernet
+                                                  headers: @ipv6
+                                                  headers: @ipv4
+                                                  headers: @udp
+                                                  payload: @payload
+                                                )pb"))
+          .RegisterMessage("@output_packet",
+                           ParsePacketAndFillInComputedFields(repo, R"pb(
+                headers: @ethernet {
+                  ethernet_header {
+                    ethernet_destination: "02:02:02:02:02:02"
+                    ethernet_source: "06:05:04:03:02:01"
+                    ethertype: "0x86dd"
+                  }
+                }
+                headers: @ipv6 { ipv6_header { hop_limit: @decremented_hop } }
+                # As the packet is not decapped, inner packet is not changed
+                headers: @ipv4 {}
+                headers: @udp
+                payload: @payload
+              )pb"))
+          .ParseTextOrDie<dvaas::PacketTestVector>(R"pb(
+            input {
+              type: DATAPLANE
+              packet { port: @ingress_port parsed: @input_packet }
+            }
+            acceptable_outputs {
+              packets { port: @egress_port parsed: @output_packet }
+            }
+          )pb");
+
+  return test_vector;
+}
+
 // Helper routine to install L3 route
 absl::StatusOr<std::vector<p4::v1::Entity>> InstallTunnelTermTable(
     pdpi::P4RuntimeSession& switch_session, pdpi::IrP4Info& ir_p4info,


### PR DESCRIPTION
Keyword Check:
/tests_sonic-pins/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.

Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 755 targets (0 packages loaded, 0 targets configured).
INFO: Found 755 targets...
INFO: Elapsed time: 31.156s, Critical Path: 30.31s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions

Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 755 targets (0 packages loaded, 0 targets configured).
INFO: Found 526 targets and 229 test targets...
INFO: Elapsed time: 254.455s, Critical Path: 147.98s
INFO: 286 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 286 total actions
//dvaas:dataplane_validation_diff_test PASSED in 0.1s
//dvaas:dataplane_validation_test PASSED in 0.1s
//dvaas:port_id_map_test PASSED in 1.1s
//dvaas:test_run_validation_golden_test PASSED in 0.1s
//dvaas:test_run_validation_test PASSED in 1.2s
//dvaas:test_run_validation_test_runner PASSED in 0.1s
//dvaas:test_vector_stats_diff_test PASSED in 0.1s
//dvaas:test_vector_stats_test PASSED in 0.1s
//dvaas:test_vector_test PASSED in 0.9s
//dvaas:user_provided_packet_test_vector_diff_test PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test PASSED in 0.1s
//gutil:collections_test PASSED in 0.8s
//gutil:io_test PASSED in 0.8s
//tests/qos:gnmi_parsers_test_runner PASSED in 0.1s
//tests/sflow:sflow_util_test PASSED in 7.2s
//thinkit:bazel_test_environment_test PASSED in 0.8s
//thinkit:generic_testbed_test PASSED in 1.3s
//thinkit:mock_control_device_test PASSED in 0.8s
//thinkit:mock_generic_testbed_test PASSED in 1.0s
//thinkit:mock_mirror_testbed_test PASSED in 0.9s
//thinkit:mock_ssh_client_test PASSED in 0.1s
//thinkit:mock_switch_test PASSED in 1.0s
//thinkit:mock_test_environment_test PASSED in 0.1s
//thinkit:switch_test PASSED in 1.0s
//tests/lib:packet_generator_test PASSED in 66.1s
Stats over 4 runs: max = 66.1s, min = 63.8s, avg = 65.4s, dev = 0.9s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test PASSED in 1.3s
Stats over 5 runs: max = 1.3s, min = 1.1s, avg = 1.1s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test PASSED in 48.2s
Stats over 50 runs: max = 48.2s, min = 1.1s, avg = 5.1s, dev = 12.4s

Executed 229 out of 229 tests: 229 tests pass.