### PR TITLE
[Comb] Update sai_pd.proto with comments regarding references for replicas.

### DIFF
--- a/bazel/BUILD.otg-models.bazel
+++ b/bazel/BUILD.otg-models.bazel
@@ -1,4 +1,5 @@
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/dvaas/BUILD.bazel
+++ b/dvaas/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test")
 
 package(

--- a/dvaas/thinkit_tests/BUILD.bazel
+++ b/dvaas/thinkit_tests/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/gutil/BUILD.bazel
+++ b/gutil/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/lib/gnmi/BUILD.bazel
+++ b/lib/gnmi/BUILD.bazel
@@ -14,6 +14,7 @@
 #
 # PINS test functions that can be run on any infrastructure that supports ThinKit.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/p4_fuzzer/BUILD.bazel
+++ b/p4_fuzzer/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test")
 
 package(

--- a/p4_pdpi/BUILD.bazel
+++ b/p4_pdpi/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/p4_pdpi/ir.proto
+++ b/p4_pdpi/ir.proto
@@ -99,7 +99,7 @@ message IrP4ActionField {
 // representation to be used within annotations.
 enum IrBuiltInAction {
   BUILT_IN_ACTION_UNSPECIFIED = 0;
-  // Corresponds to p4::v1::Replica.
+  // Corresponds to p4::v1::Replica and p4::v1::BackupReplica.
   // String representation in annotations: "builtin::replica"
   BUILT_IN_ACTION_REPLICA = 1;
 }
@@ -109,10 +109,11 @@ enum IrBuiltInAction {
 // representation to be used within `@refers_to`/`@referenced_by` annotations.
 enum IrBuiltInParameter {
   BUILT_IN_PARAMETER_UNSPECIFIED = 0;
-  // Corresponds to p4::v1::Replica::port.
+  // Corresponds to p4::v1::Replica::port and p4::v1::BackupReplica::port.
   // String representation in annotations: "replica.port"
   BUILT_IN_PARAMETER_REPLICA_PORT = 1;
-  // Corresponds to p4::v1::Replica::instance.
+  // Corresponds to p4::v1::Replica::instance and
+  // p4::v1::BackupReplica::instance.
   // String representation in annotations: "replica.instance"
   BUILT_IN_PARAMETER_REPLICA_INSTANCE = 2;
 }

--- a/p4_pdpi/packetlib/BUILD.bazel
+++ b/p4_pdpi/packetlib/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test")
 
 package(

--- a/p4_pdpi/packetlib/packetlib.cc
+++ b/p4_pdpi/packetlib/packetlib.cc
@@ -3072,8 +3072,13 @@ absl::StatusOr<int> IcmpHeaderChecksum(Packet packet, int icmp_header_index) {
                        PacketSizeInBytes(packet, icmp_header_index));
       data.AppendBits<32>(icmpv6_size);
       data.AppendBits<24>(0);
-      RETURN_IF_ERROR(
-          SerializeBits<kIpNextHeaderBitwidth>(header.next_header(), data));
+      // The `next_header` field for a ICMP header identifies the upper-layer
+      // protocol. It differs from the typical `next_header` field in an IPv6
+      // header when there are IPV6 extension headers. See
+      // https://datatracker.ietf.org/doc/html/rfc2463#section-2.3, which
+      // specifies that the `next_header` field for a ICMP header must be 58
+      // (0x3a).
+      RETURN_IF_ERROR(SerializeBits<kIpNextHeaderBitwidth>("0x3a", data));
       break;
     }
     case Header::kIpv4Header: {

--- a/p4_pdpi/references.cc
+++ b/p4_pdpi/references.cc
@@ -430,7 +430,7 @@ OutgoingConcreteTableReferences(const IrTableReference& reference_info,
                 built_in_replica_field_to_match_field_references, replica));
 	for (const auto& backup_replica : replica.backup_replicas()) {
           // Because primary and backup replicas share the same checks, we map
-          // the type Replica to BackupReplica in order to reuse logic.
+	  // the type BackupReplica to Replica in order to reuse logic.
           p4::v1::Replica backup_replica_as_replica;
           backup_replica_as_replica.set_port(backup_replica.port());
           backup_replica_as_replica.set_instance(backup_replica.instance());

--- a/p4_pdpi/testing/BUILD.bazel
+++ b/p4_pdpi/testing/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 load("//gutil/embed_data:build_defs.bzl", "cc_embed_data")
 load("//p4_pdpi:pdgen.bzl", "p4_pd_proto")
 load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test", "diff_test")

--- a/p4_symbolic/bmv2/BUILD.bazel
+++ b/p4_symbolic/bmv2/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
+
 # Placeholder: load py_binary
 load("//p4_symbolic/bmv2:test.bzl", "bmv2_protobuf_parsing_test")
 

--- a/p4_symbolic/ir/BUILD.bazel
+++ b/p4_symbolic/ir/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 load("//p4_symbolic/ir:test.bzl", "ir_parsing_test")
 
 package(

--- a/p4_symbolic/packet_synthesizer/BUILD.bazel
+++ b/p4_symbolic/packet_synthesizer/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/p4rt_app/p4runtime/BUILD.bazel
+++ b/p4rt_app/p4runtime/BUILD.bazel
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 load("//gutil/embed_data:build_defs.bzl", "cc_embed_data")
 
 package(

--- a/sai_p4/instantiations/google/BUILD.bazel
+++ b/sai_p4/instantiations/google/BUILD.bazel
@@ -14,6 +14,7 @@
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 load("//gutil/embed_data:build_defs.bzl", "cc_embed_data")
 load("//p4_pdpi:pdgen.bzl", "p4_pd_proto")
 load("//p4_pdpi/testing:diff_test.bzl", "cmd_diff_test", "diff_test")

--- a/sai_p4/instantiations/google/acl_egress.p4
+++ b/sai_p4/instantiations/google/acl_egress.p4
@@ -152,24 +152,6 @@ control acl_egress(in headers_t headers,
     size = ACL_EGRESS_DHCP_TO_HOST_TABLE_MINIMUM_GUARANTEED_SIZE;
   }
 
-  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
-  @id(ACL_EGRESS_L2_TABLE_ID)
-  @sai_acl(EGRESS)
-  table acl_egress_l2_table {
-    key = {
-      headers.ethernet.src_addr : ternary
-          @id(1) @name("src_mac")
-          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_MAC) @format(MAC_ADDRESS);
-    }
-    actions = {
-      @proto_id(1) acl_drop(local_metadata);
-      @defaultonly NoAction;
-    }
-    const default_action = NoAction;
-    counters = acl_egress_l2_counter;
-    size = ACL_EGRESS_TABLE_MINIMUM_GUARANTEED_SIZE;
-  }
-
   apply {
     // We configure the hardware to explictly ignore the ACL egress tables for
     // CPU traffic.
@@ -192,9 +174,6 @@ control acl_egress(in headers_t headers,
       acl_egress_table.apply();
 #if defined(SAI_INSTANTIATION_TOR)
       acl_egress_dhcp_to_host_table.apply();
-#endif
-#if defined(SAI_INSTANTIATION_TOR) || defined(SAI_INSTANTIATION_MIDDLEBLOCK)
-      acl_egress_l2_table.apply();
 #endif
     // Act on ACL drop metadata.
       if (local_metadata.acl_drop) {

--- a/sai_p4/instantiations/google/ids.h
+++ b/sai_p4/instantiations/google/ids.h
@@ -27,8 +27,7 @@
 #define ACL_WBB_INGRESS_TABLE_ID 0x02000103                  // 33554691
 #define ACL_EGRESS_TABLE_ID 0x02000104                       // 33554692
 #define ACL_EGRESS_DHCP_TO_HOST_TABLE_ID 0x02000108          // 33554696
-#define ACL_EGRESS_L2_TABLE_ID 0x0200010C                    // 33554700
-// Next available table id: 0x0200010D (33554701)
+// Next available table id: 0x0200010C (33554700)
 
 // --- Actions -----------------------------------------------------------------
 // NOLINTBEGIN (to disable macro names of size > 80 cols)

--- a/sai_p4/instantiations/google/middleblock.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock.p4info.pb.txt
@@ -1223,35 +1223,6 @@ tables {
   direct_resource_ids: 318767364
   size: 127
 }
-tables {
-  preamble {
-    id: 33554700
-    name: "egress.acl_egress.acl_egress_l2_table"
-    alias: "acl_egress_l2_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-    annotations: "@sai_acl(EGRESS)"
-  }
-  match_fields {
-    id: 1
-    name: "src_mac"
-    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_MAC)"
-    annotations: "@format(MAC_ADDRESS)"
-    bitwidth: 48
-    match_type: TERNARY
-  }
-  action_refs {
-    id: 16777481
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  direct_resource_ids: 318767371
-  size: 127
-}
 actions {
   preamble {
     id: 21257015
@@ -2032,17 +2003,6 @@ direct_counters {
     unit: BOTH
   }
   direct_table_id: 33554692
-}
-direct_counters {
-  preamble {
-    id: 318767371
-    name: "egress.acl_egress.acl_egress_l2_counter"
-    alias: "acl_egress_l2_counter"
-  }
-  spec {
-    unit: BOTH
-  }
-  direct_table_id: 33554700
 }
 direct_meters {
   preamble {

--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -845,22 +845,9 @@ message AclIngressMirrorAndRedirectTableEntry {
   bytes controller_metadata = 8;
 }
 
-message AclEgressL2TableEntry {
-  message Match {
-    Ternary src_mac = 1;  // ternary match / Format::MAC
-  }
-  Match match = 1;
-  message Action {
-    AclDropAction acl_drop = 1;
-  }
-  Action action = 2;
-  int32 priority = 3;
-  BytesAndPacketsCounterData counter_data = 6;
-  bytes controller_metadata = 8;
-}
-
-// Corresponds to `MulticastGroupEntry` in p4runtime.proto. This table is part
-// of the v1model architecture and is not explicitly present in the P4 program.
+// Corresponds to `MulticastGroupEntry` in p4runtime.proto. 
+// This table is part of the v1model architecture and is not 
+// explicitly present in the P4 program.
 message MulticastGroupTableEntry {
   message Match {
     string multicast_group_id =
@@ -1187,7 +1174,6 @@ message TableEntry {
     AclIngressSecurityTableEntry acl_ingress_security_table_entry = 266;
     AclIngressMirrorAndRedirectTableEntry
         acl_ingress_mirror_and_redirect_table_entry = 267;
-    AclEgressL2TableEntry acl_egress_l2_table_entry = 268;
     MulticastGroupTableEntry multicast_group_table_entry = 2047;
   }
 }

--- a/sai_p4/instantiations/google/sai_pd.proto
+++ b/sai_p4/instantiations/google/sai_pd.proto
@@ -1125,13 +1125,17 @@ message ReplicateAction {
   repeated Replica replicas = 1;
   // Corresponds to `Replica` in p4runtime.proto.
   message Replica {
-    string port = 1;      // Format::STRING
+    // Refers to 'multicast_router_interface_table.multicast_replica_port'.
+    string port = 1;  // Format::STRING
+    // Refers to 'multicast_router_interface_table.multicast_replica_instance'.
     string instance = 2;  // Format::HEX_STRING / 16 bits
     repeated BackupReplica backup_replicas = 3;
   }
   // Corresponds to `BackupReplica` in p4runtime.proto.
   message BackupReplica {
-    string port = 1;      // Format::STRING
+    // Refers to 'multicast_router_interface_table.multicast_replica_port'.
+    string port = 1;  // Format::STRING
+    // Refers to 'multicast_router_interface_table.multicast_replica_instance'.
     string instance = 2;  // Format::HEX_STRING / 16 bits
   }
 }

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -1511,35 +1511,6 @@ tables {
   direct_resource_ids: 318767368
   size: 256
 }
-tables {
-  preamble {
-    id: 33554700
-    name: "egress.acl_egress.acl_egress_l2_table"
-    alias: "acl_egress_l2_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-    annotations: "@sai_acl(EGRESS)"
-  }
-  match_fields {
-    id: 1
-    name: "src_mac"
-    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_MAC)"
-    annotations: "@format(MAC_ADDRESS)"
-    bitwidth: 48
-    match_type: TERNARY
-  }
-  action_refs {
-    id: 16777481
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  direct_resource_ids: 318767371
-  size: 127
-}
 actions {
   preamble {
     id: 21257015
@@ -2538,17 +2509,6 @@ direct_counters {
     unit: BOTH
   }
   direct_table_id: 33554696
-}
-direct_counters {
-  preamble {
-    id: 318767371
-    name: "egress.acl_egress.acl_egress_l2_counter"
-    alias: "acl_egress_l2_counter"
-  }
-  spec {
-    unit: BOTH
-  }
-  direct_table_id: 33554700
 }
 direct_meters {
   preamble {

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -1634,35 +1634,6 @@ tables {
 }
 tables {
   preamble {
-    id: 33554700
-    name: "egress.acl_egress.acl_egress_l2_table"
-    alias: "acl_egress_l2_table"
-    annotations: "@p4runtime_role(\"sdn_controller\")"
-    annotations: "@sai_acl(EGRESS)"
-  }
-  match_fields {
-    id: 1
-    name: "src_mac"
-    annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_MAC)"
-    annotations: "@format(MAC_ADDRESS)"
-    bitwidth: 48
-    match_type: TERNARY
-  }
-  action_refs {
-    id: 16777481
-    annotations: "@proto_id(1)"
-  }
-  action_refs {
-    id: 21257015
-    annotations: "@defaultonly"
-    scope: DEFAULT_ONLY
-  }
-  const_default_action_id: 21257015
-  direct_resource_ids: 318767371
-  size: 127
-}
-tables {
-  preamble {
     id: 33554693
     name: "ingress.acl_pre_ingress.acl_pre_ingress_vlan_table"
     alias: "acl_pre_ingress_vlan_table"
@@ -2877,17 +2848,6 @@ direct_counters {
     unit: BOTH
   }
   direct_table_id: 33554698
-}
-direct_counters {
-  preamble {
-    id: 318767371
-    name: "egress.acl_egress.acl_egress_l2_counter"
-    alias: "acl_egress_l2_counter"
-  }
-  spec {
-    unit: BOTH
-  }
-  direct_table_id: 33554700
 }
 direct_counters {
   preamble {

--- a/thinkit/proto/BUILD.bazel
+++ b/thinkit/proto/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
 
 package(
     default_visibility = ["//visibility:public"],


### PR DESCRIPTION
### **PR Description:**
Update sai_pd.proto with comments regarding references for replicas.

### **Keyword Check:**
bibhuprasad@bibhuprasad87:~/sonic_build_image_2025-06-23/sonic-buildimage/src/sonic-p4rt/sonic-pins/p4_pdpi$ sh ~/keyword_check.sh .
Keyword check Passed.

### **Build Results:**
bibhuprasad@8b3c841bfe91:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 755 targets (269 packages loaded, 22416 targets configured).
INFO: Found 755 targets...
INFO: Elapsed time: 8.223s, Critical Path: 0.50s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### **UT Results:**
bibhuprasad@8b3c841bfe91:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 755 targets (0 packages loaded, 383 targets configured).
INFO: Found 526 targets and 229 test targets...
INFO: Elapsed time: 202.169s, Critical Path: 144.19s
INFO: 286 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 286 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.2s
//dvaas:dataplane_validation_test                                        PASSED in 0.2s
//dvaas:port_id_map_test                                                 PASSED in 2.2s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.2s
//dvaas:test_run_validation_test                                         PASSED in 2.3s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.2s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.7s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//gutil:collections_test                                                 PASSED in 1.6s
//gutil:io_test                                                          PASSED in 1.5s
//gutil:proto_matchers_test                                              PASSED in 1.5s
//gutil:proto_ordering_test                                              PASSED in 1.7s
//gutil:proto_test                                                       PASSED in 1.6s
//gutil:status_matchers_test                                             PASSED in 1.8s
//gutil:test_artifact_writer_test                                        PASSED in 1.5s
//gutil:testing_test                                                     PASSED in 1.3s
//gutil:timer_test                                                       PASSED in 5.2s
//gutil:version_test                                                     PASSED in 4.7s
//lib:basic_switch_test                                                  PASSED in 2.9s
//lib:ixia_helper_test                                                   PASSED in 2.2s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 2.3s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 16.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 4.5s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.7s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.2s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 2.2s
//lib/utils:generic_testbed_utils_test                                   PASSED in 3.3s
//lib/utils:json_utils_test                                              PASSED in 1.6s
//lib/validator:validator_backend_test                                   PASSED in 1.5s
//lib/validator:validator_lib_test                                       PASSED in 27.0s
//p4_fuzzer:constraints_test                                             PASSED in 10.3s
//p4_fuzzer:fuzz_util_test                                               PASSED in 143.9s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 2.1s
//p4_fuzzer:oracle_util_test                                             PASSED in 5.2s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 4.1s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 4.1s
//p4_fuzzer:switch_state_test                                            PASSED in 2.5s
//p4_pdpi:built_ins_test                                                 PASSED in 1.5s
//p4_pdpi:entity_keys_test                                               PASSED in 1.3s
//p4_pdpi:ir_properties_test                                             PASSED in 1.2s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.7s
//p4_pdpi:ir_tools_test                                                  PASSED in 1.9s
//p4_pdpi:names_test                                                     PASSED in 1.8s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 2.2s
//p4_pdpi:p4info_union_test                                              PASSED in 1.5s
//p4_pdpi:reference_annotations_test                                     PASSED in 2.1s
//p4_pdpi:references_test                                                PASSED in 1.9s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.7s
//p4_pdpi:ternary_test                                                   PASSED in 1.9s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.8s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.4s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.2s
//p4_pdpi/packetlib:packetlib_debugging_test                             PASSED in 1.6s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 21.7s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 2.1s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 7.3s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.4s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.3s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.3s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.8s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.8s
//p4_pdpi/testing:info_test                                              PASSED in 0.2s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.4s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 2.2s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.3s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.1s
//p4_pdpi/testing:references_test                                        PASSED in 0.3s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.3s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.3s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.3s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.3s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.2s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 2.4s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.3s
//p4_pdpi/utils:ir_test                                                  PASSED in 2.0s
//p4_symbolic:z3_util_test                                               PASSED in 1.7s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 2.6s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 2.7s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 3.0s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 2.8s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.3s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 3.6s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 3.6s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.3s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 3.6s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.6s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.2s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.2s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.1s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.1s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.0s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.3s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.2s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.2s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.2s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.2s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.2s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.2s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.2s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.7s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 34.9s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 36.5s
//p4_symbolic/sai:sai_test                                               PASSED in 8.6s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 4.3s
//p4_symbolic/symbolic:parser_test                                       PASSED in 2.7s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 2.6s
//p4_symbolic/symbolic:util_test                                         PASSED in 1.9s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.1s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 19.9s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 2.5s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 2.8s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 3.1s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 2.7s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 2.7s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 2.7s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 2.6s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 3.1s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 1.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 2.1s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 2.2s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.2s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.7s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 3.0s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.6s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 1.9s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.1s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 2.2s
//p4rt_app/sonic:hashing_test                                            PASSED in 2.0s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 1.9s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.4s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.3s
//p4rt_app/sonic:response_handler_test                                   PASSED in 1.8s
//p4rt_app/sonic:state_verification_test                                 PASSED in 1.8s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.5s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 1.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.6s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 1.0s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.1s
//p4rt_app/tests:action_set_test                                         PASSED in 1.5s
//p4rt_app/tests:api_access_test                                         PASSED in 1.2s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.4s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.3s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 8.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.6s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.0s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.5s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.8s
//p4rt_app/tests:packetio_test                                           PASSED in 4.7s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.6s
//p4rt_app/tests:response_path_test                                      PASSED in 5.2s
//p4rt_app/tests:role_test                                               PASSED in 1.7s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.9s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 1.8s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.3s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.6s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.9s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.7s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.3s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 5.0s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 3.5s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 7.8s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 2.2s
//sai_p4/tools:p4info_tools_test                                         PASSED in 2.1s
//sai_p4/tools:packetio_tools_test                                       PASSED in 2.5s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.9s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.0s
//tests/lib:common_ir_table_entries_test                                 PASSED in 2.0s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 2.2s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.2s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 8.3s
//thinkit:bazel_test_environment_test                                    PASSED in 1.5s
//thinkit:generic_testbed_test                                           PASSED in 2.1s
//thinkit:mock_control_device_test                                       PASSED in 1.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.9s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 1.9s
//tests/lib:packet_generator_test                                        PASSED in 63.7s
  Stats over 4 runs: max = 63.7s, min = 62.3s, avg = 62.9s, dev = 0.5s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.2s
  Stats over 5 runs: max = 2.2s, min = 1.7s, avg = 2.0s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 46.1s
  Stats over 50 runs: max = 46.1s, min = 1.6s, avg = 5.7s, dev = 11.7s

Executed 229 out of 229 tests: 229 tests pass.
