### PR TITLE
[lib] Add Gnmi helper functions to set port encoded-id.

### DIFF
--- a/lib/gnmi/gnmi_helper.cc
+++ b/lib/gnmi/gnmi_helper.cc
@@ -2185,6 +2185,50 @@ absl::Status SetPortLoopbackMode(bool port_loopback,
                                       GnmiSetType::kUpdate, config_json);
 }
 
+absl::Status SetPortIngressTimestamping(bool port_ingress_timestamping,
+                                        absl::string_view interface_name,
+                                        gnmi::gNMI::StubInterface& gnmi_stub) {
+  std::string config_path =
+      absl::StrCat("interfaces/interface[name=", interface_name,
+                   "]/ethernet/config/insert-ingress-timestamp");
+  std::string config_json;
+  if (port_ingress_timestamping) {
+    config_json = "{\"google-pins-interfaces:insert-ingress-timestamp\":true}";
+  } else {
+    config_json = "{\"google-pins-interfaces:insert-ingress-timestamp\":false}";
+  }
+  return pins_test::SetGnmiConfigPath(&gnmi_stub, config_path,
+                                      GnmiSetType::kUpdate, config_json);
+}
+
+absl::Status SetPortEgressTimestamping(bool port_egress_timestamping,
+                                       absl::string_view interface_name,
+                                       gnmi::gNMI::StubInterface& gnmi_stub) {
+  std::string config_path =
+      absl::StrCat("interfaces/interface[name=", interface_name,
+                   "]/ethernet/config/insert-egress-timestamp");
+  std::string config_json;
+  if (port_egress_timestamping) {
+    config_json = "{\"google-pins-interfaces:insert-egress-timestamp\":true}";
+  } else {
+    config_json = "{\"google-pins-interfaces:insert-egress-timestamp\":false}";
+  }
+  return pins_test::SetGnmiConfigPath(&gnmi_stub, config_path,
+                                      GnmiSetType::kUpdate, config_json);
+}
+
+absl::Status SetPortEncodedIdForTimestamping(
+    int encoded_id, absl::string_view interface_name,
+    gnmi::gNMI::StubInterface& gnmi_stub) {
+  std::string config_path = absl::StrCat(
+      "interfaces/interface[name=", interface_name, "]/config/encoded-id");
+  std::string value =
+      absl::StrCat("{\"google-pins-interfaces:encoded-id\":", encoded_id, "}");
+
+  return pins_test::SetGnmiConfigPath(&gnmi_stub, config_path,
+                                      GnmiSetType::kUpdate, value);
+}
+
 absl::StatusOr<std::string> GetPortPfcRxEnable(
     const absl::string_view interface_name,
     gnmi::gNMI::StubInterface& gnmi_stub) {

--- a/lib/gnmi/gnmi_helper.h
+++ b/lib/gnmi/gnmi_helper.h
@@ -85,10 +85,6 @@ enum class GnmiFieldType {
 
 enum class DelayType : std::uint8_t { kIngressDelay, kEgressDelay };
 
-// This suggests whether the HST is running in dry-run mode or live-run mode. In
-// live run mode, HST is fully operational with ASIC access.
-enum class HstRunMode : std::uint8_t { kDryRunMode, kLiveRunMode };
-
 // Describes a single interface in a gNMI config.
 struct OpenConfigInterfaceDescription {
   std::string port_name;
@@ -611,6 +607,21 @@ absl::Status SetPortMtu(int port_mtu, const std::string& interface_name,
 absl::Status SetPortLoopbackMode(bool port_loopback,
                                  absl::string_view interface_name,
                                  gnmi::gNMI::StubInterface& gnmi_stub);
+
+// Set a port ingress timestamping.
+absl::Status SetPortIngressTimestamping(bool port_ingress_timestamping,
+                                        absl::string_view interface_name,
+                                        gnmi::gNMI::StubInterface& gnmi_stub);
+
+// Set a port egress timestamping.
+absl::Status SetPortEgressTimestamping(bool port_egress_timestamping,
+                                       absl::string_view interface_name,
+                                       gnmi::gNMI::StubInterface& gnmi_stub);
+
+// Set a ports encoded id for timestamping.
+absl::Status SetPortEncodedIdForTimestamping(
+    int encoded_id, absl::string_view interface_name,
+    gnmi::gNMI::StubInterface& gnmi_stub);
 
 // Set PFC Rx for a port.
 absl::Status SetPortPfcRxEnable(absl::string_view interface_name,

--- a/lib/gnmi/gnmi_helper.h
+++ b/lib/gnmi/gnmi_helper.h
@@ -388,6 +388,9 @@ inline bool IgnoreCpuPortName(const PortIdByNameIterType& iter) {
   return iter.first == "CPU";
 }
 
+absl::StatusOr<std::vector<std::string>> GetInterfaceNamesForGivenPortNumber(
+    gnmi::gNMI::StubInterface& stub, absl::string_view port_number);
+
 absl::StatusOr<absl::flat_hash_map<std::string, std::string>>
 GetAllInterfaceNameToPortId(
     absl::string_view gnmi_config, absl::string_view field_type = "config",
@@ -513,9 +516,17 @@ absl::StatusOr<absl::btree_set<std::string>>
 GetP4rtIdOfInterfacesInAsicMacLocalLoopbackMode(
     gnmi::gNMI::StubInterface& gnmi_stub);
 
+// Returns true if the transceiver is qualified for the given interface.
+absl::StatusOr<bool> GetTransceiverQualifiedForInterface(
+    gnmi::gNMI::StubInterface& gnmi_stub, absl::string_view interface_name);
+
 // Returns a map from interface names to their physical transceiver name.
 absl::StatusOr<absl::flat_hash_map<std::string, std::string>>
 GetInterfaceToTransceiverMap(gnmi::gNMI::StubInterface& gnmi_stub);
+
+// Returns true if the module is populated for the given interface.
+absl::StatusOr<bool> GetModuleIsPopulatedForInterface(
+    gnmi::gNMI::StubInterface& gnmi_stub, absl::string_view interface_name);
 
 // Returns a map from physical transceiver names to their part information.
 absl::StatusOr<absl::flat_hash_map<std::string, TransceiverPart>>


### PR DESCRIPTION
### **PR Description:**
Add Gnmi helper functions to set port encoded-id.

### **Keyword Check:**
bibhuprasad@bibhuprasad87:~/sonic_build_image_2025-08-20/sonic-buildimage/src/sonic-p4rt/sonic-pins/p4_pdpi$ sh ~/keyword_check.sh .
Keyword check Passed.

### **Build Results:**
bibhuprasad@8b3c841bfe91:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 758 targets (0 packages loaded, 0 targets configured).
INFO: Found 758 targets...
INFO: Elapsed time: 0.387s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### **UT Results:**
bibhuprasad@8b3c841bfe91:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 758 targets (0 packages loaded, 0 targets configured).
INFO: Found 528 targets and 230 test targets...
INFO: Elapsed time: 194.205s, Critical Path: 137.43s
INFO: 287 processes: 341 linux-sandbox, 18 local.
INFO: Build completed successfully, 287 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.3s
//dvaas:dataplane_validation_test                                        PASSED in 0.3s
//dvaas:port_id_map_test                                                 PASSED in 1.8s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.2s
//dvaas:test_run_validation_test                                         PASSED in 2.3s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.5s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//gutil:collections_test                                                 PASSED in 1.6s
//gutil:io_test                                                          PASSED in 1.5s
//gutil:proto_matchers_test                                              PASSED in 1.3s
//gutil:proto_ordering_test                                              PASSED in 1.7s
//gutil:proto_test                                                       PASSED in 1.7s
//gutil:status_matchers_test                                             PASSED in 1.3s
//gutil:test_artifact_writer_test                                        PASSED in 1.5s
//gutil:testing_test                                                     PASSED in 1.3s
//gutil:timer_test                                                       PASSED in 5.2s
//gutil:version_test                                                     PASSED in 4.4s
//lib:basic_switch_test                                                  PASSED in 2.7s
//lib:ixia_helper_test                                                   PASSED in 2.7s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 2.5s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 17.5s
//lib/gnmi:gnmi_helper_test                                              PASSED in 4.3s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.3s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.5s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 2.0s
//lib/utils:generic_testbed_utils_test                                   PASSED in 3.6s
//lib/utils:json_test_utils_test                                         PASSED in 1.4s
//lib/utils:json_utils_test                                              PASSED in 1.3s
//lib/validator:validator_backend_test                                   PASSED in 1.6s
//lib/validator:validator_lib_test                                       PASSED in 27.1s
//p4_fuzzer:constraints_test                                             PASSED in 10.4s
//p4_fuzzer:fuzz_util_test                                               PASSED in 137.3s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 2.6s
//p4_fuzzer:oracle_util_test                                             PASSED in 5.4s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 4.3s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 4.1s
//p4_fuzzer:switch_state_test                                            PASSED in 2.9s
//p4_pdpi:built_ins_test                                                 PASSED in 1.4s
//p4_pdpi:entity_keys_test                                               PASSED in 1.8s
//p4_pdpi:ir_properties_test                                             PASSED in 1.4s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.4s
//p4_pdpi:ir_tools_test                                                  PASSED in 1.8s
//p4_pdpi:names_test                                                     PASSED in 2.1s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.9s
//p4_pdpi:p4info_union_test                                              PASSED in 1.4s
//p4_pdpi:reference_annotations_test                                     PASSED in 2.0s
//p4_pdpi:references_test                                                PASSED in 2.0s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.5s
//p4_pdpi:ternary_test                                                   PASSED in 1.6s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.1s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.4s
//p4_pdpi/packetlib:packetlib_debugging_test                             PASSED in 1.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 21.6s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.4s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.3s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 7.1s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.6s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.5s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.2s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.7s
//p4_pdpi/testing:helper_function_test                                   PASSED in 2.0s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.3s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.2s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.5s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.2s
//p4_pdpi/testing:references_test                                        PASSED in 0.3s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.2s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 2.1s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.5s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.3s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.6s
//p4_pdpi/utils:ir_test                                                  PASSED in 2.0s
//p4_symbolic:z3_util_test                                               PASSED in 1.8s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 3.0s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 4.2s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.2s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 3.7s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 4.1s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 4.1s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.3s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 4.1s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 3.9s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.4s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.2s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.2s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.2s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.2s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.1s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.2s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.2s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.5s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 35.2s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 36.2s
//p4_symbolic/sai:sai_test                                               PASSED in 8.5s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 4.0s
//p4_symbolic/symbolic:parser_test                                       PASSED in 2.2s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 2.4s
//p4_symbolic/symbolic:util_test                                         PASSED in 2.1s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.5s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 20.3s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 3.0s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 3.0s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 2.4s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 2.9s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 2.7s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 3.2s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 3.2s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 3.0s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 1.5s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 2.5s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 2.3s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.3s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.5s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 2.8s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 1.8s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 2.3s
//p4rt_app/sonic:hashing_test                                            PASSED in 2.0s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 2.1s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.8s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.8s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.3s
//p4rt_app/sonic:state_verification_test                                 PASSED in 2.0s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.4s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 2.0s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.9s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.5s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.1s
//p4rt_app/tests:action_set_test                                         PASSED in 1.6s
//p4rt_app/tests:api_access_test                                         PASSED in 1.2s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.6s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.5s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.4s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 9.0s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.6s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.4s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.8s
//p4rt_app/tests:packetio_test                                           PASSED in 4.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.5s
//p4rt_app/tests:response_path_test                                      PASSED in 5.2s
//p4rt_app/tests:role_test                                               PASSED in 1.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 3.0s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.4s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 1.8s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.8s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 2.2s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.3s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.3s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 5.2s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 3.2s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 7.6s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 2.1s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.8s
//sai_p4/tools:packetio_tools_test                                       PASSED in 2.2s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 3.0s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.2s
//tests/lib:common_ir_table_entries_test                                 PASSED in 1.8s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 2.5s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.4s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.3s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 8.0s
//thinkit:bazel_test_environment_test                                    PASSED in 1.6s
//thinkit:generic_testbed_test                                           PASSED in 2.2s
//thinkit:mock_control_device_test                                       PASSED in 1.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.8s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.8s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.8s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 1.7s
//tests/lib:packet_generator_test                                        PASSED in 64.1s
  Stats over 4 runs: max = 64.1s, min = 63.2s, avg = 63.6s, dev = 0.3s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.5s
  Stats over 5 runs: max = 2.5s, min = 1.6s, avg = 2.1s, dev = 0.3s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 45.2s
  Stats over 50 runs: max = 45.2s, min = 1.5s, avg = 6.7s, dev = 12.8s

Executed 230 out of 230 tests: 230 tests pass.