### PR TITLE
[Thinkit/Tests] Add support for new PFC Rx and On2Off counter paths, and the validation for the same in PFC test.

### DIFF
--- a/tests/qos/BUILD.bazel
+++ b/tests/qos/BUILD.bazel
@@ -235,18 +235,17 @@ cc_library(
     srcs = ["qos_test_util.cc"],
     hdrs = ["qos_test_util.h"],
     deps = [
-        ":gnmi_parsers",
         "//gutil:collections",
         "//gutil:proto",
         "//gutil:status",
         "//lib/gnmi:gnmi_helper",
         "//lib/gnmi:openconfig_cc_proto",
-        "//lib/utils:json_utils",
         "//sai_p4/instantiations/google:sai_pd_cc_proto",
         "//thinkit:mirror_testbed",
         "//thinkit/proto:generic_testbed_cc_proto",
         "@com_github_gnmi//proto/gnmi:gnmi_cc_grpc_proto",
         "@com_github_gnmi//proto/gnmi:gnmi_cc_proto",
+        "@com_github_google_glog//:glog",
         "@com_github_nlohmann_json//:nlohmann_json",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
@@ -255,7 +254,6 @@ cc_library(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/time",
-        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/tests/qos/qos_test_util.h
+++ b/tests/qos/qos_test_util.h
@@ -252,6 +252,16 @@ absl::StatusOr<int64_t> GetGnmiPortEcnCounter(
 absl::StatusOr<int64_t> GetGnmiPortIngressCounter(
     absl::string_view port, gnmi::gNMI::StubInterface &gnmi_stub);
 
+enum class PfcCountersType {
+  kPfcRx,
+  kPfcOn2Off,
+};
+
+// Get PFC RX port counters.
+absl::StatusOr<int64_t> GetGnmiPortPfcCounter(
+    absl::string_view port, absl::string_view priority,
+    gnmi::gNMI::StubInterface &gnmi_stub, PfcCountersType type);
+
 // Get queues for an egress port.
 absl::StatusOr<std::vector<std::string>> GetQueuesByEgressPort(
     absl::string_view egress_port, gnmi::gNMI::StubInterface &gnmi);


### PR DESCRIPTION
Keyword Check:
/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.

Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 755 targets (269 packages loaded, 22416 targets configured).
INFO: Found 755 targets...
INFO: Elapsed time: 435.910s, Critical Path: 104.16s
INFO: 59 processes: 2 internal, 57 linux-sandbox.
INFO: Build completed successfully, 59 total actions


Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 755 targets (0 packages loaded, 383 targets configured).
INFO: Found 526 targets and 229 test targets...
INFO: Elapsed time: 272.559s, Critical Path: 147.13s
INFO: 286 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 286 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.1s
//dvaas:dataplane_validation_test                                        PASSED in 0.5s
//dvaas:port_id_map_test                                                 PASSED in 3.9s
//dvaas:test_run_validation_golden_test                                  PASSED in 1.4s
//dvaas:test_run_validation_test                                         PASSED in 3.8s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.5s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.3s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.0s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.3s
//thinkit:bazel_test_environment_test                                    PASSED in 0.9s
//thinkit:generic_testbed_test                                           PASSED in 1.5s
//thinkit:mock_control_device_test                                       PASSED in 0.9s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.2s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.0s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 3.7s
//thinkit:mock_test_environment_test                                     PASSED in 1.1s
//thinkit:switch_test                                                    PASSED in 1.1s
//tests/lib:packet_generator_test                                        PASSED in 66.4s
  Stats over 4 runs: max = 66.4s, min = 65.1s, avg = 65.7s, dev = 0.5s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.3s
  Stats over 5 runs: max = 2.3s, min = 1.0s, avg = 1.6s, dev = 0.5s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 47.5s
  Stats over 50 runs: max = 47.5s, min = 1.1s, avg = 3.4s, dev = 9.1s

Executed 229 out of 229 tests: 229 tests pass.
