### PR TITLE
[Comb] fixing cc_proto_library from otg build for packet synthesizer.

### DIFF
--- a/bazel/BUILD.otg-models.bazel
+++ b/bazel/BUILD.otg-models.bazel
@@ -1,4 +1,5 @@
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/dvaas/BUILD.bazel
+++ b/dvaas/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test")
 
 package(

--- a/dvaas/thinkit_tests/BUILD.bazel
+++ b/dvaas/thinkit_tests/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/gutil/BUILD.bazel
+++ b/gutil/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/lib/gnmi/BUILD.bazel
+++ b/lib/gnmi/BUILD.bazel
@@ -14,6 +14,7 @@
 #
 # PINS test functions that can be run on any infrastructure that supports ThinKit.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/p4_fuzzer/BUILD.bazel
+++ b/p4_fuzzer/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test")
 
 package(

--- a/p4_pdpi/BUILD.bazel
+++ b/p4_pdpi/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/p4_pdpi/ir.proto
+++ b/p4_pdpi/ir.proto
@@ -99,7 +99,7 @@ message IrP4ActionField {
 // representation to be used within annotations.
 enum IrBuiltInAction {
   BUILT_IN_ACTION_UNSPECIFIED = 0;
-  // Corresponds to p4::v1::Replica.
+  // Corresponds to p4::v1::Replica and p4::v1::BackupReplica.
   // String representation in annotations: "builtin::replica"
   BUILT_IN_ACTION_REPLICA = 1;
 }
@@ -109,10 +109,11 @@ enum IrBuiltInAction {
 // representation to be used within `@refers_to`/`@referenced_by` annotations.
 enum IrBuiltInParameter {
   BUILT_IN_PARAMETER_UNSPECIFIED = 0;
-  // Corresponds to p4::v1::Replica::port.
+  // Corresponds to p4::v1::Replica::port and p4::v1::BackupReplica::port.
   // String representation in annotations: "replica.port"
   BUILT_IN_PARAMETER_REPLICA_PORT = 1;
-  // Corresponds to p4::v1::Replica::instance.
+  // Corresponds to p4::v1::Replica::instance and
+  // p4::v1::BackupReplica::instance.
   // String representation in annotations: "replica.instance"
   BUILT_IN_PARAMETER_REPLICA_INSTANCE = 2;
 }

--- a/p4_pdpi/packetlib/BUILD.bazel
+++ b/p4_pdpi/packetlib/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test")
 
 package(

--- a/p4_pdpi/packetlib/packetlib.cc
+++ b/p4_pdpi/packetlib/packetlib.cc
@@ -3121,6 +3121,10 @@ std::string EtherType(uint32_t ether_type) {
   return ValidateAndConvertToHexString<kEthernetEthertypeBitwidth>(ether_type);
 }
 
+std::string VlanId(uint32_t vlan_id) {
+  return ValidateAndConvertToHexString<kVlanVlanIdentifierBitwidth>(vlan_id);
+}
+
 std::string IpVersion(uint32_t version) {
   return ValidateAndConvertToHexString<kIpVersionBitwidth>(version);
 }

--- a/p4_pdpi/packetlib/packetlib.cc
+++ b/p4_pdpi/packetlib/packetlib.cc
@@ -3072,8 +3072,13 @@ absl::StatusOr<int> IcmpHeaderChecksum(Packet packet, int icmp_header_index) {
                        PacketSizeInBytes(packet, icmp_header_index));
       data.AppendBits<32>(icmpv6_size);
       data.AppendBits<24>(0);
-      RETURN_IF_ERROR(
-          SerializeBits<kIpNextHeaderBitwidth>(header.next_header(), data));
+      // The `next_header` field for a ICMP header identifies the upper-layer
+      // protocol. It differs from the typical `next_header` field in an IPv6
+      // header when there are IPV6 extension headers. See
+      // https://datatracker.ietf.org/doc/html/rfc2463#section-2.3, which
+      // specifies that the `next_header` field for a ICMP header must be 58
+      // (0x3a).
+      RETURN_IF_ERROR(SerializeBits<kIpNextHeaderBitwidth>("0x3a", data));
       break;
     }
     case Header::kIpv4Header: {

--- a/p4_pdpi/packetlib/packetlib.h
+++ b/p4_pdpi/packetlib/packetlib.h
@@ -177,6 +177,7 @@ absl::StatusOr<std::string> GetEthernetTrailer(const packetlib::Packet& packet);
 // checks if the input data is truncated because its bit width exceeds the
 // limitation.
 std::string EtherType(uint32_t ether_type);
+std::string VlanId(uint32_t vlan_id);
 std::string IpVersion(uint32_t version);
 std::string IpIhl(uint32_t ihl);
 std::string IpDscp(uint32_t dscp);

--- a/p4_pdpi/references.cc
+++ b/p4_pdpi/references.cc
@@ -430,7 +430,7 @@ OutgoingConcreteTableReferences(const IrTableReference& reference_info,
                 built_in_replica_field_to_match_field_references, replica));
 	for (const auto& backup_replica : replica.backup_replicas()) {
           // Because primary and backup replicas share the same checks, we map
-          // the type Replica to BackupReplica in order to reuse logic.
+	  // the type BackupReplica to Replica in order to reuse logic.
           p4::v1::Replica backup_replica_as_replica;
           backup_replica_as_replica.set_port(backup_replica.port());
           backup_replica_as_replica.set_instance(backup_replica.instance());

--- a/p4_pdpi/references.cc
+++ b/p4_pdpi/references.cc
@@ -428,6 +428,17 @@ OutgoingConcreteTableReferences(const IrTableReference& reference_info,
             action_partial_references.emplace_back(),
             GetPartialReferenceFromReplica(
                 built_in_replica_field_to_match_field_references, replica));
+	for (const auto& backup_replica : replica.backup_replicas()) {
+          // Because primary and backup replicas share the same checks, we map
+          // the type Replica to BackupReplica in order to reuse logic.
+          p4::v1::Replica backup_replica_as_replica;
+          backup_replica_as_replica.set_port(backup_replica.port());
+          backup_replica_as_replica.set_instance(backup_replica.instance());
+          ASSIGN_OR_RETURN(action_partial_references.emplace_back(),
+                           GetPartialReferenceFromReplica(
+                               built_in_replica_field_to_match_field_references,
+                               backup_replica_as_replica));
+        }
       }
       break;
     }

--- a/p4_pdpi/testing/BUILD.bazel
+++ b/p4_pdpi/testing/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 load("//gutil/embed_data:build_defs.bzl", "cc_embed_data")
 load("//p4_pdpi:pdgen.bzl", "p4_pd_proto")
 load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test", "diff_test")

--- a/p4_pdpi/testing/references_test_runner.cc
+++ b/p4_pdpi/testing/references_test_runner.cc
@@ -69,52 +69,6 @@ OutgoingConcreteTableReferencesTestCases() {
              }
            })pb");
 
-  pdpi::TableEntry p4_group_entry_with_multiple_actions =
-      gutil::ParseProtoOrDie<pdpi::TableEntry>(
-          R"pb(golden_test_friendly_wcmp_table_entry {
-                 match { key1: "key-a" key2: "key-b" }
-                 wcmp_actions {
-                   action {
-                     golden_test_friendly_action {
-                       arg1: "act1-arg1"
-                       arg2: "act1-arg2"
-                     }
-                   }
-                   weight: 1
-                 }
-                 wcmp_actions {
-                   action {
-                     golden_test_friendly_action {
-                       arg1: "act2-arg1"
-                       arg2: "act2-arg2"
-                     }
-                   }
-                   weight: 2
-                 }
-                 wcmp_actions {
-                   action {
-                     other_golden_test_friendly_action {
-                       arg1: "act3-arg1"
-                       arg2: "act3-arg2"
-                     }
-                   }
-                   weight: 3
-                 }
-               })pb");
-
-  pdpi::TableEntry built_in_entry_with_multiple_actions =
-      gutil::ParseProtoOrDie<pdpi::TableEntry>(R"pb(
-        multicast_group_table_entry {
-          match { multicast_group_id: "0x0037" }
-          action {
-            replicate {
-              replicas { port: "port_1" instance: "0x0031" }
-              replicas { port: "port_2" instance: "0x0032" }
-            }
-          }
-        }
-      )pb");
-
   // Error test cases.
   test_cases.push_back(ConcreteTableReferenceTestCase{
       .entity = p4_entry,
@@ -335,6 +289,20 @@ OutgoingConcreteTableReferencesTestCases() {
           "P4MatchField-Refers-To-BuiltInMatchField reference creates a "
           "single concrete reference.",
   });
+  
+    pdpi::TableEntry built_in_entry_with_multiple_actions =
+      gutil::ParseProtoOrDie<pdpi::TableEntry>(R"pb(
+        multicast_group_table_entry {
+          match { multicast_group_id: "0x0037" }
+          action {
+            replicate {
+              replicas { port: "port_1" instance: "0x0031" }
+              replicas { port: "port_2" instance: "0x0032" }
+            }
+          }
+        }
+      )pb");
+
   test_cases.push_back(ConcreteTableReferenceTestCase{
       .entity = built_in_entry_with_multiple_actions,
       .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
@@ -379,6 +347,40 @@ OutgoingConcreteTableReferencesTestCases() {
           "BuiltInMatchField-Refers-To-BuiltInMatchField reference creates "
           "a single concrete reference.",
   });
+
+    pdpi::TableEntry p4_group_entry_with_multiple_actions =
+      gutil::ParseProtoOrDie<pdpi::TableEntry>(
+          R"pb(golden_test_friendly_wcmp_table_entry {
+                 match { key1: "key-a" key2: "key-b" }
+                 wcmp_actions {
+                   action {
+                     golden_test_friendly_action {
+                       arg1: "act1-arg1"
+                       arg2: "act1-arg2"
+                     }
+                   }
+                   weight: 1
+                 }
+                 wcmp_actions {
+                   action {
+                     golden_test_friendly_action {
+                       arg1: "act2-arg1"
+                       arg2: "act2-arg2"
+                     }
+                   }
+                   weight: 2
+                 }
+                 wcmp_actions {
+                   action {
+                     other_golden_test_friendly_action {
+                       arg1: "act3-arg1"
+                       arg2: "act3-arg2"
+                     }
+                   }
+                   weight: 3
+                 }
+               })pb");
+
   test_cases.push_back(ConcreteTableReferenceTestCase{
       .entity = p4_group_entry_with_multiple_actions,
       .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
@@ -487,6 +489,77 @@ OutgoingConcreteTableReferencesTestCases() {
       .description =
           "BuiltInActionField-Refers-To-BuiltInMatchField reference creates a "
           "concrete reference for every instance of the action.",
+  });
+
+    pdpi::TableEntry built_in_entry_with_multiple_backup_actions =
+      gutil::ParseProtoOrDie<pdpi::TableEntry>(R"pb(
+        multicast_group_table_entry {
+          match { multicast_group_id: "0x0037" }
+          action {
+            replicate {
+              replicas {
+                port: "port_1"
+                instance: "0x0031"
+                backup_replicas { port: "port_3" instance: "0x0033" }
+                backup_replicas { port: "port_4" instance: "0x0034" }
+              }
+              replicas {
+                port: "port_2"
+                instance: "0x0032"
+                backup_replicas { port: "port_5" instance: "0x0035" }
+              }
+            }
+          }
+        }
+      )pb");
+
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry_with_multiple_backup_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            action_field {
+              built_in_action_field {
+                action: BUILT_IN_ACTION_REPLICA
+                parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+              }
+            }
+          }
+          destination {
+            match_field { p4_match_field { field_name: "other_field" } }
+          }
+        }
+      )pb"),
+      .description =
+          "BuiltInActionField-Refers-To-P4MatchField reference creates a "
+          "concrete reference for every instance of the backup-action.",
+  });
+  test_cases.push_back(ConcreteTableReferenceTestCase{
+      .entity = built_in_entry_with_multiple_backup_actions,
+      .reference_info = gutil::ParseProtoOrDie<IrTableReference>(R"pb(
+        source_table { built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE }
+        destination_table { p4_table { table_name: "other_table" } }
+        field_references {
+          source {
+            action_field {
+              built_in_action_field {
+                action: BUILT_IN_ACTION_REPLICA
+                parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+              }
+            }
+          }
+          destination {
+            match_field {
+              built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+            }
+          }
+        }
+      )pb"),
+      .description =
+          "BuiltInActionField-Refers-To-BuiltInMatchField reference creates a "
+          "concrete reference for every instance of the backup-action.",
   });
 
   // NOTE: For all following test cases, output is similar whether destination

--- a/p4_pdpi/testing/sequencing_test_runner.cc
+++ b/p4_pdpi/testing/sequencing_test_runner.cc
@@ -1487,7 +1487,13 @@ void RunGetEntriesUnreachableFromRootsTests(const pdpi::IrP4Info& info) {
             multicast_group_table_entry {
               match { multicast_group_id: "0x0037" }
               action {
-                replicate { replicas { port: "port_1" instance: "0x0031" } }
+                replicate {
+                  replicas {
+                    port: "port_1"
+                    instance: "0x0031"
+                    backup_replicas { port: "port_2" instance: "0x0032" }
+                  }
+                }
               }
             }
           )pb",
@@ -1495,7 +1501,14 @@ void RunGetEntriesUnreachableFromRootsTests(const pdpi::IrP4Info& info) {
             referenced_by_multicast_replica_table_entry {
               match { port: "port_1" instance: "0x0031" }
               action { do_thing_4 {} }
-              controller_metadata: "Not Garbage"
+              controller_metadata: "Not Garbage because of primary replica"
+            }
+          )pb",
+          R"pb(
+            referenced_by_multicast_replica_table_entry {
+              match { port: "port_2" instance: "0x0032" }
+              action { do_thing_4 {} }
+              controller_metadata: "Not Garbage because of backup replica"
             }
           )pb",
           R"pb(

--- a/p4_pdpi/testing/testdata/references.expected
+++ b/p4_pdpi/testing/testdata/references.expected
@@ -937,6 +937,162 @@ ConcreteTableReference{
 }
 
 =========================================================================
+OutgoingConcreteTableReferences: BuiltInActionField-Refers-To-P4MatchField reference creates a concrete reference for every instance of the backup-action.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port_1"
+        instance: "0x0031"
+        backup_replicas {
+          port: "port_3"
+          instance: "0x0033"
+        }
+        backup_replicas {
+          port: "port_4"
+          instance: "0x0034"
+        }
+      }
+      replicas {
+        port: "port_2"
+        instance: "0x0032"
+        backup_replicas {
+          port: "port_5"
+          instance: "0x0035"
+        }
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    action_field {
+      built_in_action_field {
+        action: BUILT_IN_ACTION_REPLICA
+        parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+      }
+    }
+  }
+  destination {
+    match_field {
+      p4_match_field {
+        field_name: "other_field"
+      }
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'other_field', value: 'port_1' },
+  }
+}
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'other_field', value: 'port_2' },
+  }
+}
+
+=========================================================================
+OutgoingConcreteTableReferences: BuiltInActionField-Refers-To-BuiltInMatchField reference creates a concrete reference for every instance of the backup-action.
+=========================================================================
+-- INPUT --------------------------------------------------------------
+-- PD table entry --
+multicast_group_table_entry {
+  match {
+    multicast_group_id: "0x0037"
+  }
+  action {
+    replicate {
+      replicas {
+        port: "port_1"
+        instance: "0x0031"
+        backup_replicas {
+          port: "port_3"
+          instance: "0x0033"
+        }
+        backup_replicas {
+          port: "port_4"
+          instance: "0x0034"
+        }
+      }
+      replicas {
+        port: "port_2"
+        instance: "0x0032"
+        backup_replicas {
+          port: "port_5"
+          instance: "0x0035"
+        }
+      }
+    }
+  }
+}
+
+-- ReferenceInfo --
+source_table {
+  built_in_table: BUILT_IN_TABLE_MULTICAST_GROUP_TABLE
+}
+destination_table {
+  p4_table {
+    table_name: "other_table"
+  }
+}
+field_references {
+  source {
+    action_field {
+      built_in_action_field {
+        action: BUILT_IN_ACTION_REPLICA
+        parameter: BUILT_IN_PARAMETER_REPLICA_PORT
+      }
+    }
+  }
+  destination {
+    match_field {
+      built_in_match_field: BUILT_IN_MATCH_FIELD_MULTICAST_GROUP_ID
+    }
+  }
+}
+
+-- OUTPUT -------------------------------------------------------------
+-- ReferenceEntries --
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'multicast_group_id', value: 'port_1' },
+  }
+}
+ConcreteTableReference{
+  source table: 'builtin::multicast_group_table'
+  destination table: 'other_table'
+  fields: {
+    ConcreteFieldReference{ source field: 'replica.port', destination field: 'multicast_group_id', value: 'port_2' },
+  }
+}
+
+=========================================================================
 OutgoingConcreteTableReferences: Multi P4MatchField-Refers-To-MatchField references create a single concrete reference.
 =========================================================================
 -- INPUT --------------------------------------------------------------

--- a/p4_pdpi/testing/testdata/sequencing.expected
+++ b/p4_pdpi/testing/testdata/sequencing.expected
@@ -2283,6 +2283,10 @@ multicast_group_table_entry {
       replicas {
         port: "port_1"
         instance: "0x0031"
+        backup_replicas {
+          port: "port_2"
+          instance: "0x0032"
+        }
       }
     }
   }
@@ -2297,7 +2301,19 @@ referenced_by_multicast_replica_table_entry {
     do_thing_4 {
     }
   }
-  controller_metadata: "Not Garbage"
+  controller_metadata: "Not Garbage because of primary replica"
+}
+
+referenced_by_multicast_replica_table_entry {
+  match {
+    port: "port_2"
+    instance: "0x0032"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+  controller_metadata: "Not Garbage because of backup replica"
 }
 
 referenced_by_multicast_replica_table_entry {
@@ -2322,7 +2338,19 @@ referenced_by_multicast_replica_table_entry {
     do_thing_4 {
     }
   }
-  controller_metadata: "Not Garbage"
+  controller_metadata: "Not Garbage because of primary replica"
+}
+
+referenced_by_multicast_replica_table_entry {
+  match {
+    port: "port_2"
+    instance: "0x0032"
+  }
+  action {
+    do_thing_4 {
+    }
+  }
+  controller_metadata: "Not Garbage because of backup replica"
 }
 
 referenced_by_multicast_replica_table_entry {

--- a/p4_symbolic/bmv2/BUILD.bazel
+++ b/p4_symbolic/bmv2/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
+
 # Placeholder: load py_binary
 load("//p4_symbolic/bmv2:test.bzl", "bmv2_protobuf_parsing_test")
 

--- a/p4_symbolic/ir/BUILD.bazel
+++ b/p4_symbolic/ir/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 load("//p4_symbolic/ir:test.bzl", "ir_parsing_test")
 
 package(

--- a/p4_symbolic/packet_synthesizer/BUILD.bazel
+++ b/p4_symbolic/packet_synthesizer/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/sai_p4/instantiations/google/acl_egress.p4
+++ b/sai_p4/instantiations/google/acl_egress.p4
@@ -152,24 +152,6 @@ control acl_egress(in headers_t headers,
     size = ACL_EGRESS_DHCP_TO_HOST_TABLE_MINIMUM_GUARANTEED_SIZE;
   }
 
-  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
-  @id(ACL_EGRESS_L2_TABLE_ID)
-  @sai_acl(EGRESS)
-  table acl_egress_l2_table {
-    key = {
-      headers.ethernet.src_addr : ternary
-          @id(1) @name("src_mac")
-          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_MAC) @format(MAC_ADDRESS);
-    }
-    actions = {
-      @proto_id(1) acl_drop(local_metadata);
-      @defaultonly NoAction;
-    }
-    const default_action = NoAction;
-    counters = acl_egress_l2_counter;
-    size = ACL_EGRESS_TABLE_MINIMUM_GUARANTEED_SIZE;
-  }
-
   apply {
     // We configure the hardware to explictly ignore the ACL egress tables for
     // CPU traffic.
@@ -192,9 +174,6 @@ control acl_egress(in headers_t headers,
       acl_egress_table.apply();
 #if defined(SAI_INSTANTIATION_TOR)
       acl_egress_dhcp_to_host_table.apply();
-#endif
-#if defined(SAI_INSTANTIATION_TOR) || defined(SAI_INSTANTIATION_MIDDLEBLOCK)
-      acl_egress_l2_table.apply();
 #endif
     // Act on ACL drop metadata.
       if (local_metadata.acl_drop) {

--- a/sai_p4/instantiations/google/ids.h
+++ b/sai_p4/instantiations/google/ids.h
@@ -27,8 +27,7 @@
 #define ACL_WBB_INGRESS_TABLE_ID 0x02000103                  // 33554691
 #define ACL_EGRESS_TABLE_ID 0x02000104                       // 33554692
 #define ACL_EGRESS_DHCP_TO_HOST_TABLE_ID 0x02000108          // 33554696
-#define ACL_EGRESS_L2_TABLE_ID 0x0200010C                    // 33554700
-// Next available table id: 0x0200010D (33554701)
+// Next available table id: 0x0200010C (33554700)
 
 // --- Actions -----------------------------------------------------------------
 // NOLINTBEGIN (to disable macro names of size > 80 cols)

--- a/sai_p4/instantiations/google/middleblock.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock.p4info.pb.txt
@@ -1223,35 +1223,6 @@ tables {
   direct_resource_ids: 318767364
   size: 127
 }
-tables {
-  preamble {
-    id: 33554700
-    name: "egress.acl_egress.acl_egress_l2_table"
-    alias: "acl_egress_l2_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-    annotations: "@sai_acl(EGRESS)"
-  }
-  match_fields {
-    id: 1
-    name: "src_mac"
-    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_MAC)"
-    annotations: "@format(MAC_ADDRESS)"
-    bitwidth: 48
-    match_type: TERNARY
-  }
-  action_refs {
-    id: 16777481
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  direct_resource_ids: 318767371
-  size: 127
-}
 actions {
   preamble {
     id: 21257015
@@ -2032,17 +2003,6 @@ direct_counters {
     unit: BOTH
   }
   direct_table_id: 33554692
-}
-direct_counters {
-  preamble {
-    id: 318767371
-    name: "egress.acl_egress.acl_egress_l2_counter"
-    alias: "acl_egress_l2_counter"
-  }
-  spec {
-    unit: BOTH
-  }
-  direct_table_id: 33554700
 }
 direct_meters {
   preamble {

--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -845,22 +845,9 @@ message AclIngressMirrorAndRedirectTableEntry {
   bytes controller_metadata = 8;
 }
 
-message AclEgressL2TableEntry {
-  message Match {
-    Ternary src_mac = 1;  // ternary match / Format::MAC
-  }
-  Match match = 1;
-  message Action {
-    AclDropAction acl_drop = 1;
-  }
-  Action action = 2;
-  int32 priority = 3;
-  BytesAndPacketsCounterData counter_data = 6;
-  bytes controller_metadata = 8;
-}
-
-// Corresponds to `MulticastGroupEntry` in p4runtime.proto. This table is part
-// of the v1model architecture and is not explicitly present in the P4 program.
+// Corresponds to `MulticastGroupEntry` in p4runtime.proto. 
+// This table is part of the v1model architecture and is not 
+// explicitly present in the P4 program.
 message MulticastGroupTableEntry {
   message Match {
     string multicast_group_id =
@@ -1187,7 +1174,6 @@ message TableEntry {
     AclIngressSecurityTableEntry acl_ingress_security_table_entry = 266;
     AclIngressMirrorAndRedirectTableEntry
         acl_ingress_mirror_and_redirect_table_entry = 267;
-    AclEgressL2TableEntry acl_egress_l2_table_entry = 268;
     MulticastGroupTableEntry multicast_group_table_entry = 2047;
   }
 }

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -1511,35 +1511,6 @@ tables {
   direct_resource_ids: 318767368
   size: 256
 }
-tables {
-  preamble {
-    id: 33554700
-    name: "egress.acl_egress.acl_egress_l2_table"
-    alias: "acl_egress_l2_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-    annotations: "@sai_acl(EGRESS)"
-  }
-  match_fields {
-    id: 1
-    name: "src_mac"
-    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_MAC)"
-    annotations: "@format(MAC_ADDRESS)"
-    bitwidth: 48
-    match_type: TERNARY
-  }
-  action_refs {
-    id: 16777481
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  direct_resource_ids: 318767371
-  size: 127
-}
 actions {
   preamble {
     id: 21257015
@@ -2538,17 +2509,6 @@ direct_counters {
     unit: BOTH
   }
   direct_table_id: 33554696
-}
-direct_counters {
-  preamble {
-    id: 318767371
-    name: "egress.acl_egress.acl_egress_l2_counter"
-    alias: "acl_egress_l2_counter"
-  }
-  spec {
-    unit: BOTH
-  }
-  direct_table_id: 33554700
 }
 direct_meters {
   preamble {

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -1634,35 +1634,6 @@ tables {
 }
 tables {
   preamble {
-    id: 33554700
-    name: "egress.acl_egress.acl_egress_l2_table"
-    alias: "acl_egress_l2_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-    annotations: "@sai_acl(EGRESS)"
-  }
-  match_fields {
-    id: 1
-    name: "src_mac"
-    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_MAC)"
-    annotations: "@format(MAC_ADDRESS)"
-    bitwidth: 48
-    match_type: TERNARY
-  }
-  action_refs {
-    id: 16777481
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  direct_resource_ids: 318767371
-  size: 127
-}
-tables {
-  preamble {
     id: 33554693
     name: "ingress.acl_pre_ingress.acl_pre_ingress_vlan_table"
     alias: "acl_pre_ingress_vlan_table"
@@ -2877,17 +2848,6 @@ direct_counters {
     unit: BOTH
   }
   direct_table_id: 33554698
-}
-direct_counters {
-  preamble {
-    id: 318767371
-    name: "egress.acl_egress.acl_egress_l2_counter"
-    alias: "acl_egress_l2_counter"
-  }
-  spec {
-    unit: BOTH
-  }
-  direct_table_id: 33554700
 }
 direct_counters {
   preamble {

--- a/sai_p4/tools/BUILD.bazel
+++ b/sai_p4/tools/BUILD.bazel
@@ -54,7 +54,6 @@ cc_library(
     deps = [
         "//lib/gnmi:gnmi_helper",
         "//p4_pdpi:ir_cc_proto",
-        "//p4_pdpi:p4_runtime_session",
         "//sai_p4/fixed:p4_ids",
         "//sai_p4/instantiations/google:sai_pd_cc_proto",
         "@com_github_gnmi//proto/gnmi:gnmi_cc_grpc_proto",
@@ -62,6 +61,8 @@ cc_library(
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+	"@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
     ],
 )
 

--- a/sai_p4/tools/auxiliary_entries_for_v1model_targets.cc
+++ b/sai_p4/tools/auxiliary_entries_for_v1model_targets.cc
@@ -31,24 +31,44 @@
 #include "sai_p4/instantiations/google/sai_pd.pb.h"
 
 namespace sai {
+namespace {
 
-p4::v1::Entity MakeV1modelPacketReplicationEngineEntryRequiredForPunts() {
-  p4::v1::Entity entity;
+enum class TaggingMode {
+  kTagged,
+  kUntagged,
+};
 
-  p4::v1::CloneSessionEntry& clone_session =
-      *entity.mutable_packet_replication_engine_entry()
-           ->mutable_clone_session_entry();
-  clone_session.set_session_id(COPY_TO_CPU_SESSION_ID);
-  p4::v1::Replica& replica = *clone_session.add_replicas();
-  replica.set_egress_port(SAI_P4_CPU_PORT);
-  replica.set_instance(SAI_P4_REPLICA_INSTANCE_PACKET_IN);
-
-  return entity;
+absl::StatusOr<pdpi::IrEntity> CreateVlanMembershipEntity(
+    absl::string_view vlan_id, absl::string_view port, TaggingMode tagging_mode,
+    bool auxiliary_table = false) {
+  pdpi::IrEntity aux_ir_entity;
+  aux_ir_entity.mutable_table_entry()->set_table_name(
+      auxiliary_table ? "v1model_auxiliary_vlan_membership_table"
+                      : "vlan_membership_table");
+  pdpi::IrMatch& vlan_match =
+      *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
+  vlan_match.set_name("vlan_id");
+  vlan_match.mutable_exact()->set_hex_str(vlan_id);
+  pdpi::IrMatch& port_match =
+      *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
+  port_match.set_name("port");
+  port_match.mutable_exact()->set_str(port);
+  if (tagging_mode == TaggingMode::kTagged) {
+    aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
+        auxiliary_table ? "v1model_auxiliary_make_tagged_member"
+                        : "make_tagged_member");
+  } else if (tagging_mode == TaggingMode::kUntagged) {
+    aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
+        auxiliary_table ? "v1model_auxiliary_make_untagged_member"
+                        : "make_untagged_member");
+  } else {
+    return absl::InternalError("Unsupported action in vlan_membership_table");
+  }
+  return aux_ir_entity;
 }
 
-absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
-    pdpi::IrEntities ir_entities, gnmi::gNMI::StubInterface& gnmi_stub,
-    pdpi::IrP4Info ir_p4info) {
+absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntitiesForLoopbackPorts(
+    gnmi::gNMI::StubInterface& gnmi_stub) {
   // Get the loopback mode map from the gNMI stub.
   absl::btree_set<std::string> loopback_mode_port_set;
   ASSIGN_OR_RETURN(
@@ -69,9 +89,15 @@ absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
     aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
         "egress_loopback");
   }
+  return auxiliary_ir_entities;
+}
 
+absl::StatusOr<pdpi::IrEntities>
+CreateV1ModelAuxiliaryVlanMembershipTableEntities(
+    pdpi::IrEntities ir_entities) {
   // For each entry in VLAN membership table, create an entry for v1model
   // auxiliary VLAN membership table.
+  pdpi::IrEntities auxiliary_ir_entities;
   for (const auto& ir_entity : ir_entities.entities()) {
     if (ir_entity.table_entry().table_name() != "vlan_membership_table") {
       continue;
@@ -92,40 +118,109 @@ absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
     }
     if (!vlan_id.has_value()) {
       return absl::FailedPreconditionError(
-          absl::StrCat("Expected match on field `vlan_id` in "
-                       "vlan_membership_table_entry, but got ",
+          absl::StrCat("Expected match on field `vlan_id` in ",
+                       ir_entity.table_entry().table_name(), ", but got ",
                        ir_entity.table_entry().ShortDebugString()));
     }
     if (!port.has_value()) {
       return absl::FailedPreconditionError(
-          absl::StrCat("Expected match on field `port` in "
-                       "vlan_membership_table_entry, but got ",
+          absl::StrCat("Expected match on field `port` in ",
+                       ir_entity.table_entry().table_name(), ", but got ",
                        ir_entity.table_entry().ShortDebugString()));
     }
 
-    pdpi::IrEntity& aux_ir_entity = *auxiliary_ir_entities.add_entities();
-    aux_ir_entity.mutable_table_entry()->set_table_name(
-        "v1model_auxiliary_vlan_membership_table");
-    pdpi::IrMatch& vlan_match =
-        *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
-    vlan_match.set_name("vlan_id");
-    vlan_match.mutable_exact()->set_hex_str(*vlan_id);
-    pdpi::IrMatch& port_match =
-        *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
-    port_match.set_name("port");
-    port_match.mutable_exact()->set_str(*port);
-    if (ir_entity.table_entry().action().name() == "make_tagged_member") {
-      aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
-          "v1model_auxiliary_make_tagged_member");
-    } else if (ir_entity.table_entry().action().name() ==
-               "make_untagged_member") {
-      aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
-          "v1model_auxiliary_make_untagged_member");
-    } else {
-      return absl::InternalError("Unsupported action in vlan_membership_table");
-    }
+    ASSIGN_OR_RETURN(
+        *auxiliary_ir_entities.add_entities(),
+        CreateVlanMembershipEntity(
+            *vlan_id, *port,
+            ir_entity.table_entry().action().name() == "make_tagged_member"
+                ? TaggingMode::kTagged
+                : TaggingMode::kUntagged,
+            /*auxiliary_table=*/true));
   }
+  return auxiliary_ir_entities;
+}
 
+// TODO: Remove this function once we switch to SUB_PORT RIFS that
+// do not manipulate VLAN membership.
+absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntitiesForSubPortRifs(
+    pdpi::IrEntities ir_entities) {
+  // For each SUB_PORT RIF (i.e. entry in router_interface_table with action
+  // set_port_and_src_mac_and_vlan_id with port `p` and vlan `v`), add auxiliary
+  // entries to make `p` a tagged member of `v`.
+  pdpi::IrEntities auxiliary_ir_entities;
+  for (const auto& ir_entity : ir_entities.entities()) {
+    if (!(ir_entity.table_entry().table_name() == "router_interface_table" &&
+          ir_entity.table_entry().action().name() ==
+              "set_port_and_src_mac_and_vlan_id")) {
+      continue;
+    }
+    std::optional<absl::string_view> vlan_id;
+    std::optional<absl::string_view> port;
+
+    for (const auto& param : ir_entity.table_entry().action().params()) {
+      if (param.name() == "vlan_id") {
+        vlan_id = param.value().hex_str();
+      } else if (param.name() == "port") {
+        port = param.value().str();
+      }
+    }
+    if (!vlan_id.has_value()) {
+      return absl::FailedPreconditionError(absl::StrCat(
+          "Expected param `vlan_id` in ", ir_entity.table_entry().table_name(),
+          ", but got ", ir_entity.table_entry().ShortDebugString()));
+    }
+    if (!port.has_value()) {
+      return absl::FailedPreconditionError(absl::StrCat(
+          "Expected param `port` in ", ir_entity.table_entry().table_name(),
+          ", but got ", ir_entity.table_entry().ShortDebugString()));
+    }
+
+    ASSIGN_OR_RETURN(
+        *auxiliary_ir_entities.add_entities(),
+        CreateVlanMembershipEntity(*vlan_id, *port, TaggingMode::kTagged,
+                                   /*auxiliary_table=*/false));
+    ASSIGN_OR_RETURN(
+        *auxiliary_ir_entities.add_entities(),
+        CreateVlanMembershipEntity(*vlan_id, *port, TaggingMode::kTagged,
+                                   /*auxiliary_table=*/true));
+  }
+  return auxiliary_ir_entities;
+}
+
+}  // namespace
+
+p4::v1::Entity MakeV1modelPacketReplicationEngineEntryRequiredForPunts() {
+  p4::v1::Entity entity;
+
+  p4::v1::CloneSessionEntry& clone_session =
+      *entity.mutable_packet_replication_engine_entry()
+           ->mutable_clone_session_entry();
+  clone_session.set_session_id(COPY_TO_CPU_SESSION_ID);
+  p4::v1::Replica& replica = *clone_session.add_replicas();
+  replica.set_egress_port(SAI_P4_CPU_PORT);
+  replica.set_instance(SAI_P4_REPLICA_INSTANCE_PACKET_IN);
+
+  return entity;
+}
+
+absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
+    pdpi::IrEntities ir_entities, gnmi::gNMI::StubInterface& gnmi_stub) {
+  pdpi::IrEntities auxiliary_ir_entities;
+  ASSIGN_OR_RETURN(pdpi::IrEntities loopback_ports_entities,
+                   CreateV1ModelAuxiliaryEntitiesForLoopbackPorts(gnmi_stub));
+  auxiliary_ir_entities.MergeFrom(loopback_ports_entities);
+
+  ASSIGN_OR_RETURN(
+      pdpi::IrEntities vlan_membership_entities,
+      CreateV1ModelAuxiliaryVlanMembershipTableEntities(ir_entities));
+  auxiliary_ir_entities.MergeFrom(vlan_membership_entities);
+
+  // TODO: Remove this function once we switch to SUB_PORT RIFS
+  // that do not manipulate VLAN membership.
+  ASSIGN_OR_RETURN(pdpi::IrEntities sub_port_rifs_entities,
+                   CreateV1ModelAuxiliaryEntitiesForSubPortRifs(ir_entities));
+  auxiliary_ir_entities.MergeFrom(sub_port_rifs_entities);
   return auxiliary_ir_entities;
 }
 

--- a/sai_p4/tools/auxiliary_entries_for_v1model_targets.cc
+++ b/sai_p4/tools/auxiliary_entries_for_v1model_targets.cc
@@ -14,10 +14,14 @@
 
 #include "sai_p4/tools/auxiliary_entries_for_v1model_targets.h"
 
+#include <optional>
 #include <string>
 
 #include "absl/container/btree_set.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
 #include "gutil/status.h"
 #include "lib/gnmi/gnmi_helper.h"
 #include "p4/v1/p4runtime.pb.h"
@@ -42,30 +46,87 @@ p4::v1::Entity MakeV1modelPacketReplicationEngineEntryRequiredForPunts() {
   return entity;
 }
 
-absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryTableEntries(
-    gnmi::gNMI::StubInterface& gnmi_stub, pdpi::IrP4Info ir_p4info) {
-  // Get the loopback mode map from the gNMI stub
+absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
+    pdpi::IrEntities ir_entities, gnmi::gNMI::StubInterface& gnmi_stub,
+    pdpi::IrP4Info ir_p4info) {
+  // Get the loopback mode map from the gNMI stub.
   absl::btree_set<std::string> loopback_mode_port_set;
   ASSIGN_OR_RETURN(
       loopback_mode_port_set,
       pins_test::GetP4rtIdOfInterfacesInAsicMacLocalLoopbackMode(gnmi_stub));
 
-  // Create IrEntities by using the gNMI loopback mode map to fill the loopback
-  // table entries.
-  pdpi::IrEntities ir_entities;
+  // For each port configured to be in loopback mode in gNMI, add an entry to
+  // the loopback table.
+  pdpi::IrEntities auxiliary_ir_entities;
   for (const auto& loopback_mode_port : loopback_mode_port_set) {
-    pdpi::IrEntity* ir_entity = ir_entities.add_entities();
-    ir_entity->mutable_table_entry()->set_table_name(
+    pdpi::IrEntity& aux_ir_entity = *auxiliary_ir_entities.add_entities();
+    aux_ir_entity.mutable_table_entry()->set_table_name(
         "egress_port_loopback_table");
-    pdpi::IrMatch* match =
-        ir_entity->mutable_table_entry()->mutable_matches()->Add();
-    match->set_name("out_port");
-    match->mutable_exact()->set_str(loopback_mode_port);
-    ir_entity->mutable_table_entry()->mutable_action()->set_name(
+    pdpi::IrMatch& match =
+        *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
+    match.set_name("out_port");
+    match.mutable_exact()->set_str(loopback_mode_port);
+    aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
         "egress_loopback");
   }
 
-  return ir_entities;
+  // For each entry in VLAN membership table, create an entry for v1model
+  // auxiliary VLAN membership table.
+  for (const auto& ir_entity : ir_entities.entities()) {
+    if (ir_entity.table_entry().table_name() != "vlan_membership_table") {
+      continue;
+    }
+
+    std::optional<absl::string_view> vlan_id;
+    std::optional<absl::string_view> port;
+    for (const auto& match : ir_entity.table_entry().matches()) {
+      if (match.name() == "vlan_id") {
+        vlan_id = match.exact().hex_str();
+      } else if (match.name() == "port") {
+        port = match.exact().str();
+      } else {
+        return absl::FailedPreconditionError(absl::StrCat(
+            "Unexpected match '", match.name(),
+            "' in vlan_membership_table, got ", ir_entity.ShortDebugString()));
+      }
+    }
+    if (!vlan_id.has_value()) {
+      return absl::FailedPreconditionError(
+          absl::StrCat("Expected match on field `vlan_id` in "
+                       "vlan_membership_table_entry, but got ",
+                       ir_entity.table_entry().ShortDebugString()));
+    }
+    if (!port.has_value()) {
+      return absl::FailedPreconditionError(
+          absl::StrCat("Expected match on field `port` in "
+                       "vlan_membership_table_entry, but got ",
+                       ir_entity.table_entry().ShortDebugString()));
+    }
+
+    pdpi::IrEntity& aux_ir_entity = *auxiliary_ir_entities.add_entities();
+    aux_ir_entity.mutable_table_entry()->set_table_name(
+        "v1model_auxiliary_vlan_membership_table");
+    pdpi::IrMatch& vlan_match =
+        *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
+    vlan_match.set_name("vlan_id");
+    vlan_match.mutable_exact()->set_hex_str(*vlan_id);
+    pdpi::IrMatch& port_match =
+        *aux_ir_entity.mutable_table_entry()->mutable_matches()->Add();
+    port_match.set_name("port");
+    port_match.mutable_exact()->set_str(*port);
+    if (ir_entity.table_entry().action().name() == "make_tagged_member") {
+      aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
+          "v1model_auxiliary_make_tagged_member");
+    } else if (ir_entity.table_entry().action().name() ==
+               "make_untagged_member") {
+      aux_ir_entity.mutable_table_entry()->mutable_action()->set_name(
+          "v1model_auxiliary_make_untagged_member");
+    } else {
+      return absl::InternalError("Unsupported action in vlan_membership_table");
+    }
+  }
+
+  return auxiliary_ir_entities;
 }
 
 }  // namespace sai

--- a/sai_p4/tools/auxiliary_entries_for_v1model_targets.h
+++ b/sai_p4/tools/auxiliary_entries_for_v1model_targets.h
@@ -41,8 +41,7 @@ p4::v1::Entity MakeV1modelPacketReplicationEngineEntryRequiredForPunts();
 // given entities (e.g. VLAN membership) and gNMI configuration (e.g. port
 // loopback mode).
 absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
-    pdpi::IrEntities ir_entities, gnmi::gNMI::StubInterface& gnmi_stub,
-    pdpi::IrP4Info ir_p4info);
+    pdpi::IrEntities ir_entities, gnmi::gNMI::StubInterface& gnmi_stub);
 
 }  // namespace sai
 

--- a/sai_p4/tools/auxiliary_entries_for_v1model_targets.h
+++ b/sai_p4/tools/auxiliary_entries_for_v1model_targets.h
@@ -24,7 +24,8 @@
 
 #include "absl/status/statusor.h"
 #include "p4/v1/p4runtime.pb.h"
-#include "p4_pdpi/p4_runtime_session.h"
+#include "p4_pdpi/ir.pb.h"
+#include "proto/gnmi/gnmi.grpc.pb.h"
 
 namespace sai {
 
@@ -36,11 +37,13 @@ namespace sai {
 // Not required by PINS targets, since PINS has this config built-in.
 p4::v1::Entity MakeV1modelPacketReplicationEngineEntryRequiredForPunts();
 
-// Creates entries for v1Model auxiliary tables that model the effects of the
-// given gNMI configuration in on packet forwarding (e.g. port loopback mode).
-absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryTableEntries(
-    gnmi::gNMI::StubInterface& gnmi_stub, pdpi::IrP4Info ir_p4info);
+// Creates entities for v1Model auxiliary tables that model the effects of the
+// given entities (e.g. VLAN membership) and gNMI configuration (e.g. port
+// loopback mode).
+absl::StatusOr<pdpi::IrEntities> CreateV1ModelAuxiliaryEntities(
+    pdpi::IrEntities ir_entities, gnmi::gNMI::StubInterface& gnmi_stub,
+    pdpi::IrP4Info ir_p4info);
 
 }  // namespace sai
 
-#endif // PINS_SAI_P4_TOOLS_AUXILIARY_ENTRIES_FOR_V1MODEL_TARGETS_H_
+#endif  // PINS_SAI_P4_TOOLS_AUXILIARY_ENTRIES_FOR_V1MODEL_TARGETS_H_

--- a/sai_p4/tools/auxiliary_entries_for_v1model_targets_test.cc
+++ b/sai_p4/tools/auxiliary_entries_for_v1model_targets_test.cc
@@ -94,12 +94,11 @@ TEST(AuxiliaryIrEntitiesForV1ModelTarget, GenerateAuxiliaryLoopbackEntities) {
       .WillRepeatedly(
           DoAll(SetArgPointee<2>(response), Return(grpc::Status::OK)));
 
-  pdpi::IrP4Info ir_p4info = sai::GetIrP4Info(sai::Instantiation::kTor);
   pdpi::IrEntities ir_entities;
 
-  ASSERT_OK_AND_ASSIGN(pdpi::IrEntities auxiliary_ir_entities,
-                       sai::CreateV1ModelAuxiliaryEntities(
-                           ir_entities, mock_gnmi_stub, ir_p4info));
+  ASSERT_OK_AND_ASSIGN(
+      pdpi::IrEntities auxiliary_ir_entities,
+      sai::CreateV1ModelAuxiliaryEntities(ir_entities, mock_gnmi_stub));
   EXPECT_THAT(auxiliary_ir_entities, gutil::EqualsProto(expected_entities));
 }
 
@@ -128,8 +127,6 @@ TEST(AuxiliaryIrEntitiesForV1ModelTarget,
   EXPECT_CALL(mock_gnmi_stub, Get)
       .WillRepeatedly(
           DoAll(SetArgPointee<2>(response), Return(grpc::Status::OK)));
-
-  pdpi::IrP4Info ir_p4info = sai::GetIrP4Info(sai::Instantiation::kTor);
 
   ASSERT_OK_AND_ASSIGN(pdpi::IrEntities auxiliary_ir_entities,
                        sai::CreateV1ModelAuxiliaryEntities(
@@ -164,7 +161,7 @@ TEST(AuxiliaryIrEntitiesForV1ModelTarget,
                                    }
                                  }
                                )pb"),
-                           mock_gnmi_stub, ir_p4info));
+                           mock_gnmi_stub));
 
   EXPECT_THAT(
       auxiliary_ir_entities,

--- a/sai_p4/tools/auxiliary_entries_for_v1model_targets_test.cc
+++ b/sai_p4/tools/auxiliary_entries_for_v1model_targets_test.cc
@@ -18,7 +18,7 @@ using testing::DoAll;
 using testing::Return;
 using testing::SetArgPointee;
 
-TEST(AuxilaryEntriesForV1ModelTarget, V1ModelAuxTableEntries) {
+TEST(AuxiliaryIrEntitiesForV1ModelTarget, GenerateAuxiliaryLoopbackEntities) {
   gnmi::GetResponse response;
   *response.add_notification()
        ->add_update()
@@ -29,21 +29,21 @@ TEST(AuxilaryEntriesForV1ModelTarget, V1ModelAuxTableEntries) {
         "interface": [
           {
             "name":"EthernetEnabled0",
-             "state":{
+            "state":{
               "loopback-mode":"ASIC_MAC_LOCAL",
               "openconfig-p4rt:id": 2
             }
           },
           {
             "name":"EthernetEnabled1",
-             "state":{
+            "state":{
               "loopback-mode":"NOT_ASIC_MAC_LOCAL",
               "openconfig-p4rt:id": 4
             }
           },
           {
             "name":"EthernetEnabled2",
-             "state":{
+            "state":{
               "loopback-mode":"ASIC_MAC_LOCAL",
               "openconfig-p4rt:id": 5
             }
@@ -95,11 +95,13 @@ TEST(AuxilaryEntriesForV1ModelTarget, V1ModelAuxTableEntries) {
           DoAll(SetArgPointee<2>(response), Return(grpc::Status::OK)));
 
   pdpi::IrP4Info ir_p4info = sai::GetIrP4Info(sai::Instantiation::kTor);
+  pdpi::IrEntities ir_entities;
 
-  ASSERT_OK_AND_ASSIGN(
-      pdpi::IrEntities entities,
-      sai::CreateV1ModelAuxiliaryTableEntries(mock_gnmi_stub, ir_p4info));
-  EXPECT_THAT(entities, gutil::EqualsProto(expected_entities));
+  ASSERT_OK_AND_ASSIGN(pdpi::IrEntities auxiliary_ir_entities,
+                       sai::CreateV1ModelAuxiliaryEntities(
+                           ir_entities, mock_gnmi_stub, ir_p4info));
+  EXPECT_THAT(auxiliary_ir_entities, gutil::EqualsProto(expected_entities));
 }
 
 }  // namespace
+


### PR DESCRIPTION
### **PR Description:**
fixing cc_proto_library from otg build for packet synthesizer.

### **Keyword Check:**
bibhuprasad@bibhuprasad87:~/sonic_build_image_2025-06-23/sonic-buildimage/src/sonic-p4rt/sonic-pins/p4_pdpi$ sh ~/keyword_check.sh .
Keyword check Passed.

### **Build Results:**
bibhuprasad@8b3c841bfe91:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 755 targets (3 packages loaded, 350 targets configured).
INFO: Found 755 targets...
INFO: Elapsed time: 0.552s, Critical Path: 0.04s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### **UT Results:**
bibhuprasad@8b3c841bfe91:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 755 targets (0 packages loaded, 50 targets configured).
INFO: Found 526 targets and 229 test targets...
INFO: Elapsed time: 203.975s, Critical Path: 147.45s
INFO: 286 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 286 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.2s
//dvaas:dataplane_validation_test                                        PASSED in 0.1s
//dvaas:port_id_map_test                                                 PASSED in 1.8s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 2.1s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.9s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//gutil:collections_test                                                 PASSED in 1.3s
//gutil:io_test                                                          PASSED in 1.3s
//gutil:proto_matchers_test                                              PASSED in 1.5s
//gutil:proto_ordering_test                                              PASSED in 1.6s
//gutil:proto_test                                                       PASSED in 1.6s
//gutil:status_matchers_test                                             PASSED in 1.6s
//gutil:test_artifact_writer_test                                        PASSED in 1.5s
//gutil:testing_test                                                     PASSED in 1.7s
//gutil:timer_test                                                       PASSED in 5.2s
//gutil:version_test                                                     PASSED in 5.2s
//lib:basic_switch_test                                                  PASSED in 1.8s
//lib:ixia_helper_test                                                   PASSED in 2.7s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 2.4s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 17.6s
//lib/gnmi:gnmi_helper_test                                              PASSED in 4.5s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.7s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.6s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 2.2s
//lib/utils:generic_testbed_utils_test                                   PASSED in 4.0s
//lib/utils:json_utils_test                                              PASSED in 1.7s
//lib/validator:validator_backend_test                                   PASSED in 1.5s
//lib/validator:validator_lib_test                                       PASSED in 27.3s
//p4_fuzzer:constraints_test                                             PASSED in 9.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 147.3s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 1.9s
//p4_fuzzer:oracle_util_test                                             PASSED in 5.3s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 4.4s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 4.1s
//p4_fuzzer:switch_state_test                                            PASSED in 2.7s
//p4_pdpi:built_ins_test                                                 PASSED in 1.7s
//p4_pdpi:entity_keys_test                                               PASSED in 1.5s
//p4_pdpi:ir_properties_test                                             PASSED in 1.7s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.6s
//p4_pdpi:ir_tools_test                                                  PASSED in 1.8s
//p4_pdpi:names_test                                                     PASSED in 2.0s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 2.0s
//p4_pdpi:p4info_union_test                                              PASSED in 1.3s
//p4_pdpi:reference_annotations_test                                     PASSED in 2.0s
//p4_pdpi:references_test                                                PASSED in 1.9s
//p4_pdpi:sequencing_util_test                                           PASSED in 2.1s
//p4_pdpi:ternary_test                                                   PASSED in 1.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.6s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.6s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.5s
//p4_pdpi/packetlib:packetlib_debugging_test                             PASSED in 1.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 21.6s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.4s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 7.6s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.4s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.6s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.2s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.8s
//p4_pdpi/testing:helper_function_test                                   PASSED in 2.0s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.8s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.2s
//p4_pdpi/testing:references_test                                        PASSED in 0.2s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.2s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 2.2s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.4s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.4s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.7s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.7s
//p4_symbolic:z3_util_test                                               PASSED in 1.6s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 2.7s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 2.7s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 2.8s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 2.7s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 3.7s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 3.3s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 3.2s
//p4_symbolic/ir:cfg_test                                                PASSED in 2.1s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.1s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.3s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.3s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.2s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.2s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.2s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.2s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.2s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.2s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.2s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.2s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.2s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.8s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 35.2s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 37.2s
//p4_symbolic/sai:sai_test                                               PASSED in 8.6s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 4.0s
//p4_symbolic/symbolic:parser_test                                       PASSED in 2.4s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 2.5s
//p4_symbolic/symbolic:util_test                                         PASSED in 2.0s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.6s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 20.3s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 3.1s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 2.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 2.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 3.1s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 3.0s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 3.5s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 2.5s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 3.0s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 1.1s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 2.0s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 2.3s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.2s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.8s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 2.4s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.6s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 2.2s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.3s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 2.3s
//p4rt_app/sonic:hashing_test                                            PASSED in 1.9s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 2.0s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.8s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.6s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.3s
//p4rt_app/sonic:state_verification_test                                 PASSED in 2.2s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.5s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 2.0s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.5s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.2s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.2s
//p4rt_app/tests:action_set_test                                         PASSED in 1.5s
//p4rt_app/tests:api_access_test                                         PASSED in 1.3s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.4s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.3s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 8.9s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.6s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.0s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.4s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.8s
//p4rt_app/tests:packetio_test                                           PASSED in 4.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.2s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.8s
//p4rt_app/tests:response_path_test                                      PASSED in 5.3s
//p4rt_app/tests:role_test                                               PASSED in 1.7s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.9s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.4s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 2.1s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.9s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.8s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.8s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.7s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.3s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 5.2s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 3.1s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 7.2s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 1.9s
//sai_p4/tools:p4info_tools_test                                         PASSED in 2.1s
//sai_p4/tools:packetio_tools_test                                       PASSED in 2.3s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 3.3s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.6s
//tests/lib:common_ir_table_entries_test                                 PASSED in 2.0s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 2.6s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.2s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 8.1s
//thinkit:bazel_test_environment_test                                    PASSED in 1.5s
//thinkit:generic_testbed_test                                           PASSED in 2.2s
//thinkit:mock_control_device_test                                       PASSED in 1.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.9s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.8s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.9s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 2.1s
//tests/lib:packet_generator_test                                        PASSED in 63.8s
  Stats over 4 runs: max = 63.8s, min = 61.2s, avg = 62.5s, dev = 1.1s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.2s
  Stats over 5 runs: max = 2.2s, min = 1.5s, avg = 1.9s, dev = 0.3s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 45.6s
  Stats over 50 runs: max = 45.6s, min = 1.4s, avg = 5.8s, dev = 11.6s

Executed 229 out of 229 tests: 229 tests pass.
